### PR TITLE
fix: replace dockerfile-parser with dockerfile-parser-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,23 +455,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.4"
+name = "dockerfile-parser-rs"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
-
-[[package]]
-name = "dockerfile-parser"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa53f9cb1532d7d7c19e269848ede84d7c80d59264c658469f0051a1d88c2780"
+checksum = "6eebbb3337addb19f9c9049615b1883f6fd292a6b727ac7180280e5c367975b6"
 dependencies = [
- "enquote",
- "lazy_static",
- "pest",
- "pest_derive",
+ "clap",
  "regex",
- "snafu",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -494,15 +486,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "enquote"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c36cb11dbde389f4096111698d8b567c0720e3452fd5ac3e6b4e47e1939932"
-dependencies = [
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "equivalent"
@@ -773,7 +756,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "directories",
- "dockerfile-parser",
+ "dockerfile-parser-rs",
  "owo-colors",
  "predicates",
  "ratatui",
@@ -1573,27 +1556,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snafu"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 toml = "1.1"
 directories = "6.0"
 thiserror = "2.0"
-dockerfile-parser = "0.9.0"
+dockerfile-parser-rs = "3.3.0"
 tempfile = "3.20"
 owo-colors = { version = "4", features = ["supports-colors"] }
 ratatui = "0.30"

--- a/docs/pages/getting-started/why.mdx
+++ b/docs/pages/getting-started/why.mdx
@@ -152,7 +152,7 @@ jackin' is built in Rust for three reasons:
 
 1. **Performance and safety.** An orchestrator that launches and manages Docker containers, parses Dockerfiles, renders TUI interfaces, and handles concurrent agent state needs to be fast and correct. Rust's ownership model and `unsafe_code = "forbid"` policy mean jackin' has zero unsafe code and catches entire classes of bugs at compile time.
 
-2. **Growing ecosystem.** Rust's adoption in infrastructure tooling, container runtimes, and CLI tools has accelerated significantly. The libraries jackin' depends on — `clap`, `ratatui`, `serde`, `dockerfile-parser` — are mature and actively maintained.
+2. **Growing ecosystem.** Rust's adoption in infrastructure tooling, container runtimes, and CLI tools has accelerated significantly. The libraries jackin' depends on — `clap`, `ratatui`, `serde`, `dockerfile-parser-rs` — are mature and actively maintained.
 
 3. **AI-friendly.** From practical experience, AI coding agents produce more reliable Rust code than most other systems languages. The strong type system and compiler feedback loop gives agents clear signals about what's wrong and how to fix it — leading to better AI-assisted contributions to the project itself.
 

--- a/docs/pages/reference/architecture.mdx
+++ b/docs/pages/reference/architecture.mdx
@@ -198,7 +198,7 @@ jackin' itself is built in Rust:
 | Terminal UI | `ratatui` + `crossterm` |
 | Table output | `tabled` |
 | Configuration | `serde` + `toml` |
-| Dockerfile parsing | `dockerfile-parser` |
+| Dockerfile parsing | `dockerfile-parser-rs` |
 | Error handling | `anyhow` + `thiserror` |
 | Colored output | `owo-colors` |
 

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -1,5 +1,7 @@
-use dockerfile_parser::{Dockerfile, Instruction};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use dockerfile_parser_rs::{Dockerfile, Instruction};
 
 pub const CONSTRUCT_IMAGE: &str = "projectjackin/construct:trixie";
 
@@ -13,28 +15,41 @@ pub struct ValidatedDockerfile {
 
 pub fn validate_agent_dockerfile(dockerfile_path: &Path) -> anyhow::Result<ValidatedDockerfile> {
     let dockerfile_contents = std::fs::read_to_string(dockerfile_path)?;
-    let dockerfile = Dockerfile::parse(&dockerfile_contents).map_err(|error| {
+    let dockerfile = Dockerfile::from_str(&dockerfile_contents).map_err(|error| {
         anyhow::anyhow!("invalid agent repo: unable to parse Dockerfile: {error}")
     })?;
 
-    let final_stage = dockerfile.iter_stages().last().ok_or_else(|| {
-        anyhow::anyhow!("invalid agent repo: Dockerfile must contain at least one FROM instruction")
-    })?;
+    let Some((platform, image, alias)) =
+        dockerfile
+            .instructions
+            .iter()
+            .rev()
+            .find_map(|instruction| {
+                let Instruction::From {
+                    platform,
+                    image,
+                    alias,
+                } = instruction
+                else {
+                    return None;
+                };
 
-    let Some(Instruction::From(from)) = final_stage.instructions.first() else {
+                Some((platform, image, alias))
+            })
+    else {
         anyhow::bail!("invalid agent repo: Dockerfile must contain at least one FROM instruction")
     };
 
     anyhow::ensure!(
-        from.flags.is_empty() && from.image.as_ref() == CONSTRUCT_IMAGE,
+        platform.is_none() && image == CONSTRUCT_IMAGE,
         "invalid agent repo: final Dockerfile stage must use literal FROM {CONSTRUCT_IMAGE}"
     );
 
     Ok(ValidatedDockerfile {
         dockerfile_path: dockerfile_path.to_path_buf(),
         dockerfile_contents,
-        final_stage_image: from.image.to_string(),
-        final_stage_alias: from.alias.as_ref().map(ToString::to_string),
+        final_stage_image: image.clone(),
+        final_stage_alias: alias.clone(),
     })
 }
 


### PR DESCRIPTION
## Summary
- replace the `dockerfile-parser` dependency with `dockerfile-parser-rs`
- update Dockerfile contract validation to use the new crate API `Instruction::From { platform, image, alias }` while preserving the existing literal final-stage check
- update docs that name the Dockerfile parsing crate

## Verification
- `cargo fmt -- --check && cargo clippy && cargo nextest run`
- `bun install --frozen-lockfile`
- `bun run build`
