### PR TITLE
fix: improve debug mode output and exit behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
       - run: cargo test --locked

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup mise
         uses: jdx/mise-action@v2
@@ -39,7 +39,7 @@ jobs:
         run: mise exec -- bun --bun run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/dist
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,7 +28,7 @@ jobs:
             echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: jackin-project/jackin
           ref: ${{ steps.source.outputs.sha }}
@@ -51,7 +51,7 @@ jobs:
             echo "sha256=$sha256"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: jackin-project/homebrew-tap
           ref: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine version
         id: version
@@ -37,8 +37,9 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --locked
 
   build:
@@ -59,11 +60,15 @@ jobs:
     env:
       VERSION: ${{ needs.check-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
 
       - name: Install cross
         if: matrix.cross
@@ -96,7 +101,7 @@ jobs:
     env:
       VERSION: ${{ needs.check-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:

--- a/TESTING.md
+++ b/TESTING.md
@@ -30,10 +30,11 @@ Do **not** use `cargo test` — always use `cargo nextest run`.
 
 ## Pre-commit Verification
 
-Before committing any changes, **always** run both clippy and tests:
+Before committing any changes, **always** run formatting, clippy, and tests:
 
 ```sh
-cargo clippy && cargo nextest run
+cargo fmt -- --check && cargo clippy && cargo nextest run
 ```
 
-Both must pass with zero warnings and zero failures.
+All three must pass with zero warnings and zero failures.
+If formatting fails, run `cargo fmt` to fix it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run(cli: Cli) -> Result<()> {
             debug,
         } => {
             runner.debug = debug;
+            tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
 
             let (class, workspace_input) = if let Some(sel) = selector {
@@ -253,7 +254,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 &ad_hoc_mounts,
             )?;
             let opts = runtime::LoadOptions {
-                no_intro,
+                no_intro: no_intro || debug,
                 debug,
                 rebuild,
             };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -592,7 +592,10 @@ fn render_exit(agent_display_name: &str, runner: &mut impl CommandRunner, opts: 
     if opts.no_intro {
         return;
     }
-    tui::matrix_outro(agent_display_name, &list_running_agent_display_names(runner).unwrap_or_default());
+    tui::matrix_outro(
+        agent_display_name,
+        &list_running_agent_display_names(runner).unwrap_or_default(),
+    );
 }
 
 pub fn hardline_agent(container_name: &str, runner: &mut impl CommandRunner) -> anyhow::Result<()> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -454,7 +454,10 @@ fn launch_agent_runtime(
         run_args.push(ms);
     }
     run_args.push(image);
-    runner.run("docker", &run_args, None)?;
+    let result = runner.run("docker", &run_args, None);
+    // Ensure cleanup debug logs start on a fresh line after the interactive session
+    eprintln!();
+    result?;
 
     Ok(())
 }
@@ -586,13 +589,10 @@ pub fn load_agent(
 }
 
 fn render_exit(agent_display_name: &str, runner: &mut impl CommandRunner, opts: &LoadOptions) {
-    tui::clear_screen();
-    let remaining = list_running_agent_display_names(runner).unwrap_or_default();
     if opts.no_intro {
-        tui::simple_outro(agent_display_name, &remaining);
-    } else {
-        tui::matrix_outro(agent_display_name, &remaining);
+        return;
     }
+    tui::matrix_outro(agent_display_name, &list_running_agent_display_names(runner).unwrap_or_default());
 }
 
 pub fn hardline_agent(container_name: &str, runner: &mut impl CommandRunner) -> anyhow::Result<()> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,12 @@
 use owo_colors::OwoColorize;
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_debug_mode(enabled: bool) {
+    DEBUG_MODE.store(enabled, Ordering::Relaxed);
+}
 
 // ── Color palette ────────────────────────────────────────────────────────
 
@@ -607,7 +614,13 @@ where
     let mut last_err = None;
     let mut frame_idx: usize = 0;
 
+    let debug = DEBUG_MODE.load(Ordering::Relaxed);
     for _attempt in 0..max_attempts {
+        // In debug mode, clear the spinner line before polling so debug output appears cleanly
+        if debug {
+            eprint!("\r\x1b[2K");
+            let _ = io::stderr().flush();
+        }
         match poll() {
             Ok(()) => {
                 eprint!("\r\x1b[2K");
@@ -724,6 +737,9 @@ pub fn set_terminal_title(title: &str) {
 }
 
 pub fn clear_screen() {
+    if DEBUG_MODE.load(Ordering::Relaxed) {
+        return;
+    }
     eprint!("\x1b[2J\x1b[H");
     let _ = io::stderr().flush();
 }


### PR DESCRIPTION
## Summary
- Remove `clear_screen` on exit so Docker errors remain visible in the terminal
- Skip intro/outro animations in debug mode (`--debug` implies `--no-intro`)
- Fix spinner and `[debug]` log overlap during Docker-in-Docker wait
- Add newline separator after interactive `docker run` to prevent cleanup logs from overlapping with Claude Code's TUI
- Disable all `clear_screen` calls in debug mode via a global `AtomicBool` flag

## Test plan
- [ ] Run `jackin load --debug` and verify no screen clears happen
- [ ] Run `jackin load --debug` and verify spinner + debug logs don't overlap during DinD wait
- [ ] Run `jackin load` (no debug) and verify intro/outro animations still work
- [ ] Run `jackin load --debug` with a failing container and verify the Docker error is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)