### PR TITLE
fix: resolve relative paths in workspace CLI arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ use selector::{ClassSelector, Selector};
 use std::io::ErrorKind;
 use std::path::Path;
 use workspace::{
-    LoadWorkspaceInput, WorkspaceConfig, WorkspaceEdit, expand_tilde, parse_mount_spec,
+    LoadWorkspaceInput, WorkspaceConfig, WorkspaceEdit, expand_tilde,
+    parse_mount_spec_resolved, resolve_path,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -239,7 +240,7 @@ pub fn run(cli: Cli) -> Result<()> {
 
             let ad_hoc_mounts = mounts
                 .iter()
-                .map(|value| parse_mount_spec(value))
+                .map(|value| parse_mount_spec_resolved(value))
                 .collect::<Result<Vec<_>>>()?;
 
             let resolved_workspace = crate::workspace::resolve_load_workspace(
@@ -427,10 +428,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 allowed_agents,
                 default_agent,
             } => {
-                let expanded_workdir = workspace::expand_tilde(&workdir);
+                let expanded_workdir = workspace::resolve_path(&workdir);
                 let mut all_mounts: Vec<_> = mounts
                     .iter()
-                    .map(|value| parse_mount_spec(value))
+                    .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
                 if !no_workdir_mount {
                     let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
@@ -590,7 +591,7 @@ pub fn run(cli: Cli) -> Result<()> {
             } => {
                 let upsert_mounts = mounts
                     .iter()
-                    .map(|value| parse_mount_spec(value))
+                    .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
 
                 // Collect what changed for the summary
@@ -627,7 +628,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 config.edit_workspace(
                     &name,
                     WorkspaceEdit {
-                        workdir,
+                        workdir: workdir.map(|w| resolve_path(&w)),
                         upsert_mounts,
                         remove_destinations,
                         allowed_agents_to_add: allowed_agents,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -176,7 +176,10 @@ mod tests {
 
         assert_eq!(
             validated.dockerfile.dockerfile_path,
-            temp.path().join("docker/agent.Dockerfile")
+            temp.path()
+                .canonicalize()
+                .unwrap()
+                .join("docker/agent.Dockerfile")
         );
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -58,16 +58,16 @@ pub fn resolve_path(path: &str) -> String {
 }
 
 pub fn parse_mount_spec(spec: &str) -> anyhow::Result<MountConfig> {
-    parse_mount_spec_inner(spec, false)
+    Ok(parse_mount_spec_inner(spec, false))
 }
 
 /// Like [`parse_mount_spec`] but also resolves relative paths to absolute.
 /// Use this for CLI arguments where the user may pass relative paths.
 pub fn parse_mount_spec_resolved(spec: &str) -> anyhow::Result<MountConfig> {
-    parse_mount_spec_inner(spec, true)
+    Ok(parse_mount_spec_inner(spec, true))
 }
 
-fn parse_mount_spec_inner(spec: &str, resolve: bool) -> anyhow::Result<MountConfig> {
+fn parse_mount_spec_inner(spec: &str, resolve: bool) -> MountConfig {
     let (raw, readonly) = spec
         .strip_suffix(":ro")
         .map_or((spec, false), |value| (value, true));
@@ -82,11 +82,11 @@ fn parse_mount_spec_inner(spec: &str, resolve: bool) -> anyhow::Result<MountConf
         dst.to_string()
     };
 
-    Ok(MountConfig {
+    MountConfig {
         src: expanded_src,
         dst,
         readonly,
-    })
+    }
 }
 
 /// Structural validation: absolute paths, no duplicate destinations.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -46,14 +46,36 @@ pub fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+/// Expand tilde and resolve relative paths to absolute using the current working directory.
+pub fn resolve_path(path: &str) -> String {
+    let expanded = expand_tilde(path);
+    if !expanded.starts_with('/') {
+        if let Ok(cwd) = std::env::current_dir() {
+            return cwd.join(&expanded).display().to_string();
+        }
+    }
+    expanded
+}
+
 pub fn parse_mount_spec(spec: &str) -> anyhow::Result<MountConfig> {
+    parse_mount_spec_inner(spec, false)
+}
+
+/// Like [`parse_mount_spec`] but also resolves relative paths to absolute.
+/// Use this for CLI arguments where the user may pass relative paths.
+pub fn parse_mount_spec_resolved(spec: &str) -> anyhow::Result<MountConfig> {
+    parse_mount_spec_inner(spec, true)
+}
+
+fn parse_mount_spec_inner(spec: &str, resolve: bool) -> anyhow::Result<MountConfig> {
     let (raw, readonly) = spec
         .strip_suffix(":ro")
         .map_or((spec, false), |value| (value, true));
     let (src, dst) = raw
         .split_once(':')
         .map_or_else(|| (raw, raw), |(s, d)| (s, d));
-    let expanded_src = expand_tilde(src);
+    let expand = if resolve { resolve_path } else { expand_tilde };
+    let expanded_src = expand(src);
     let dst = if src == dst {
         expanded_src.clone()
     } else {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -343,6 +343,49 @@ mod tests {
     }
 
     #[test]
+    fn resolve_path_resolves_relative_to_cwd() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_path("my-project");
+
+        assert_eq!(resolved, cwd.join("my-project").display().to_string());
+        assert!(resolved.starts_with('/'));
+    }
+
+    #[test]
+    fn resolve_path_leaves_absolute_unchanged() {
+        assert_eq!(resolve_path("/workspace/project"), "/workspace/project");
+    }
+
+    #[test]
+    fn parse_mount_spec_resolved_resolves_relative_src_and_dst() {
+        let cwd = std::env::current_dir().unwrap();
+        let mount = parse_mount_spec_resolved("my-project").unwrap();
+        let expected = cwd.join("my-project").display().to_string();
+
+        assert_eq!(mount.src, expected);
+        assert_eq!(mount.dst, expected);
+        assert!(!mount.readonly);
+    }
+
+    #[test]
+    fn parse_mount_spec_resolved_resolves_relative_src_with_explicit_dst() {
+        let cwd = std::env::current_dir().unwrap();
+        let mount = parse_mount_spec_resolved("my-project:/workspace/project").unwrap();
+
+        assert_eq!(mount.src, cwd.join("my-project").display().to_string());
+        assert_eq!(mount.dst, "/workspace/project");
+        assert!(!mount.readonly);
+    }
+
+    #[test]
+    fn parse_mount_spec_does_not_resolve_relative_paths() {
+        let mount = parse_mount_spec("my-project").unwrap();
+
+        assert_eq!(mount.src, "my-project");
+        assert_eq!(mount.dst, "my-project");
+    }
+
+    #[test]
     fn current_dir_workspace_uses_same_host_and_container_path() {
         let dir = tempdir().unwrap();
         let workspace = current_dir_workspace(dir.path()).unwrap();


### PR DESCRIPTION
## Summary
- `workspace add --workdir jackin` and `--mount homebrew-tap` failed with "workdir must be an absolute container path" because `expand_tilde` only handled `~` expansion, not relative paths
- Added `resolve_path()` (tilde expansion + cwd join) and `parse_mount_spec_resolved()` for CLI entry points, while keeping the stricter `expand_tilde` / `parse_mount_spec` for config-file paths where relative sources should remain rejected
- Fixed a pre-existing macOS test comparing uncanonicalized temp path against canonicalized result (`/var` vs `/private/var`)

## Test plan
- [x] All 137 existing tests pass
- [ ] Run `jackin workspace add test --workdir jackin --mount homebrew-tap` with relative paths and verify it resolves correctly
- [ ] Verify config-file mount sources with relative paths are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)