### PR TITLE
fix: use positional arg for shellfirm init

### DIFF
--- a/docker/construct/zshrc
+++ b/docker/construct/zshrc
@@ -3,4 +3,4 @@ eval "$(starship init zsh)"
 
 # Security tools (disable with JACKIN_DISABLE_TIRITH=1 / JACKIN_DISABLE_SHELLFIRM=1)
 [[ "${JACKIN_DISABLE_TIRITH:-0}" != "1" ]] && eval "$(tirith init --shell zsh)"
-[[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]] && eval "$(shellfirm init --shell zsh)"
+[[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]] && eval "$(shellfirm init zsh)"


### PR DESCRIPTION
## Summary

- Fix `shellfirm init` invocation in `docker/construct/zshrc` — use positional argument (`shellfirm init zsh`) instead of the unsupported `--shell` flag (`shellfirm init --shell zsh`)
- This caused an error on every container shell login: `error: unexpected argument '--shell' found`

## Test plan

- [ ] Rebuild construct image locally: `just construct-build-local`
- [ ] Enter the container: `docker exec -ti jackin-the-architect zsh`
- [ ] Confirm no `shellfirm` error on shell startup
- [ ] Verify `shellfirm` is active by running a risky command (e.g., `rm -rf /`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)