### PR TITLE
Implement construct Bake workflow

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+    env:
+      CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-amd64
 
     steps:
       - name: Checkout repository
@@ -53,6 +55,8 @@ jobs:
 
       - name: Push amd64 staging image
         if: github.event_name != 'pull_request'
+        env:
+          CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-amd64,mode=max
         run: just construct-push-platform amd64
 
   build-arm64:
@@ -60,6 +64,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
+    env:
+      CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-arm64
 
     steps:
       - name: Checkout repository
@@ -90,6 +96,8 @@ jobs:
 
       - name: Push arm64 staging image
         if: github.event_name != 'pull_request'
+        env:
+          CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-arm64,mode=max
         run: just construct-push-platform arm64
 
   publish-manifest:

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -1,4 +1,4 @@
-name: Build and Push Construct Image
+name: Construct Image
 
 on:
   push:
@@ -19,6 +19,7 @@ on:
 
 jobs:
   build-amd64:
+    name: amd64
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -55,6 +56,7 @@ jobs:
         run: just construct-push-platform amd64
 
   build-arm64:
+    name: arm64
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -91,6 +93,7 @@ jobs:
         run: just construct-push-platform arm64
 
   publish-manifest:
+    name: publish manifest
     if: github.event_name != 'pull_request'
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-24.04

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    env:
-      CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-amd64
 
     steps:
       - name: Checkout repository
@@ -49,13 +47,21 @@ jobs:
       - name: Bootstrap buildx
         run: just construct-init-buildx
 
+      - name: Expose GitHub Actions cache runtime
+        if: github.event_name == 'pull_request'
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Build amd64 for pull requests
         if: github.event_name == 'pull_request'
+        env:
+          CACHE_FROM: type=gha,scope=construct-pr-amd64
+          CACHE_TO: type=gha,scope=construct-pr-amd64,mode=max
         run: just construct-build-platform amd64
 
       - name: Push amd64 image by digest
         if: github.event_name != 'pull_request'
         env:
+          CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-amd64
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-amd64,mode=max
         run: just construct-push-platform amd64
 
@@ -73,8 +79,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-    env:
-      CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-arm64
 
     steps:
       - name: Checkout repository
@@ -99,13 +103,21 @@ jobs:
       - name: Bootstrap buildx
         run: just construct-init-buildx
 
+      - name: Expose GitHub Actions cache runtime
+        if: github.event_name == 'pull_request'
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Build arm64 for pull requests
         if: github.event_name == 'pull_request'
+        env:
+          CACHE_FROM: type=gha,scope=construct-pr-arm64
+          CACHE_TO: type=gha,scope=construct-pr-arm64,mode=max
         run: just construct-build-platform arm64
 
       - name: Push arm64 image by digest
         if: github.event_name != 'pull_request'
         env:
+          CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-arm64
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-arm64,mode=max
         run: just construct-push-platform arm64
 

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -38,7 +38,7 @@ jobs:
           driver: docker-container
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -48,25 +48,25 @@ jobs:
         run: just construct-init-buildx
 
       - name: Expose GitHub Actions cache runtime
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
         uses: crazy-max/ghaction-github-runtime@v3
 
-      - name: Build amd64 for pull requests
-        if: github.event_name == 'pull_request'
+      - name: Build amd64 without push
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
         env:
           CACHE_FROM: type=gha,scope=construct-pr-amd64
           CACHE_TO: type=gha,scope=construct-pr-amd64,mode=max
         run: just construct-build-platform amd64
 
       - name: Push amd64 image by digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         env:
           CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-amd64
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-amd64,mode=max
         run: just construct-push-platform amd64
 
       - name: Upload amd64 digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
           name: construct-digest-amd64
@@ -94,7 +94,7 @@ jobs:
           driver: docker-container
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -104,25 +104,25 @@ jobs:
         run: just construct-init-buildx
 
       - name: Expose GitHub Actions cache runtime
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
         uses: crazy-max/ghaction-github-runtime@v3
 
-      - name: Build arm64 for pull requests
-        if: github.event_name == 'pull_request'
+      - name: Build arm64 without push
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
         env:
           CACHE_FROM: type=gha,scope=construct-pr-arm64
           CACHE_TO: type=gha,scope=construct-pr-arm64,mode=max
         run: just construct-build-platform arm64
 
       - name: Push arm64 image by digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         env:
           CACHE_FROM: type=registry,ref=projectjackin/construct:buildcache-arm64
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-arm64,mode=max
         run: just construct-push-platform arm64
 
       - name: Upload arm64 digest
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
           name: construct-digest-arm64
@@ -132,7 +132,7 @@ jobs:
 
   publish-manifest:
     name: publish manifest
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -4,20 +4,22 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/construct.yml'
+      - 'Justfile'
+      - 'docker-bake.hcl'
       - 'docker/construct/**'
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/construct.yml'
+      - 'Justfile'
+      - 'docker-bake.hcl'
       - 'docker/construct/**'
   workflow_dispatch:
 
-env:
-  IMAGE_NAME: projectjackin/construct
-
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-
+  build-amd64:
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -25,8 +27,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Docker Buildx
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          name: jackin-construct
+          driver: docker-container
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
@@ -35,27 +43,81 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=trixie
-            type=sha,prefix=trixie-
+      - name: Bootstrap buildx
+        run: just construct-init-buildx
 
-      - name: Load tool versions
-        run: cat docker/construct/versions.env >> "$GITHUB_ENV"
+      - name: Build amd64 for pull requests
+        if: github.event_name == 'pull_request'
+        run: just construct-build-platform amd64
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Push amd64 staging image
+        if: github.event_name != 'pull_request'
+        run: just construct-push-platform amd64
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          context: docker/construct
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            TIRITH_VERSION=${{ env.TIRITH_VERSION }}
-            SHELLFIRM_VERSION=${{ env.SHELLFIRM_VERSION }}
+          name: jackin-construct
+          driver: docker-container
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Bootstrap buildx
+        run: just construct-init-buildx
+
+      - name: Build arm64 for pull requests
+        if: github.event_name == 'pull_request'
+        run: just construct-build-platform arm64
+
+      - name: Push arm64 staging image
+        if: github.event_name != 'pull_request'
+        run: just construct-push-platform arm64
+
+  publish-manifest:
+    if: github.event_name != 'pull_request'
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          name: jackin-construct
+          driver: docker-container
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Bootstrap buildx
+        run: just construct-init-buildx
+
+      - name: Publish multi-platform manifest
+        run: just construct-publish-manifest

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -53,11 +53,20 @@ jobs:
         if: github.event_name == 'pull_request'
         run: just construct-build-platform amd64
 
-      - name: Push amd64 staging image
+      - name: Push amd64 image by digest
         if: github.event_name != 'pull_request'
         env:
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-amd64,mode=max
         run: just construct-push-platform amd64
+
+      - name: Upload amd64 digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: construct-digest-amd64
+          path: /tmp/jackin-construct-digests/amd64.digest
+          if-no-files-found: error
+          retention-days: 1
 
   build-arm64:
     name: arm64
@@ -94,11 +103,20 @@ jobs:
         if: github.event_name == 'pull_request'
         run: just construct-build-platform arm64
 
-      - name: Push arm64 staging image
+      - name: Push arm64 image by digest
         if: github.event_name != 'pull_request'
         env:
           CACHE_TO: type=registry,ref=projectjackin/construct:buildcache-arm64,mode=max
         run: just construct-push-platform arm64
+
+      - name: Upload arm64 digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: construct-digest-arm64
+          path: /tmp/jackin-construct-digests/arm64.digest
+          if-no-files-found: error
+          retention-days: 1
 
   publish-manifest:
     name: publish manifest
@@ -129,6 +147,13 @@ jobs:
 
       - name: Bootstrap buildx
         run: just construct-init-buildx
+
+      - name: Download platform digests
+        uses: actions/download-artifact@v5
+        with:
+          pattern: construct-digest-*
+          path: /tmp/jackin-construct-digests
+          merge-multiple: true
 
       - name: Publish multi-platform manifest
         run: just construct-publish-manifest

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -26,20 +26,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           name: jackin-construct
           driver: docker-container
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Expose GitHub Actions cache runtime
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
-        uses: crazy-max/ghaction-github-runtime@v3
+        uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.1.0
 
       - name: Build amd64 without push
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload amd64 digest
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: construct-digest-amd64
           path: /tmp/jackin-construct-digests/amd64.digest
@@ -82,20 +82,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           name: jackin-construct
           driver: docker-container
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Expose GitHub Actions cache runtime
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
-        uses: crazy-max/ghaction-github-runtime@v3
+        uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.1.0
 
       - name: Build arm64 without push
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload arm64 digest
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: construct-digest-arm64
           path: /tmp/jackin-construct-digests/arm64.digest
@@ -140,19 +140,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
         with:
           name: jackin-construct
           driver: docker-container
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
         run: just construct-init-buildx
 
       - name: Download platform digests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: construct-digest-*
           path: /tmp/jackin-construct-digests

--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,7 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 set export
 
-buildx_builder := "jackin-construct"
+buildx_builder := env_var_or_default("BUILDX_BUILDER", "jackin-construct")
 
 # Computed defaults — fallbacks ensure `just --list` works in partial checkouts
 _default_git_sha := `git rev-parse --short=12 HEAD 2>/dev/null || echo dev`
@@ -38,6 +38,21 @@ construct-init-buildx:
       docker buildx inspect "{{buildx_builder}}" --bootstrap
     fi
 
+# Inspect the configured Buildx builder and list available builders
+construct-doctor-buildx:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker buildx ls
+    docker buildx inspect "{{buildx_builder}}" --bootstrap
+
+# Recreate the configured Buildx builder from scratch
+construct-reset-buildx:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker buildx rm --force "{{buildx_builder}}" >/dev/null 2>&1 || true
+    docker buildx create --name "{{buildx_builder}}" --driver docker-container --use
+    docker buildx inspect "{{buildx_builder}}" --bootstrap
+
 # Build the construct image for the host platform and load it locally
 construct-build-local:
     docker buildx bake \
@@ -66,6 +81,9 @@ construct-build-platform platform:
     )
     if [ -n "${CACHE_FROM:-}" ]; then
       args+=(--set "construct-local.cache-from=${CACHE_FROM}")
+    fi
+    if [ -n "${CACHE_TO:-}" ]; then
+      args+=(--set "construct-local.cache-to=${CACHE_TO}")
     fi
     args+=(construct-local)
     "${args[@]}"

--- a/Justfile
+++ b/Justfile
@@ -15,12 +15,14 @@ _default_shellfirm_version := `awk -F= '$1 == "SHELLFIRM_VERSION" { print $2 }' 
 
 # Resolved build variables — env-var overrides take priority
 REGISTRY_IMAGE := env_var_or_default("REGISTRY_IMAGE", "projectjackin/construct")
+LOCAL_REGISTRY_IMAGE := env_var_or_default("LOCAL_REGISTRY_IMAGE", "jackin-local/construct")
 STABLE_TAG := env_var_or_default("STABLE_TAG", "trixie")
 GIT_SHA := env_var_or_default("GIT_SHA", _default_git_sha)
 SHA_TAG := STABLE_TAG + "-" + GIT_SHA
 LOCAL_PLATFORM := env_var_or_default("LOCAL_PLATFORM", _default_local_platform)
 TIRITH_VERSION := env_var_or_default("TIRITH_VERSION", _default_tirith_version)
 SHELLFIRM_VERSION := env_var_or_default("SHELLFIRM_VERSION", _default_shellfirm_version)
+DIGEST_DIR := env_var_or_default("DIGEST_DIR", "/tmp/jackin-construct-digests")
 
 default:
     @just --list
@@ -68,7 +70,7 @@ construct-build-platform platform:
     args+=(construct-local)
     "${args[@]}"
 
-# Push a single-platform image to the registry (CI-only for canonical registry)
+# Push a single-platform image by digest (CI-only for canonical registry)
 construct-push-platform platform:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -80,18 +82,21 @@ construct-push-platform platform:
         exit 1
         ;;
     esac
-    staging_tag="${SHA_TAG}-{{platform}}"
     if [ -z "${CI:-}" ] && [ "$REGISTRY_IMAGE" = "projectjackin/construct" ]; then
       printf "Set REGISTRY_IMAGE to your own namespace before using construct-push-platform locally.\n" >&2
       exit 1
     fi
+    mkdir -p "${DIGEST_DIR}"
+    metadata_file="$(mktemp "${TMPDIR:-/tmp}/jackin-construct-{{platform}}.XXXXXX.json")"
+    trap 'rm -f "${metadata_file}"' EXIT
+    digest_file="${DIGEST_FILE:-${DIGEST_DIR}/{{platform}}.digest}"
     export PLATFORMS="$docker_platform"
     args=(
       docker buildx bake
       --builder "{{buildx_builder}}"
       --file docker-bake.hcl
-      --push
-      --set "construct-publish.tags=${REGISTRY_IMAGE}:${staging_tag}"
+      --metadata-file "${metadata_file}"
+      --set "construct-publish.output=type=image,name=${REGISTRY_IMAGE},push-by-digest=true,name-canonical=true,push=true"
     )
     if [ -n "${CACHE_FROM:-}" ]; then
       args+=(--set "construct-publish.cache-from=${CACHE_FROM}")
@@ -101,10 +106,15 @@ construct-push-platform platform:
     fi
     args+=(construct-publish)
     "${args[@]}"
+    digest="$(tr -d '[:space:]' < "${metadata_file}" | sed -n 's/.*"containerimage.digest":"\([^"]*\)".*/\1/p')"
+    if [ -z "${digest}" ]; then
+      printf "Unable to determine pushed digest from %s\n" "${metadata_file}" >&2
+      exit 1
+    fi
+    printf '%s\n' "${digest}" > "${digest_file}"
+    printf 'Wrote %s digest to %s\n' "{{platform}}" "${digest_file}"
 
-# NOTE: platform suffixes (-amd64, -arm64) are coupled to the PLATFORMS list in docker-bake.hcl.
-#
-# Combine per-platform staging images into a multi-platform manifest (CI-only for canonical registry)
+# Combine per-platform digest pushes into a multi-platform manifest (CI-only for canonical registry)
 construct-publish-manifest:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -112,11 +122,25 @@ construct-publish-manifest:
       printf "Set REGISTRY_IMAGE to your own namespace before using construct-publish-manifest locally.\n" >&2
       exit 1
     fi
+    refs=()
+    for platform in amd64 arm64; do
+      digest_file="${DIGEST_DIR}/${platform}.digest"
+      if [ ! -f "${digest_file}" ]; then
+        printf "Missing digest file for %s at %s\n" "${platform}" "${digest_file}" >&2
+        printf "Run construct-push-platform %s first or set DIGEST_DIR to the downloaded digest artifacts.\n" "${platform}" >&2
+        exit 1
+      fi
+      digest="$(tr -d '[:space:]' < "${digest_file}")"
+      if [ -z "${digest}" ]; then
+        printf "Digest file %s is empty\n" "${digest_file}" >&2
+        exit 1
+      fi
+      refs+=("${REGISTRY_IMAGE}@${digest}")
+    done
     docker buildx imagetools create \
       --tag "${REGISTRY_IMAGE}:${STABLE_TAG}" \
       --tag "${REGISTRY_IMAGE}:${SHA_TAG}" \
-      "${REGISTRY_IMAGE}:${SHA_TAG}-amd64" \
-      "${REGISTRY_IMAGE}:${SHA_TAG}-arm64"
+      "${refs[@]}"
     docker buildx imagetools inspect "${REGISTRY_IMAGE}:${SHA_TAG}"
 
 # Print the resolved Bake configuration (dry-run inspection)

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,115 @@
+# ---------------------------------------------------------------------------
+# Justfile — construct image orchestration
+# ---------------------------------------------------------------------------
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+set export
+
+buildx_builder := "jackin-construct"
+
+# Computed defaults — fallbacks ensure `just --list` works in partial checkouts
+_default_git_sha := `git rev-parse --short=12 HEAD 2>/dev/null || echo dev`
+_default_local_platform := `case "$(uname -m)" in x86_64|amd64) echo linux/amd64 ;; arm64|aarch64) echo linux/arm64 ;; *) printf "unsupported host architecture: %s\n" "$(uname -m)" >&2; exit 1 ;; esac`
+_default_tirith_version := `awk -F= '$1 == "TIRITH_VERSION" { print $2 }' docker/construct/versions.env 2>/dev/null || echo ""`
+_default_shellfirm_version := `awk -F= '$1 == "SHELLFIRM_VERSION" { print $2 }' docker/construct/versions.env 2>/dev/null || echo ""`
+
+# Resolved build variables — env-var overrides take priority
+REGISTRY_IMAGE := env_var_or_default("REGISTRY_IMAGE", "projectjackin/construct")
+STABLE_TAG := env_var_or_default("STABLE_TAG", "trixie")
+GIT_SHA := env_var_or_default("GIT_SHA", _default_git_sha)
+SHA_TAG := STABLE_TAG + "-" + GIT_SHA
+LOCAL_PLATFORM := env_var_or_default("LOCAL_PLATFORM", _default_local_platform)
+TIRITH_VERSION := env_var_or_default("TIRITH_VERSION", _default_tirith_version)
+SHELLFIRM_VERSION := env_var_or_default("SHELLFIRM_VERSION", _default_shellfirm_version)
+
+default:
+    @just --list
+
+# Create and bootstrap the named Buildx builder
+construct-init-buildx:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if docker buildx inspect "{{buildx_builder}}" >/dev/null 2>&1; then
+      docker buildx inspect "{{buildx_builder}}" --bootstrap
+    else
+      docker buildx create --name "{{buildx_builder}}" --driver docker-container --use
+      docker buildx inspect "{{buildx_builder}}" --bootstrap
+    fi
+
+# Build the construct image for the host platform and load it locally
+construct-build-local:
+    docker buildx bake \
+      --builder "{{buildx_builder}}" \
+      --file docker-bake.hcl \
+      --load \
+      construct-local
+
+# Build for a specific platform and load it locally
+construct-build-platform platform:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{platform}}" in
+      amd64) export LOCAL_PLATFORM="linux/amd64" ;;
+      arm64) export LOCAL_PLATFORM="linux/arm64" ;;
+      *)
+        printf "platform must be amd64 or arm64, got %s\n" "{{platform}}" >&2
+        exit 1
+        ;;
+    esac
+    docker buildx bake \
+      --builder "{{buildx_builder}}" \
+      --file docker-bake.hcl \
+      --load \
+      construct-local
+
+# Push a single-platform image to the registry (CI-only for canonical registry)
+construct-push-platform platform:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{platform}}" in
+      amd64) docker_platform="linux/amd64" ;;
+      arm64) docker_platform="linux/arm64" ;;
+      *)
+        printf "platform must be amd64 or arm64, got %s\n" "{{platform}}" >&2
+        exit 1
+        ;;
+    esac
+    staging_tag="${SHA_TAG}-{{platform}}"
+    if [ -z "${CI:-}" ] && [ "$REGISTRY_IMAGE" = "projectjackin/construct" ]; then
+      printf "Set REGISTRY_IMAGE to your own namespace before using construct-push-platform locally.\n" >&2
+      exit 1
+    fi
+    export PLATFORMS="$docker_platform"
+    docker buildx bake \
+      --builder "{{buildx_builder}}" \
+      --file docker-bake.hcl \
+      --push \
+      --set "construct-publish.tags=${REGISTRY_IMAGE}:${staging_tag}" \
+      construct-publish
+
+# NOTE: platform suffixes (-amd64, -arm64) are coupled to the PLATFORMS list in docker-bake.hcl.
+#
+# Combine per-platform staging images into a multi-platform manifest (CI-only for canonical registry)
+construct-publish-manifest:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "${CI:-}" ] && [ "$REGISTRY_IMAGE" = "projectjackin/construct" ]; then
+      printf "Set REGISTRY_IMAGE to your own namespace before using construct-publish-manifest locally.\n" >&2
+      exit 1
+    fi
+    docker buildx imagetools create \
+      --tag "${REGISTRY_IMAGE}:${STABLE_TAG}" \
+      --tag "${REGISTRY_IMAGE}:${SHA_TAG}" \
+      "${REGISTRY_IMAGE}:${SHA_TAG}-amd64" \
+      "${REGISTRY_IMAGE}:${SHA_TAG}-arm64"
+    docker buildx imagetools inspect "${REGISTRY_IMAGE}:${SHA_TAG}"
+
+# Print the resolved Bake configuration (dry-run inspection)
+construct-inspect:
+    PLATFORMS="linux/amd64,linux/arm64" \
+      docker buildx bake \
+      --builder "{{buildx_builder}}" \
+      --file docker-bake.hcl \
+      --print \
+      construct-local \
+      construct-publish

--- a/Justfile
+++ b/Justfile
@@ -56,11 +56,17 @@ construct-build-platform platform:
         exit 1
         ;;
     esac
-    docker buildx bake \
-      --builder "{{buildx_builder}}" \
-      --file docker-bake.hcl \
-      --load \
-      construct-local
+    args=(
+      docker buildx bake
+      --builder "{{buildx_builder}}"
+      --file docker-bake.hcl
+      --load
+    )
+    if [ -n "${CACHE_FROM:-}" ]; then
+      args+=(--set "construct-local.cache-from=${CACHE_FROM}")
+    fi
+    args+=(construct-local)
+    "${args[@]}"
 
 # Push a single-platform image to the registry (CI-only for canonical registry)
 construct-push-platform platform:
@@ -80,12 +86,21 @@ construct-push-platform platform:
       exit 1
     fi
     export PLATFORMS="$docker_platform"
-    docker buildx bake \
-      --builder "{{buildx_builder}}" \
-      --file docker-bake.hcl \
-      --push \
-      --set "construct-publish.tags=${REGISTRY_IMAGE}:${staging_tag}" \
-      construct-publish
+    args=(
+      docker buildx bake
+      --builder "{{buildx_builder}}"
+      --file docker-bake.hcl
+      --push
+      --set "construct-publish.tags=${REGISTRY_IMAGE}:${staging_tag}"
+    )
+    if [ -n "${CACHE_FROM:-}" ]; then
+      args+=(--set "construct-publish.cache-from=${CACHE_FROM}")
+    fi
+    if [ -n "${CACHE_TO:-}" ]; then
+      args+=(--set "construct-publish.cache-to=${CACHE_TO}")
+    fi
+    args+=(construct-publish)
+    "${args[@]}"
 
 # NOTE: platform suffixes (-amd64, -arm64) are coupled to the PLATFORMS list in docker-bake.hcl.
 #

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -17,6 +17,8 @@ Quick navigation reference for AI agents working in this repository.
 | `SECURITY_EXCEPTIONS.md` | Accepted security findings — do not re-flag |
 | `release.toml` | Release configuration |
 | `mise.toml` | Tool version management (bun) |
+| `Justfile` | Construct image build commands — contributor-facing `just` wrapper |
+| `docker-bake.hcl` | Declarative Docker Bake build graph for the construct image |
 | `.gitignore` | Git ignore rules |
 
 ## Open Items — `todo/`

--- a/README.md
+++ b/README.md
@@ -74,17 +74,6 @@ To develop jackin' itself, use [The Architect](https://github.com/donbeave/jacki
 jackin load the-architect
 ```
 
-## Construct Image Development
-
-Construct image changes use checked-in Docker build tooling instead of workflow-only commands. Contributors working on the base image should install [`just`](https://github.com/casey/just), bootstrap buildx once, and validate the image locally before opening a pull request:
-
-```sh
-just construct-init-buildx
-just construct-build-local
-```
-
-The declarative build graph lives in `docker-bake.hcl`, and GitHub Actions reuses the same `just` commands for native `amd64` and `arm64` builds.
-
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ To develop jackin' itself, use [The Architect](https://github.com/donbeave/jacki
 jackin load the-architect
 ```
 
+## Construct Image Development
+
+Construct image changes use checked-in Docker build tooling instead of workflow-only commands. Contributors working on the base image should install [`just`](https://github.com/casey/just), bootstrap buildx once, and validate the image locally before opening a pull request:
+
+```sh
+just construct-init-buildx
+just construct-build-local
+```
+
+The declarative build graph lives in `docker-bake.hcl`, and GitHub Actions reuses the same `just` commands for native `amd64` and `arm64` builds.
+
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The full documentation lives at **<https://jackin.tailrocks.com/>** and covers:
 - [Core Concepts](https://jackin.tailrocks.com/getting-started/concepts/) — operators, agents, constructs, and workspaces
 - [Commands](https://jackin.tailrocks.com/commands/load/) — complete CLI reference
 - [Creating Agents](https://jackin.tailrocks.com/developing/creating-agents/) — build your own agent repos
-- [The Construct Image](https://jackin.tailrocks.com/developing/construct-image/) — what's inside the shared base image
+- [The Construct Image](https://jackin.tailrocks.com/developing/construct-image/) — what's inside the shared base image and how it is built
 - [Architecture](https://jackin.tailrocks.com/reference/architecture/) — how jackin' orchestrates containers and networks
 
 ## Development

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,12 +3,16 @@
 // ---------------------------------------------------------------------------
 // Usage:
 //   docker buildx bake --file docker-bake.hcl construct-local
-//   docker buildx bake --file docker-bake.hcl construct-publish --push
+//   docker buildx bake --file docker-bake.hcl --set 'construct-publish.output=type=image,name=user/app,push=true' construct-publish
 //   docker buildx bake --file docker-bake.hcl --print   (inspect resolved config)
 // ---------------------------------------------------------------------------
 
 variable "REGISTRY_IMAGE" {
   default = "projectjackin/construct"
+}
+
+variable "LOCAL_REGISTRY_IMAGE" {
+  default = "jackin-local/construct"
 }
 
 variable "STABLE_TAG" {
@@ -71,20 +75,19 @@ target "_construct-common" {
 target "construct-local" {
   inherits = ["_construct-common"]
   tags = [
-    "${REGISTRY_IMAGE}:${STABLE_TAG}",
-    "${REGISTRY_IMAGE}:${SHA_TAG}",
+    "${LOCAL_REGISTRY_IMAGE}:${STABLE_TAG}",
+    "${LOCAL_REGISTRY_IMAGE}:${SHA_TAG}",
   ]
   platforms = [LOCAL_PLATFORM]
 }
 
 // ---------------------------------------------------------------------------
-// Publish build — multi-platform, intended for --push
+// Publish build — multi-platform, intended for digest pushes and manifest assembly
 // ---------------------------------------------------------------------------
 target "construct-publish" {
   inherits = ["_construct-common"]
-  tags = [
-    "${REGISTRY_IMAGE}:${STABLE_TAG}",
-    "${REGISTRY_IMAGE}:${SHA_TAG}",
+  output = [
+    "type=image,name=${REGISTRY_IMAGE}",
   ]
   platforms = split(",", PLATFORMS)
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -86,6 +86,15 @@ target "construct-local" {
 // ---------------------------------------------------------------------------
 target "construct-publish" {
   inherits = ["_construct-common"]
+  attest = [
+    {
+      type = "provenance"
+      mode = "max"
+    },
+    {
+      type = "sbom"
+    },
+  ]
   output = [
     "type=image,name=${REGISTRY_IMAGE}",
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// docker-bake.hcl — declarative build graph for the construct image
+// ---------------------------------------------------------------------------
+// Usage:
+//   docker buildx bake --file docker-bake.hcl construct-local
+//   docker buildx bake --file docker-bake.hcl construct-publish --push
+//   docker buildx bake --file docker-bake.hcl --print   (inspect resolved config)
+// ---------------------------------------------------------------------------
+
+variable "REGISTRY_IMAGE" {
+  default = "projectjackin/construct"
+}
+
+variable "STABLE_TAG" {
+  default = "trixie"
+}
+
+variable "GIT_SHA" {
+  default = "dev"
+}
+
+variable "SHA_TAG" {
+  default = "trixie-dev"
+}
+
+variable "LOCAL_PLATFORM" {
+  default = "linux/amd64"
+}
+
+variable "PLATFORMS" {
+  default = "linux/amd64,linux/arm64"
+}
+
+variable "TIRITH_VERSION" {
+  default = ""
+}
+
+variable "SHELLFIRM_VERSION" {
+  default = ""
+}
+
+// ---------------------------------------------------------------------------
+// Default group — all construct targets
+// ---------------------------------------------------------------------------
+group "default" {
+  targets = ["construct-local"]
+}
+
+// ---------------------------------------------------------------------------
+// Base target — shared context, args, and OCI labels
+// ---------------------------------------------------------------------------
+target "_construct-common" {
+  context    = "docker/construct"
+  dockerfile = "Dockerfile"
+  args = {
+    TIRITH_VERSION    = TIRITH_VERSION
+    SHELLFIRM_VERSION = SHELLFIRM_VERSION
+  }
+  labels = {
+    "org.opencontainers.image.title"       = "jackin construct"
+    "org.opencontainers.image.description" = "Shared base image for jackin agents"
+    "org.opencontainers.image.source"      = "https://github.com/jackin-project/jackin"
+    "org.opencontainers.image.url"         = "https://jackin.tailrocks.com/developing/construct-image/"
+    "org.opencontainers.image.revision"    = GIT_SHA
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local build — single platform, loaded into the Docker daemon
+// ---------------------------------------------------------------------------
+target "construct-local" {
+  inherits = ["_construct-common"]
+  tags = [
+    "${REGISTRY_IMAGE}:${STABLE_TAG}",
+    "${REGISTRY_IMAGE}:${SHA_TAG}",
+  ]
+  platforms = [LOCAL_PLATFORM]
+}
+
+// ---------------------------------------------------------------------------
+// Publish build — multi-platform, intended for --push
+// ---------------------------------------------------------------------------
+target "construct-publish" {
+  inherits = ["_construct-common"]
+  tags = [
+    "${REGISTRY_IMAGE}:${STABLE_TAG}",
+    "${REGISTRY_IMAGE}:${SHA_TAG}",
+  ]
+  platforms = split(",", PLATFORMS)
+}

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -4,7 +4,7 @@ This directory contains the source for `projectjackin/construct:trixie` — the 
 
 In The Matrix, the construct is the base simulated environment loaded before a mission. In jackin, it's the foundation layer providing system tools, shell environment, and container infrastructure that all agents inherit.
 
-For full details — including what's installed, the image layer architecture, and how to extend it — see the [Construct Image](https://jackin.tailrocks.com/developing/construct-image/) documentation.
+For full details — including what's installed, how it is built, the image layer architecture, and how to extend it — see the [Construct Image](https://jackin.tailrocks.com/developing/construct-image/) documentation.
 
 ## Files
 
@@ -35,7 +35,7 @@ Agent repos build on top of the construct. jackin then generates a derived layer
 
 Construct image builds are defined by the repo-root `docker-bake.hcl` file and wrapped by the repo-root `Justfile`.
 
-The supported local validation flow, architecture-specific debugging commands, publish rehearsal workflow, CI behavior, and published tags are documented on the [Construct Image](https://jackin.tailrocks.com/developing/construct-image/) page.
+The supported local validation flow, architecture-specific debugging commands, advanced publish rehearsal workflow, CI behavior, and published tags are documented on the [Construct Image](https://jackin.tailrocks.com/developing/construct-image/) page.
 
 ## Related
 

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -33,10 +33,34 @@ Agent repos build on top of the construct. jackin then generates a derived layer
 
 ## Building
 
-The image is automatically built and pushed to Docker Hub via GitHub Actions when changes are made to this directory. Tags:
+Construct image builds are defined by the repo-root `docker-bake.hcl` file and wrapped by the repo-root `Justfile`. Install [`just`](https://github.com/casey/just), then bootstrap buildx and build the image locally:
+
+```sh
+just construct-init-buildx
+just construct-build-local
+```
+
+To debug a specific architecture locally, run one of these commands:
+
+```sh
+just construct-build-platform amd64
+just construct-build-platform arm64
+```
+
+To rehearse publishing, point `REGISTRY_IMAGE` at your own namespace instead of the canonical `projectjackin/construct` repository:
+
+```sh
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform amd64
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform arm64
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
+```
+
+Construct CI now triggers when changes touch any construct build input, including `docker/construct/**`, `docker-bake.hcl`, `Justfile`, and `.github/workflows/construct.yml`.
+
+Public tags remain:
 
 - `projectjackin/construct:trixie` — stable tag
-- `projectjackin/construct:trixie-{sha}` — commit-specific tags
+- `projectjackin/construct:trixie-<sha>` — commit-specific tag
 
 ## Related
 

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -1,6 +1,6 @@
 # Construct Image
 
-This directory contains the source for `projectjackin/construct:trixie` — the shared base Docker image that every [jackin](https://github.com/donbeave/jackin) agent starts from.
+This directory contains the source for `projectjackin/construct:trixie` — the shared base Docker image that every [jackin](https://github.com/jackin-project/jackin) agent starts from.
 
 In The Matrix, the construct is the base simulated environment loaded before a mission. In jackin, it's the foundation layer providing system tools, shell environment, and container infrastructure that all agents inherit.
 
@@ -33,34 +33,9 @@ Agent repos build on top of the construct. jackin then generates a derived layer
 
 ## Building
 
-Construct image builds are defined by the repo-root `docker-bake.hcl` file and wrapped by the repo-root `Justfile`. Install [`just`](https://github.com/casey/just), then bootstrap buildx and build the image locally:
+Construct image builds are defined by the repo-root `docker-bake.hcl` file and wrapped by the repo-root `Justfile`.
 
-```sh
-just construct-init-buildx
-just construct-build-local
-```
-
-To debug a specific architecture locally, run one of these commands:
-
-```sh
-just construct-build-platform amd64
-just construct-build-platform arm64
-```
-
-To rehearse publishing, point `REGISTRY_IMAGE` at your own namespace instead of the canonical `projectjackin/construct` repository:
-
-```sh
-REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform amd64
-REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform arm64
-REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
-```
-
-Construct CI now triggers when changes touch any construct build input, including `docker/construct/**`, `docker-bake.hcl`, `Justfile`, and `.github/workflows/construct.yml`.
-
-Public tags remain:
-
-- `projectjackin/construct:trixie` — stable tag
-- `projectjackin/construct:trixie-<sha>` — commit-specific tag
+The supported local validation flow, architecture-specific debugging commands, publish rehearsal workflow, CI behavior, and published tags are documented on the [Construct Image](https://jackin.tailrocks.com/developing/construct-image/) page.
 
 ## Related
 

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -78,6 +78,10 @@ just construct-init-buildx
 just construct-build-local
 ```
 
+By default, local validation loads the image into your Docker daemon as `jackin-local/construct:trixie`, so it does not silently replace the canonical `projectjackin/construct:trixie` base image that normal `jackin` workflows consume.
+
+If you intentionally want to test `jackin` against your local construct build, rerun the build with `LOCAL_REGISTRY_IMAGE=projectjackin/construct`.
+
 Use `just construct-inspect` to print the fully resolved Bake config without building the image.
 
 ### Platform-specific debugging
@@ -88,6 +92,8 @@ To force a specific target architecture during local debugging:
 just construct-build-platform amd64
 just construct-build-platform arm64
 ```
+
+These commands work when your buildx builder supports the target platform natively or through emulation.
 
 ### Publish rehearsal
 
@@ -107,7 +113,7 @@ REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
 
 GitHub Actions reuses the same `just` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, `docker-bake.hcl`, `Justfile`, or `.github/workflows/construct.yml`.
 
-Pull requests build both architectures natively without pushing images. Pushes to `main` publish per-platform staging images first, then assemble the final multi-platform manifest.
+Pull requests build both architectures natively without pushing images. Pushes to `main` publish each platform by digest first, then assemble the final multi-platform manifest from those digests. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
 
 The published tags are:
 - `projectjackin/construct:trixie` — the stable tag

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -61,7 +61,25 @@ The construct creates a `claude` user with:
 
 ## How it's built
 
-The construct source code lives at [`docker/construct/`](https://github.com/donbeave/jackin/tree/main/docker/construct) in the jackin' repository. It's automatically built and pushed to Docker Hub via GitHub Actions when changes are made to that directory.
+The construct source code lives at [`docker/construct/`](https://github.com/jackin-project/jackin/tree/main/docker/construct) in the jackin' repository. The declarative build definition lives in the repo-root `docker-bake.hcl`, and the supported command wrapper is the repo-root `Justfile`.
+
+Before opening a pull request for construct changes, validate the image locally:
+
+```bash
+just construct-init-buildx
+just construct-build-local
+```
+
+To force a specific target architecture during local debugging:
+
+```bash
+just construct-build-platform amd64
+just construct-build-platform arm64
+```
+
+`docker/construct/versions.env` remains the source of truth for the pinned `tirith` and `shellfirm` build args used by `docker/construct/Dockerfile`.
+
+GitHub Actions reuses the same `just` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, `docker-bake.hcl`, `Justfile`, or `.github/workflows/construct.yml`.
 
 The image is tagged as:
 - `projectjackin/construct:trixie` — the stable tag

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -67,7 +67,7 @@ The construct source code lives at [`docker/construct/`](https://github.com/jack
 
 ## Build workflow
 
-Construct contributors should treat `just` as the supported command surface and Docker Bake as the underlying build engine.
+Use `just` for day-to-day construct work. Docker Bake is the underlying build engine, but contributors should treat `just` as the supported command surface.
 
 ### Local validation
 
@@ -80,11 +80,11 @@ just construct-build-local
 
 By default, local validation loads the image into your Docker daemon as `jackin-local/construct:trixie`, so it does not silently replace the canonical `projectjackin/construct:trixie` base image that normal `jackin` workflows consume.
 
-If you intentionally want to test `jackin` against your local construct build, rerun the build with `LOCAL_REGISTRY_IMAGE=projectjackin/construct`.
+If you intentionally want to test `jackin` against your local construct build, rerun the build with `LOCAL_REGISTRY_IMAGE=projectjackin/construct just construct-build-local`.
 
 Use `just construct-inspect` to print the fully resolved Bake config without building the image.
 
-If builder state gets stale or confusing, run `just construct-doctor-buildx` to inspect it or `just construct-reset-buildx` to recreate it. Set `BUILDX_BUILDER` if you want to isolate this workflow from your default local builder name.
+If builder state gets stale or confusing, run `just construct-doctor-buildx` to inspect it or `just construct-reset-buildx` to recreate it. Set `BUILDX_BUILDER` before running `just` if you want to isolate this workflow under a different local builder name.
 
 ### Platform-specific debugging
 
@@ -97,9 +97,9 @@ just construct-build-platform arm64
 
 These commands work when your buildx builder supports the target platform natively or through emulation.
 
-### Publish rehearsal
+### Advanced publish rehearsal
 
-To rehearse the publish flow locally, point `REGISTRY_IMAGE` at your own registry namespace instead of the canonical `projectjackin/construct` repository:
+If you need to rehearse the release path against a temporary registry, point `REGISTRY_IMAGE` at your own namespace instead of the canonical `projectjackin/construct` repository:
 
 ```bash
 REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform amd64
@@ -115,11 +115,11 @@ REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
 
 GitHub Actions reuses the same `just` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, `docker-bake.hcl`, `Justfile`, or `.github/workflows/construct.yml`.
 
-Pull requests build both architectures natively without pushing images. Those PR validation jobs use the GitHub Actions cache backend so cache state stays inside Actions instead of being published to Docker Hub.
+Pull requests, plus manual workflow runs against non-`main` branches, build both architectures natively without pushing images. Those validation jobs use the GitHub Actions cache backend so cache state stays inside Actions instead of being published to Docker Hub.
 
-Pushes to `main` publish each platform by digest first, then assemble the final multi-platform manifest from those digests. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
+Pushes to `main`, plus manual workflow runs against `main`, publish each platform by digest first, then assemble the final multi-platform manifest from those digests. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
 
-Publish builds also attach explicit provenance and SBOM attestations to the pushed image metadata.
+Published images also carry explicit BuildKit provenance and SBOM attestations.
 
 The published tags are:
 - `projectjackin/construct:trixie` — the stable tag

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -84,6 +84,8 @@ If you intentionally want to test `jackin` against your local construct build, r
 
 Use `just construct-inspect` to print the fully resolved Bake config without building the image.
 
+If builder state gets stale or confusing, run `just construct-doctor-buildx` to inspect it or `just construct-reset-buildx` to recreate it. Set `BUILDX_BUILDER` if you want to isolate this workflow from your default local builder name.
+
 ### Platform-specific debugging
 
 To force a specific target architecture during local debugging:
@@ -113,7 +115,11 @@ REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
 
 GitHub Actions reuses the same `just` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, `docker-bake.hcl`, `Justfile`, or `.github/workflows/construct.yml`.
 
-Pull requests build both architectures natively without pushing images. Pushes to `main` publish each platform by digest first, then assemble the final multi-platform manifest from those digests. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
+Pull requests build both architectures natively without pushing images. Those PR validation jobs use the GitHub Actions cache backend so cache state stays inside Actions instead of being published to Docker Hub.
+
+Pushes to `main` publish each platform by digest first, then assemble the final multi-platform manifest from those digests. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
+
+Publish builds also attach explicit provenance and SBOM attestations to the pushed image metadata.
 
 The published tags are:
 - `projectjackin/construct:trixie` — the stable tag

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -63,12 +63,24 @@ The construct creates a `claude` user with:
 
 The construct source code lives at [`docker/construct/`](https://github.com/jackin-project/jackin/tree/main/docker/construct) in the jackin' repository. The declarative build definition lives in the repo-root `docker-bake.hcl`, and the supported command wrapper is the repo-root `Justfile`.
 
+`docker/construct/versions.env` remains the source of truth for the pinned `tirith` and `shellfirm` build args used by `docker/construct/Dockerfile`.
+
+## Build workflow
+
+Construct contributors should treat `just` as the supported command surface and Docker Bake as the underlying build engine.
+
+### Local validation
+
 Before opening a pull request for construct changes, validate the image locally:
 
 ```bash
 just construct-init-buildx
 just construct-build-local
 ```
+
+Use `just construct-inspect` to print the fully resolved Bake config without building the image.
+
+### Platform-specific debugging
 
 To force a specific target architecture during local debugging:
 
@@ -77,13 +89,29 @@ just construct-build-platform amd64
 just construct-build-platform arm64
 ```
 
-`docker/construct/versions.env` remains the source of truth for the pinned `tirith` and `shellfirm` build args used by `docker/construct/Dockerfile`.
+### Publish rehearsal
+
+To rehearse the publish flow locally, point `REGISTRY_IMAGE` at your own registry namespace instead of the canonical `projectjackin/construct` repository:
+
+```bash
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform amd64
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-push-platform arm64
+REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER just construct-publish-manifest
+```
+
+<Aside type="caution">
+`just construct-push-platform` and `just construct-publish-manifest` intentionally refuse to publish to `projectjackin/construct` unless they are running in CI.
+</Aside>
+
+### CI behavior
 
 GitHub Actions reuses the same `just` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, `docker-bake.hcl`, `Justfile`, or `.github/workflows/construct.yml`.
 
-The image is tagged as:
+Pull requests build both architectures natively without pushing images. Pushes to `main` publish per-platform staging images first, then assemble the final multi-platform manifest.
+
+The published tags are:
 - `projectjackin/construct:trixie` — the stable tag
-- `projectjackin/construct:trixie-{sha}` — commit-specific tags
+- `projectjackin/construct:trixie-<sha>` — commit-specific tag
 
 ## The derived image layer
 

--- a/docs/superpowers/specs/2026-04-08-construct-bake-design.md
+++ b/docs/superpowers/specs/2026-04-08-construct-bake-design.md
@@ -211,7 +211,7 @@ should use:
 
 This supports debugging architecture-specific issues without editing CI files.
 
-### Optional Advanced Local Publishing
+### Optional Advanced Publish Rehearsal
 
 Advanced contributors who want to rehearse the full release flow can use:
 
@@ -262,6 +262,15 @@ images. This validates the construct on both platforms before merge.
 Pull request validation should prefer the GitHub Actions cache backend so cache
 state stays inside Actions. Registry-backed cache should be reserved for actual
 publish flows on `main`.
+
+### Manual Dispatch Behavior
+
+Manual workflow runs against non-`main` branches should follow the same
+non-push validation path as pull requests.
+
+Manual workflow runs against `main` can reuse the real publish path when a
+maintainer explicitly wants to re-run or rehearse the release workflow from the
+canonical branch.
 
 ## Manifest Strategy
 
@@ -343,8 +352,10 @@ smallest robust design.
 3. `just construct-build-platform amd64` and
    `just construct-build-platform arm64` both work when supported by the local
    builder setup.
-4. Pull requests validate both native architectures without pushing.
-5. Pushes to `main` build both native platform images, record their digests,
-   and publish a final multi-platform manifest from those digests.
+4. Pull requests and manual workflow runs against non-`main` branches validate
+   both native architectures without pushing.
+5. Pushes to `main`, plus manual workflow runs against `main`, build both
+   native platform images, record their digests, and publish a final
+   multi-platform manifest from those digests.
 6. `docker buildx imagetools inspect projectjackin/construct:trixie` shows both
    `linux/amd64` and `linux/arm64` after publish.

--- a/docs/superpowers/specs/2026-04-08-construct-bake-design.md
+++ b/docs/superpowers/specs/2026-04-08-construct-bake-design.md
@@ -1,0 +1,334 @@
+# Construct Image Build Orchestration With Docker Bake and Just
+
+This design replaces the current workflow-only construct image publishing logic
+with a local-first build interface built on Docker Bake and a repo-local
+`Justfile`.
+
+The goal is to make the construct image build reproducible outside GitHub
+Actions, while still supporting native `linux/amd64` and `linux/arm64`
+publishing in CI.
+
+## Goals
+
+- Make the construct image build reproducible locally with checked-in commands.
+- Keep GitHub Actions as a thin runner-and-credentials wrapper around shared
+  repo commands.
+- Support native single-platform builds for local development and split-runner
+  CI.
+- Support multi-platform publish by combining independently built platform
+  images into one manifest.
+- Document `just` as the contributor-facing command surface for construct image
+  work.
+
+## Non-Goals
+
+- Generalizing the system for every future Docker image in the repository.
+- Replacing the construct `Dockerfile`.
+- Switching to Cloud Native Buildpacks.
+- Requiring contributors to understand GitHub Actions internals to build or
+  validate the construct locally.
+
+## Why Docker Bake
+
+Docker Bake is the right build engine for this repository because it provides:
+
+- Declarative build definitions in version-controlled files.
+- Local and CI reuse through the same `docker buildx bake` targets.
+- Explicit platform configuration.
+- Command-line overrides for platforms, outputs, tags, and variables.
+- Native support for `--load`, `--push`, `--print`, and `--list` workflows.
+
+This keeps the actual build graph in one place while avoiding long,
+workflow-only `docker buildx build ...` command strings.
+
+Cloud Native Buildpacks are not a good fit here. They are designed to build
+application images without maintaining Dockerfiles, while `jackin` explicitly
+owns a curated `docker/construct/Dockerfile` and needs direct control over
+platforms, tags, and manifest publishing.
+
+## Design Principles
+
+### Local-First
+
+The build contract must be executable by contributors on their own machines
+before they open a pull request. CI should reuse the same commands, not define
+its own separate image-publishing logic.
+
+### Thin Wrappers
+
+The declarative build graph should live in Bake. Human-friendly commands should
+live in a `Justfile`. Only logic that is awkward to express in Bake or Just
+alone should move into small helper scripts.
+
+### Native Platform Builds
+
+`amd64` and `arm64` should build natively in CI on matching GitHub-hosted
+runners. Local developers should be able to build their default host platform
+without paying a multi-platform or emulation cost.
+
+### Stable Public Interface
+
+Contributors should use short stable commands such as `just construct-build-local`
+instead of memorizing Bake target names or GitHub Actions YAML.
+
+## Files Introduced
+
+- `docker-bake.hcl` — source of truth for construct image build targets and
+  variables.
+- `Justfile` — contributor-facing wrapper for construct build, push, and
+  manifest commands.
+
+No new binary or Rust-based wrapper is introduced in v1.
+
+## Bake File Responsibilities
+
+The root-level `docker-bake.hcl` becomes the declarative definition of the
+construct image build.
+
+It should define:
+
+- A default registry/image name variable for `projectjackin/construct`.
+- Shared tags for the stable `trixie` tag and commit-specific tag.
+- Shared labels and build metadata.
+- Shared context and Dockerfile path pointing at `docker/construct/`.
+- Shared default multi-platform configuration containing:
+  - `linux/amd64`
+  - `linux/arm64`
+- Separate targets for local loading and publish-oriented builds.
+
+### Recommended Target Shape
+
+The Bake file should define a small target set, for example:
+
+- `_construct-common`
+  - internal shared target
+  - context: `docker/construct`
+  - tags and labels derived from variables
+  - default platforms: `linux/amd64`, `linux/arm64`
+
+- `construct-local`
+  - inherits from `_construct-common`
+  - intended for local development
+  - no registry push by default
+  - used with `--load` and optional platform override
+
+- `construct-publish`
+  - inherits from `_construct-common`
+  - intended for publish flows
+  - used with `--push` in CI or advanced local workflows
+
+This separation keeps local and publish workflows obvious without duplicating
+the actual build configuration.
+
+## Variable Model
+
+Bake variables should cover the parts developers and CI need to override
+without editing files:
+
+- `REGISTRY_IMAGE`
+  - default: `projectjackin/construct`
+- `STABLE_TAG`
+  - default: `trixie`
+- `SHA_TAG`
+  - default derived from the current commit hash via environment or wrapper
+- `PLATFORMS`
+  - default: `linux/amd64,linux/arm64`
+
+The wrapper layer can set these variables before calling Bake so both local and
+CI usage stay consistent.
+
+## Justfile Responsibilities
+
+The `Justfile` is the supported human-facing interface. It should be documented
+as a contributor prerequisite for construct image work.
+
+### Command Surface
+
+The command surface should be explicit and small:
+
+- `just construct-init-buildx`
+  - ensure a usable buildx builder exists locally
+
+- `just construct-build-local`
+  - build the construct for the default local platform
+  - load it into the local Docker image store
+  - no push
+
+- `just construct-build-platform platform`
+  - build exactly one requested platform locally
+  - example: `just construct-build-platform amd64`
+  - example: `just construct-build-platform arm64`
+
+- `just construct-push-platform platform`
+  - push exactly one platform image
+  - used by split native CI jobs and optional advanced local publishing
+
+- `just construct-publish-manifest`
+  - assemble the final multi-platform manifest from previously pushed platform
+    images
+  - publish:
+    - `projectjackin/construct:trixie`
+    - `projectjackin/construct:trixie-<sha>`
+
+- `just construct-inspect`
+  - print the resolved Bake config or available Bake targets for debugging
+
+### Why Just
+
+`just` provides:
+
+- a readable command catalog via `just --list`
+- low-maintenance wrappers without building a custom CLI first
+- easy reuse in CI via identical commands
+
+This gives contributors a stable interface while Bake remains the underlying
+build engine.
+
+## Local Development Experience
+
+### Default Local Flow
+
+The normal contributor flow for construct work should be:
+
+1. `just construct-init-buildx`
+2. `just construct-build-local`
+
+This is optimized for the developer's current machine and should avoid pushing
+anything to a registry.
+
+### Explicit Single-Platform Debugging
+
+When a contributor needs deterministic control over target architecture, they
+should use:
+
+1. `just construct-build-platform amd64`
+2. `just construct-build-platform arm64`
+
+This supports debugging architecture-specific issues without editing CI files.
+
+### Optional Advanced Local Publishing
+
+Advanced contributors who want to rehearse the full release flow can use:
+
+1. `just construct-push-platform amd64`
+2. `just construct-push-platform arm64`
+3. `just construct-publish-manifest`
+
+This mirrors the CI publish model but remains optional for day-to-day
+development.
+
+## CI Workflow Design
+
+The construct workflow should stop embedding raw Docker build logic and instead
+call the same `just` commands contributors use locally.
+
+### Build Jobs
+
+Replace the current single publish job in
+`.github/workflows/construct.yml` with two native build jobs:
+
+- `build-amd64`
+  - runs on `ubuntu-24.04`
+  - runs `just construct-push-platform amd64` on `main`
+  - runs the non-push local-equivalent validation path on pull requests
+
+- `build-arm64`
+  - runs on `ubuntu-24.04-arm`
+  - runs `just construct-push-platform arm64` on `main`
+  - runs the non-push local-equivalent validation path on pull requests
+
+### Manifest Job
+
+Add a final `publish-manifest` job that:
+
+- depends on both native build jobs
+- runs only after both succeed
+- creates and publishes the multi-platform manifest tags
+
+This ensures there is no partial release where only one architecture is
+published.
+
+### Pull Request Behavior
+
+Pull requests should build both architectures natively but should not push
+images. This validates the construct on both platforms before merge.
+
+## Manifest Strategy
+
+The manifest publish step should remain explicit and separate from the native
+per-platform build steps.
+
+Responsibilities of `just construct-publish-manifest`:
+
+- collect the expected platform image references
+- create a multi-arch manifest from those platform-specific images
+- push the stable public tags
+
+The public tag surface should stay intentionally small:
+
+- `projectjackin/construct:trixie`
+- `projectjackin/construct:trixie-<sha>`
+
+V1 does not publish permanent `-amd64` or `-arm64` public convenience tags.
+That keeps the registry surface simpler and avoids encouraging consumers to pin
+the wrong shape.
+
+## Buildx Bootstrap
+
+Local reproducibility requires a predictable buildx bootstrap path.
+
+`just construct-init-buildx` should:
+
+- create a named buildx builder if one does not exist
+- select it for subsequent commands
+- inspect or bootstrap it so contributors can verify the local setup quickly
+
+This replaces the implicit GitHub Actions-only buildx setup with a documented
+local command.
+
+## Documentation Changes
+
+The implementation should document `just` explicitly in the contributor docs for
+construct image work.
+
+At minimum, update:
+
+- `README.md`
+- `docker/construct/README.md`
+- relevant docs pages under `docs/src/content/docs/developing/`
+
+The docs should explain:
+
+- `just` is the supported command wrapper for construct image builds
+- Bake is the underlying declarative build definition
+- local contributors should validate construct changes with `just` before
+  opening a pull request
+
+## Why Not A Custom Rust Wrapper Yet
+
+A dedicated Rust CLI could eventually provide stronger validation and richer
+ergonomics, but it is not needed for v1.
+
+Using Bake plus Just keeps the system:
+
+- local-first
+- explicit
+- easy to inspect
+- much smaller than introducing a new maintained build tool immediately
+
+If the repository later grows into multiple images with shared conventions,
+revisiting a custom wrapper can make sense. For now, Bake plus Just is the
+smallest robust design.
+
+## Verification Plan
+
+1. `just construct-init-buildx` succeeds on a fresh contributor machine.
+2. `just construct-build-local` produces a locally loadable construct image.
+3. `just construct-build-platform amd64` and
+   `just construct-build-platform arm64` both work when supported by the local
+   builder setup.
+4. Pull requests validate both native architectures without pushing.
+5. Pushes to `main` build both native platform images and publish a final
+   multi-platform manifest.
+6. `docker buildx imagetools inspect projectjackin/construct:trixie` shows both
+   `linux/amd64` and `linux/arm64` after publish.

--- a/docs/superpowers/specs/2026-04-08-construct-bake-design.md
+++ b/docs/superpowers/specs/2026-04-08-construct-bake-design.md
@@ -259,6 +259,10 @@ published.
 Pull requests should build both architectures natively but should not push
 images. This validates the construct on both platforms before merge.
 
+Pull request validation should prefer the GitHub Actions cache backend so cache
+state stays inside Actions. Registry-backed cache should be reserved for actual
+publish flows on `main`.
+
 ## Manifest Strategy
 
 The manifest publish step should remain explicit and separate from the native
@@ -270,6 +274,7 @@ Responsibilities of `just construct-publish-manifest`:
 - create a multi-arch manifest from those platform-specific images
 - push the stable public tags
 - consume per-platform digests rather than public `-amd64` / `-arm64` tags
+- attach explicit provenance and SBOM attestations to published images
 
 The public tag surface should stay intentionally small:
 
@@ -290,6 +295,8 @@ Local reproducibility requires a predictable buildx bootstrap path.
 - create a named buildx builder if one does not exist
 - select it for subsequent commands
 - inspect or bootstrap it so contributors can verify the local setup quickly
+- allow the builder name to be overridden with `BUILDX_BUILDER`
+- provide a documented reset/doctor path when local builder state becomes stale
 
 This replaces the implicit GitHub Actions-only buildx setup with a documented
 local command.

--- a/docs/superpowers/specs/2026-04-08-construct-bake-design.md
+++ b/docs/superpowers/specs/2026-04-08-construct-bake-design.md
@@ -127,6 +127,8 @@ without editing files:
 
 - `REGISTRY_IMAGE`
   - default: `projectjackin/construct`
+- `LOCAL_REGISTRY_IMAGE`
+  - default: `jackin-local/construct`
 - `STABLE_TAG`
   - default: `trixie`
 - `SHA_TAG`
@@ -194,7 +196,10 @@ The normal contributor flow for construct work should be:
 2. `just construct-build-local`
 
 This is optimized for the developer's current machine and should avoid pushing
-anything to a registry.
+anything to a registry. It should also avoid overwriting the canonical
+`projectjackin/construct:trixie` tag in the developer's local Docker daemon by
+default. Maintainers can still opt into canonical local tags explicitly when
+they need to test `jackin` against a locally built construct.
 
 ### Explicit Single-Platform Debugging
 
@@ -215,7 +220,8 @@ Advanced contributors who want to rehearse the full release flow can use:
 3. `just construct-publish-manifest`
 
 This mirrors the CI publish model but remains optional for day-to-day
-development.
+development. The per-platform push step should record digests for later
+manifest assembly instead of relying on public architecture-suffixed tags.
 
 ## CI Workflow Design
 
@@ -263,6 +269,7 @@ Responsibilities of `just construct-publish-manifest`:
 - collect the expected platform image references
 - create a multi-arch manifest from those platform-specific images
 - push the stable public tags
+- consume per-platform digests rather than public `-amd64` / `-arm64` tags
 
 The public tag surface should stay intentionally small:
 
@@ -271,7 +278,8 @@ The public tag surface should stay intentionally small:
 
 V1 does not publish permanent `-amd64` or `-arm64` public convenience tags.
 That keeps the registry surface simpler and avoids encouraging consumers to pin
-the wrong shape.
+the wrong shape. Split CI jobs should therefore push platform images by digest
+and assemble the final manifest from those digests.
 
 ## Buildx Bootstrap
 

--- a/docs/superpowers/specs/2026-04-08-construct-bake-design.md
+++ b/docs/superpowers/specs/2026-04-08-construct-bake-design.md
@@ -331,12 +331,13 @@ smallest robust design.
 ## Verification Plan
 
 1. `just construct-init-buildx` succeeds on a fresh contributor machine.
-2. `just construct-build-local` produces a locally loadable construct image.
+2. `just construct-build-local` produces a locally loadable construct image
+   under the isolated default `jackin-local/construct:trixie` tag.
 3. `just construct-build-platform amd64` and
    `just construct-build-platform arm64` both work when supported by the local
    builder setup.
 4. Pull requests validate both native architectures without pushing.
-5. Pushes to `main` build both native platform images and publish a final
-   multi-platform manifest.
+5. Pushes to `main` build both native platform images, record their digests,
+   and publish a final multi-platform manifest from those digests.
 6. `docker buildx imagetools inspect projectjackin/construct:trixie` shows both
    `linux/amd64` and `linux/arm64` after publish.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 bun = "latest"
+just = "latest"


### PR DESCRIPTION
## Summary
- add a repo-root docker-bake.hcl and Justfile for local-first construct image builds
- split construct CI into native amd64/arm64 jobs plus final manifest publishing
- document the new Bake/Just workflow and keep the approved design spec in-tree

## Test Plan
- [x] just construct-init-buildx
- [x] just construct-inspect
- [x] just construct-build-local
- [x] just construct-build-platform arm64
- [x] cargo fmt -- --check
- [x] cargo clippy
- [x] cargo nextest run
- [x] cd docs && bun install --frozen-lockfile && bun run build