### PR TITLE
feat: add --no-workdir-mount to workspace edit, rename add -> create

### DIFF
--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -15,13 +15,13 @@ A workspace describes project access, not agent tooling. It answers: which host 
 
 ## Subcommands
 
-### `workspace add`
+### `workspace create`
 
 ```bash
-jackin workspace add <NAME> --workdir <PATH> [OPTIONS]
+jackin workspace create <NAME> --workdir <PATH> [OPTIONS]
 ```
 
-Save a new workspace definition.
+Create a new workspace definition.
 
 | Option | Description |
 |---|---|
@@ -32,10 +32,10 @@ Save a new workspace definition.
 | `--default-agent <NAME>` | Agent class to auto-select |
 
 ```bash
-jackin workspace add my-app --workdir ~/Projects/my-app
-jackin workspace add my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
-jackin workspace add monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
-jackin workspace add restricted --workdir ~/app --allowed-agent agent-smith --default-agent agent-smith
+jackin workspace create my-app --workdir ~/Projects/my-app
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
+jackin workspace create monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
+jackin workspace create restricted --workdir ~/app --allowed-agent agent-smith --default-agent agent-smith
 ```
 
 ### `workspace list`

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -94,8 +94,8 @@ jackin exile
   <TabItem label="Multiple projects">
     ```bash
     # Save workspaces for your projects
-    jackin workspace add frontend --workdir ~/Projects/frontend
-    jackin workspace add backend --workdir ~/Projects/backend
+    jackin workspace create frontend --workdir ~/Projects/frontend
+    jackin workspace create backend --workdir ~/Projects/backend
 
     # Load agents into different workspaces
     jackin load agent-smith frontend
@@ -107,7 +107,7 @@ jackin exile
   <TabItem label="One workspace, different agents">
     ```bash
     # Same project access boundary, different tool profiles
-    jackin workspace add monorepo --workdir ~/Projects/monorepo
+    jackin workspace create monorepo --workdir ~/Projects/monorepo
 
     jackin load agent-smith monorepo
     jackin load the-architect monorepo

--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -62,7 +62,7 @@ These mounts are one-time — they apply only to this specific container launch.
 Save mounts as part of a workspace definition:
 
 ```bash
-jackin workspace add my-app \
+jackin workspace create my-app \
   --workdir ~/Projects/my-app \
   --mount ~/cache:/cache:ro
 ```
@@ -118,7 +118,7 @@ jackin config mount remove gradle-cache
 When multiple mount sources are resolved, jackin' combines them in this order:
 
 1. **Global mounts** (from `jackin config mount`)
-2. **Workspace mounts** (from `jackin workspace add`)
+2. **Workspace mounts** (from `jackin workspace create`)
 3. **Auto-mounted workdir** (unless `--no-workdir-mount`)
 4. **Load-time mounts** (from `jackin load --mount`)
 

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -50,7 +50,7 @@ If you regularly work on the same project, a saved workspace turns your mount la
 For projects you work on regularly, save a workspace:
 
 ```bash
-jackin workspace add my-app --workdir ~/Projects/my-app
+jackin workspace create my-app --workdir ~/Projects/my-app
 ```
 
 Now you can load agents into it from anywhere:
@@ -83,7 +83,7 @@ The auto-mount keeps host and container paths identical, which avoids confusion 
 Workspaces can include additional directories beyond the workdir:
 
 ```bash
-jackin workspace add my-app \
+jackin workspace create my-app \
   --workdir ~/Projects/my-app \
   --mount ~/cache:/cache:ro \
   --mount ~/shared-libs:/libs:ro
@@ -94,7 +94,7 @@ jackin workspace add my-app \
 If you need the container layout to differ from your host:
 
 ```bash
-jackin workspace add monorepo \
+jackin workspace create monorepo \
   --workdir /workspace \
   --no-workdir-mount \
   --mount ~/src:/workspace
@@ -140,7 +140,7 @@ jackin workspace remove my-app
 You can limit which agents are allowed to use a workspace:
 
 ```bash
-jackin workspace add secure-api \
+jackin workspace create secure-api \
   --workdir ~/Projects/secure-api \
   --allowed-agent agent-smith \
   --default-agent agent-smith

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -46,7 +46,7 @@ readonly = true
 | `default_agent` | Default agent selector |
 | `last_agent` | Most recently used agent selector for this workspace |
 
-When you use `jackin workspace add`, the common case is to make `workdir` and the first mount destination the same absolute path. If you need a different container layout, use `--no-workdir-mount` and define mounts explicitly.
+When you use `jackin workspace create`, the common case is to make `workdir` and the first mount destination the same absolute path. If you need a different container layout, use `--no-workdir-mount` and define mounts explicitly.
 
 ### Global mounts
 

--- a/docs/superpowers/plans/2026-04-03-new-user-docs-mental-model-rewrite.md
+++ b/docs/superpowers/plans/2026-04-03-new-user-docs-mental-model-rewrite.md
@@ -117,7 +117,7 @@ One project may intentionally use several agent classes. That is not redundancy.
 
 - [ ] **Step 3: Expand the `## Workspaces` section so saved workspaces feel operationally useful**
 
-Replace the paragraph that begins `Think of a workspace as answering:` through the numbered list ending with `Created with jackin workspace add and reusable across sessions.` with the following content:
+Replace the paragraph that begins `Think of a workspace as answering:` through the numbered list ending with `Created with jackin workspace create and reusable across sessions.` with the following content:
 
 ```mdx
 Think of a workspace as answering: "Which project files can this agent see, and where do they appear in the container?"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,7 +159,7 @@ pub enum ConfigCommand {
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]
 pub enum WorkspaceCommand {
-    /// Save a new workspace definition
+    /// Create a new workspace definition
     ///
     /// By default the workdir path is automatically mounted into the container
     /// at the same location (host path = container path). Use --no-workdir-mount
@@ -169,12 +169,12 @@ pub enum WorkspaceCommand {
         styles = HELP_STYLES,
         after_long_help = "\
 Examples:
-  jackin workspace add my-app --workdir ~/Projects/my-app
-  jackin workspace add my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
-  jackin workspace add monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
-  jackin workspace add restricted --workdir ~/app --allowed-agent agent-smith --default-agent agent-smith"
+  jackin workspace create my-app --workdir ~/Projects/my-app
+  jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
+  jackin workspace create monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
+  jackin workspace create restricted --workdir ~/app --allowed-agent agent-smith --default-agent agent-smith"
     )]
-    Add {
+    Create {
         /// Unique name for this workspace
         name: String,
         /// Working directory (automatically mounted at the same path unless --no-workdir-mount)
@@ -217,6 +217,7 @@ Examples:
   jackin workspace edit my-app --workdir ~/new-dir
   jackin workspace edit my-app --mount ~/cache:/cache:ro
   jackin workspace edit my-app --remove-destination /old-mount
+  jackin workspace edit my-app --no-workdir-mount
   jackin workspace edit my-app --allowed-agent chainargos/the-architect
   jackin workspace edit my-app --default-agent agent-smith
   jackin workspace edit my-app --clear-default-agent"
@@ -233,6 +234,9 @@ Examples:
         /// Remove a mount by its container destination path (repeatable)
         #[arg(long = "remove-destination")]
         remove_destinations: Vec<String>,
+        /// Remove the auto-mounted workdir (the mount where src = dst = workdir)
+        #[arg(long, default_value_t = false)]
+        no_workdir_mount: bool,
         /// Grant an agent access to this workspace (repeatable)
         #[arg(long = "allowed-agent")]
         allowed_agents: Vec<String>,
@@ -470,11 +474,11 @@ mod tests {
     }
 
     #[test]
-    fn parses_workspace_add_command() {
+    fn parses_workspace_create_command() {
         let cli = Cli::try_parse_from([
             "jackin",
             "workspace",
-            "add",
+            "create",
             "big-monorepo",
             "--workdir",
             "/workspace/project",
@@ -492,17 +496,17 @@ mod tests {
         assert!(matches!(
             cli.command,
             Command::Workspace {
-                command: WorkspaceCommand::Add { .. }
+                command: WorkspaceCommand::Create { .. }
             }
         ));
     }
 
     #[test]
-    fn parses_workspace_add_with_workdir_only() {
+    fn parses_workspace_create_with_workdir_only() {
         let cli = Cli::try_parse_from([
             "jackin",
             "workspace",
-            "add",
+            "create",
             "my-app",
             "--workdir",
             "/tmp/my-app",
@@ -512,8 +516,34 @@ mod tests {
         assert!(matches!(
             cli.command,
             Command::Workspace {
-                command: WorkspaceCommand::Add {
+                command: WorkspaceCommand::Create {
                     no_workdir_mount: false,
+                    ..
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_workspace_create_with_no_workdir_mount() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "workspace",
+            "create",
+            "monorepo",
+            "--workdir",
+            "/workspace",
+            "--no-workdir-mount",
+            "--mount",
+            "/tmp/src:/workspace",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Workspace {
+                command: WorkspaceCommand::Create {
+                    no_workdir_mount: true,
                     ..
                 }
             }
@@ -538,6 +568,28 @@ mod tests {
             cli.command,
             Command::Workspace {
                 command: WorkspaceCommand::Edit { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_workspace_edit_with_no_workdir_mount() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "workspace",
+            "edit",
+            "my-app",
+            "--no-workdir-mount",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Workspace {
+                command: WorkspaceCommand::Edit {
+                    no_workdir_mount: true,
+                    ..
+                }
             }
         ));
     }
@@ -675,20 +727,20 @@ mod tests {
     // ── Workspace subcommand help ───────────────────────────────────────
 
     #[test]
-    fn workspace_add_help_shows_auto_mount_and_examples() {
-        let help = help_text(&["jackin", "workspace", "add", "--help"]);
+    fn workspace_create_help_shows_auto_mount_and_examples() {
+        let help = help_text(&["jackin", "workspace", "create", "--help"]);
         assert!(
             help.contains("automatically mounted"),
             "auto-mount behavior not documented"
         );
         assert!(help.contains("--no-workdir-mount"), "opt-out flag missing");
         assert!(help.contains("Examples:"));
-        assert!(help.contains("jackin workspace add my-app --workdir ~/Projects/my-app"));
+        assert!(help.contains("jackin workspace create my-app --workdir ~/Projects/my-app"));
     }
 
     #[test]
-    fn workspace_add_help_shows_mount_format() {
-        let help = help_text(&["jackin", "workspace", "add", "--help"]);
+    fn workspace_create_help_shows_mount_format() {
+        let help = help_text(&["jackin", "workspace", "create", "--help"]);
         assert!(
             help.contains("path[:ro]") && help.contains("src:dst[:ro]"),
             "mount format missing"
@@ -753,7 +805,7 @@ mod tests {
             vec!["jackin", "exile", "--help"],
             vec!["jackin", "purge", "--help"],
             vec!["jackin", "launch", "--help"],
-            vec!["jackin", "workspace", "add", "--help"],
+            vec!["jackin", "workspace", "create", "--help"],
             vec!["jackin", "workspace", "list", "--help"],
             vec!["jackin", "workspace", "show", "--help"],
             vec!["jackin", "workspace", "edit", "--help"],

--- a/src/config.rs
+++ b/src/config.rs
@@ -256,7 +256,11 @@ impl AppConfig {
         result
     }
 
-    pub fn add_workspace(&mut self, name: &str, workspace: WorkspaceConfig) -> anyhow::Result<()> {
+    pub fn create_workspace(
+        &mut self,
+        name: &str,
+        workspace: WorkspaceConfig,
+    ) -> anyhow::Result<()> {
         if self.workspaces.contains_key(name) {
             anyhow::bail!("workspace {name:?} already exists; use `workspace edit`");
         }
@@ -288,6 +292,17 @@ impl AppConfig {
             workspace.mounts.retain(|mount| mount.dst != dst);
             if workspace.mounts.len() == original_len {
                 anyhow::bail!("unknown workspace mount destination: {dst}");
+            }
+        }
+
+        if edit.no_workdir_mount {
+            let workdir = &workspace.workdir;
+            let original_len = workspace.mounts.len();
+            workspace
+                .mounts
+                .retain(|mount| !(mount.src == *workdir && mount.dst == *workdir));
+            if workspace.mounts.len() == original_len {
+                anyhow::bail!("no auto-mounted workdir found (mount where src = dst = {workdir})");
             }
         }
 
@@ -621,7 +636,7 @@ readonly = true
         let src = temp.path().display().to_string();
 
         config
-            .add_workspace(
+            .create_workspace(
                 "big-monorepo",
                 WorkspaceConfig {
                     workdir: "/workspace/project".to_string(),
@@ -729,7 +744,7 @@ dst = "/workspace/src"
             last_agent: None,
         };
         config
-            .add_workspace("big-monorepo", original.clone())
+            .create_workspace("big-monorepo", original.clone())
             .unwrap();
 
         let err = config
@@ -749,7 +764,7 @@ dst = "/workspace/src"
     }
 
     #[test]
-    fn add_workspace_rejects_duplicate_name_and_preserves_existing_value() {
+    fn create_workspace_rejects_duplicate_name_and_preserves_existing_value() {
         let temp = tempdir().unwrap();
         let mut config = AppConfig::default();
         let original = WorkspaceConfig {
@@ -764,11 +779,11 @@ dst = "/workspace/src"
             last_agent: None,
         };
         config
-            .add_workspace("big-monorepo", original.clone())
+            .create_workspace("big-monorepo", original.clone())
             .unwrap();
 
         let err = config
-            .add_workspace(
+            .create_workspace(
                 "big-monorepo",
                 WorkspaceConfig {
                     workdir: "/workspace/other".to_string(),
@@ -811,7 +826,7 @@ dst = "/workspace/src"
             last_agent: None,
         };
         config
-            .add_workspace("big-monorepo", original.clone())
+            .create_workspace("big-monorepo", original.clone())
             .unwrap();
 
         let err = config
@@ -861,7 +876,7 @@ dst = "/workspace/src"
             last_agent: None,
         };
         config
-            .add_workspace("big-monorepo", original.clone())
+            .create_workspace("big-monorepo", original.clone())
             .unwrap();
 
         let err = config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,7 @@ pub fn run(cli: Cli) -> Result<()> {
             },
         },
         Command::Workspace { command } => match command {
-            WorkspaceCommand::Add {
+            WorkspaceCommand::Create {
                 name,
                 workdir,
                 mounts,
@@ -452,7 +452,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                 }
                 let mount_count = all_mounts.len();
-                config.add_workspace(
+                config.create_workspace(
                     &name,
                     WorkspaceConfig {
                         workdir: expanded_workdir,
@@ -464,7 +464,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 )?;
                 config.save(&paths)?;
                 println!(
-                    "Added workspace {name:?} (workdir: {}, {mount_count} mount(s)).",
+                    "Created workspace {name:?} (workdir: {}, {mount_count} mount(s)).",
                     tui::shorten_home(&workdir)
                 );
                 Ok(())
@@ -476,7 +476,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     println!();
                     println!("Add one with:");
                     println!(
-                        "  jackin workspace add <name> --workdir /path/to/project --mount /path/to/project"
+                        "  jackin workspace create <name> --workdir /path/to/project --mount /path/to/project"
                     );
                 } else {
                     use tabled::settings::Style;
@@ -589,6 +589,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 workdir,
                 mounts,
                 remove_destinations,
+                no_workdir_mount,
                 allowed_agents,
                 remove_allowed_agents,
                 default_agent,
@@ -618,6 +619,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 for dst in &remove_destinations {
                     changes.push(format!("removed mount {}", tui::shorten_home(dst)));
                 }
+                if no_workdir_mount {
+                    changes.push("removed workdir auto-mount".to_string());
+                }
                 for agent in &allowed_agents {
                     changes.push(format!("allowed agent {agent}"));
                 }
@@ -636,6 +640,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         workdir: workdir.map(|w| resolve_path(&w)),
                         upsert_mounts,
                         remove_destinations,
+                        no_workdir_mount,
                         allowed_agents_to_add: allowed_agents,
                         allowed_agents_to_remove: remove_allowed_agents,
                         default_agent: if clear_default_agent {
@@ -795,11 +800,11 @@ mod tests {
         assert!(msg.contains("neither a saved workspace nor a directory"));
     }
 
-    /// Simulates `jackin workspace add jackin --workdir jackin --mount sibling-project`
+    /// Simulates `jackin workspace create jackin --workdir jackin --mount sibling-project`
     /// from a parent directory. Both relative workdir and mount must be resolved to
-    /// absolute paths so that `add_workspace` validation passes.
+    /// absolute paths so that `create_workspace` validation passes.
     #[test]
-    fn workspace_add_resolves_relative_workdir_and_mounts() {
+    fn workspace_create_resolves_relative_workdir_and_mounts() {
         let temp = tempfile::tempdir().unwrap();
         let workdir_dir = temp.path().join("jackin");
         let mount_dir = temp.path().join("sibling-project");
@@ -813,7 +818,7 @@ mod tests {
         let mount = parse_mount_spec_resolved("sibling-project").unwrap();
 
         let mut config = config::AppConfig::default();
-        let result = config.add_workspace(
+        let result = config.create_workspace(
             "jackin",
             WorkspaceConfig {
                 workdir: expanded_workdir.clone(),
@@ -840,11 +845,11 @@ mod tests {
         assert!(ws.mounts.iter().all(|m| m.src.starts_with('/')));
     }
 
-    /// Simulates `jackin workspace add jackin --workdir . --mount ../jackin-agent-smith`
+    /// Simulates `jackin workspace create jackin --workdir . --mount ../jackin-agent-smith`
     /// from inside the project directory. Dot-workdir and parent-relative mount must both
     /// resolve to clean absolute paths.
     #[test]
-    fn workspace_add_resolves_dot_workdir_and_dotdot_mount() {
+    fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
         let temp = tempfile::tempdir().unwrap();
         let workdir_dir = temp.path().join("jackin");
         let sibling_dir = temp.path().join("jackin-agent-smith");
@@ -858,7 +863,7 @@ mod tests {
         let mount = parse_mount_spec_resolved("../jackin-agent-smith").unwrap();
 
         let mut config = config::AppConfig::default();
-        let result = config.add_workspace(
+        let result = config.create_workspace(
             "jackin",
             WorkspaceConfig {
                 workdir: expanded_workdir.clone(),
@@ -886,6 +891,153 @@ mod tests {
         assert!(mount.src.ends_with("/jackin-agent-smith"));
     }
 
+    /// Simulates `jackin workspace create my-app --workdir /tmp/app` (default behavior).
+    /// The workdir must be auto-mounted as the first mount.
+    #[test]
+    fn workspace_create_auto_mounts_workdir_by_default() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("my-app");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+
+        let expanded_workdir = workdir_dir.display().to_string();
+
+        // Simulate default behavior: no_workdir_mount = false
+        let no_workdir_mount = false;
+        let mut all_mounts: Vec<workspace::MountConfig> = vec![];
+        if !no_workdir_mount {
+            let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
+            if !already_mounted {
+                all_mounts.insert(
+                    0,
+                    workspace::MountConfig {
+                        src: expanded_workdir.clone(),
+                        dst: expanded_workdir.clone(),
+                        readonly: false,
+                    },
+                );
+            }
+        }
+
+        let mut config = config::AppConfig::default();
+        config
+            .create_workspace(
+                "my-app",
+                WorkspaceConfig {
+                    workdir: expanded_workdir.clone(),
+                    mounts: all_mounts,
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        let ws = config.workspaces.get("my-app").unwrap();
+        assert_eq!(ws.mounts.len(), 1);
+        assert_eq!(ws.mounts[0].src, expanded_workdir);
+        assert_eq!(ws.mounts[0].dst, expanded_workdir);
+        assert!(!ws.mounts[0].readonly);
+    }
+
+    /// Simulates `jackin workspace create monorepo --workdir /workspace --no-workdir-mount
+    /// --mount /tmp/src:/workspace`. The workdir must NOT be auto-mounted.
+    #[test]
+    fn workspace_create_no_workdir_mount_skips_auto_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let src_dir = temp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let src_path = src_dir.display().to_string();
+
+        // Simulate --no-workdir-mount with explicit mount
+        let no_workdir_mount = true;
+        let mut all_mounts = vec![workspace::MountConfig {
+            src: src_path.clone(),
+            dst: "/workspace".to_string(),
+            readonly: false,
+        }];
+        if !no_workdir_mount {
+            // This block should NOT execute
+            all_mounts.insert(
+                0,
+                workspace::MountConfig {
+                    src: "/workspace".to_string(),
+                    dst: "/workspace".to_string(),
+                    readonly: false,
+                },
+            );
+        }
+
+        let mut config = config::AppConfig::default();
+        config
+            .create_workspace(
+                "monorepo",
+                WorkspaceConfig {
+                    workdir: "/workspace".to_string(),
+                    mounts: all_mounts,
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        let ws = config.workspaces.get("monorepo").unwrap();
+        assert_eq!(ws.mounts.len(), 1, "should only have the explicit mount");
+        assert_eq!(ws.mounts[0].src, src_path);
+        assert_eq!(ws.mounts[0].dst, "/workspace");
+    }
+
+    /// When the workdir is already covered by an explicit --mount, the auto-mount
+    /// should be skipped even without --no-workdir-mount.
+    #[test]
+    fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("project");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+
+        let expanded_workdir = workdir_dir.display().to_string();
+
+        // Simulate: user explicitly mounts workdir via --mount
+        let no_workdir_mount = false;
+        let mut all_mounts = vec![workspace::MountConfig {
+            src: expanded_workdir.clone(),
+            dst: expanded_workdir.clone(),
+            readonly: true, // user chose read-only
+        }];
+        if !no_workdir_mount {
+            let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
+            if !already_mounted {
+                all_mounts.insert(
+                    0,
+                    workspace::MountConfig {
+                        src: expanded_workdir.clone(),
+                        dst: expanded_workdir.clone(),
+                        readonly: false,
+                    },
+                );
+            }
+        }
+
+        let mut config = config::AppConfig::default();
+        config
+            .create_workspace(
+                "project",
+                WorkspaceConfig {
+                    workdir: expanded_workdir.clone(),
+                    mounts: all_mounts,
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        let ws = config.workspaces.get("project").unwrap();
+        assert_eq!(ws.mounts.len(), 1, "no duplicate mount should be added");
+        assert!(ws.mounts[0].readonly, "original mount properties preserved");
+    }
+
     /// Simulates `jackin workspace edit jackin --mount sibling-dev` where the mount
     /// is a relative directory name. The resolved mount must pass validation.
     #[test]
@@ -900,7 +1052,7 @@ mod tests {
 
         let mut config = config::AppConfig::default();
         config
-            .add_workspace(
+            .create_workspace(
                 "jackin",
                 WorkspaceConfig {
                     workdir: workdir_abs.clone(),
@@ -936,5 +1088,106 @@ mod tests {
         assert_eq!(ws.mounts.len(), 2);
         assert!(ws.mounts[1].src.starts_with('/'));
         assert!(ws.mounts[1].src.ends_with("/jackin-dev"));
+    }
+
+    /// Simulates `jackin workspace edit my-app --no-workdir-mount` to remove the
+    /// auto-mounted workdir after workspace creation.
+    #[test]
+    fn workspace_edit_no_workdir_mount_removes_auto_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workdir_dir = temp.path().join("my-app");
+        let extra_dir = temp.path().join("extra");
+        std::fs::create_dir_all(&workdir_dir).unwrap();
+        std::fs::create_dir_all(&extra_dir).unwrap();
+
+        let workdir_abs = workdir_dir.display().to_string();
+        let extra_abs = extra_dir.display().to_string();
+
+        let mut config = config::AppConfig::default();
+        // Create workspace with auto-mounted workdir + an extra mount
+        config
+            .create_workspace(
+                "my-app",
+                WorkspaceConfig {
+                    workdir: workdir_abs.clone(),
+                    mounts: vec![
+                        workspace::MountConfig {
+                            src: workdir_abs.clone(),
+                            dst: workdir_abs.clone(),
+                            readonly: false,
+                        },
+                        workspace::MountConfig {
+                            src: extra_abs.clone(),
+                            dst: workdir_abs.clone() + "/extra",
+                            readonly: false,
+                        },
+                    ],
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(config.workspaces.get("my-app").unwrap().mounts.len(), 2);
+
+        // Now remove the workdir auto-mount
+        config
+            .edit_workspace(
+                "my-app",
+                WorkspaceEdit {
+                    no_workdir_mount: true,
+                    ..WorkspaceEdit::default()
+                },
+            )
+            .unwrap();
+
+        let ws = config.workspaces.get("my-app").unwrap();
+        assert_eq!(ws.mounts.len(), 1, "auto-mount should be removed");
+        assert_eq!(ws.mounts[0].dst, workdir_abs.clone() + "/extra");
+    }
+
+    /// `--no-workdir-mount` on edit should fail if there is no auto-mounted workdir.
+    #[test]
+    fn workspace_edit_no_workdir_mount_fails_when_no_auto_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let src_dir = temp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let src_abs = src_dir.display().to_string();
+
+        let mut config = config::AppConfig::default();
+        // Create workspace that was originally made with --no-workdir-mount
+        config
+            .create_workspace(
+                "monorepo",
+                WorkspaceConfig {
+                    workdir: "/workspace".to_string(),
+                    mounts: vec![workspace::MountConfig {
+                        src: src_abs,
+                        dst: "/workspace".to_string(),
+                        readonly: false,
+                    }],
+                    allowed_agents: vec![],
+                    default_agent: None,
+                    last_agent: None,
+                },
+            )
+            .unwrap();
+
+        let err = config
+            .edit_workspace(
+                "monorepo",
+                WorkspaceEdit {
+                    no_workdir_mount: true,
+                    ..WorkspaceEdit::default()
+                },
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("no auto-mounted workdir found"),
+            "expected clear error, got: {err}"
+        );
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -27,6 +27,7 @@ pub struct WorkspaceEdit {
     pub workdir: Option<String>,
     pub upsert_mounts: Vec<MountConfig>,
     pub remove_destinations: Vec<String>,
+    pub no_workdir_mount: bool,
     pub allowed_agents_to_add: Vec<String>,
     pub allowed_agents_to_remove: Vec<String>,
     pub default_agent: Option<Option<String>>,


### PR DESCRIPTION
## Summary

- **`--no-workdir-mount` on `workspace edit`**: Users who forgot the flag during workspace creation can now remove the auto-mounted workdir with `jackin workspace edit <name> --no-workdir-mount`. Errors clearly if no auto-mount exists.
- **Rename `workspace add` -> `workspace create`**: Aligns with common CLI conventions (gh, kubectl). Updated all source code, tests, and documentation.
- **7 new tests**: CLI parsing for `--no-workdir-mount` on both create and edit, functional tests for auto-mount default behavior, skip-when-already-mounted, edit removal, and error case.

## Test plan

- [x] `cargo fmt -- --check` — no issues
- [x] `cargo clippy` — no warnings
- [x] `cargo nextest run` — 230/230 passed (was 223)
- [ ] Manually verify `jackin workspace create` and `jackin workspace edit --no-workdir-mount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)