### PR TITLE
Rename construct image to projectjackin/construct

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: donbeave/jackin-construct
+  IMAGE_NAME: projectjackin/construct
 
 jobs:
   build-and-push:

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -1,6 +1,6 @@
 # Construct Image
 
-This directory contains the source for `donbeave/jackin-construct:trixie` — the shared base Docker image that every [jackin](https://github.com/donbeave/jackin) agent starts from.
+This directory contains the source for `projectjackin/construct:trixie` — the shared base Docker image that every [jackin](https://github.com/donbeave/jackin) agent starts from.
 
 In The Matrix, the construct is the base simulated environment loaded before a mission. In jackin, it's the foundation layer providing system tools, shell environment, and container infrastructure that all agents inherit.
 
@@ -34,8 +34,8 @@ Agent repos build on top of the construct. jackin then generates a derived layer
 
 The image is automatically built and pushed to Docker Hub via GitHub Actions when changes are made to this directory. Tags:
 
-- `donbeave/jackin-construct:trixie` — stable tag
-- `donbeave/jackin-construct:trixie-{sha}` — commit-specific tags
+- `projectjackin/construct:trixie` — stable tag
+- `projectjackin/construct:trixie-{sha}` — commit-specific tags
 
 ## Related
 

--- a/docs/src/content/docs/developing/agent-manifest.mdx
+++ b/docs/src/content/docs/developing/agent-manifest.mdx
@@ -48,7 +48,7 @@ The Dockerfile path must:
 - Be relative (no absolute paths)
 - Stay inside the repository (no `../` escapes)
 - Point to a valid Dockerfile
-- Have a final stage that starts with `FROM donbeave/jackin-construct:trixie`
+- Have a final stage that starts with `FROM projectjackin/construct:trixie`
 
 ## `[claude]`
 

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -7,12 +7,12 @@ import { Aside } from '@astrojs/starlight/components';
 
 ## What is the construct?
 
-`donbeave/jackin-construct:trixie` is the shared base Docker image for every agent. In The Matrix, the construct is the white void — the base simulation loaded before a mission. In jackin', it's the foundation layer that provides system tools, shell environment, and container infrastructure.
+`projectjackin/construct:trixie` is the shared base Docker image for every agent. In The Matrix, the construct is the white void — the base simulation loaded before a mission. In jackin', it's the foundation layer that provides system tools, shell environment, and container infrastructure.
 
 Every agent Dockerfile starts from the construct:
 
 ```dockerfile
-FROM donbeave/jackin-construct:trixie
+FROM projectjackin/construct:trixie
 ```
 
 ## What's inside
@@ -64,8 +64,8 @@ The construct creates a `claude` user with:
 The construct source code lives at [`docker/construct/`](https://github.com/donbeave/jackin/tree/main/docker/construct) in the jackin' repository. It's automatically built and pushed to Docker Hub via GitHub Actions when changes are made to that directory.
 
 The image is tagged as:
-- `donbeave/jackin-construct:trixie` — the stable tag
-- `donbeave/jackin-construct:trixie-{sha}` — commit-specific tags
+- `projectjackin/construct:trixie` — the stable tag
+- `projectjackin/construct:trixie-{sha}` — commit-specific tags
 
 ## The derived image layer
 

--- a/docs/src/content/docs/developing/creating-agents.mdx
+++ b/docs/src/content/docs/developing/creating-agents.mdx
@@ -31,7 +31,7 @@ Creating a custom agent lets you define a specialized environment for a specific
 3. **Create the Dockerfile**
 
    ```dockerfile title="Dockerfile"
-   FROM donbeave/jackin-construct:trixie
+   FROM projectjackin/construct:trixie
 
    # Install Rust via mise
    RUN mise install rust@stable && mise use --global rust@stable
@@ -61,11 +61,11 @@ Creating a custom agent lets you define a specialized environment for a specific
 Your final stage **must** start from the construct image:
 
 ```dockerfile
-FROM donbeave/jackin-construct:trixie
+FROM projectjackin/construct:trixie
 ```
 
 <Aside type="caution">
-This is the literal string jackin' checks for. `FROM donbeave/jackin-construct:latest` or any other tag will fail validation.
+This is the literal string jackin' checks for. `FROM projectjackin/construct:latest` or any other tag will fail validation.
 </Aside>
 
 ### Multi-stage builds are supported
@@ -80,7 +80,7 @@ COPY tools/ .
 RUN cargo build --release
 
 # Final stage — must use the construct
-FROM donbeave/jackin-construct:trixie
+FROM projectjackin/construct:trixie
 COPY --from=builder /build/target/release/my-tool /usr/local/bin/
 ```
 

--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -62,7 +62,7 @@ A single agent class can have multiple running **instances**. Each instance is a
 In The Matrix, the construct is the empty white space where programs are loaded before a mission. In jackin', the **construct** is the shared base Docker image that every agent starts from:
 
 ```
-donbeave/jackin-construct:trixie
+projectjackin/construct:trixie
 ```
 
 The construct provides:

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -68,7 +68,7 @@ On macOS, [OrbStack](https://orbstack.dev/) is a lightweight alternative to Dock
 
 jackin' itself is a single binary. When you first load an agent, jackin' will:
 
-1. **Pull the construct image** (`donbeave/jackin-construct:trixie`) — a Debian-based image with system tools, Docker CLI, git, and more
+1. **Pull the construct image** (`projectjackin/construct:trixie`) — a Debian-based image with system tools, Docker CLI, git, and more
 2. **Clone the agent repo** — cached at `~/.jackin/agents/`
 3. **Build a derived image** — layers the agent's tools and Claude Code on top of the construct
 4. **Create a Docker network** — per-agent isolation

--- a/docs/src/content/docs/guides/agent-repos.mdx
+++ b/docs/src/content/docs/guides/agent-repos.mdx
@@ -94,11 +94,11 @@ Every agent repo must satisfy a contract:
 3. **The Dockerfile path must be relative** and must stay inside the repo checkout (no `../` escapes)
 4. **The final Dockerfile stage must use the construct base**:
    ```dockerfile
-   FROM donbeave/jackin-construct:trixie
+   FROM projectjackin/construct:trixie
    ```
    An optional alias is allowed:
    ```dockerfile
-   FROM donbeave/jackin-construct:trixie AS runtime
+   FROM projectjackin/construct:trixie AS runtime
    ```
 5. **Earlier stages may use any base image** — multi-stage builds are fully supported
 6. **No symlinks** — the derived build-context generator currently rejects symlinks
@@ -122,7 +122,7 @@ name = "Frontend Engineer"
 ```
 
 ```dockerfile title="Dockerfile"
-FROM donbeave/jackin-construct:trixie
+FROM projectjackin/construct:trixie
 
 # Install Node.js via mise
 RUN mise install node@22 && mise use --global node@22

--- a/docs/superpowers/plans/2026-04-04-pre-launch-hooks-and-env-vars.md
+++ b/docs/superpowers/plans/2026-04-04-pre-launch-hooks-and-env-vars.md
@@ -855,7 +855,7 @@ fn accepts_manifest_with_valid_pre_launch_hook() {
     .unwrap();
     std::fs::write(
         temp.path().join("Dockerfile"),
-        "FROM donbeave/jackin-construct:trixie\n",
+        "FROM projectjackin/construct:trixie\n",
     )
     .unwrap();
     std::fs::write(
@@ -874,7 +874,7 @@ fn rejects_pre_launch_hook_outside_repo() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("Dockerfile"),
-        "FROM donbeave/jackin-construct:trixie\n",
+        "FROM projectjackin/construct:trixie\n",
     )
     .unwrap();
     std::fs::write(
@@ -893,7 +893,7 @@ fn rejects_pre_launch_hook_that_does_not_exist() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("Dockerfile"),
-        "FROM donbeave/jackin-construct:trixie\n",
+        "FROM projectjackin/construct:trixie\n",
     )
     .unwrap();
     std::fs::write(
@@ -912,7 +912,7 @@ fn rejects_absolute_pre_launch_hook_path() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("Dockerfile"),
-        "FROM donbeave/jackin-construct:trixie\n",
+        "FROM projectjackin/construct:trixie\n",
     )
     .unwrap();
     std::fs::write(
@@ -933,7 +933,7 @@ fn rejects_empty_pre_launch_hook() {
     std::fs::write(temp.path().join("hooks/pre-launch.sh"), "").unwrap();
     std::fs::write(
         temp.path().join("Dockerfile"),
-        "FROM donbeave/jackin-construct:trixie\n",
+        "FROM projectjackin/construct:trixie\n",
     )
     .unwrap();
     std::fs::write(
@@ -1450,7 +1450,7 @@ Add to the `mod tests` block in `src/derived_image.rs`:
 #[test]
 fn renders_derived_dockerfile_with_pre_launch_hook() {
     let dockerfile =
-        render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", Some("hooks/pre-launch.sh"));
+        render_derived_dockerfile("FROM projectjackin/construct:trixie\n", Some("hooks/pre-launch.sh"));
 
     assert!(dockerfile.contains(
         "COPY hooks/pre-launch.sh /home/claude/.jackin-runtime/pre-launch.sh"
@@ -1463,7 +1463,7 @@ fn renders_derived_dockerfile_with_pre_launch_hook() {
 #[test]
 fn renders_derived_dockerfile_without_pre_launch_hook() {
     let dockerfile =
-        render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None);
+        render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None);
 
     assert!(!dockerfile.contains("pre-launch.sh"));
 }
@@ -1599,7 +1599,7 @@ fn ensure_runtime_assets_are_included(
 
 Update existing tests that call `render_derived_dockerfile` to pass `None`:
 
-- `renders_derived_dockerfile_with_workspace_and_entrypoint` → `render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None)`
+- `renders_derived_dockerfile_with_workspace_and_entrypoint` → `render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None)`
 - `renders_derived_dockerfile_installs_claude_as_claude_user` → same
 - `renders_derived_dockerfile_rewrites_claude_uid_and_gid` → same
 
@@ -1903,7 +1903,7 @@ The Dockerfile path must:
 - Be relative (no absolute paths)
 - Stay inside the repository (no `../` escapes)
 - Point to a valid Dockerfile
-- Have a final stage that starts with `FROM donbeave/jackin-construct:trixie`
+- Have a final stage that starts with `FROM projectjackin/construct:trixie`
 
 ## `[claude]`
 
@@ -2205,7 +2205,7 @@ cat > test-agent/hooks/pre-launch.sh << 'HOOK'
 echo "Pre-launch hook running"
 HOOK
 cat > test-agent/Dockerfile << 'DF'
-FROM donbeave/jackin-construct:trixie
+FROM projectjackin/construct:trixie
 DF
 cat > test-agent/jackin.agent.toml << 'TOML'
 dockerfile = "Dockerfile"

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn renders_derived_dockerfile_with_workspace_and_entrypoint() {
-        let dockerfile = render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None);
+        let dockerfile = render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None);
 
         assert!(dockerfile.contains("RUN curl -fsSL https://claude.ai/install.sh | bash"));
         assert!(!dockerfile.contains("WORKDIR"));
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn renders_derived_dockerfile_installs_claude_as_claude_user() {
-        let dockerfile = render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None);
+        let dockerfile = render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None);
         let install = r#"USER claude
 ARG JACKIN_CACHE_BUST=0
 RUN curl -fsSL https://claude.ai/install.sh | bash
@@ -173,7 +173,7 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
 
     #[test]
     fn renders_derived_dockerfile_rewrites_claude_uid_and_gid() {
-        let dockerfile = render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None);
+        let dockerfile = render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None);
 
         assert!(dockerfile.contains("ARG JACKIN_HOST_UID=1000"));
         assert!(dockerfile.contains("ARG JACKIN_HOST_GID=1000"));
@@ -185,7 +185,7 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
     #[test]
     fn renders_derived_dockerfile_with_pre_launch_hook() {
         let dockerfile = render_derived_dockerfile(
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
             Some("hooks/pre-launch.sh"),
         );
 
@@ -198,7 +198,7 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
 
     #[test]
     fn renders_derived_dockerfile_without_pre_launch_hook() {
-        let dockerfile = render_derived_dockerfile("FROM donbeave/jackin-construct:trixie\n", None);
+        let dockerfile = render_derived_dockerfile("FROM projectjackin/construct:trixie\n", None);
 
         assert!(!dockerfile.contains("pre-launch.sh"));
     }
@@ -213,7 +213,7 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
         let repo = tempdir().unwrap();
         std::fs::write(
             repo.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -244,7 +244,7 @@ plugins = []
         let repo = tempdir().unwrap();
         std::fs::write(
             repo.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -280,7 +280,7 @@ plugins = []
         let repo = tempdir().unwrap();
         std::fs::write(
             repo.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -135,7 +135,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
@@ -162,7 +162,7 @@ plugins = ["code-review@claude-plugins-official", "feature-dev@claude-plugins-of
         .unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -205,7 +205,7 @@ plugins = []
         std::fs::create_dir_all(temp.path().join("docker")).unwrap();
         std::fs::write(
             temp.path().join("docker/agent.Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -242,7 +242,7 @@ echo hello
         .unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -276,7 +276,7 @@ pre_launch = "hooks/pre-launch.sh"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -302,7 +302,7 @@ pre_launch = "../escape.sh"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -328,7 +328,7 @@ pre_launch = "hooks/missing.sh"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -356,7 +356,7 @@ pre_launch = "/etc/evil.sh"
         std::fs::write(temp.path().join("hooks/pre-launch.sh"), "").unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -390,7 +390,7 @@ pre_launch = "hooks/pre-launch.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -1,7 +1,7 @@
 use dockerfile_parser::{Dockerfile, Instruction};
 use std::path::{Path, PathBuf};
 
-pub const CONSTRUCT_IMAGE: &str = "donbeave/jackin-construct:trixie";
+pub const CONSTRUCT_IMAGE: &str = "projectjackin/construct:trixie";
 
 #[derive(Debug, Clone)]
 pub struct ValidatedDockerfile {
@@ -52,7 +52,7 @@ mod tests {
             r#"FROM rust:1.87 AS builder
 RUN cargo build
 
-FROM donbeave/jackin-construct:trixie AS runtime
+FROM projectjackin/construct:trixie AS runtime
 COPY --from=builder /app /workspace/app
 "#,
         )
@@ -75,7 +75,7 @@ COPY --from=builder /app /workspace/app
         assert!(
             error
                 .to_string()
-                .contains("donbeave/jackin-construct:trixie")
+                .contains("projectjackin/construct:trixie")
         );
     }
 
@@ -85,7 +85,7 @@ COPY --from=builder /app /workspace/app
         let dockerfile = temp.path().join("Dockerfile");
         std::fs::write(
             &dockerfile,
-            r#"ARG BASE=donbeave/jackin-construct:trixie
+            r#"ARG BASE=projectjackin/construct:trixie
 FROM ${BASE}
 "#,
         )
@@ -96,7 +96,7 @@ FROM ${BASE}
         assert!(
             error
                 .to_string()
-                .contains("literal FROM donbeave/jackin-construct:trixie")
+                .contains("literal FROM projectjackin/construct:trixie")
         );
     }
 }

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -72,11 +72,7 @@ COPY --from=builder /app /workspace/app
 
         let error = validate_agent_dockerfile(&dockerfile).unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("projectjackin/construct:trixie")
-        );
+        assert!(error.to_string().contains("projectjackin/construct:trixie"));
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -941,7 +941,7 @@ mod tests {
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1164,7 +1164,7 @@ jackin-agent-smith-clone-1"#
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1247,7 +1247,7 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1331,7 +1331,7 @@ plugins = ["code-review@claude-plugins-official"]
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1399,7 +1399,7 @@ plugins = []
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1473,7 +1473,7 @@ plugins = []
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1541,7 +1541,7 @@ plugins = ["code-review@claude-plugins-official"]
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1632,7 +1632,7 @@ plugins = []
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1671,7 +1671,7 @@ plugins = []
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1828,7 +1828,7 @@ plugins = []
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(
@@ -1882,7 +1882,7 @@ plugins = []
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
-            "FROM donbeave/jackin-construct:trixie\n",
+            "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
         std::fs::write(

--- a/todo/construct-user-creation.md
+++ b/todo/construct-user-creation.md
@@ -4,7 +4,7 @@
 
 ## Problem
 
-The construct image (`donbeave/jackin-construct:trixie`) creates the `claude` user at UID/GID 1000 during its build. The derived image then has to remap the user with `usermod`/`groupmod` to match the host user's UID/GID. This is a hack — the construct makes assumptions about the user that the derived layer immediately undoes.
+The construct image (`projectjackin/construct:trixie`) creates the `claude` user at UID/GID 1000 during its build. The derived image then has to remap the user with `usermod`/`groupmod` to match the host user's UID/GID. This is a hack — the construct makes assumptions about the user that the derived layer immediately undoes.
 
 ## Why It Matters
 
@@ -19,9 +19,9 @@ The construct image (`donbeave/jackin-construct:trixie`) creates the `claude` us
 
 2. **Build construct locally instead of pulling**: jackin' builds the construct from source as a build stage, passing UID/GID at build time. No published image needed. Tradeoff: first build is slower (installs all system packages), but Docker caches it locally. Breaks the agent repo standalone build contract.
 
-3. **Keep construct as-is, just pull latest before build**: `docker pull donbeave/jackin-construct:trixie` before each build to keep it fresh. Doesn't fix the user remapping problem but prevents stale base images. Least disruptive.
+3. **Keep construct as-is, just pull latest before build**: `docker pull projectjackin/construct:trixie` before each build to keep it fresh. Doesn't fix the user remapping problem but prevents stale base images. Least disruptive.
 
-4. **Hybrid**: Construct stays published without a user. A thin `jackin-base` local image adds the user. Agent Dockerfiles still `FROM donbeave/jackin-construct:trixie` for their build stages, but the final runtime stage uses the local base. Preserves the agent author contract while fixing the user problem.
+4. **Hybrid**: Construct stays published without a user. A thin `jackin-base` local image adds the user. Agent Dockerfiles still `FROM projectjackin/construct:trixie` for their build stages, but the final runtime stage uses the local base. Preserves the agent author contract while fixing the user problem.
 
 ## Related Files
 


### PR DESCRIPTION
## Summary
- Rename Docker image from `donbeave/jackin-construct` to `projectjackin/construct` across all source code, tests, docs, and GitHub Actions
- Part of the migration to the `projectjackin` Docker Hub organization

## Test plan
- [x] `cargo check` passes
- [x] All 210 tests pass
- [ ] Merge and trigger `construct.yml` workflow to verify Docker Hub push

🤖 Generated with [Claude Code](https://claude.com/claude-code)