### PR TITLE
style: collapse resolve_path clippy branch

### DIFF
--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -397,10 +397,7 @@ mod tests {
 
     #[test]
     fn resolve_path_normalizes_absolute_with_dotdot() {
-        assert_eq!(
-            resolve_path("/a/b/../c"),
-            "/a/c"
-        );
+        assert_eq!(resolve_path("/a/b/../c"), "/a/c");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -68,14 +68,12 @@ fn normalize_path(path: &Path) -> PathBuf {
 /// directory, and normalize `.` / `..` components.
 pub fn resolve_path(path: &str) -> String {
     let expanded = expand_tilde(path);
-    let abs = if !expanded.starts_with('/') {
-        if let Ok(cwd) = std::env::current_dir() {
-            cwd.join(&expanded)
-        } else {
-            return expanded;
-        }
-    } else {
+    let abs = if expanded.starts_with('/') {
         PathBuf::from(&expanded)
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(&expanded)
+    } else {
+        return expanded;
     };
     normalize_path(&abs).display().to_string()
 }


### PR DESCRIPTION
## Summary
- collapse the `resolve_path` absolute-path branch shape to satisfy Clippy pedantic lints
- preserve existing `resolve_path` behavior while removing the remaining warning on `main`

## Test Plan
- [x] cargo clippy
- [x] cargo nextest run
