### PR TITLE
fix: include commit count in preview version for brew upgrade

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           repository: jackin-project/jackin
           ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 0
 
       - name: Compute preview metadata
         id: meta
@@ -40,13 +41,14 @@ jobs:
           base_version=${base_version%-dev}
           full_sha="${{ steps.source.outputs.sha }}"
           short_sha=$(printf '%s' "$full_sha" | cut -c1-7)
+          commit_count=$(git rev-list --count HEAD)
           tarball_url="https://github.com/jackin-project/jackin/archive/${full_sha}.tar.gz"
           curl -fL "$tarball_url" -o jackin-preview.tar.gz
           sha256=$(shasum -a 256 jackin-preview.tar.gz | awk '{print $1}')
           {
             echo "full_sha=$full_sha"
             echo "short_sha=$short_sha"
-            echo "version=${base_version}-preview+${short_sha}"
+            echo "version=${base_version}-preview.${commit_count}+${short_sha}"
             echo "tarball_url=$tarball_url"
             echo "sha256=$sha256"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Adds monotonic commit count to the preview version pre-release segment
- Changes version format from `0.5.0-preview+5f2593c` to `0.5.0-preview.347+5f2593c`
- `brew upgrade jackin@preview` now works because each push produces a genuinely newer semver version
- Adds `fetch-depth: 0` to the checkout step so `git rev-list --count HEAD` has full history

### Why

Homebrew (and semver) ignores `+metadata` for version comparison. The old format `0.5.0-preview+aaa` vs `0.5.0-preview+bbb` looked identical, forcing users to `brew reinstall` instead of `brew upgrade`.

The commit count in the pre-release segment (`preview.347` vs `preview.348`) is monotonically increasing and part of semver comparison, so brew correctly detects newer versions.

This follows the same pattern used by PHP nightly and Gel CLI nightly homebrew formulas.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes
- [x] `cargo nextest run` — 204 tests pass
- [ ] After merge: verify preview formula version includes commit count
- [ ] After merge: `brew update && brew upgrade jackin@preview` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)