### PR TITLE
feat: publish homebrew preview channel

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,102 @@
+name: Publish Homebrew Preview
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: homebrew-tap-publish
+  cancel-in-progress: true
+
+jobs:
+  publish-preview:
+    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve source SHA
+        id: source
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          repository: jackin-project/jackin
+          ref: ${{ steps.source.outputs.sha }}
+
+      - name: Compute preview metadata
+        id: meta
+        run: |
+          base_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          base_version=${base_version%-dev}
+          full_sha="${{ steps.source.outputs.sha }}"
+          short_sha=$(printf '%s' "$full_sha" | cut -c1-7)
+          tarball_url="https://github.com/jackin-project/jackin/archive/${full_sha}.tar.gz"
+          curl -fL "$tarball_url" -o jackin-preview.tar.gz
+          sha256=$(shasum -a 256 jackin-preview.tar.gz | awk '{print $1}')
+          {
+            echo "full_sha=$full_sha"
+            echo "short_sha=$short_sha"
+            echo "version=${base_version}-preview+${short_sha}"
+            echo "tarball_url=$tarball_url"
+            echo "sha256=$sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: jackin-project/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Verify preview alias
+        run: |
+          test -L homebrew-tap/Aliases/jackin@preview
+          test "$(readlink homebrew-tap/Aliases/jackin@preview)" = "../Formula/jackin-preview.rb"
+
+      - name: Rewrite preview formula
+        run: |
+          cat > homebrew-tap/Formula/jackin-preview.rb <<EOF
+          class JackinPreview < Formula
+            desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
+            homepage "https://github.com/jackin-project/jackin"
+            url "${{ steps.meta.outputs.tarball_url }}"
+            version "${{ steps.meta.outputs.version }}"
+            sha256 "${{ steps.meta.outputs.sha256 }}"
+            license "Apache-2.0"
+
+            depends_on "rust" => :build
+            depends_on "docker" => :optional
+
+            conflicts_with "jackin-project/tap/jackin", because: "preview and stable install the same binary"
+
+            def install
+              system "cargo", "install", *std_cargo_args
+            end
+
+            test do
+              assert_match "jackin", shell_output("#{bin}/jackin --version")
+            end
+          end
+          EOF
+
+      - name: Commit and push tap update
+        working-directory: homebrew-tap
+        run: |
+          git add Formula/jackin-preview.rb
+          if git diff --cached --quiet --exit-code; then
+            echo "Preview formula already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "jackin@preview ${{ steps.meta.outputs.version }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: mislav/bump-homebrew-formula-action@v4
         with:
           formula-name: jackin
-          homebrew-tap: donbeave/homebrew-tap
+          homebrew-tap: jackin-project/homebrew-tap
           tag-name: v${{ needs.check-version.outputs.version }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.87"
 description = "Matrix-inspired CLI for orchestrating AI coding agents at scale"
 homepage = "https://www.zhokhov.com/jackin/"
-repository = "https://github.com/donbeave/jackin"
+repository = "https://github.com/jackin-project/jackin"
 license = "Apache-2.0"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ Source code: <https://github.com/jackin-project/jackin>
 
 ```sh
 brew tap jackin-project/tap
+
+# Stable
 brew install jackin
+
+# OR rolling preview channel
+brew install jackin@preview
 ```
 
 Or [build from source](https://www.zhokhov.com/jackin/getting-started/installation/) if you prefer.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Jack your AI coding agents into the Matrix — their own isolated worlds, scoped
 
 Documentation: <https://www.zhokhov.com/jackin/>
 
-Source code: <https://github.com/donbeave/jackin>
+Source code: <https://github.com/jackin-project/jackin>
 
 > **Current status:** jackin' is built as a proof of concept around [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as its first and only supported agent runtime. Support for additional runtimes is [on the roadmap](https://www.zhokhov.com/jackin/reference/roadmap/).
 
 ## Install
 
 ```sh
-brew tap donbeave/tap
+brew tap jackin-project/tap
 brew install jackin
 ```
 
@@ -45,10 +45,10 @@ Learn more: [Why jackin'?](https://www.zhokhov.com/jackin/getting-started/why/) 
 
 | Repository | Description |
 |---|---|
-| [jackin](https://github.com/donbeave/jackin) | CLI source code (this repo) |
+| [jackin](https://github.com/jackin-project/jackin) | CLI source code (this repo) |
 | [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) | Default general-purpose agent |
 | [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) | Rust development agent (used for jackin' development) |
-| [construct image source](https://github.com/donbeave/jackin/tree/main/docker/construct) | Shared base Docker image for all agents |
+| [construct image source](https://github.com/jackin-project/jackin/tree/main/docker/construct) | Shared base Docker image for all agents |
 
 ## Documentation
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,10 +14,10 @@ export default defineConfig({
         replacesTitle: true,
       },
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/donbeave/jackin' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/jackin-project/jackin' },
       ],
       editLink: {
-        baseUrl: 'https://github.com/donbeave/jackin/edit/main/docs/',
+        baseUrl: 'https://github.com/jackin-project/jackin/edit/main/docs/',
       },
       customCss: ['./src/styles/custom.css'],
       head: [

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -17,17 +17,17 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
     The easiest way to install on macOS or Linux:
 
     ```bash
-    brew tap donbeave/tap
+    brew tap jackin-project/tap
     brew install jackin
     ```
 
-    The Homebrew formulae are maintained in the [donbeave/homebrew-tap](https://github.com/donbeave/homebrew-tap) repository.
+    The Homebrew formulae are maintained in the [jackin-project/homebrew-tap](https://github.com/jackin-project/homebrew-tap) repository.
   </TabItem>
   <TabItem label="From source">
     Requires Rust 1.87 or newer:
 
     ```bash
-    cargo install --git https://github.com/donbeave/jackin.git
+    cargo install --git https://github.com/jackin-project/jackin.git
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -18,7 +18,15 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
     ```bash
     brew tap jackin-project/tap
+
+    # Stable
     brew install jackin
+    ```
+
+    Or install the rolling preview channel instead:
+
+    ```bash
+    brew install jackin@preview
     ```
 
     The Homebrew formulae are maintained in the [jackin-project/homebrew-tap](https://github.com/jackin-project/homebrew-tap) repository.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -57,7 +57,12 @@ jackin' is intentionally transparent about its tradeoffs. It is a container-base
 ```bash
 # Install via Homebrew
 brew tap jackin-project/tap
+
+# Stable
 brew install jackin
+
+# Or install the rolling preview channel
+brew install jackin@preview
 
 # Load an agent into the current directory
 jackin load agent-smith

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/donbeave/jackin
+      link: https://github.com/jackin-project/jackin
       icon: external
       variant: minimal
 ---
@@ -56,7 +56,7 @@ jackin' is intentionally transparent about its tradeoffs. It is a container-base
 
 ```bash
 # Install via Homebrew
-brew tap donbeave/tap
+brew tap jackin-project/tap
 brew install jackin
 
 # Load an agent into the current directory
@@ -80,7 +80,7 @@ jackin launch
 
 | Repository | Description |
 |---|---|
-| [jackin](https://github.com/donbeave/jackin) | CLI source code |
+| [jackin](https://github.com/jackin-project/jackin) | CLI source code |
 | [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) | Default general-purpose agent |
 | [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) | Rust development agent (used for jackin' development) |
-| [homebrew-tap](https://github.com/donbeave/homebrew-tap) | Homebrew formulae for installing jackin' |
+| [homebrew-tap](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for installing jackin' |

--- a/docs/superpowers/plans/2026-04-07-homebrew-preview-channel.md
+++ b/docs/superpowers/plans/2026-04-07-homebrew-preview-channel.md
@@ -1,0 +1,568 @@
+# Homebrew Preview Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a `jackin@preview` Homebrew formula from the latest successful `main` commit and move the Homebrew-facing GitHub organization references from `donbeave` to `jackin-project`.
+
+**Architecture:** Keep the stable and preview channels separate. The stable path continues to use the existing tagged release workflow, but it must target `jackin-project/homebrew-tap`. The preview path adds a new workflow in the `jackin` repo that rewrites `jackin@preview` in the sibling tap repo using a pinned commit tarball and a Ghostty-style version string (`<base>-preview+<shortsha>`).
+
+**Tech Stack:** GitHub Actions, Homebrew formulae, shell scripting, Rust project metadata from `Cargo.toml`, Astro Starlight docs, Bun.
+
+**Assumption:** This plan only migrates GitHub organization references for the `jackin` source repository and the Homebrew tap. It does not change Docker Hub image namespaces or agent repository URLs such as `jackin-agent-smith` until those are confirmed separately.
+
+---
+
+## File Map
+
+- Modify: `Cargo.toml` — update the canonical repository URL for the `jackin` crate.
+- Modify: `README.md` — update the source repository URL and Homebrew tap install command.
+- Modify: `.github/workflows/release.yml` — retarget the stable Homebrew bump job to `jackin-project/homebrew-tap`.
+- Create: `.github/workflows/preview.yml` — publish `jackin@preview` after successful CI on `main`.
+- Modify: `docs/astro.config.mjs` — update GitHub and edit-link URLs for docs.
+- Modify: `docs/src/content/docs/getting-started/installation.mdx` — update Homebrew/source install instructions and add preview install instructions.
+- Modify: `docs/src/content/docs/index.mdx` — update Homebrew quick-start commands and repository links, and add the preview channel command.
+- Modify: `../homebrew-tap/Formula/jackin.rb` — update `homepage`, `url`, and `head` to `jackin-project/jackin`.
+- Create: `../homebrew-tap/Formula/jackin@preview.rb` — add the rolling preview formula.
+- Modify: `../homebrew-tap/README.md` — update the tap namespace and add preview installation instructions.
+
+### Task 1: Migrate `jackin` Homebrew-Facing Org References
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `README.md`
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/astro.config.mjs`
+- Modify: `docs/src/content/docs/getting-started/installation.mdx`
+- Modify: `docs/src/content/docs/index.mdx`
+
+- [ ] **Step 1: Confirm the old `donbeave` references still exist in the `jackin` repo**
+
+Run:
+
+```bash
+rg -n "github.com/donbeave/jackin|donbeave/homebrew-tap|brew tap donbeave/tap|donbeave/tap" \
+  Cargo.toml \
+  README.md \
+  .github/workflows/release.yml \
+  docs/astro.config.mjs \
+  docs/src/content/docs/getting-started/installation.mdx \
+  docs/src/content/docs/index.mdx
+```
+
+Expected: matches in all six files.
+
+- [ ] **Step 2: Update the repository URL and stable tap target in the `jackin` repo**
+
+Edit the files to contain these exact fragments:
+
+```toml
+# Cargo.toml
+repository = "https://github.com/jackin-project/jackin"
+```
+
+```yaml
+# .github/workflows/release.yml
+      - uses: mislav/bump-homebrew-formula-action@v4
+        with:
+          formula-name: jackin
+          homebrew-tap: jackin-project/homebrew-tap
+          tag-name: v${{ needs.check-version.outputs.version }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+```
+
+```js
+// docs/astro.config.mjs
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/jackin-project/jackin' },
+      ],
+      editLink: {
+        baseUrl: 'https://github.com/jackin-project/jackin/edit/main/docs/',
+      },
+```
+
+````md
+<!-- README.md -->
+Source code: <https://github.com/jackin-project/jackin>
+
+```sh
+brew tap jackin-project/tap
+brew install jackin
+```
+````
+
+- [ ] **Step 3: Update the docs pages with the new org and tap namespace**
+
+Edit the docs content to contain these exact blocks:
+
+````mdx
+<!-- docs/src/content/docs/getting-started/installation.mdx -->
+  <TabItem label="Homebrew">
+    The easiest way to install on macOS or Linux:
+
+    ```bash
+    brew tap jackin-project/tap
+    brew install jackin
+    ```
+
+    The Homebrew formulae are maintained in the [jackin-project/homebrew-tap](https://github.com/jackin-project/homebrew-tap) repository.
+  </TabItem>
+  <TabItem label="From source">
+    Requires Rust 1.87 or newer:
+
+    ```bash
+    cargo install --git https://github.com/jackin-project/jackin.git
+    ```
+  </TabItem>
+````
+
+````mdx
+<!-- docs/src/content/docs/index.mdx -->
+  actions:
+    - text: View on GitHub
+      link: https://github.com/jackin-project/jackin
+      icon: external
+      variant: minimal
+
+```bash
+# Install via Homebrew
+brew tap jackin-project/tap
+brew install jackin
+```
+
+| [jackin](https://github.com/jackin-project/jackin) | CLI source code |
+| [homebrew-tap](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for installing jackin' |
+````
+
+- [ ] **Step 4: Verify no stale `donbeave` Homebrew or repo references remain in the touched `jackin` files**
+
+Run:
+
+```bash
+rg -n "github.com/donbeave/jackin|donbeave/homebrew-tap|brew tap donbeave/tap|donbeave/tap" \
+  Cargo.toml \
+  README.md \
+  .github/workflows/release.yml \
+  docs/astro.config.mjs \
+  docs/src/content/docs/getting-started/installation.mdx \
+  docs/src/content/docs/index.mdx
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run the required `jackin` repo verification before committing**
+
+Run:
+
+```bash
+cargo clippy && cargo nextest run
+cd docs && bun run build
+```
+
+Expected: clippy passes with zero warnings promoted to errors, `cargo nextest run` passes, and the docs site builds successfully.
+
+- [ ] **Step 6: Commit the `jackin` repo org migration changes**
+
+Run:
+
+```bash
+git add Cargo.toml README.md .github/workflows/release.yml docs/astro.config.mjs docs/src/content/docs/getting-started/installation.mdx docs/src/content/docs/index.mdx
+git commit -m "chore: move homebrew publishing to jackin-project"
+```
+
+### Task 2: Update the Tap Repo and Add `jackin@preview`
+
+**Files:**
+- Modify: `../homebrew-tap/Formula/jackin.rb`
+- Create: `../homebrew-tap/Formula/jackin@preview.rb`
+- Modify: `../homebrew-tap/README.md`
+
+- [ ] **Step 1: Create a dedicated branch in the sibling tap repo**
+
+Run:
+
+```bash
+git -C ../homebrew-tap checkout -b feature/homebrew-preview-channel
+```
+
+Expected: Git reports `Switched to a new branch 'feature/homebrew-preview-channel'`.
+
+- [ ] **Step 2: Confirm the stable tap formula and README still point at `donbeave` and that `jackin@preview.rb` does not exist yet**
+
+Run:
+
+```bash
+rg -n "donbeave|jackin-project" ../homebrew-tap/Formula/jackin.rb ../homebrew-tap/README.md
+test ! -f ../homebrew-tap/Formula/jackin@preview.rb
+```
+
+Expected: `rg` shows `donbeave` matches in the stable formula and README, and `test` succeeds because `jackin@preview.rb` is not present yet.
+
+- [ ] **Step 3: Update the stable tap formula to the `jackin-project` organization**
+
+Replace `../homebrew-tap/Formula/jackin.rb` with this exact content:
+
+```ruby
+class Jackin < Formula
+  desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
+  homepage "https://github.com/jackin-project/jackin"
+  url "https://github.com/jackin-project/jackin/archive/refs/tags/v0.4.0.tar.gz"
+  sha256 "f28a180a1039e15e1525e7e2c0b7b3aa556d3ff15152cb91048aff4cdcff6b95"
+  license "Apache-2.0"
+  head "https://github.com/jackin-project/jackin.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "docker" => :optional
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "jackin", shell_output("#{bin}/jackin --version")
+  end
+end
+```
+
+- [ ] **Step 4: Generate the initial `jackin@preview` formula from the current `origin/main` commit of `jackin`**
+
+Run from the `jackin` repo root:
+
+```bash
+git fetch origin main
+FULL_SHA=$(git rev-parse origin/main)
+SHORT_SHA=$(git rev-parse --short=7 origin/main)
+BASE_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+BASE_VERSION=${BASE_VERSION%-dev}
+TARBALL_URL="https://github.com/jackin-project/jackin/archive/${FULL_SHA}.tar.gz"
+TMP_TARBALL=$(mktemp /tmp/jackin-preview.XXXXXX.tar.gz)
+curl -L "$TARBALL_URL" -o "$TMP_TARBALL"
+SHA256=$(shasum -a 256 "$TMP_TARBALL" | awk '{print $1}')
+cat > ../homebrew-tap/Formula/jackin@preview.rb <<EOF
+class JackinATPreview < Formula
+  desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
+  homepage "https://github.com/jackin-project/jackin"
+  url "${TARBALL_URL}"
+  version "${BASE_VERSION}-preview+${SHORT_SHA}"
+  sha256 "${SHA256}"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+  depends_on "docker" => :optional
+
+  conflicts_with "jackin", because: "preview and stable install the same binary"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "jackin", shell_output("#{bin}/jackin --version")
+  end
+end
+EOF
+rm -f "$TMP_TARBALL"
+```
+
+- [ ] **Step 5: Expand the tap README with the new organization and preview instructions**
+
+Replace `../homebrew-tap/README.md` with this exact content:
+
+````md
+# Homebrew Tap
+
+Homebrew formulae for [jackin](https://github.com/jackin-project/jackin) and related tools.
+
+## Installation
+
+```sh
+brew tap jackin-project/tap
+brew install jackin
+```
+
+## Preview Channel
+
+```sh
+brew install jackin@preview
+```
+
+## Updating
+
+```sh
+brew update
+brew upgrade jackin
+brew upgrade jackin@preview
+```
+````
+
+- [ ] **Step 6: Audit the stable and preview formulas from the tap repo**
+
+Run:
+
+```bash
+TAP_PATH=$(python3 - <<'PY'
+import os
+print(os.path.realpath('../homebrew-tap'))
+PY
+)
+brew untap jackin-project/tap >/dev/null 2>&1 || true
+brew tap jackin-project/tap "$TAP_PATH"
+brew audit --strict --formula jackin-project/tap/jackin
+brew audit --strict --formula jackin-project/tap/jackin@preview
+```
+
+Expected: both audits pass.
+
+- [ ] **Step 7: Install the preview formula locally from source to verify the tap works end-to-end**
+
+Run:
+
+```bash
+brew install --build-from-source jackin-project/tap/jackin@preview
+jackin --version
+```
+
+Expected: Homebrew builds `jackin@preview` successfully and `jackin --version` prints a version string containing `jackin`.
+
+- [ ] **Step 8: Commit the tap repo changes**
+
+Run:
+
+```bash
+git -C ../homebrew-tap add Formula/jackin.rb Formula/jackin@preview.rb README.md
+git -C ../homebrew-tap commit -m "feat: add jackin preview formula"
+```
+
+### Task 3: Add Preview Automation and Final Docs Updates in `jackin`
+
+**Files:**
+- Create: `.github/workflows/preview.yml`
+- Modify: `README.md`
+- Modify: `docs/src/content/docs/getting-started/installation.mdx`
+- Modify: `docs/src/content/docs/index.mdx`
+
+- [ ] **Step 1: Confirm the preview workflow does not exist yet**
+
+Run:
+
+```bash
+test ! -f .github/workflows/preview.yml
+```
+
+Expected: success.
+
+- [ ] **Step 2: Create `.github/workflows/preview.yml` with the exact preview publication flow**
+
+Write this exact file:
+
+```yaml
+name: Publish Homebrew Preview
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-preview:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve source SHA
+        id: source
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          repository: jackin-project/jackin
+          ref: ${{ steps.source.outputs.sha }}
+
+      - name: Compute preview metadata
+        id: meta
+        run: |
+          base_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          base_version=${base_version%-dev}
+          full_sha="${{ steps.source.outputs.sha }}"
+          short_sha=$(printf '%s' "$full_sha" | cut -c1-7)
+          tarball_url="https://github.com/jackin-project/jackin/archive/${full_sha}.tar.gz"
+          curl -L "$tarball_url" -o jackin-preview.tar.gz
+          sha256=$(shasum -a 256 jackin-preview.tar.gz | awk '{print $1}')
+          {
+            echo "full_sha=$full_sha"
+            echo "short_sha=$short_sha"
+            echo "version=${base_version}-preview+${short_sha}"
+            echo "tarball_url=$tarball_url"
+            echo "sha256=$sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: jackin-project/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Rewrite preview formula
+        run: |
+          cat > homebrew-tap/Formula/jackin@preview.rb <<EOF
+          class JackinATPreview < Formula
+            desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
+            homepage "https://github.com/jackin-project/jackin"
+            url "${{ steps.meta.outputs.tarball_url }}"
+            version "${{ steps.meta.outputs.version }}"
+            sha256 "${{ steps.meta.outputs.sha256 }}"
+            license "Apache-2.0"
+
+            depends_on "rust" => :build
+            depends_on "docker" => :optional
+
+            conflicts_with "jackin", because: "preview and stable install the same binary"
+
+            def install
+              system "cargo", "install", *std_cargo_args
+            end
+
+            test do
+              assert_match "jackin", shell_output("#{bin}/jackin --version")
+            end
+          end
+          EOF
+
+      - name: Commit and push tap update
+        working-directory: homebrew-tap
+        run: |
+          if git diff --quiet -- Formula/jackin@preview.rb; then
+            echo "Preview formula already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/jackin@preview.rb
+          git commit -m "jackin@preview ${{ steps.meta.outputs.version }}"
+          git push
+```
+
+- [ ] **Step 3: Update the top-level README and docs to advertise the preview channel**
+
+Edit the files so they contain these exact fragments:
+
+````md
+<!-- README.md -->
+```sh
+brew tap jackin-project/tap
+brew install jackin
+
+# Rolling preview channel
+brew install jackin@preview
+```
+````
+
+````mdx
+<!-- docs/src/content/docs/getting-started/installation.mdx -->
+    Install the rolling preview channel with:
+
+    ```bash
+    brew install jackin@preview
+    ```
+````
+
+````mdx
+<!-- docs/src/content/docs/index.mdx -->
+```bash
+# Install via Homebrew
+brew tap jackin-project/tap
+brew install jackin
+
+# Or install the rolling preview channel
+brew install jackin@preview
+```
+````
+
+- [ ] **Step 4: Parse the new workflow and verify the expected keys and tap target are present**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; workflow = YAML.load_file(".github/workflows/preview.yml"); puts workflow.fetch("jobs").keys'
+rg -n "jackin-project/homebrew-tap|workflow_run|jackin@preview|preview\+" .github/workflows/preview.yml .github/workflows/release.yml
+```
+
+Expected: Ruby prints `publish-preview`, and `rg` shows the `jackin-project/homebrew-tap` target plus the preview workflow markers.
+
+- [ ] **Step 5: Run the required `jackin` repo verification before committing the workflow and docs**
+
+Run:
+
+```bash
+cargo clippy && cargo nextest run
+cd docs && bun run build
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 6: Commit the preview workflow and docs changes**
+
+Run:
+
+```bash
+git add .github/workflows/preview.yml README.md docs/src/content/docs/getting-started/installation.mdx docs/src/content/docs/index.mdx
+git commit -m "feat: publish homebrew preview channel"
+```
+
+### Task 4: Final Cross-Repo Verification
+
+**Files:**
+- Verify only: `.github/workflows/release.yml`
+- Verify only: `.github/workflows/preview.yml`
+- Verify only: `../homebrew-tap/Formula/jackin.rb`
+- Verify only: `../homebrew-tap/Formula/jackin@preview.rb`
+- Verify only: `../homebrew-tap/README.md`
+
+- [ ] **Step 1: Verify the stable and preview tap files now point to `jackin-project`**
+
+Run:
+
+```bash
+rg -n "github.com/jackin-project/jackin|jackin-project/homebrew-tap|jackin-project/tap" \
+  .github/workflows/release.yml \
+  .github/workflows/preview.yml \
+  README.md \
+  docs/src/content/docs/getting-started/installation.mdx \
+  docs/src/content/docs/index.mdx \
+  ../homebrew-tap/Formula/jackin.rb \
+  ../homebrew-tap/Formula/jackin@preview.rb \
+  ../homebrew-tap/README.md
+```
+
+Expected: matches in all intended files, all using `jackin-project`, with no `donbeave` output in this subset.
+
+- [ ] **Step 2: Re-run the tap audits after all commits are in place**
+
+Run:
+
+```bash
+brew audit --strict --formula jackin-project/tap/jackin
+brew audit --strict --formula jackin-project/tap/jackin@preview
+```
+
+Expected: both pass.
+
+- [ ] **Step 3: Confirm both repos are clean after their commits**
+
+Run:
+
+```bash
+git status --short
+git -C ../homebrew-tap status --short
+```
+
+Expected: no output from either command.

--- a/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
+++ b/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
@@ -67,7 +67,7 @@ The preview publication flow is:
 5. It computes `preview_version = <base>-preview+<shortsha>`.
 6. It downloads the source tarball for the exact commit SHA.
 7. It computes the tarball `sha256`.
-8. It updates `Formula/jackin@preview.rb` in `donbeave/homebrew-tap`.
+8. It updates `Formula/jackin@preview.rb` in `jackin-project/homebrew-tap`.
 9. It commits and pushes the tap change if the formula content changed.
 
 ## `jackin` Repository Changes
@@ -100,7 +100,7 @@ The workflow should:
 5. Download the commit tarball from GitHub:
    - `https://github.com/donbeave/jackin/archive/${full_sha}.tar.gz`
 6. Compute `sha256` for that tarball.
-7. Clone `donbeave/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
+7. Clone `jackin-project/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
 8. Rewrite `Formula/jackin@preview.rb` with the new version, URL, and checksum.
 9. Commit and push only when the resulting file differs from the current one.
 
@@ -108,7 +108,7 @@ The workflow should:
 
 The workflow will use the existing tap automation model:
 
-- `HOMEBREW_TAP_TOKEN` with permission to push to `donbeave/homebrew-tap`
+- `HOMEBREW_TAP_TOKEN` with permission to push to `jackin-project/homebrew-tap`
 
 No new external service is required.
 
@@ -150,7 +150,7 @@ end
 
 The separate formula provides:
 
-- a clear install surface for preview users: `brew install donbeave/tap/jackin@preview`
+- a clear install surface for preview users: `brew install jackin-project/tap/jackin@preview`
 - isolation from the stable update path
 - a reproducible, pinned formula for each published preview state
 
@@ -214,7 +214,7 @@ When implementing this design, verify the following:
    `<base>-preview+<shortsha>` format.
 3. `Formula/jackin@preview.rb` is updated correctly in the tap.
 4. `brew audit --strict --formula jackin@preview` passes in the tap repository.
-5. A local install of `donbeave/tap/jackin@preview` succeeds.
+5. A local install of `jackin-project/tap/jackin@preview` succeeds.
 6. The existing stable release workflow still updates only `jackin`.
 
 ## Implementation Summary

--- a/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
+++ b/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
@@ -1,0 +1,229 @@
+# Homebrew Preview Channel Design
+
+This design adds an automatically updated Homebrew preview channel for `jackin`.
+The goal is to make the latest successful commit from `main` easy to install and
+test locally via the existing tap, while keeping the stable release flow
+separate and unchanged.
+
+## Goals
+
+- Add a `jackin@preview` formula in the Homebrew tap.
+- Update `jackin@preview` automatically after successful CI runs on `main`.
+- Keep preview builds source-based so users can validate the latest code without
+  introducing a separate binary packaging system.
+- Use a Ghostty-style preview version string that contains both a semver core
+  and a commit hash.
+- Preserve the existing tagged stable release flow for `jackin`.
+
+## Non-Goals
+
+- Replacing the stable `jackin` formula.
+- Publishing prebuilt preview binaries.
+- Changing the meaning of `brew install --HEAD jackin`.
+- Introducing a nightly schedule or a separate prerelease branch.
+
+## Naming and Versioning
+
+The rolling channel will be named `preview`, not `nightly` or `tip`.
+
+Rationale:
+
+- `nightly` implies a time-based build cadence, which does not match publishing
+  after every successful `main` commit.
+- `tip` is technically accurate for latest-commit builds, but `preview` is the
+  chosen product-facing channel name.
+- `preview` aligns with the intent of an unstable but easy-to-install prerelease
+  channel.
+
+The preview formula version format will be:
+
+```text
+0.5.0-preview+abc1234
+```
+
+Where:
+
+- `0.5.0` comes from `Cargo.toml` after stripping the `-dev` suffix.
+- `preview` is the release channel identifier.
+- `abc1234` is the short SHA for the successful `main` commit.
+
+This follows the Ghostty-style format requested by the user. In the Homebrew
+tap, the version will be set explicitly so the formula does not rely on URL
+inference.
+
+## High-Level Flow
+
+There will be two separate Homebrew update paths:
+
+- Stable release path: existing tagged release workflow updates `jackin`.
+- Preview path: new `main` workflow updates `jackin@preview`.
+
+The preview publication flow is:
+
+1. A commit lands on `main`.
+2. The normal CI workflow succeeds.
+3. A new preview workflow runs after that successful CI completion.
+4. The workflow reads the base version from `Cargo.toml`.
+5. It computes `preview_version = <base>-preview+<shortsha>`.
+6. It downloads the source tarball for the exact commit SHA.
+7. It computes the tarball `sha256`.
+8. It updates `Formula/jackin@preview.rb` in `donbeave/homebrew-tap`.
+9. It commits and pushes the tap change if the formula content changed.
+
+## `jackin` Repository Changes
+
+Add a new workflow at `.github/workflows/preview.yml`.
+
+### Triggering
+
+The workflow should run on:
+
+- `workflow_run` for the existing `CI` workflow
+- only when that workflow completed successfully
+- only for the `main` branch
+- optional `workflow_dispatch` for manual reruns
+
+This ensures preview publication reflects the latest successful CI state, not
+merely the latest pushed commit.
+
+### Workflow Responsibilities
+
+The workflow should:
+
+1. Check out the exact commit that passed CI.
+2. Read the package version from `Cargo.toml`.
+3. Strip a trailing `-dev` suffix to get the semver base.
+4. Compute:
+   - `full_sha`
+   - `short_sha`
+   - `preview_version="${base_version}-preview+${short_sha}"`
+5. Download the commit tarball from GitHub:
+   - `https://github.com/donbeave/jackin/archive/${full_sha}.tar.gz`
+6. Compute `sha256` for that tarball.
+7. Clone `donbeave/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
+8. Rewrite `Formula/jackin@preview.rb` with the new version, URL, and checksum.
+9. Commit and push only when the resulting file differs from the current one.
+
+### Secrets
+
+The workflow will use the existing tap automation model:
+
+- `HOMEBREW_TAP_TOKEN` with permission to push to `donbeave/homebrew-tap`
+
+No new external service is required.
+
+## Tap Changes
+
+Add a new formula at `Formula/jackin@preview.rb`.
+
+### Formula Shape
+
+The preview formula should intentionally mirror the stable formula closely.
+
+Expected structure:
+
+```ruby
+class JackinATPreview < Formula
+  desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
+  homepage "https://github.com/donbeave/jackin"
+  url "https://github.com/donbeave/jackin/archive/<fullsha>.tar.gz"
+  version "0.5.0-preview+abc1234"
+  sha256 "..."
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+  depends_on "docker" => :optional
+
+  conflicts_with "jackin", because: "preview and stable install the same binary"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "jackin", shell_output("#{bin}/jackin --version")
+  end
+end
+```
+
+### Why a Separate Formula
+
+The separate formula provides:
+
+- a clear install surface for preview users: `brew install donbeave/tap/jackin@preview`
+- isolation from the stable update path
+- a reproducible, pinned formula for each published preview state
+
+### Why Not Reuse `head`
+
+The stable formula already exposes `head`, but `head` is not a great fit for the
+desired workflow because:
+
+- it is less discoverable than a named preview channel
+- it tracks a moving branch at install time rather than a pinned successful CI
+  commit
+- it does not provide a user-facing preview version string
+
+`head` remains useful for direct developer installs, while `jackin@preview`
+becomes the curated rolling preview channel.
+
+## Update Semantics
+
+Each published preview formula is tied to one exact commit tarball and checksum.
+That means:
+
+- installs are reproducible for the current formula revision
+- the tap always points to the latest successful `main` commit
+- users can run `brew update && brew upgrade jackin@preview` to move forward
+
+The tap does not preserve a historical catalog of preview formula revisions.
+It only advances the current `jackin@preview` formula.
+
+## Failure Handling
+
+The preview workflow should fail without modifying the tap when:
+
+- `Cargo.toml` does not contain a parseable version
+- the tarball download fails
+- the checksum cannot be computed
+- the tap cannot be cloned or pushed
+
+The workflow should no-op successfully when the generated formula content is
+identical to the current tap file.
+
+## User Experience
+
+Users get three installation modes:
+
+- `brew install jackin` for stable tagged releases
+- `brew install jackin@preview` for the latest successful `main` build
+- `brew install --HEAD jackin` for a direct developer-style install from Git
+
+This makes each channel distinct:
+
+- stable = tagged release
+- preview = curated rolling prerelease from green `main`
+- head = raw branch install
+
+## Verification Plan
+
+When implementing this design, verify the following:
+
+1. The new preview workflow runs only after successful CI on `main`.
+2. The generated preview version string matches the expected
+   `<base>-preview+<shortsha>` format.
+3. `Formula/jackin@preview.rb` is updated correctly in the tap.
+4. `brew audit --strict --formula jackin@preview` passes in the tap repository.
+5. A local install of `donbeave/tap/jackin@preview` succeeds.
+6. The existing stable release workflow still updates only `jackin`.
+
+## Implementation Summary
+
+Implementation will involve:
+
+- adding `.github/workflows/preview.yml` in `jackin`
+- adding `Formula/jackin@preview.rb` in `homebrew-tap`
+- documenting preview installation in the tap README and relevant project docs
+
+No changes are required to the stable release formula beyond leaving it in
+place.

--- a/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
+++ b/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
@@ -98,7 +98,7 @@ The workflow should:
    - `short_sha`
    - `preview_version="${base_version}-preview+${short_sha}"`
 5. Download the commit tarball from GitHub:
-   - `https://github.com/donbeave/jackin/archive/${full_sha}.tar.gz`
+   - `https://github.com/jackin-project/jackin/archive/${full_sha}.tar.gz`
 6. Compute `sha256` for that tarball.
 7. Clone `jackin-project/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
 8. Rewrite `Formula/jackin@preview.rb` with the new version, URL, and checksum.
@@ -125,8 +125,8 @@ Expected structure:
 ```ruby
 class JackinATPreview < Formula
   desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
-  homepage "https://github.com/donbeave/jackin"
-  url "https://github.com/donbeave/jackin/archive/<fullsha>.tar.gz"
+  homepage "https://github.com/jackin-project/jackin"
+  url "https://github.com/jackin-project/jackin/archive/<fullsha>.tar.gz"
   version "0.5.0-preview+abc1234"
   sha256 "..."
   license "Apache-2.0"


### PR DESCRIPTION
## Summary
- move Homebrew-facing jackin org references from `donbeave` to `jackin-project`
- retarget stable Homebrew publishing to `jackin-project/homebrew-tap`
- add preview publish automation and preview install docs for `jackin@preview`

## Test Plan
- [x] `cargo clippy && cargo nextest run`
- [x] `cd docs && bun run build`