### PR TITLE
chore: bump version to 0.5.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 rust-version = "1.87"
 description = "Matrix-inspired CLI for orchestrating AI coding agents at scale"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ use selector::{ClassSelector, Selector};
 use std::io::ErrorKind;
 use std::path::Path;
 use workspace::{
-    LoadWorkspaceInput, WorkspaceConfig, WorkspaceEdit, expand_tilde,
-    parse_mount_spec_resolved, resolve_path,
+    LoadWorkspaceInput, WorkspaceConfig, WorkspaceEdit, expand_tilde, parse_mount_spec_resolved,
+    resolve_path,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Bump version from 0.4.0 to 0.5.0-dev for next development cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)