### PR TITLE
fix: allow workdir to be a parent of mount destinations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,17 @@ Never commit directly to `main`.
 See [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) for a navigational map of the codebase, documentation site, Docker assets, and CI workflows.
 Use it to quickly locate files and understand which docs to update alongside code changes.
 
-## Testing
+## Pre-commit Verification
 
-See [TESTING.md](TESTING.md) for test runner setup, commands, and pre-commit verification requirements.
+Before committing **any** change, run all three checks and ensure zero warnings and zero failures:
+
+```sh
+cargo fmt -- --check && cargo clippy && cargo nextest run
+```
+
+If formatting fails, run `cargo fmt` to fix it, then re-run the checks.
+
+See [TESTING.md](TESTING.md) for test runner setup, commands, and additional details.
 
 ## Security Exceptions
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,11 +609,9 @@ readonly = true
         let error =
             crate::workspace::validate_workspace_config("big-monorepo", &workspace).unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
-        );
+        assert!(error.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
     }
 
     #[test]
@@ -649,11 +647,9 @@ readonly = true
             )
             .unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
-        );
+        assert!(error.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
         assert_eq!(
             config.workspaces.get("big-monorepo").unwrap().workdir,
             "/workspace/project"
@@ -683,11 +679,9 @@ dst = "/workspace/src"
 
         let error = AppConfig::load_or_init(&paths).unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
-        );
+        assert!(error.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
     }
 
     #[test]
@@ -748,10 +742,9 @@ dst = "/workspace/src"
             )
             .unwrap_err();
 
-        assert!(
-            err.to_string()
-                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
-        );
+        assert!(err.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
         assert_eq!(config.workspaces.get("big-monorepo").unwrap(), &original);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -612,7 +612,7 @@ readonly = true
         assert!(
             error
                 .to_string()
-                .contains("must be equal to or inside one of the workspace mount destinations")
+                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
         );
     }
 
@@ -652,7 +652,7 @@ readonly = true
         assert!(
             error
                 .to_string()
-                .contains("must be equal to or inside one of the workspace mount destinations")
+                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
         );
         assert_eq!(
             config.workspaces.get("big-monorepo").unwrap().workdir,
@@ -686,7 +686,7 @@ dst = "/workspace/src"
         assert!(
             error
                 .to_string()
-                .contains("must be equal to or inside one of the workspace mount destinations")
+                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
         );
     }
 
@@ -716,7 +716,7 @@ dst = "/workspace/src"
         std::fs::write(&paths.config_file, toml_str).unwrap();
 
         let err = AppConfig::load_or_init(&paths).unwrap_err();
-        assert!(err.to_string().contains("workspace \"broken\" workdir must be equal to or inside one of the workspace mount destinations"));
+        assert!(err.to_string().contains("workspace \"broken\" workdir must be equal to, inside, or a parent of one of the workspace mount destinations"));
     }
 
     #[test]
@@ -750,7 +750,7 @@ dst = "/workspace/src"
 
         assert!(
             err.to_string()
-                .contains("must be equal to or inside one of the workspace mount destinations")
+                .contains("must be equal to, inside, or a parent of one of the workspace mount destinations")
         );
         assert_eq!(config.workspaces.get("big-monorepo").unwrap(), &original);
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -165,10 +165,7 @@ pub fn validate_workspace_config(name: &str, workspace: &WorkspaceConfig) -> any
         let dst = mount.dst.trim_end_matches('/');
         workspace.workdir == dst
             || workspace.workdir.starts_with(&format!("{dst}/"))
-            || dst.starts_with(&format!(
-                "{}/",
-                workspace.workdir.trim_end_matches('/')
-            ))
+            || dst.starts_with(&format!("{}/", workspace.workdir.trim_end_matches('/')))
     });
     anyhow::ensure!(
         covers_workdir,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -161,15 +161,18 @@ pub fn validate_workspace_config(name: &str, workspace: &WorkspaceConfig) -> any
 
     validate_mount_specs(&workspace.mounts)?;
 
-    let within_mount = workspace.mounts.iter().any(|mount| {
-        workspace.workdir == mount.dst
-            || workspace
-                .workdir
-                .starts_with(&format!("{}/", mount.dst.trim_end_matches('/')))
+    let covers_workdir = workspace.mounts.iter().any(|mount| {
+        let dst = mount.dst.trim_end_matches('/');
+        workspace.workdir == dst
+            || workspace.workdir.starts_with(&format!("{dst}/"))
+            || dst.starts_with(&format!(
+                "{}/",
+                workspace.workdir.trim_end_matches('/')
+            ))
     });
     anyhow::ensure!(
-        within_mount,
-        "workspace {name:?} workdir must be equal to or inside one of the workspace mount destinations"
+        covers_workdir,
+        "workspace {name:?} workdir must be equal to, inside, or a parent of one of the workspace mount destinations"
     );
 
     if let Some(default_agent) = &workspace.default_agent
@@ -708,5 +711,119 @@ mod tests {
                 .to_string()
                 .contains("ad-hoc mount destination conflicts")
         );
+    }
+
+    // -- validate_workspace_config: workdir vs mount destination coverage ------
+
+    fn workspace_with_workdir_and_dst(workdir: &str, dst: &str) -> WorkspaceConfig {
+        WorkspaceConfig {
+            workdir: workdir.to_string(),
+            mounts: vec![MountConfig {
+                src: "/tmp/src".to_string(),
+                dst: dst.to_string(),
+                readonly: false,
+            }],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+        }
+    }
+
+    #[test]
+    fn validate_workdir_equal_to_mount_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace/project", "/workspace/project");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_workdir_inside_mount_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace/project/src", "/workspace/project");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_workdir_deeply_nested_inside_mount_dst() {
+        let ws =
+            workspace_with_workdir_and_dst("/workspace/project/src/main", "/workspace/project");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_workdir_parent_of_mount_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace", "/workspace/project");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_workdir_grandparent_of_mount_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace", "/workspace/project/src");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_workdir_parent_with_trailing_slash_on_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace", "/workspace/project/");
+        validate_workspace_config("test", &ws).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_workdir_sibling_of_mount_dst() {
+        let ws = workspace_with_workdir_and_dst("/workspace/other", "/workspace/project");
+        let err = validate_workspace_config("test", &ws).unwrap_err();
+        assert!(err.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_workdir_with_prefix_overlap_but_not_parent() {
+        // /workspace/project-v2 is NOT inside /workspace/project
+        let ws = workspace_with_workdir_and_dst("/workspace/project-v2", "/workspace/project");
+        let err = validate_workspace_config("test", &ws).unwrap_err();
+        assert!(err.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_mount_dst_with_prefix_overlap_but_not_child() {
+        // /workspace/project is NOT a parent of /workspace/project-v2
+        let ws = workspace_with_workdir_and_dst("/workspace/project", "/workspace/project-v2");
+        let err = validate_workspace_config("test", &ws).unwrap_err();
+        assert!(err.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_completely_unrelated_workdir() {
+        let ws = workspace_with_workdir_and_dst("/home/user", "/workspace/project");
+        let err = validate_workspace_config("test", &ws).unwrap_err();
+        assert!(err.to_string().contains(
+            "must be equal to, inside, or a parent of one of the workspace mount destinations"
+        ));
+    }
+
+    #[test]
+    fn validate_workdir_parent_of_any_mount_dst() {
+        let ws = WorkspaceConfig {
+            workdir: "/workspace".to_string(),
+            mounts: vec![
+                MountConfig {
+                    src: "/tmp/a".to_string(),
+                    dst: "/other/path".to_string(),
+                    readonly: false,
+                },
+                MountConfig {
+                    src: "/tmp/b".to_string(),
+                    dst: "/workspace/project".to_string(),
+                    readonly: false,
+                },
+            ],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+        };
+        validate_workspace_config("test", &ws).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Relaxes workspace validation to allow `workdir` to be a parent directory of mount destinations, not just equal to or inside one
- Enables multi-project workspace layouts where workdir is the common ancestor (e.g. `~/Projects/jackin-project`) of several mounted subdirectories (e.g. `~/Projects/jackin-project/jackin`, `~/Projects/jackin-project/jackin-dev`)
- Adds 11 comprehensive tests covering positive cases (equal, inside, parent, grandparent, trailing slash, multi-mount) and negative cases (sibling, prefix overlap, unrelated paths)

## Test plan

- [x] All 204 tests pass (`cargo test`)
- [x] Positive: workdir equal to mount dst
- [x] Positive: workdir inside mount dst
- [x] Positive: workdir deeply nested inside mount dst
- [x] Positive: workdir is parent of mount dst
- [x] Positive: workdir is grandparent of mount dst
- [x] Positive: workdir parent with trailing slash on dst
- [x] Positive: workdir parent of any mount in multi-mount workspace
- [x] Negative: sibling directories rejected
- [x] Negative: prefix overlap without parent relationship rejected (both directions)
- [x] Negative: completely unrelated paths rejected
- [x] Documentation verified — no docs reference the old validation rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)