### PR TITLE
feat: auto-rebuild Docker image when Claude Code is outdated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod runtime;
 pub mod selector;
 pub mod terminal_prompter;
 pub mod tui;
+pub mod version_check;
 pub mod workspace;
 
 use anyhow::Result;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -8,6 +8,7 @@ pub struct JackinPaths {
     pub config_file: PathBuf,
     pub agents_dir: PathBuf,
     pub data_dir: PathBuf,
+    pub cache_dir: PathBuf,
 }
 
 impl JackinPaths {
@@ -21,6 +22,7 @@ impl JackinPaths {
             config_file: config_dir.join("config.toml"),
             agents_dir: home_dir.join(".jackin/agents"),
             data_dir: home_dir.join(".jackin/data"),
+            cache_dir: home_dir.join(".jackin/cache"),
             home_dir,
             config_dir,
         })
@@ -33,6 +35,7 @@ impl JackinPaths {
             config_file: config_dir.join("config.toml"),
             agents_dir: home_dir.join(".jackin/agents"),
             data_dir: home_dir.join(".jackin/data"),
+            cache_dir: home_dir.join(".jackin/cache"),
             home_dir,
             config_dir,
         }
@@ -42,6 +45,7 @@ impl JackinPaths {
         std::fs::create_dir_all(&self.config_dir)?;
         std::fs::create_dir_all(&self.agents_dir)?;
         std::fs::create_dir_all(&self.data_dir)?;
+        std::fs::create_dir_all(&self.cache_dir)?;
         Ok(())
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -247,7 +247,7 @@ fn resolve_agent_repo(
 }
 
 /// Build the Docker image for the agent. Returns the image name.
-#[allow(clippy::similar_names)]
+#[allow(clippy::similar_names, clippy::too_many_arguments)]
 fn build_agent_image(
     paths: &JackinPaths,
     selector: &ClassSelector,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,6 +6,7 @@ use crate::paths::JackinPaths;
 use crate::repo::{CachedRepo, validate_agent_repo};
 use crate::selector::ClassSelector;
 use crate::tui;
+use crate::version_check;
 use owo_colors::OwoColorize;
 
 pub struct LoadOptions {
@@ -248,6 +249,7 @@ fn resolve_agent_repo(
 /// Build the Docker image for the agent. Returns the image name.
 #[allow(clippy::similar_names)]
 fn build_agent_image(
+    paths: &JackinPaths,
     selector: &ClassSelector,
     cached_repo: &CachedRepo,
     validated_repo: &crate::repo::ValidatedAgentRepo,
@@ -305,6 +307,7 @@ fn build_agent_image(
         let version = version.trim();
         if !version.is_empty() {
             eprintln!("        Claude {version}");
+            version_check::store_image_version(paths, &image, version);
         }
     }
 
@@ -535,13 +538,22 @@ pub fn load_agent(
     let mut cleanup = LoadCleanup::new(container_name.clone(), dind.clone(), network.clone());
     let load_result = (|| -> anyhow::Result<()> {
         // Step 2: Build Docker image
+        let rebuild = opts.rebuild || {
+            let img = image_name(selector);
+            let needs_update = version_check::needs_claude_update(paths, &img, runner);
+            if needs_update {
+                eprintln!("        Claude update available — rebuilding image");
+            }
+            needs_update
+        };
         steps.next("Building Docker image");
         let image = build_agent_image(
+            paths,
             selector,
             &cached_repo,
             &validated_repo,
             &host,
-            opts.rebuild,
+            rebuild,
             opts.debug,
             runner,
         )?;

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -1,0 +1,207 @@
+use crate::docker::CommandRunner;
+use crate::paths::JackinPaths;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+/// How long we trust the cached npm lookup before re-checking.
+const NPM_CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
+
+/// File that caches the latest published Claude Code version from npm.
+fn npm_cache_path(paths: &JackinPaths) -> PathBuf {
+    paths.cache_dir.join("claude-latest-version")
+}
+
+/// File that records the Claude Code version baked into a given Docker image.
+fn image_version_path(paths: &JackinPaths, image: &str) -> PathBuf {
+    paths.cache_dir.join(format!("image-claude-version/{image}"))
+}
+
+/// Query npm for the latest published `@anthropic-ai/claude-code` version,
+/// returning a cached value when the cache is still fresh.
+pub fn latest_claude_version(
+    paths: &JackinPaths,
+    runner: &mut impl CommandRunner,
+) -> Option<String> {
+    let cache_file = npm_cache_path(paths);
+
+    // Return cached value if fresh enough
+    if let Some(cached) = read_if_fresh(&cache_file, NPM_CACHE_TTL) {
+        return Some(cached);
+    }
+
+    // Query npm
+    let version = runner
+        .capture(
+            "npm",
+            &["view", "@anthropic-ai/claude-code", "version"],
+            None,
+        )
+        .ok()?;
+    let version = version.trim().to_string();
+    if version.is_empty() {
+        return None;
+    }
+
+    // Persist to cache (best-effort)
+    let _ = write_cached(&cache_file, &version);
+    Some(version)
+}
+
+/// Read the Claude Code version we stored for a previously-built image.
+pub fn stored_image_version(paths: &JackinPaths, image: &str) -> Option<String> {
+    let path = image_version_path(paths, image);
+    std::fs::read_to_string(path).ok().map(|s| s.trim().to_string())
+}
+
+/// Persist the Claude Code version that was just installed into an image.
+pub fn store_image_version(paths: &JackinPaths, image: &str, version: &str) {
+    let path = image_version_path(paths, image);
+    let _ = write_cached(&path, version);
+}
+
+/// Returns `true` when the image contains an older Claude Code version than
+/// the latest published release, meaning the image should be rebuilt.
+pub fn needs_claude_update(
+    paths: &JackinPaths,
+    image: &str,
+    runner: &mut impl CommandRunner,
+) -> bool {
+    let installed = match stored_image_version(paths, image) {
+        Some(v) => v,
+        None => return false, // first build — let it proceed normally
+    };
+    let latest = match latest_claude_version(paths, runner) {
+        Some(v) => v,
+        None => return false, // npm unavailable — don't force a rebuild
+    };
+    installed != latest
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+/// Read a cache file only if it was modified within `ttl`.
+fn read_if_fresh(path: &PathBuf, ttl: Duration) -> Option<String> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    if SystemTime::now().duration_since(modified).unwrap_or(ttl) >= ttl {
+        return None;
+    }
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Write content to a cache file, creating parent directories as needed.
+fn write_cached(path: &PathBuf, content: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::JackinPaths;
+    use tempfile::tempdir;
+
+    #[test]
+    fn stores_and_reads_image_version() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        store_image_version(&paths, "jackin-agent-smith", "2.1.91");
+
+        assert_eq!(
+            stored_image_version(&paths, "jackin-agent-smith"),
+            Some("2.1.91".to_string())
+        );
+    }
+
+    #[test]
+    fn needs_update_when_versions_differ() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        store_image_version(&paths, "jackin-agent-smith", "2.1.91");
+        // Seed the npm cache with a newer version
+        let cache = npm_cache_path(&paths);
+        let _ = write_cached(&cache, "2.1.92");
+
+        let mut runner = StubRunner("2.1.92".to_string());
+        assert!(needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+    }
+
+    #[test]
+    fn no_update_when_versions_match() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        store_image_version(&paths, "jackin-agent-smith", "2.1.92");
+        let cache = npm_cache_path(&paths);
+        let _ = write_cached(&cache, "2.1.92");
+
+        let mut runner = StubRunner("2.1.92".to_string());
+        assert!(!needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+    }
+
+    #[test]
+    fn no_update_on_first_build() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        let mut runner = StubRunner("2.1.92".to_string());
+        // No stored version yet → should not force rebuild
+        assert!(!needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+    }
+
+    #[test]
+    fn expired_cache_is_ignored() {
+        let temp = tempdir().unwrap();
+        let cache_file = temp.path().join("expired");
+        std::fs::write(&cache_file, "2.1.91").unwrap();
+
+        // A zero TTL means any file is always expired
+        assert!(read_if_fresh(&cache_file, Duration::ZERO).is_none());
+    }
+
+    #[test]
+    fn fresh_cache_is_returned() {
+        let temp = tempdir().unwrap();
+        let cache_file = temp.path().join("fresh");
+        std::fs::write(&cache_file, "2.1.92").unwrap();
+
+        assert_eq!(
+            read_if_fresh(&cache_file, NPM_CACHE_TTL),
+            Some("2.1.92".to_string())
+        );
+    }
+
+    /// Minimal [`CommandRunner`] that returns a fixed string for any `capture`.
+    struct StubRunner(String);
+
+    impl CommandRunner for StubRunner {
+        fn run(
+            &mut self,
+            _program: &str,
+            _args: &[&str],
+            _cwd: Option<&std::path::Path>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn capture(
+            &mut self,
+            _program: &str,
+            _args: &[&str],
+            _cwd: Option<&std::path::Path>,
+        ) -> anyhow::Result<String> {
+            Ok(self.0.clone())
+        }
+    }
+}

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -13,7 +13,9 @@ fn npm_cache_path(paths: &JackinPaths) -> PathBuf {
 
 /// File that records the Claude Code version baked into a given Docker image.
 fn image_version_path(paths: &JackinPaths, image: &str) -> PathBuf {
-    paths.cache_dir.join(format!("image-claude-version/{image}"))
+    paths
+        .cache_dir
+        .join(format!("image-claude-version/{image}"))
 }
 
 /// Query npm for the latest published `@anthropic-ai/claude-code` version,
@@ -50,7 +52,9 @@ pub fn latest_claude_version(
 /// Read the Claude Code version we stored for a previously-built image.
 pub fn stored_image_version(paths: &JackinPaths, image: &str) -> Option<String> {
     let path = image_version_path(paths, image);
-    std::fs::read_to_string(path).ok().map(|s| s.trim().to_string())
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
 }
 
 /// Persist the Claude Code version that was just installed into an image.
@@ -66,13 +70,11 @@ pub fn needs_claude_update(
     image: &str,
     runner: &mut impl CommandRunner,
 ) -> bool {
-    let installed = match stored_image_version(paths, image) {
-        Some(v) => v,
-        None => return false, // first build — let it proceed normally
+    let Some(installed) = stored_image_version(paths, image) else {
+        return false; // first build — let it proceed normally
     };
-    let latest = match latest_claude_version(paths, runner) {
-        Some(v) => v,
-        None => return false, // npm unavailable — don't force a rebuild
+    let Some(latest) = latest_claude_version(paths, runner) else {
+        return false; // npm unavailable — don't force a rebuild
     };
     installed != latest
 }
@@ -132,7 +134,11 @@ mod tests {
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+        assert!(needs_claude_update(
+            &paths,
+            "jackin-agent-smith",
+            &mut runner
+        ));
     }
 
     #[test]
@@ -146,7 +152,11 @@ mod tests {
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(!needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+        assert!(!needs_claude_update(
+            &paths,
+            "jackin-agent-smith",
+            &mut runner
+        ));
     }
 
     #[test]
@@ -157,7 +167,11 @@ mod tests {
 
         let mut runner = StubRunner("2.1.92".to_string());
         // No stored version yet → should not force rebuild
-        assert!(!needs_claude_update(&paths, "jackin-agent-smith", &mut runner));
+        assert!(!needs_claude_update(
+            &paths,
+            "jackin-agent-smith",
+            &mut runner
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a version check before each `jackin load` that compares the Claude Code version in the Docker image against the latest published npm version (`@anthropic-ai/claude-code`)
- When an update is available, automatically rebuilds the image with a cache-busting build arg so the install script fetches the new release
- Caches the npm version lookup for 1 hour at `~/.jackin/cache/` to avoid hitting the registry on every launch
- Records the per-image Claude Code version after each successful build for instant future comparisons

## Test plan
- [x] All 210 existing tests pass
- [x] 6 new unit tests for `version_check` module covering: store/read, needs-update detection, first-build passthrough, cache expiry, and cache freshness
- [ ] Manual: run `jackin load` with an outdated image and verify "Claude update available — rebuilding image" message appears
- [ ] Manual: run `jackin load` again immediately and verify no unnecessary rebuild (npm cache hit, versions match)
- [ ] Manual: verify `jackin load --rebuild` still forces a rebuild regardless of version match

🤖 Generated with [Claude Code](https://claude.com/claude-code)