### PR TITLE
fix: pin preview tap checkout to main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: jackin-project/homebrew-tap
+          ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 

--- a/docs/superpowers/plans/2026-04-07-homebrew-preview-channel.md
+++ b/docs/superpowers/plans/2026-04-07-homebrew-preview-channel.md
@@ -6,6 +6,8 @@
 
 **Architecture:** Keep the stable and preview channels separate. The stable path continues to use the existing tagged release workflow, but it must target `jackin-project/homebrew-tap`. The preview path adds a new workflow in the `jackin` repo that rewrites `jackin@preview` in the sibling tap repo using a pinned commit tarball and a Ghostty-style version string (`<base>-preview+<shortsha>`).
 
+**Implementation note:** Homebrew does not support a literal `Formula/jackin@preview.rb` file for a non-numeric `@preview` suffix. The implemented tap layout therefore uses `Formula/jackin-preview.rb` as the canonical formula file plus an `Aliases/jackin@preview` symlink so users still install the preview channel as `jackin@preview`.
+
 **Tech Stack:** GitHub Actions, Homebrew formulae, shell scripting, Rust project metadata from `Cargo.toml`, Astro Starlight docs, Bun.
 
 **Assumption:** This plan only migrates GitHub organization references for the `jackin` source repository and the Homebrew tap. It does not change Docker Hub image namespaces or agent repository URLs such as `jackin-agent-smith` until those are confirmed separately.
@@ -22,7 +24,8 @@
 - Modify: `docs/src/content/docs/getting-started/installation.mdx` — update Homebrew/source install instructions and add preview install instructions.
 - Modify: `docs/src/content/docs/index.mdx` — update Homebrew quick-start commands and repository links, and add the preview channel command.
 - Modify: `../homebrew-tap/Formula/jackin.rb` — update `homepage`, `url`, and `head` to `jackin-project/jackin`.
-- Create: `../homebrew-tap/Formula/jackin@preview.rb` — add the rolling preview formula.
+- Create: `../homebrew-tap/Formula/jackin-preview.rb` — add the rolling preview formula.
+- Create: `../homebrew-tap/Aliases/jackin@preview` — expose the preview formula under the user-facing channel name.
 - Modify: `../homebrew-tap/README.md` — update the tap namespace and add preview installation instructions.
 
 ### Task 1: Migrate `jackin` Homebrew-Facing Org References
@@ -174,7 +177,8 @@ git commit -m "chore: move homebrew publishing to jackin-project"
 
 **Files:**
 - Modify: `../homebrew-tap/Formula/jackin.rb`
-- Create: `../homebrew-tap/Formula/jackin@preview.rb`
+- Create: `../homebrew-tap/Formula/jackin-preview.rb`
+- Create: `../homebrew-tap/Aliases/jackin@preview`
 - Modify: `../homebrew-tap/README.md`
 
 - [ ] **Step 1: Create a dedicated branch in the sibling tap repo**
@@ -187,16 +191,17 @@ git -C ../homebrew-tap checkout -b feature/homebrew-preview-channel
 
 Expected: Git reports `Switched to a new branch 'feature/homebrew-preview-channel'`.
 
-- [ ] **Step 2: Confirm the stable tap formula and README still point at `donbeave` and that `jackin@preview.rb` does not exist yet**
+- [ ] **Step 2: Confirm the stable tap formula and README still point at `donbeave` and that the preview formula and alias do not exist yet**
 
 Run:
 
 ```bash
 rg -n "donbeave|jackin-project" ../homebrew-tap/Formula/jackin.rb ../homebrew-tap/README.md
-test ! -f ../homebrew-tap/Formula/jackin@preview.rb
+test ! -f ../homebrew-tap/Formula/jackin-preview.rb
+test ! -L ../homebrew-tap/Aliases/jackin@preview
 ```
 
-Expected: `rg` shows `donbeave` matches in the stable formula and README, and `test` succeeds because `jackin@preview.rb` is not present yet.
+Expected: `rg` shows `donbeave` matches in the stable formula and README, and both `test` commands succeed because the preview formula and alias are not present yet.
 
 - [ ] **Step 3: Update the stable tap formula to the `jackin-project` organization**
 
@@ -224,7 +229,7 @@ class Jackin < Formula
 end
 ```
 
-- [ ] **Step 4: Generate the initial `jackin@preview` formula from the current `origin/main` commit of `jackin`**
+- [ ] **Step 4: Generate the initial preview formula and alias from the current `origin/main` commit of `jackin`**
 
 Run from the `jackin` repo root:
 
@@ -238,8 +243,8 @@ TARBALL_URL="https://github.com/jackin-project/jackin/archive/${FULL_SHA}.tar.gz
 TMP_TARBALL=$(mktemp /tmp/jackin-preview.XXXXXX.tar.gz)
 curl -L "$TARBALL_URL" -o "$TMP_TARBALL"
 SHA256=$(shasum -a 256 "$TMP_TARBALL" | awk '{print $1}')
-cat > ../homebrew-tap/Formula/jackin@preview.rb <<EOF
-class JackinATPreview < Formula
+cat > ../homebrew-tap/Formula/jackin-preview.rb <<EOF
+class JackinPreview < Formula
   desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
   homepage "https://github.com/jackin-project/jackin"
   url "${TARBALL_URL}"
@@ -261,6 +266,8 @@ class JackinATPreview < Formula
   end
 end
 EOF
+mkdir -p ../homebrew-tap/Aliases
+ln -sfn ../Formula/jackin-preview.rb ../homebrew-tap/Aliases/jackin@preview
 rm -f "$TMP_TARBALL"
 ```
 
@@ -329,7 +336,7 @@ Expected: Homebrew builds `jackin@preview` successfully and `jackin --version` p
 Run:
 
 ```bash
-git -C ../homebrew-tap add Formula/jackin.rb Formula/jackin@preview.rb README.md
+git -C ../homebrew-tap add Formula/jackin.rb Formula/jackin-preview.rb Aliases/jackin@preview README.md
 git -C ../homebrew-tap commit -m "feat: add jackin preview formula"
 ```
 
@@ -408,13 +415,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: jackin-project/homebrew-tap
+          ref: main
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
+      - name: Verify preview alias
+        run: |
+          test -L homebrew-tap/Aliases/jackin@preview
+          test "$(readlink homebrew-tap/Aliases/jackin@preview)" = "../Formula/jackin-preview.rb"
+
       - name: Rewrite preview formula
         run: |
-          cat > homebrew-tap/Formula/jackin@preview.rb <<EOF
-          class JackinATPreview < Formula
+          cat > homebrew-tap/Formula/jackin-preview.rb <<EOF
+          class JackinPreview < Formula
             desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
             homepage "https://github.com/jackin-project/jackin"
             url "${{ steps.meta.outputs.tarball_url }}"
@@ -440,13 +453,13 @@ jobs:
       - name: Commit and push tap update
         working-directory: homebrew-tap
         run: |
-          if git diff --quiet -- Formula/jackin@preview.rb; then
+          if git diff --quiet -- Formula/jackin-preview.rb; then
             echo "Preview formula already up to date"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Formula/jackin@preview.rb
+          git add Formula/jackin-preview.rb
           git commit -m "jackin@preview ${{ steps.meta.outputs.version }}"
           git push
 ```
@@ -524,7 +537,8 @@ git commit -m "feat: publish homebrew preview channel"
 - Verify only: `.github/workflows/release.yml`
 - Verify only: `.github/workflows/preview.yml`
 - Verify only: `../homebrew-tap/Formula/jackin.rb`
-- Verify only: `../homebrew-tap/Formula/jackin@preview.rb`
+- Verify only: `../homebrew-tap/Formula/jackin-preview.rb`
+- Verify only: `../homebrew-tap/Aliases/jackin@preview`
 - Verify only: `../homebrew-tap/README.md`
 
 - [ ] **Step 1: Verify the stable and preview tap files now point to `jackin-project`**
@@ -539,7 +553,8 @@ rg -n "github.com/jackin-project/jackin|jackin-project/homebrew-tap|jackin-proje
   docs/src/content/docs/getting-started/installation.mdx \
   docs/src/content/docs/index.mdx \
   ../homebrew-tap/Formula/jackin.rb \
-  ../homebrew-tap/Formula/jackin@preview.rb \
+  ../homebrew-tap/Formula/jackin-preview.rb \
+  ../homebrew-tap/Aliases/jackin@preview \
   ../homebrew-tap/README.md
 ```
 

--- a/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
+++ b/docs/superpowers/specs/2026-04-07-homebrew-preview-channel-design.md
@@ -5,6 +5,19 @@ The goal is to make the latest successful commit from `main` easy to install and
 test locally via the existing tap, while keeping the stable release flow
 separate and unchanged.
 
+## Implemented Detail
+
+Homebrew does not support a literal `Formula/jackin@preview.rb` file for a
+non-numeric `@preview` suffix because formula class-name mapping only special-
+cases `@` followed by digits. The implemented tap layout therefore uses:
+
+- `Formula/jackin-preview.rb` as the canonical preview formula file
+- `Aliases/jackin@preview` as a symlink so users still run
+  `brew install jackin@preview`
+
+The preview workflow rewrites `Formula/jackin-preview.rb` and verifies the
+`jackin@preview` alias exists before pushing tap updates.
+
 ## Goals
 
 - Add a `jackin@preview` formula in the Homebrew tap.
@@ -67,7 +80,7 @@ The preview publication flow is:
 5. It computes `preview_version = <base>-preview+<shortsha>`.
 6. It downloads the source tarball for the exact commit SHA.
 7. It computes the tarball `sha256`.
-8. It updates `Formula/jackin@preview.rb` in `jackin-project/homebrew-tap`.
+8. It updates `Formula/jackin-preview.rb` in `jackin-project/homebrew-tap`.
 9. It commits and pushes the tap change if the formula content changed.
 
 ## `jackin` Repository Changes
@@ -101,7 +114,7 @@ The workflow should:
    - `https://github.com/jackin-project/jackin/archive/${full_sha}.tar.gz`
 6. Compute `sha256` for that tarball.
 7. Clone `jackin-project/homebrew-tap` using `HOMEBREW_TAP_TOKEN`.
-8. Rewrite `Formula/jackin@preview.rb` with the new version, URL, and checksum.
+8. Rewrite `Formula/jackin-preview.rb` with the new version, URL, and checksum.
 9. Commit and push only when the resulting file differs from the current one.
 
 ### Secrets
@@ -114,7 +127,8 @@ No new external service is required.
 
 ## Tap Changes
 
-Add a new formula at `Formula/jackin@preview.rb`.
+Add a new canonical preview formula at `Formula/jackin-preview.rb` and expose
+it through `Aliases/jackin@preview`.
 
 ### Formula Shape
 
@@ -123,7 +137,7 @@ The preview formula should intentionally mirror the stable formula closely.
 Expected structure:
 
 ```ruby
-class JackinATPreview < Formula
+class JackinPreview < Formula
   desc "Matrix-inspired CLI for orchestrating AI coding agents at scale"
   homepage "https://github.com/jackin-project/jackin"
   url "https://github.com/jackin-project/jackin/archive/<fullsha>.tar.gz"
@@ -212,7 +226,8 @@ When implementing this design, verify the following:
 1. The new preview workflow runs only after successful CI on `main`.
 2. The generated preview version string matches the expected
    `<base>-preview+<shortsha>` format.
-3. `Formula/jackin@preview.rb` is updated correctly in the tap.
+3. `Formula/jackin-preview.rb` is updated correctly in the tap and the
+   `jackin@preview` alias still resolves to it.
 4. `brew audit --strict --formula jackin@preview` passes in the tap repository.
 5. A local install of `jackin-project/tap/jackin@preview` succeeds.
 6. The existing stable release workflow still updates only `jackin`.
@@ -222,7 +237,7 @@ When implementing this design, verify the following:
 Implementation will involve:
 
 - adding `.github/workflows/preview.yml` in `jackin`
-- adding `Formula/jackin@preview.rb` in `homebrew-tap`
+- adding `Formula/jackin-preview.rb` and `Aliases/jackin@preview` in `homebrew-tap`
 - documenting preview installation in the tap README and relevant project docs
 
 No changes are required to the stable release formula beyond leaving it in


### PR DESCRIPTION
## Summary
- pin the preview workflow's homebrew-tap checkout to `main` so `actions/checkout` does not perform default-branch discovery against the tap repo
- record the implemented alias-based preview tap layout in the approved design spec
- update the implementation plan so its file paths and workflow snippets match the shipped `jackin-preview.rb` plus `Aliases/jackin@preview` approach

## Test Plan
- [x] `ruby -e 'require "yaml"; workflow = YAML.load_file(".github/workflows/preview.yml"); puts workflow.fetch("jobs").keys'`
- [x] `cargo clippy && cargo nextest run`
- [x] `cd docs && bun run build`
