### PR TITLE
fix: address pre-launch env review findings

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -41,4 +41,4 @@ fi
 
 printf '\033[2J\033[H'
 
-exec env CLAUDE_ENV=docker claude --dangerously-skip-permissions --verbose
+exec env CLAUDE_ENV="${CLAUDE_ENV:-docker}" claude --dangerously-skip-permissions --verbose

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -41,4 +41,4 @@ fi
 
 printf '\033[2J\033[H'
 
-exec env CLAUDE_ENV="${CLAUDE_ENV:-docker}" claude --dangerously-skip-permissions --verbose
+exec claude --dangerously-skip-permissions --verbose

--- a/docs/src/content/docs/developing/agent-manifest.mdx
+++ b/docs/src/content/docs/developing/agent-manifest.mdx
@@ -25,9 +25,6 @@ plugins = ["code-review@claude-plugins-official"]
 [hooks]
 pre_launch = "hooks/pre-launch.sh"
 
-[env.CLAUDE_ENV]
-default = "docker"
-
 [env.PROJECT]
 interactive = true
 options = ["project1", "project2"]
@@ -132,16 +129,12 @@ Declare environment variables that the agent needs at runtime. Each variable is 
 - `options` requires `interactive = true`
 - `depends_on` entries must use the `env.` prefix (e.g., `"env.PROJECT"`)
 - `depends_on` must reference variables declared in the same manifest
+- `CLAUDE_ENV` is reserved for jackin and cannot be declared in `[env]`
 - Circular dependencies are rejected
 
-### Static variables
+### Runtime-managed variables
 
-Set automatically with no user interaction:
-
-```toml
-[env.CLAUDE_ENV]
-default = "docker"
-```
+jackin sets `CLAUDE_ENV=jackin` automatically inside the container to mark the isolated runtime. Do not declare `CLAUDE_ENV` in `[env]`.
 
 ### Interactive text input
 
@@ -228,9 +221,6 @@ plugins = ["code-review@claude-plugins-official"]
 
 [hooks]
 pre_launch = "hooks/pre-launch.sh"
-
-[env.CLAUDE_ENV]
-default = "docker"
 
 [env.CONTEXT7_API_KEY]
 interactive = true

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -204,9 +204,8 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
     }
 
     #[test]
-    fn entrypoint_preserves_existing_claude_env() {
-        assert!(ENTRYPOINT_SH.contains("CLAUDE_ENV=\"${CLAUDE_ENV:-docker}\""));
-        assert!(!ENTRYPOINT_SH.contains("CLAUDE_ENV=docker claude"));
+    fn entrypoint_does_not_override_claude_env() {
+        assert!(!ENTRYPOINT_SH.contains("CLAUDE_ENV="));
     }
 
     #[test]

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -204,6 +204,12 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
     }
 
     #[test]
+    fn entrypoint_preserves_existing_claude_env() {
+        assert!(ENTRYPOINT_SH.contains("CLAUDE_ENV=\"${CLAUDE_ENV:-docker}\""));
+        assert!(!ENTRYPOINT_SH.contains("CLAUDE_ENV=docker claude"));
+    }
+
+    #[test]
     fn creates_temp_context_with_repo_copy_and_runtime_assets() {
         let repo = tempdir().unwrap();
         std::fs::write(

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -70,7 +70,11 @@ pub fn resolve_env(
                 vars.push((name.clone(), value));
             }
             PromptResult::Skipped => {
-                skipped.insert(name.clone());
+                if decl.skippable {
+                    skipped.insert(name.clone());
+                } else {
+                    anyhow::bail!("env var {name}: required prompt cannot be skipped");
+                }
             }
         }
     }
@@ -253,6 +257,21 @@ mod tests {
         let resolved = resolve_env(&decls, &prompter).unwrap();
 
         assert!(resolved.vars.is_empty());
+    }
+
+    #[test]
+    fn required_var_cannot_be_skipped() {
+        let mut decls = BTreeMap::new();
+        decls.insert("BRANCH".to_string(), interactive_text("Branch:"));
+        let prompter = MockPrompter::new(vec![PromptResult::Skipped]);
+
+        let error = match resolve_env(&decls, &prompter) {
+            Ok(_) => panic!("required skipped var should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("BRANCH"));
+        assert!(error.to_string().contains("skip"));
     }
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,6 +2,9 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::Path;
 
+pub const JACKIN_RUNTIME_ENV_NAME: &str = "CLAUDE_ENV";
+pub const JACKIN_RUNTIME_ENV_VALUE: &str = "jackin";
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentManifest {
@@ -72,6 +75,12 @@ impl AgentManifest {
         let mut warnings = Vec::new();
 
         for (name, decl) in &self.env {
+            if name == JACKIN_RUNTIME_ENV_NAME {
+                anyhow::bail!(
+                    "env var {name}: reserved for jackin runtime metadata and set automatically to {JACKIN_RUNTIME_ENV_VALUE}"
+                );
+            }
+
             // Non-interactive without default is an error
             if !decl.interactive && decl.default_value.is_none() {
                 anyhow::bail!("env var {name}: non-interactive variable must have a default value");
@@ -398,7 +407,7 @@ post_launch = "bad"
 [claude]
 plugins = []
 
-[env.CLAUDE_ENV]
+[env.RUNTIME]
 default = "docker"
 "#,
         )
@@ -407,7 +416,7 @@ default = "docker"
         let manifest = AgentManifest::load(temp.path()).unwrap();
 
         assert_eq!(manifest.env.len(), 1);
-        let var = &manifest.env["CLAUDE_ENV"];
+        let var = &manifest.env["RUNTIME"];
         assert_eq!(var.default_value.as_deref(), Some("docker"));
         assert!(!var.interactive);
     }
@@ -696,7 +705,7 @@ prompt = "Branch:"
 [claude]
 plugins = []
 
-[env.CLAUDE_ENV]
+[env.RUNTIME]
 default = "docker"
 
 [env.PROJECT]
@@ -717,6 +726,29 @@ default = "main"
         let warnings = manifest.validate().unwrap();
 
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn validate_rejects_reserved_claude_env_name() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.CLAUDE_ENV]
+default = "docker"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("CLAUDE_ENV"));
     }
 
     #[test]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -87,6 +87,9 @@ fn validate_relative_path(repo_dir: &Path, path_str: &str, label: &str) -> anyho
     if !resolved.is_file() {
         anyhow::bail!("invalid agent repo: missing {}", resolved.display());
     }
+    if std::fs::symlink_metadata(&resolved)?.file_type().is_symlink() {
+        anyhow::bail!("invalid agent repo: {label} path must not be a symlink");
+    }
 
     let canonical_repo = repo_dir.canonicalize()?;
     let canonical_resolved = resolved.canonicalize()?;
@@ -369,5 +372,40 @@ pre_launch = "hooks/pre-launch.sh"
         let error = validate_agent_repo(temp.path()).unwrap_err();
 
         assert!(error.to_string().contains("empty"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_pre_launch_hook_inside_repo() {
+        let temp = tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("hooks")).unwrap();
+        std::fs::write(temp.path().join("real-hook.sh"), "#!/bin/bash\necho hi\n").unwrap();
+        std::os::unix::fs::symlink(
+            temp.path().join("real-hook.sh"),
+            temp.path().join("hooks/pre-launch.sh"),
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM donbeave/jackin-construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[hooks]
+pre_launch = "hooks/pre-launch.sh"
+"#,
+        )
+        .unwrap();
+
+        let error = validate_agent_repo(temp.path()).unwrap_err();
+
+        assert!(error.to_string().contains("symlink"));
+        assert!(error.to_string().contains("pre_launch"));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -418,7 +418,15 @@ fn launch_agent_runtime(
         run_args.extend_from_slice(&["-e", "CLAUDE_DEBUG=1"]);
     }
     let mut env_strings: Vec<String> = Vec::new();
+    env_strings.push(format!(
+        "{}={}",
+        crate::manifest::JACKIN_RUNTIME_ENV_NAME,
+        crate::manifest::JACKIN_RUNTIME_ENV_VALUE
+    ));
     for (key, value) in &resolved_env.vars {
+        if key == crate::manifest::JACKIN_RUNTIME_ENV_NAME {
+            continue;
+        }
         env_strings.push(format!("{key}={value}"));
     }
     for env_str in &env_strings {
@@ -1838,5 +1846,56 @@ plugins = []
             .find(|call| call.contains("docker run -it"))
             .unwrap();
         assert!(run_cmd.contains("jackin.display_name=Agent Smith"));
+    }
+
+    #[test]
+    fn load_agent_sets_claude_env_to_jackin() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "jackin-agent-smith".to_string(),
+        ]);
+
+        let repo_dir = paths.agents_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM donbeave/jackin-construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let workspace = repo_workspace(&repo_dir);
+        load_agent(
+            &paths,
+            &mut config,
+            &selector,
+            &workspace,
+            &mut runner,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+
+        let run_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker run -it"))
+            .unwrap();
+        assert!(run_cmd.contains("-e CLAUDE_ENV=jackin"));
     }
 }


### PR DESCRIPTION
## Summary
- reject skipping required interactive env prompts
- preserve caller-provided CLAUDE_ENV in the runtime entrypoint
- reject symlinked pre_launch hook paths during agent repo validation

## Verification
- cargo clippy
- cargo nextest run