### PR TITLE
Add TODO: expose DinD hostname as JACKIN_DIND_HOSTNAME

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 
 - [Construct Image: User Creation Responsibility](todo/construct-user-creation.md) — UID/GID remapping hack in derived images
 - [DinD Running Without TLS Authentication](todo/dind-tls.md) — unauthenticated Docker daemon on agent network
+- [Expose DinD Hostname as `JACKIN_DIND_HOSTNAME`](todo/dind-hostname-env-var.md) — agents need DinD hostname for service connectivity without parsing `DOCKER_HOST`
 - [Orphaned DinD Container on Agent Launch Failure](todo/orphaned-dind-cleanup.md) — sidecar left running when agent fails to start
 - [1Password Integration for Agent Secrets](todo/onepassword-integration.md) — first-class secret injection at launch time
 - [Agent Source Trust Model](todo/agent-source-trust.md) — trust-on-first-use for third-party agent repos

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -53,6 +53,11 @@ jackin's architecture is runtime-agnostic. The construct and workspace system wo
 
 - **Construct user creation optimization** — move user creation to the derived layer to eliminate UID/GID remapping
 - **1Password integration** — inject secrets from 1Password vaults without exposing them as files in the container
+- **DinD hostname env var (`JACKIN_DIND_HOSTNAME`)** — expose the DinD sidecar's hostname so agents can connect to docker-compose services without parsing `DOCKER_HOST`
+
+:::tip
+Detailed design documents for individual TODO items live in the [`todo/`](https://github.com/jackin-project/jackin/tree/main/todo) directory. Each file is a self-contained proposal with problem statement, options, and related files.
+:::
 
 ## Vision
 

--- a/todo/AGENTS.md
+++ b/todo/AGENTS.md
@@ -1,0 +1,14 @@
+# TODO Items
+
+This directory contains self-contained design documents for planned work. Each file describes a problem, options, and related files.
+
+## Index
+
+The root [TODO.md](../TODO.md) is the authoritative index of all open items. Keep it in sync when adding, resolving, or removing items here.
+
+## Conventions
+
+- One file per item, named with a short hyphenated slug (e.g., `dind-tls.md`)
+- Each file must include: **Status**, **Problem**, **Why It Matters**, and **Related Files** sections
+- When an item is implemented, update its status to "Resolved" and move it from the "Open Items" section in `TODO.md` to a "Resolved" section (or remove it)
+- All changes to TODO items must be reflected in the [Roadmap](../docs/pages/reference/roadmap.mdx) documentation page — keep the roadmap and TODO items aligned

--- a/todo/CLAUDE.md
+++ b/todo/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/todo/dind-hostname-env-var.md
+++ b/todo/dind-hostname-env-var.md
@@ -1,0 +1,55 @@
+# Expose DinD Hostname as `JACKIN_DIND_HOSTNAME`
+
+**Status**: Proposed
+
+## Problem
+
+Agents that run docker-compose services inside DinD need to connect to those services from the agent container. The only way to discover the DinD sidecar's hostname today is to parse `DOCKER_HOST`:
+
+```bash
+POSTGRESQL_DB_HOST="$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')"
+```
+
+This works but conflates two concerns: `DOCKER_HOST` is semantically about Docker API access, not network routing to services running inside DinD.
+
+## Why It Matters
+
+- **Common pattern**: Any agent using docker-compose with port-mapped services (PostgreSQL, Redis, RabbitMQ) needs the DinD hostname to connect from the agent container
+- **Fragility**: Parsing `DOCKER_HOST` breaks if jackin changes transport (e.g., TLS with different port, socket mounting)
+- **Discoverability**: Agent authors must know `DOCKER_HOST` exists and understand its format. A `JACKIN_*` env var is self-documenting alongside `JACKIN_CLAUDE_ENV`
+
+## Proposal
+
+Export `JACKIN_DIND_HOSTNAME` with the DinD container's hostname on the shared network. In `runtime.rs`:
+
+```rust
+let dind = format!("{container_name}-dind");
+let docker_host = format!("DOCKER_HOST=tcp://{dind}:2375");
+let dind_hostname = format!("JACKIN_DIND_HOSTNAME={dind}");  // new
+```
+
+Then pass it to the agent container's environment alongside `DOCKER_HOST`.
+
+## Agent Usage
+
+Pre-launch hooks become trivial:
+
+```bash
+# Before (parsing DOCKER_HOST)
+export POSTGRESQL_DB_HOST="$(echo "$DOCKER_HOST" | sed 's|tcp://||;s|:.*||')"
+
+# After (direct use)
+export POSTGRESQL_DB_HOST="$JACKIN_DIND_HOSTNAME"
+```
+
+## What NOT to add
+
+- `JACKIN_DIND_PORT` — always 2375, already in `DOCKER_HOST`, no standalone use case
+- `JACKIN_NETWORK_NAME` — internal Docker plumbing, agents shouldn't need it
+- Domain-specific vars like `POSTGRESQL_DB_HOST` — that's the agent's responsibility
+
+## Related Files
+
+- `src/runtime.rs` — where `DOCKER_HOST` is constructed and passed to the container
+- `docker/runtime/entrypoint.sh` — runtime setup (no changes needed)
+- `src/manifest.rs` — `JACKIN_CLAUDE_ENV` reserved var precedent


### PR DESCRIPTION
## Summary

- Adds a new TODO item proposing `JACKIN_DIND_HOSTNAME` env var for agent containers
- Agents running docker-compose services inside DinD need the sidecar's network hostname to connect to port-mapped services (PostgreSQL, Redis, etc.)
- Today agents must parse `DOCKER_HOST` (`tcp://name:2375`) which conflates Docker API access with network routing
- The proposed env var follows the `JACKIN_*` naming convention and is a one-line change in `runtime.rs`

## Motivation

When an agent runs `docker compose up` inside DinD, services like PostgreSQL expose ports on the DinD container. The agent container needs the DinD hostname to connect to those services. Currently, agent authors must parse `DOCKER_HOST` to extract it — a workaround that breaks if the transport changes (TLS, socket mounting) and isn't discoverable.

A dedicated `JACKIN_DIND_HOSTNAME` env var makes this a direct lookup instead of string parsing, and follows the existing `JACKIN_*` convention.

## Test plan

- [ ] Review the TODO design document in `todo/dind-hostname-env-var.md`
- [ ] No code changes — this is a proposal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)