### PR TITLE
fix: normalize relative paths and add integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,16 @@
 See [RULES.md](RULES.md) for project-wide conventions that apply to all AI agents.
 Follow them strictly.
 
+## Branching
+
+All new features and bug fixes must be developed on a dedicated feature branch.
+Never commit directly to `main`.
+
+- Create a branch from `main` before starting work: `git checkout -b feature/<short-description>`
+- Use prefixes that match the type of change: `feature/`, `fix/`, `refactor/`, `chore/`
+- Keep branch names short, lowercase, and hyphen-separated
+- Merge back to `main` via pull request after review
+
 ## Project Structure
 
 See [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) for a navigational map of the codebase, documentation site, Docker assets, and CI workflows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,8 +358,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 } => {
                     let ro = if readonly { " (read-only)" } else { "" };
                     let scope_label = scope.as_deref().unwrap_or("global");
+                    let resolved_src = resolve_path(&src);
                     let mount = config::MountConfig {
-                        src: src.clone(),
+                        src: resolved_src,
                         dst: dst.clone(),
                         readonly,
                     };
@@ -788,5 +789,148 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("neither a saved workspace nor a directory"));
+    }
+
+    /// Simulates `jackin workspace add jackin --workdir jackin --mount sibling-project`
+    /// from a parent directory. Both relative workdir and mount must be resolved to
+    /// absolute paths so that `add_workspace` validation passes.
+    #[test]
+    fn workspace_add_resolves_relative_workdir_and_mounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("jackin");
+        let mount_dir = temp.path().join("sibling-project");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+        std::fs::create_dir_all(&mount_dir).unwrap();
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        let expanded_workdir = workspace::resolve_path("jackin");
+        let mount = parse_mount_spec_resolved("sibling-project").unwrap();
+
+        let mut config = config::AppConfig::default();
+        let result = config.add_workspace(
+            "jackin",
+            WorkspaceConfig {
+                workdir: expanded_workdir.clone(),
+                mounts: vec![
+                    workspace::MountConfig {
+                        src: expanded_workdir.clone(),
+                        dst: expanded_workdir.clone(),
+                        readonly: false,
+                    },
+                    mount,
+                ],
+                allowed_agents: vec![],
+                default_agent: None,
+                last_agent: None,
+            },
+        );
+
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        result.unwrap();
+        let ws = config.workspaces.get("jackin").unwrap();
+        assert!(ws.workdir.starts_with('/'));
+        assert!(!ws.workdir.contains(".."));
+        assert!(ws.mounts.iter().all(|m| m.src.starts_with('/')));
+    }
+
+    /// Simulates `jackin workspace add jackin --workdir . --mount ../jackin-agent-smith`
+    /// from inside the project directory. Dot-workdir and parent-relative mount must both
+    /// resolve to clean absolute paths.
+    #[test]
+    fn workspace_add_resolves_dot_workdir_and_dotdot_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("jackin");
+        let sibling_dir = temp.path().join("jackin-agent-smith");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&workdir_dir).unwrap();
+
+        let expanded_workdir = workspace::resolve_path(".");
+        let mount = parse_mount_spec_resolved("../jackin-agent-smith").unwrap();
+
+        let mut config = config::AppConfig::default();
+        let result = config.add_workspace(
+            "jackin",
+            WorkspaceConfig {
+                workdir: expanded_workdir.clone(),
+                mounts: vec![
+                    workspace::MountConfig {
+                        src: expanded_workdir.clone(),
+                        dst: expanded_workdir.clone(),
+                        readonly: false,
+                    },
+                    mount.clone(),
+                ],
+                allowed_agents: vec![],
+                default_agent: None,
+                last_agent: None,
+            },
+        );
+
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        result.unwrap();
+        let ws = config.workspaces.get("jackin").unwrap();
+        assert!(ws.workdir.starts_with('/'));
+        assert!(!ws.workdir.contains(".."));
+        assert!(!mount.src.contains(".."), "mount src must not contain '..'");
+        assert!(mount.src.ends_with("/jackin-agent-smith"));
+    }
+
+    /// Simulates `jackin workspace edit jackin --mount sibling-dev` where the mount
+    /// is a relative directory name. The resolved mount must pass validation.
+    #[test]
+    fn workspace_edit_resolves_relative_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("jackin");
+        let dev_dir = temp.path().join("jackin-dev");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+        std::fs::create_dir_all(&dev_dir).unwrap();
+
+        let workdir_abs = workdir_dir.display().to_string();
+
+        let mut config = config::AppConfig::default();
+        config
+            .add_workspace(
+                "jackin",
+                WorkspaceConfig {
+                    workdir: workdir_abs.clone(),
+                    mounts: vec![workspace::MountConfig {
+                        src: workdir_abs.clone(),
+                        dst: workdir_abs.clone(),
+                        readonly: false,
+                    }],
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        let mount = parse_mount_spec_resolved("jackin-dev").unwrap();
+
+        let result = config.edit_workspace(
+            "jackin",
+            WorkspaceEdit {
+                upsert_mounts: vec![mount.clone()],
+                ..WorkspaceEdit::default()
+            },
+        );
+
+        std::env::set_current_dir(original_cwd).unwrap();
+
+        result.unwrap();
+        let ws = config.workspaces.get("jackin").unwrap();
+        assert_eq!(ws.mounts.len(), 2);
+        assert!(ws.mounts[1].src.starts_with('/'));
+        assert!(ws.mounts[1].src.ends_with("/jackin-dev"));
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MountConfig {
@@ -46,15 +46,38 @@ pub fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
-/// Expand tilde and resolve relative paths to absolute using the current working directory.
-pub fn resolve_path(path: &str) -> String {
-    let expanded = expand_tilde(path);
-    if !expanded.starts_with('/') {
-        if let Ok(cwd) = std::env::current_dir() {
-            return cwd.join(&expanded).display().to_string();
+/// Normalize an absolute path by resolving `.` and `..` components without
+/// touching the filesystem (unlike [`std::fs::canonicalize`]).
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut parts: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                if let Some(Component::Normal(_)) = parts.last() {
+                    parts.pop();
+                }
+            }
+            Component::CurDir => {}
+            c => parts.push(c),
         }
     }
-    expanded
+    parts.iter().collect()
+}
+
+/// Expand tilde, resolve relative paths to absolute using the current working
+/// directory, and normalize `.` / `..` components.
+pub fn resolve_path(path: &str) -> String {
+    let expanded = expand_tilde(path);
+    let abs = if !expanded.starts_with('/') {
+        if let Ok(cwd) = std::env::current_dir() {
+            cwd.join(&expanded)
+        } else {
+            return expanded;
+        }
+    } else {
+        PathBuf::from(&expanded)
+    };
+    normalize_path(&abs).display().to_string()
 }
 
 pub fn parse_mount_spec(spec: &str) -> anyhow::Result<MountConfig> {
@@ -357,6 +380,44 @@ mod tests {
     }
 
     #[test]
+    fn resolve_path_normalizes_dot_to_cwd() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_path(".");
+
+        assert_eq!(resolved, cwd.display().to_string());
+    }
+
+    #[test]
+    fn resolve_path_normalizes_parent_component() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_path("../sibling");
+        let expected = cwd.parent().unwrap().join("sibling");
+
+        assert_eq!(resolved, expected.display().to_string());
+        assert!(!resolved.contains(".."));
+    }
+
+    #[test]
+    fn resolve_path_normalizes_absolute_with_dotdot() {
+        assert_eq!(
+            resolve_path("/a/b/../c"),
+            "/a/c"
+        );
+    }
+
+    #[test]
+    fn normalize_path_handles_multiple_parent_refs() {
+        let path = Path::new("/a/b/c/../../d");
+        assert_eq!(normalize_path(path), PathBuf::from("/a/d"));
+    }
+
+    #[test]
+    fn normalize_path_preserves_root_on_excessive_parents() {
+        let path = Path::new("/a/../../../b");
+        assert_eq!(normalize_path(path), PathBuf::from("/b"));
+    }
+
+    #[test]
     fn parse_mount_spec_resolved_resolves_relative_src_and_dst() {
         let cwd = std::env::current_dir().unwrap();
         let mount = parse_mount_spec_resolved("my-project").unwrap();
@@ -375,6 +436,26 @@ mod tests {
         assert_eq!(mount.src, cwd.join("my-project").display().to_string());
         assert_eq!(mount.dst, "/workspace/project");
         assert!(!mount.readonly);
+    }
+
+    #[test]
+    fn parse_mount_spec_resolved_normalizes_dotdot_in_relative_path() {
+        let cwd = std::env::current_dir().unwrap();
+        let mount = parse_mount_spec_resolved("../sibling-project").unwrap();
+        let expected = cwd.parent().unwrap().join("sibling-project");
+
+        assert_eq!(mount.src, expected.display().to_string());
+        assert_eq!(mount.dst, expected.display().to_string());
+        assert!(!mount.src.contains(".."));
+    }
+
+    #[test]
+    fn parse_mount_spec_resolved_normalizes_dot_path() {
+        let cwd = std::env::current_dir().unwrap();
+        let mount = parse_mount_spec_resolved(".").unwrap();
+
+        assert_eq!(mount.src, cwd.display().to_string());
+        assert_eq!(mount.dst, cwd.display().to_string());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `resolve_path` now normalizes `.` and `..` components so paths like `../sibling` resolve to clean absolute paths (e.g. `/a/c` instead of `/a/b/../c`)
- `config mount add --src` now resolves relative paths (was passing raw input directly)
- Added 10 new tests: 7 unit tests for `normalize_path`/`resolve_path`/`parse_mount_spec_resolved` and 3 integration tests mirroring exact CLI scenarios (`workspace add` with relative workdir/mounts, `workspace edit` with relative mount)
- Updated `AGENTS.md` with branching policy requiring feature branches for all new work

## Test plan

- [x] All 152 tests pass (`cargo test`)
- [ ] Manual verification: `jackin workspace add ws --workdir . --mount ../sibling` resolves to clean absolute paths
- [ ] Manual verification: `jackin workspace edit ws --mount relative-dir` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)