### PR TITLE
fix: make MCP server registration idempotent

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -33,12 +33,12 @@ fi
 
 run_maybe_quiet /home/claude/install-plugins.sh
 
-# Register security tool MCP servers
+# Register security tool MCP servers (ignore "already exists" on subsequent runs)
 if [[ "${JACKIN_DISABLE_TIRITH:-0}" != "1" ]]; then
-    run_maybe_quiet claude mcp add tirith -- tirith mcp-server
+    run_maybe_quiet claude mcp add tirith -- tirith mcp-server || true
 fi
 if [[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]]; then
-    run_maybe_quiet claude mcp add shellfirm -- shellfirm mcp-server
+    run_maybe_quiet claude mcp add shellfirm -- shellfirm mcp-server || true
 fi
 
 # Run pre-launch hook if present


### PR DESCRIPTION
## Summary

- Add `|| true` to `claude mcp add` commands in the entrypoint so they don't abort the script when the MCP server is already registered from a previous run

## Root cause

`claude mcp add` exits non-zero when the server already exists. The `.claude` directory is volume-mounted and persists between container restarts, so on the second `jackin load` the tirith registration fails, `set -euo pipefail` kills the entrypoint, and Claude never launches.

Introduced by #22.

## Test plan

- [x] `cargo nextest run` — 213 tests pass
- [ ] Run `jackin load` twice in a row — second run should launch Claude successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)