### PR TITLE
Fix broken internal doc links after custom domain switch

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -77,4 +77,4 @@ Subsequent loads reuse the cached image and agent repo (unless you pass `--rebui
 
 ## Next steps
 
-Ready to go? Head to the [Quick Start](/jackin/getting-started/quickstart/) to load your first agent.
+Ready to go? Head to the [Quick Start](/getting-started/quickstart/) to load your first agent.

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -126,6 +126,6 @@ jackin exile
 
 ## Next steps
 
-- Learn the [Core Concepts](/jackin/getting-started/concepts/) behind jackin's architecture
-- Set up [Workspaces](/jackin/guides/workspaces/) for your projects
-- Understand the [Security Model](/jackin/guides/security-model/)
+- Learn the [Core Concepts](/getting-started/concepts/) behind jackin's architecture
+- Set up [Workspaces](/guides/workspaces/) for your projects
+- Understand the [Security Model](/guides/security-model/)

--- a/docs/src/content/docs/getting-started/why.mdx
+++ b/docs/src/content/docs/getting-started/why.mdx
@@ -115,7 +115,7 @@ So the honest comparison is this:
 - if you want the **strongest local isolation boundary**, Docker Sandboxes is ahead
 - if you want **open, local-first agent orchestration**, jackin' is the better fit
 
-For a deeper comparison, including adjacent approaches and where jackin' is weaker today, see [Comparison with Alternatives](/jackin/guides/comparison/).
+For a deeper comparison, including adjacent approaches and where jackin' is weaker today, see [Comparison with Alternatives](/guides/comparison/).
 
 ## What jackin' is NOT
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
   tagline: Isolate AI coding agents in Docker containers. You're the Operator. They're already inside.
   actions:
     - text: Get Started
-      link: /jackin/getting-started/why/
+      link: /getting-started/why/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -49,7 +49,7 @@ That separation is the point. A backend agent and frontend agent can work on the
 </CardGrid>
 
 <Aside>
-jackin' is intentionally transparent about its tradeoffs. It is a container-based isolation model, not a microVM sandbox. If you want the honest comparison with Docker Sandboxes and related approaches, read [Comparison with Alternatives](/jackin/guides/comparison/).
+jackin' is intentionally transparent about its tradeoffs. It is a container-based isolation model, not a microVM sandbox. If you want the honest comparison with Docker Sandboxes and related approaches, read [Comparison with Alternatives](/guides/comparison/).
 </Aside>
 
 ## Quick start
@@ -74,11 +74,11 @@ jackin launch
 `agent-smith` is just the default starter agent class name in this project. Your own classes might be named `frontend`, `backend`, or `review-only`.
 
 <CardGrid>
-  <LinkCard title="Installation" href="/jackin/getting-started/installation/" description="All the ways to install jackin'" />
-  <LinkCard title="Core Concepts" href="/jackin/getting-started/concepts/" description="Understand operators, agents, and constructs" />
-  <LinkCard title="Creating Agents" href="/jackin/developing/creating-agents/" description="Build your own agent repos" />
-  <LinkCard title="Security Model" href="/jackin/guides/security-model/" description="How jackin' keeps your system safe" />
-  <LinkCard title="Comparison" href="/jackin/guides/comparison/" description="jackin' vs Docker Sandboxes and alternatives" />
+  <LinkCard title="Installation" href="/getting-started/installation/" description="All the ways to install jackin'" />
+  <LinkCard title="Core Concepts" href="/getting-started/concepts/" description="Understand operators, agents, and constructs" />
+  <LinkCard title="Creating Agents" href="/developing/creating-agents/" description="Build your own agent repos" />
+  <LinkCard title="Security Model" href="/guides/security-model/" description="How jackin' keeps your system safe" />
+  <LinkCard title="Comparison" href="/guides/comparison/" description="jackin' vs Docker Sandboxes and alternatives" />
 </CardGrid>
 
 ## Ecosystem


### PR DESCRIPTION
## Summary
- Strip `/jackin/` prefix from all internal doc links (href, markdown links, frontmatter)
- These links broke when the base path was removed in #20 for the custom domain

## Test plan
- [ ] Verify links on https://jackin.tailrocks.com/ resolve correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)