### PR TITLE
Fix unnecessary image rebuilds from version suffix mismatch

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,11 +307,11 @@ fn build_agent_image(
         let version = version.trim();
         if !version.is_empty() {
             eprintln!("        Claude {version}");
-            // `claude --version` returns e.g. "2.1.96 (Claude Code)" but the npm
-            // cache stores just the semver ("2.1.96"). Strip the suffix so the
-            // comparison in `needs_claude_update` works correctly.
-            let semver = version.split_whitespace().next().unwrap_or(version);
-            version_check::store_image_version(paths, &image, semver);
+            if let Some(semver) = version_check::parse_claude_version(version) {
+                version_check::store_image_version(paths, &image, semver);
+            } else {
+                eprintln!("warning: unexpected claude --version output: {version:?}");
+            }
         }
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,7 +307,11 @@ fn build_agent_image(
         let version = version.trim();
         if !version.is_empty() {
             eprintln!("        Claude {version}");
-            version_check::store_image_version(paths, &image, version);
+            // `claude --version` returns e.g. "2.1.96 (Claude Code)" but the npm
+            // cache stores just the semver ("2.1.96"). Strip the suffix so the
+            // comparison in `needs_claude_update` works correctly.
+            let semver = version.split_whitespace().next().unwrap_or(version);
+            version_check::store_image_version(paths, &image, semver);
         }
     }
 

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -79,6 +79,19 @@ pub fn needs_claude_update(
     installed != latest
 }
 
+/// Extract a bare semver string from `claude --version` output.
+///
+/// The command returns e.g. `"2.1.96 (Claude Code)"` but we only need the
+/// `"2.1.96"` portion to compare against the npm registry.  Returns `None`
+/// when the output doesn't look like a version string.
+pub fn parse_claude_version(raw: &str) -> Option<&str> {
+    let token = raw.split_whitespace().next()?;
+    if token.split('.').count() < 2 || !token.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(token)
+}
+
 // ── helpers ────────────────────────────────────────────────────────────
 
 /// Read a cache file only if it was modified within `ttl`.
@@ -194,6 +207,31 @@ mod tests {
             read_if_fresh(&cache_file, NPM_CACHE_TTL),
             Some("2.1.92".to_string())
         );
+    }
+
+    #[test]
+    fn parse_claude_version_strips_suffix() {
+        assert_eq!(parse_claude_version("2.1.96 (Claude Code)"), Some("2.1.96"));
+    }
+
+    #[test]
+    fn parse_claude_version_bare_semver() {
+        assert_eq!(parse_claude_version("2.1.96"), Some("2.1.96"));
+    }
+
+    #[test]
+    fn parse_claude_version_two_part() {
+        assert_eq!(parse_claude_version("1.0"), Some("1.0"));
+    }
+
+    #[test]
+    fn parse_claude_version_rejects_garbage() {
+        assert_eq!(parse_claude_version("not-a-version"), None);
+    }
+
+    #[test]
+    fn parse_claude_version_rejects_empty() {
+        assert_eq!(parse_claude_version(""), None);
     }
 
     /// Minimal [`CommandRunner`] that returns a fixed string for any `capture`.


### PR DESCRIPTION
## Summary

- `claude --version` returns `"2.1.96 (Claude Code)"` but the npm cache stores just `"2.1.96"`. The string mismatch caused `needs_claude_update` to always return `true`, triggering unnecessary Docker image rebuilds every time.
- Extract version parsing into `parse_claude_version()` in `version_check.rs` with proper validation — rejects non-version output and prints a warning instead of caching bad data.
- Adds 5 unit tests covering: suffix stripping, bare semver, two-part versions, garbage input, and empty strings.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo nextest run` — all 223 tests pass (5 new)
- [ ] Manual: run `jackin load` for an agent already at the latest Claude version and verify it skips the rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)