### PR TITLE
fix(docs): update GitHub Pages URL to jackin-project org

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
-  site: 'https://donbeave.github.io',
+  site: 'https://jackin-project.github.io',
   base: '/jackin',
   integrations: [
     starlight({
@@ -25,7 +25,7 @@ export default defineConfig({
           tag: 'meta',
           attrs: {
             property: 'og:image',
-            content: 'https://donbeave.github.io/jackin/og-image.png',
+            content: 'https://jackin-project.github.io/jackin/og-image.png',
           },
         },
       ],


### PR DESCRIPTION
## Summary
- Updated `site` in `astro.config.mjs` from `donbeave.github.io` to `jackin-project.github.io`
- Updated `og:image` meta tag URL accordingly

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm site deploys to `https://jackin-project.github.io/jackin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)