### PR TITLE
feat: embed git-aware version in binary output

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -80,11 +80,12 @@ jobs:
             conflicts_with "jackin-project/tap/jackin", because: "preview and stable install the same binary"
 
             def install
+              ENV["JACKIN_VERSION_OVERRIDE"] = version.to_s
               system "cargo", "install", *std_cargo_args
             end
 
             test do
-              assert_match "jackin", shell_output("#{bin}/jackin --version")
+              assert_match version.to_s, shell_output("#{bin}/jackin --version")
             end
           end
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
         run: cargo install cross --locked
 
       - name: Build
+        env:
+          JACKIN_VERSION_OVERRIDE: ${{ needs.check-version.outputs.version }}
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=JACKIN_VERSION_OVERRIDE");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+
+    let version = std::env::var("JACKIN_VERSION_OVERRIDE")
+        .ok()
+        .unwrap_or_else(|| {
+            let cargo_version = env!("CARGO_PKG_VERSION");
+            let short_sha = Command::new("git")
+                .args(["rev-parse", "--short=7", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string());
+
+            short_sha.map_or_else(
+                || cargo_version.to_string(),
+                |sha| format!("{cargo_version}+{sha}"),
+            )
+        });
+
+    println!("cargo:rustc-env=JACKIN_VERSION={version}");
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ const BANNER: &str = concat!(
 
 /// Send agents into the Matrix
 #[derive(Debug, Parser)]
-#[command(name = "jackin", version, styles = HELP_STYLES, before_help = BANNER)]
+#[command(name = "jackin", version = env!("JACKIN_VERSION"), styles = HELP_STYLES, before_help = BANNER)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,


### PR DESCRIPTION
## Summary

- Adds `build.rs` that computes version at compile time from Cargo.toml + git SHA
- `jackin --version` now outputs Ghostty-style versions: `jackin 0.5.0-dev+a31e949`
- Preview formula sets `JACKIN_VERSION_OVERRIDE` so `brew install jackin@preview` reports `0.5.0-preview+a31e949`
- Release workflow sets `JACKIN_VERSION_OVERRIDE` for clean release versions

### Version formats by channel

| Channel | Example |
|---|---|
| Local dev | `0.5.0-dev+a31e949` |
| Preview (`brew install jackin@preview`) | `0.5.0-preview+a31e949` |
| Stable (`brew install jackin`) | `0.5.0` |

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo nextest run` — 204 tests pass
- [x] `cargo run -- --version` outputs `jackin 0.5.0-dev+<sha>`
- [x] `JACKIN_VERSION_OVERRIDE=0.5.0-preview+abc1234 cargo run -- --version` outputs override
- [ ] After merge: verify preview workflow publishes updated formula
- [ ] After merge: `brew upgrade jackin@preview` reports new version

## Note

The stable homebrew formula (`jackin.rb`) in `jackin-project/homebrew-tap` also needs the `JACKIN_VERSION_OVERRIDE` update in its `install` block — already applied locally at `/Users/donbeave/Projects/jackin-project/homebrew-tap/Formula/jackin.rb`, needs to be committed to that repo separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)