### PR TITLE
Add jackin-validate binary for agent repo validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Package
         run: |
           archive="jackin-${VERSION}-${{ matrix.target }}.tar.gz"
-          tar -czf "$archive" -C "target/${{ matrix.target }}/release" jackin
+          tar -czf "$archive" -C "target/${{ matrix.target }}/release" jackin jackin-validate
           shasum -a 256 "$archive" > "$archive.sha256"
 
       - uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ repository = "https://github.com/jackin-project/jackin"
 license = "Apache-2.0"
 publish = false
 
+[[bin]]
+name = "jackin"
+path = "src/main.rs"
+
+[[bin]]
+name = "jackin-validate"
+path = "src/bin/validate.rs"
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive", "color"] }

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -42,16 +42,19 @@ fn main() -> ExitCode {
     }
 
     // Validate manifest
-    match AgentManifest::load(&repo_dir) {
-        Ok(manifest) => match manifest.validate() {
-            Ok(warnings) => {
-                for w in &warnings {
-                    eprintln!("warning: {}", w.message);
+    let manifest_path = repo_dir.join("jackin.agent.toml");
+    if manifest_path.exists() {
+        match AgentManifest::load(&repo_dir) {
+            Ok(manifest) => match manifest.validate() {
+                Ok(warnings) => {
+                    for w in &warnings {
+                        eprintln!("warning: {}", w.message);
+                    }
                 }
-            }
-            Err(e) => errors.push(format!("manifest validation: {e}")),
-        },
-        Err(e) => errors.push(format!("manifest load: {e}")),
+                Err(e) => errors.push(format!("manifest validation: {e}")),
+            },
+            Err(e) => errors.push(format!("manifest load: {e}")),
+        }
     }
 
     if errors.is_empty() {

--- a/src/bin/validate.rs
+++ b/src/bin/validate.rs
@@ -1,0 +1,66 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use jackin::manifest::AgentManifest;
+use jackin::repo_contract::validate_agent_dockerfile;
+
+const REQUIRED_FILES: &[&str] = &[
+    "Dockerfile",
+    "jackin.agent.toml",
+    ".dockerignore",
+    ".gitignore",
+];
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: jackin-validate <agent-repo-path>");
+        return ExitCode::FAILURE;
+    }
+
+    let repo_dir = PathBuf::from(&args[1]);
+    if !repo_dir.is_dir() {
+        eprintln!("Error: {} is not a directory", repo_dir.display());
+        return ExitCode::FAILURE;
+    }
+
+    let mut errors: Vec<String> = Vec::new();
+
+    // Check required files
+    for file in REQUIRED_FILES {
+        if !repo_dir.join(file).exists() {
+            errors.push(format!("missing required file: {file}"));
+        }
+    }
+
+    // Validate Dockerfile
+    let dockerfile_path = repo_dir.join("Dockerfile");
+    if dockerfile_path.exists() {
+        if let Err(e) = validate_agent_dockerfile(&dockerfile_path) {
+            errors.push(format!("Dockerfile: {e}"));
+        }
+    }
+
+    // Validate manifest
+    match AgentManifest::load(&repo_dir) {
+        Ok(manifest) => match manifest.validate() {
+            Ok(warnings) => {
+                for w in &warnings {
+                    eprintln!("warning: {}", w.message);
+                }
+            }
+            Err(e) => errors.push(format!("manifest validation: {e}")),
+        },
+        Err(e) => errors.push(format!("manifest load: {e}")),
+    }
+
+    if errors.is_empty() {
+        println!("All checks passed");
+        ExitCode::SUCCESS
+    } else {
+        for error in &errors {
+            eprintln!("error: {error}");
+        }
+        ExitCode::FAILURE
+    }
+}

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -1,0 +1,107 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+#[test]
+fn validate_passes_for_valid_agent_repo() {
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("Dockerfile"),
+        "FROM projectjackin/construct:trixie\nRUN echo hello\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("jackin.agent.toml"),
+        "dockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join(".dockerignore"), ".git\n").unwrap();
+    std::fs::write(temp.path().join(".gitignore"), "target/\n").unwrap();
+
+    Command::cargo_bin("jackin-validate")
+        .unwrap()
+        .arg(temp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("All checks passed"));
+}
+
+#[test]
+fn validate_fails_for_wrong_base_image() {
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("Dockerfile"),
+        "FROM debian:trixie\nRUN echo hello\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("jackin.agent.toml"),
+        "dockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join(".dockerignore"), ".git\n").unwrap();
+    std::fs::write(temp.path().join(".gitignore"), "target/\n").unwrap();
+
+    Command::cargo_bin("jackin-validate")
+        .unwrap()
+        .arg(temp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("projectjackin/construct:trixie"));
+}
+
+#[test]
+fn validate_fails_for_missing_dockerignore() {
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("Dockerfile"),
+        "FROM projectjackin/construct:trixie\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("jackin.agent.toml"),
+        "dockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join(".gitignore"), "target/\n").unwrap();
+
+    Command::cargo_bin("jackin-validate")
+        .unwrap()
+        .arg(temp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(".dockerignore"));
+}
+
+#[test]
+fn validate_fails_for_invalid_manifest() {
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("Dockerfile"),
+        "FROM projectjackin/construct:trixie\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("jackin.agent.toml"),
+        "dockerfile = \"Dockerfile\"\nunknown_field = true\n\n[claude]\nplugins = []\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join(".dockerignore"), ".git\n").unwrap();
+    std::fs::write(temp.path().join(".gitignore"), "target/\n").unwrap();
+
+    Command::cargo_bin("jackin-validate")
+        .unwrap()
+        .arg(temp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown field"));
+}
+
+#[test]
+fn validate_fails_with_no_args() {
+    Command::cargo_bin("jackin-validate")
+        .unwrap()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage"));
+}


### PR DESCRIPTION
## Summary

- Adds `jackin-validate` binary target that validates agent repos against the project contract (Dockerfile FROM check, manifest schema, required files)
- Includes `jackin-validate` in release archives alongside the main `jackin` binary
- Powers the new [`validate-agent-action`](https://github.com/jackin-project/validate-agent-action) GitHub Action

## Test plan

- [x] 5 new integration tests covering: valid repo, wrong base image, missing `.dockerignore`, invalid manifest, no-args usage
- [x] All 218 tests pass (`cargo nextest run`)
- [x] `cargo fmt -- --check` and `cargo clippy` clean
- [ ] After merge + release, verify `validate-agent-action` can download and run the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)