### PR TITLE
feat: support custom plugin marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Learn more: [Why jackin'?](https://jackin.tailrocks.com/getting-started/why/) ·
 | Repository | Description |
 |---|---|
 | [jackin](https://github.com/jackin-project/jackin) | CLI source code (this repo) |
-| [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) | Default general-purpose agent |
-| [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) | Rust development agent (used for jackin' development) |
+| [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose agent |
+| [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) | Rust development agent (used for jackin' development) |
 | [construct image source](https://github.com/jackin-project/jackin/tree/main/docker/construct) | Shared base Docker image for all agents |
 
 ## Documentation
@@ -68,7 +68,7 @@ The full documentation lives at **<https://jackin.tailrocks.com/>** and covers:
 
 ## Development
 
-To develop jackin' itself, use [The Architect](https://github.com/donbeave/jackin-the-architect) — a dedicated agent with the full Rust toolchain:
+To develop jackin' itself, use [The Architect](https://github.com/jackin-project/jackin-the-architect) — a dedicated agent with the full Rust toolchain:
 
 ```sh
 jackin load the-architect

--- a/TODO.md
+++ b/TODO.md
@@ -16,4 +16,7 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
 - [Interactive Env Vars and Resolution](todo/env-var-interpolation.md) — interactive prompts, workspace overrides, and secret resolution for env vars
-- [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install GitHub-hosted plugins from `jackin.agent.toml`
+
+## Resolved
+
+- [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -40,5 +40,5 @@ The supported local validation flow, architecture-specific debugging commands, a
 ## Related
 
 - [Creating Agents](https://jackin.tailrocks.com/developing/creating-agents/) — how to build agent repos on top of the construct
-- [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) — default agent (example of extending the construct)
-- [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) — Rust development agent (another example)
+- [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) — default agent (example of extending the construct)
+- [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) — Rust development agent (another example)

--- a/docker/construct/install-plugins.sh
+++ b/docker/construct/install-plugins.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-plugins_file="/home/claude/.jackin/plugins.json"
+plugins_file="${JACKIN_PLUGINS_FILE:-/home/claude/.jackin/plugins.json}"
 
 run_maybe_quiet() {
     if [ "${JACKIN_DEBUG:-0}" = "1" ]; then
         "$@"
     else
-        "$@" > /dev/null 2>&1
+        "$@" > /dev/null
     fi
 }
 
@@ -15,7 +15,22 @@ if [ ! -f "$plugins_file" ]; then
     exit 0
 fi
 
-run_maybe_quiet claude plugin marketplace add anthropics/claude-plugins-official || true
+claude plugin marketplace add anthropics/claude-plugins-official > /dev/null 2>&1 || true
+
+jq -c '.marketplaces[]?' "$plugins_file" | while IFS= read -r marketplace; do
+    [ -n "$marketplace" ] || continue
+    source=$(printf '%s' "$marketplace" | jq -r '.source')
+    args=(claude plugin marketplace add "$source")
+    sparse_paths=()
+    while IFS= read -r sparse; do
+        [ -n "$sparse" ] || continue
+        sparse_paths+=("$sparse")
+    done < <(printf '%s' "$marketplace" | jq -r '.sparse[]?')
+    if [ "${#sparse_paths[@]}" -gt 0 ]; then
+        args+=(--sparse "${sparse_paths[@]}")
+    fi
+    run_maybe_quiet "${args[@]}"
+done
 
 jq -r '.plugins[]?' "$plugins_file" | while IFS= read -r plugin; do
     [ -n "$plugin" ] || continue

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -21,8 +21,8 @@ name = "The Architect"
 [claude]
 plugins = [
   "code-review@claude-plugins-official",
-  "superpowers@superpowers-marketplace",
   "feature-dev@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
 
@@ -76,8 +76,8 @@ dockerfile = "Dockerfile"
 [claude]
 plugins = [
   "code-review@claude-plugins-official",
-  "superpowers@superpowers-marketplace",
   "feature-dev@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
 
@@ -106,8 +106,8 @@ Example:
 [claude]
 plugins = [
   "code-review@claude-plugins-official",
-  "superpowers@superpowers-marketplace",
   "feature-dev@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
 
@@ -270,8 +270,8 @@ name = "The Architect"
 [claude]
 plugins = [
   "code-review@claude-plugins-official",
-  "superpowers@superpowers-marketplace",
   "feature-dev@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
 

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -19,11 +19,19 @@ dockerfile = "Dockerfile"
 name = "The Architect"
 
 [claude]
-plugins = ["superpowers@superpowers-marketplace"]
+plugins = [
+  "code-review@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
+  "feature-dev@claude-plugins-official",
+  "jackin-dev@jackin-marketplace",
+]
 
 [[claude.marketplaces]]
 source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "jackin-project/jackin-marketplace"
 
 [hooks]
 pre_launch = "hooks/pre-launch.sh"
@@ -67,8 +75,10 @@ dockerfile = "Dockerfile"
 
 [claude]
 plugins = [
+  "code-review@claude-plugins-official",
   "superpowers@superpowers-marketplace",
-  "jackin-dev@jackin-marketplace"
+  "feature-dev@claude-plugins-official",
+  "jackin-dev@jackin-marketplace",
 ]
 
 [[claude.marketplaces]]
@@ -94,11 +104,19 @@ Example:
 
 ```toml [jackin.agent.toml]
 [claude]
-plugins = ["superpowers@superpowers-marketplace"]
+plugins = [
+  "code-review@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
+  "feature-dev@claude-plugins-official",
+  "jackin-dev@jackin-marketplace",
+]
 
 [[claude.marketplaces]]
 source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "jackin-project/jackin-marketplace"
 ```
 
 ## `[identity]`
@@ -251,7 +269,9 @@ name = "The Architect"
 
 [claude]
 plugins = [
+  "code-review@claude-plugins-official",
   "superpowers@superpowers-marketplace",
+  "feature-dev@claude-plugins-official",
   "jackin-dev@jackin-marketplace",
 ]
 

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -76,7 +76,7 @@ source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 ```
 
 Each `[[claude.marketplaces]]` block maps to `claude plugin marketplace add <source>`. If `sparse` is set, jackin passes those paths as `claude plugin marketplace add <source> --sparse path1 path2`.
@@ -260,7 +260,7 @@ source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 
 [hooks]
 pre_launch = "hooks/pre-launch.sh"

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -19,7 +19,11 @@ dockerfile = "Dockerfile"
 name = "The Architect"
 
 [claude]
-plugins = ["code-review@claude-plugins-official"]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
 
 [hooks]
 pre_launch = "hooks/pre-launch.sh"
@@ -54,6 +58,7 @@ The Dockerfile path must:
 | Field | Required | Description |
 |---|---|---|
 | `plugins` | No | List of Claude plugin identifiers to install at runtime |
+| `marketplaces` | No | List of marketplace registrations to add before plugin installation |
 
 Example values:
 
@@ -62,9 +67,38 @@ dockerfile = "Dockerfile"
 
 [claude]
 plugins = [
-  "code-review@claude-plugins-official",
-  "feature-dev@claude-plugins-official"
+  "superpowers@superpowers-marketplace",
+  "jackin-dev@jackin-marketplace"
 ]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
+```
+
+Each `[[claude.marketplaces]]` block maps to `claude plugin marketplace add <source>`. If `sparse` is set, jackin passes those paths as `claude plugin marketplace add <source> --sparse path1 path2`.
+
+### `[[claude.marketplaces]]`
+
+Each marketplace block declares one Claude marketplace source to register before plugin installation.
+
+| Field | Required | Description |
+|---|---|---|
+| `source` | Yes | Raw marketplace source passed to `claude plugin marketplace add` |
+| `sparse` | No | Optional sparse-checkout paths for monorepo-backed marketplaces |
+
+Example:
+
+```toml [jackin.agent.toml]
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
 ```
 
 ## `[identity]`
@@ -216,7 +250,17 @@ dockerfile = "docker/Dockerfile.agent"
 name = "The Architect"
 
 [claude]
-plugins = ["code-review@claude-plugins-official"]
+plugins = [
+  "superpowers@superpowers-marketplace",
+  "jackin-dev@jackin-marketplace",
+]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
 
 [hooks]
 pre_launch = "hooks/pre-launch.sh"

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -138,8 +138,8 @@ dockerfile = "Dockerfile"
 [claude]
 plugins = [
   "code-review@claude-plugins-official",
-  "superpowers@superpowers-marketplace",
   "feature-dev@claude-plugins-official",
+  "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
 

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -146,7 +146,7 @@ source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 
 [identity]
 name = "My Agent"
@@ -174,7 +174,7 @@ jackin load your-agent-name --rebuild --debug
 
 | Agent | Purpose | Repository |
 |---|---|---|
-| **Agent Smith** | Default general-purpose agent | [donbeave/jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) |
-| **The Architect** | Rust development (used for jackin' itself) | [donbeave/jackin-the-architect](https://github.com/donbeave/jackin-the-architect) |
+| **Agent Smith** | Default general-purpose agent | [jackin-project/jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) |
+| **The Architect** | Rust development (used for jackin' itself) | [jackin-project/jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) |
 
 These repos are good starting points when creating your own agent. Agent Smith is intentionally minimal, while The Architect shows a more involved setup with Rust tooling and build dependencies.

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -130,6 +130,30 @@ name = "My Agent"
 
 These plugin IDs are written into the agent's runtime state and installed automatically when the container starts.
 
+If you need plugins from a custom marketplace, declare the marketplace separately and keep plugin IDs fully qualified:
+
+```toml [jackin.agent.toml]
+dockerfile = "Dockerfile"
+
+[claude]
+plugins = [
+  "superpowers@superpowers-marketplace",
+  "jackin-dev@jackin-marketplace",
+]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
+
+[identity]
+name = "My Agent"
+```
+
+jackin adds each declared marketplace at container startup, then installs each plugin ID exactly as written.
+
 ## Testing your agent
 
 The fastest way to test is to load it:

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -137,7 +137,9 @@ dockerfile = "Dockerfile"
 
 [claude]
 plugins = [
+  "code-review@claude-plugins-official",
   "superpowers@superpowers-marketplace",
+  "feature-dev@claude-plugins-official",
   "jackin-dev@jackin-marketplace",
 ]
 

--- a/docs/pages/getting-started/concepts.mdx
+++ b/docs/pages/getting-started/concepts.mdx
@@ -153,7 +153,7 @@ Here's what happens when you run `jackin load agent-smith ~/Projects/my-app`:
 
 ```
 1. Resolve agent class "agent-smith"
-   └─ Clone/update github.com/donbeave/jackin-agent-smith
+   └─ Clone/update github.com/jackin-project/jackin-agent-smith
 
 2. Validate agent repo contract
    └─ Check jackin.agent.toml and Dockerfile

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -73,6 +73,6 @@ jackin launch
 | Repository | Description |
 |---|---|
 | [jackin](https://github.com/jackin-project/jackin) | CLI source code |
-| [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) | Default general-purpose agent |
-| [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) | Rust development agent (used for jackin' development) |
+| [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose agent |
+| [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) | Rust development agent (used for jackin' development) |
 | [homebrew-tap](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for installing jackin' |

--- a/docs/pages/reference/architecture.mdx
+++ b/docs/pages/reference/architecture.mdx
@@ -133,7 +133,7 @@ The DinD sidecar currently runs without TLS. Any container on that per-agent net
 ~/.jackin/
 ├── agents/                        # Cached agent repos
 │   └── github.com/
-│       └── donbeave/
+│       └── jackin-project/
 │           └── jackin-agent-smith/
 ├── data/                          # Persisted state per instance
 │   └── jackin-agent-smith/

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -24,6 +24,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Homebrew installation
 - Namespaced agent classes (e.g., `chainargos/frontend-engineer`)
 - Last-agent memory per workspace
+- Custom Claude plugin marketplaces in `jackin.agent.toml`
 
 ## Planned
 

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -66,11 +66,11 @@ jackin' is designed as a **local-first development tool** with a focus on excell
 
 The longer-term vision extends to deployment ecosystems. Kubernetes support will enable jackin' as a debug container platform — loading an AI agent into a production pod to safely investigate issues, with the same workspace and mount controls that make local use safe.
 
-The project welcomes suggestions and contributions. If jackin' works for your use case — or almost works but needs something different — [open an issue](https://github.com/donbeave/jackin/issues) or submit a pull request.
+The project welcomes suggestions and contributions. If jackin' works for your use case — or almost works but needs something different — [open an issue](https://github.com/jackin-project/jackin/issues) or submit a pull request.
 
 ## Contributing
 
-jackin' is open source under the Apache 2.0 license. To develop and test jackin' itself, use [The Architect](https://github.com/donbeave/jackin-the-architect) — a dedicated agent with the full Rust toolchain:
+jackin' is open source under the Apache 2.0 license. To develop and test jackin' itself, use [The Architect](https://github.com/jackin-project/jackin-the-architect) — a dedicated agent with the full Rust toolchain:
 
 ```bash
 jackin load the-architect

--- a/docs/superpowers/plans/2026-04-04-jackin-dev-plugin.md
+++ b/docs/superpowers/plans/2026-04-04-jackin-dev-plugin.md
@@ -2,13 +2,13 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Create a Claude Code plugin (`donbeave/jackin-dev`) with three release skills: `/release-check`, `/release-notes`, and `/release`.
+**Goal:** Create a Claude Code plugin (`jackin-project/jackin-dev`) with three release skills: `/release-check`, `/release-notes`, and `/release`.
 
 **Architecture:** A standalone plugin repo with `skills/` directory containing three SKILL.md files. Cross-agent support via `AGENTS.md` (for Codex and Amp) and `.claude-plugin/plugin.json` (for Claude Code native discovery). No scripts or dependencies — skills are pure markdown runbooks that agents follow.
 
 **Tech Stack:** Claude Code plugin format, YAML frontmatter, markdown, `gh` CLI commands, `cargo-release`
 
-**Spec:** `docs/superpowers/specs/2026-04-04-jackin-dev-plugin-design.md` in the `donbeave/jackin` repo.
+**Spec:** `docs/superpowers/specs/2026-04-04-jackin-dev-plugin-design.md` in the `jackin-project/jackin` repo.
 
 ---
 
@@ -48,7 +48,7 @@ jackin-dev/
 - Create: `.codex/INSTALL.md`
 - Create: `hooks/hooks.json`
 
-**Prerequisite:** The user has created the `donbeave/jackin-dev` GitHub repository and cloned it locally.
+**Prerequisite:** The user has created the `jackin-project/jackin-dev` GitHub repository and cloned it locally.
 
 - [ ] **Step 1: Create the plugin manifest**
 
@@ -62,8 +62,8 @@ Create `.claude-plugin/plugin.json`:
   "author": {
     "name": "Alexey Zhokhov"
   },
-  "homepage": "https://github.com/donbeave/jackin-dev",
-  "repository": "https://github.com/donbeave/jackin-dev",
+  "homepage": "https://github.com/jackin-project/jackin-dev",
+  "repository": "https://github.com/jackin-project/jackin-dev",
   "license": "Apache-2.0",
   "keywords": ["release", "changelog", "validation", "cargo-release", "rust"]
 }
@@ -84,7 +84,7 @@ Create `README.md`:
 ```markdown
 # jackin-dev
 
-Development workflow plugin for the [jackin](https://github.com/donbeave/jackin) project. Provides skills for release management, validation, and changelog generation.
+Development workflow plugin for the [jackin](https://github.com/jackin-project/jackin) project. Provides skills for release management, validation, and changelog generation.
 
 ## Skills
 
@@ -120,7 +120,7 @@ Amp reads `AGENTS.md` and discovers skills from `.claude/skills/` compatibility 
 
 ## Requirements
 
-These skills are designed for the `donbeave/jackin` repository and expect:
+These skills are designed for the `jackin-project/jackin` repository and expect:
 
 - `cargo-release` installed (`cargo install cargo-release`)
 - `gh` CLI authenticated (`gh auth login`)
@@ -159,7 +159,7 @@ Create `AGENTS.md`:
 ```markdown
 # AGENTS.md
 
-This is a Claude Code plugin providing development workflow skills for the [jackin](https://github.com/donbeave/jackin) project.
+This is a Claude Code plugin providing development workflow skills for the [jackin](https://github.com/jackin-project/jackin) project.
 
 ## Available Skills
 
@@ -206,7 +206,7 @@ Codex does not have a native plugin system. To use these skills:
 
 1. Clone this repo alongside your project:
    ```sh
-   git clone https://github.com/donbeave/jackin-dev.git
+   git clone https://github.com/jackin-project/jackin-dev.git
    ```
 
 2. Reference the skills in your project's `AGENTS.md`:
@@ -527,13 +527,13 @@ Format as Keep a Changelog with PR links:
 ## [Unreleased]
 
 ### Added
-- Add TUI launcher for interactive agent selection ([#12](https://github.com/donbeave/jackin/pull/12))
+- Add TUI launcher for interactive agent selection ([#12](https://github.com/jackin-project/jackin/pull/12))
 
 ### Fixed
-- Fix symlink escape in container mounts ([#15](https://github.com/donbeave/jackin/pull/15))
+- Fix symlink escape in container mounts ([#15](https://github.com/jackin-project/jackin/pull/15))
 
 ### Changed
-- Extract testing instructions into TESTING.md ([#18](https://github.com/donbeave/jackin/pull/18))
+- Extract testing instructions into TESTING.md ([#18](https://github.com/jackin-project/jackin/pull/18))
 ```
 
 Only include sections that have entries. Do not include empty sections.
@@ -746,7 +746,7 @@ Remind the user:
 > - Create the GitHub Release with artifacts
 > - Update the Homebrew tap
 >
-> Monitor at: https://github.com/donbeave/jackin/actions/workflows/release.yml"
+> Monitor at: https://github.com/jackin-project/jackin/actions/workflows/release.yml"
 
 ## Error Recovery
 
@@ -768,12 +768,12 @@ git commit -m "feat: add release orchestrator skill"
 
 ### Task 5: Apply Prerequisites to the jackin Repository
 
-This task applies changes to the `donbeave/jackin` repo (not the plugin repo).
+This task applies changes to the `jackin-project/jackin` repo (not the plugin repo).
 
 **Files:**
-- Create: `donbeave/jackin/.github/workflows/ci.yml`
-- Modify: `donbeave/jackin/release.toml`
-- Create: `donbeave/jackin/CHANGELOG.md`
+- Create: `jackin-project/jackin/.github/workflows/ci.yml`
+- Modify: `jackin-project/jackin/release.toml`
+- Create: `jackin-project/jackin/CHANGELOG.md`
 
 - [ ] **Step 1: Create the CI workflow**
 

--- a/docs/superpowers/plans/2026-04-10-custom-plugin-marketplaces.md
+++ b/docs/superpowers/plans/2026-04-10-custom-plugin-marketplaces.md
@@ -98,7 +98,7 @@ plugins = []
 plugins = []
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 "#,
         )
         .unwrap();
@@ -313,7 +313,7 @@ fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
       "sparse": ["plugins", ".claude-plugin"]
     },
     {
-      "source": "donbeave/jackin-marketplace",
+      "source": "jackin-project/jackin-marketplace",
       "sparse": []
     }
   ],
@@ -395,7 +395,7 @@ else:
         fs::read_to_string(log_file).unwrap(),
         "plugin marketplace add anthropics/claude-plugins-official\n\
 plugin marketplace add obra/superpowers-marketplace --sparse plugins --sparse .claude-plugin\n\
-plugin marketplace add donbeave/jackin-marketplace\n\
+plugin marketplace add jackin-project/jackin-marketplace\n\
 plugin install superpowers@superpowers-marketplace\n\
 plugin install jackin-dev@jackin-marketplace\n"
     );
@@ -521,7 +521,7 @@ source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 
 [identity]
 name = "My Agent"
@@ -546,7 +546,7 @@ Resolved
 
 ## Problem
 
-`jackin.agent.toml` could declare Claude plugin IDs, but the runtime bootstrap only added the official Anthropic marketplace. Custom marketplaces such as `donbeave/jackin-marketplace` still required manual `/plugin marketplace add` steps inside the container.
+`jackin.agent.toml` could declare Claude plugin IDs, but the runtime bootstrap only added the official Anthropic marketplace. Custom marketplaces such as `jackin-project/jackin-marketplace` still required manual `/plugin marketplace add` steps inside the container.
 
 ## Why It Matters
 

--- a/docs/superpowers/plans/2026-04-10-custom-plugin-marketplaces.md
+++ b/docs/superpowers/plans/2026-04-10-custom-plugin-marketplaces.md
@@ -1,0 +1,675 @@
+# Custom Plugin Marketplaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `[[claude.marketplaces]]` support to `jackin.agent.toml` so jackin can add custom Claude plugin marketplaces, including optional `sparse` paths, before installing manifest-declared plugins.
+
+**Architecture:** Keep `jackin` as a thin wrapper over Claude Code’s existing CLI flow. Rust handles manifest parsing and runtime-state serialization, while the existing container bootstrap script consumes that state and runs `claude plugin marketplace add ...` followed by `claude plugin install ...` in order.
+
+**Tech Stack:** Rust, serde, serde_json, TOML, bash, jq-compatible JSON parsing, Vocs/MDX docs
+
+**Spec:** [docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md](file:///Users/donbeave/Projects/jackin-project/jackin/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md)
+
+---
+
+## File Structure
+
+```text
+src/manifest.rs                         # Manifest schema, marketplace config type, parsing tests
+src/instance.rs                         # Runtime bootstrap JSON serialization and tests
+docker/construct/install-plugins.sh     # Startup bootstrap for marketplace add + plugin install
+tests/install_plugins_bootstrap.rs      # Regression test for shell bootstrap command ordering and sparse flags
+docs/pages/developing/agent-manifest.mdx  # Manifest schema docs and examples
+docs/pages/developing/creating-agents.mdx # Agent authoring example with custom marketplace
+todo/custom-plugin-marketplace.md       # Mark TODO item resolved with required sections
+TODO.md                                 # Move item from Open Items to Resolved
+docs/pages/reference/roadmap.mdx        # Reflect completed marketplace support in roadmap
+```
+
+---
+
+### Task 1: Extend the Manifest Schema for Marketplace Blocks
+
+**Files:**
+- Modify: `src/manifest.rs`
+
+- [ ] **Step 1: Write the failing manifest parsing tests**
+
+Add these tests near the existing manifest tests in `src/manifest.rs`:
+
+```rust
+    #[test]
+    fn loads_manifest_with_marketplaces_and_plugins() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert_eq!(manifest.claude.plugins, vec!["superpowers@superpowers-marketplace"]);
+        assert_eq!(manifest.claude.marketplaces.len(), 1);
+        assert_eq!(
+            manifest.claude.marketplaces[0].source,
+            "obra/superpowers-marketplace"
+        );
+        assert_eq!(
+            manifest.claude.marketplaces[0].sparse,
+            vec!["plugins", ".claude-plugin"]
+        );
+    }
+
+    #[test]
+    fn loads_manifest_without_marketplaces_defaults_to_empty() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert!(manifest.claude.marketplaces.is_empty());
+    }
+
+    #[test]
+    fn loads_manifest_marketplace_without_sparse_defaults_to_empty() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert_eq!(manifest.claude.marketplaces.len(), 1);
+        assert!(manifest.claude.marketplaces[0].sparse.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run the targeted tests and verify they fail for the right reason**
+
+Run:
+
+```bash
+cargo test loads_manifest_with_marketplaces_and_plugins -- --exact
+cargo test loads_manifest_without_marketplaces_defaults_to_empty -- --exact
+cargo test loads_manifest_marketplace_without_sparse_defaults_to_empty -- --exact
+```
+
+Expected: at least the first test fails because `ClaudeConfig` does not yet accept `marketplaces`, producing a TOML unknown-field or missing-field assertion failure.
+
+- [ ] **Step 3: Implement the minimal manifest schema changes**
+
+Update `src/manifest.rs` so the marketplace block is part of the existing manifest model:
+
+```rust
+use serde::{Deserialize, Serialize};
+```
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ClaudeMarketplaceConfig {
+    pub source: String,
+    #[serde(default)]
+    pub sparse: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClaudeConfig {
+    #[serde(default)]
+    pub marketplaces: Vec<ClaudeMarketplaceConfig>,
+    #[serde(default)]
+    pub plugins: Vec<String>,
+}
+```
+
+Keep `marketplaces` and `plugins` both additive and default-empty so existing manifests remain valid.
+
+- [ ] **Step 4: Re-run the targeted tests and verify they pass**
+
+Run:
+
+```bash
+cargo test loads_manifest_with_marketplaces_and_plugins -- --exact
+cargo test loads_manifest_without_marketplaces_defaults_to_empty -- --exact
+cargo test loads_manifest_marketplace_without_sparse_defaults_to_empty -- --exact
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Commit the manifest schema change**
+
+```bash
+git add src/manifest.rs
+git commit -m "feat: add manifest support for Claude marketplaces"
+```
+
+---
+
+### Task 2: Persist Marketplace Data into Runtime Bootstrap State
+
+**Files:**
+- Modify: `src/instance.rs`
+
+- [ ] **Step 1: Write the failing runtime state test**
+
+Replace the existing JSON bootstrap assertion in `src/instance.rs` with a marketplace-aware test:
+
+```rust
+    #[test]
+    fn prepares_plugins_json_with_marketplaces_for_runtime_bootstrap() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+
+        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
+        let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&state.plugins_json).unwrap(),
+            r#"{
+  "marketplaces": [
+    {
+      "source": "obra/superpowers-marketplace",
+      "sparse": [
+        "plugins",
+        ".claude-plugin"
+      ]
+    }
+  ],
+  "plugins": [
+    "superpowers@superpowers-marketplace"
+  ]
+}"#
+        );
+    }
+```
+
+- [ ] **Step 2: Run the targeted test and verify it fails**
+
+Run:
+
+```bash
+cargo test prepares_plugins_json_with_marketplaces_for_runtime_bootstrap -- --exact
+```
+
+Expected: failure because the serialized JSON still contains only the `plugins` array.
+
+- [ ] **Step 3: Implement the minimal runtime-state serialization change**
+
+Update `src/instance.rs` so the mounted bootstrap file includes marketplace objects:
+
+```rust
+use crate::manifest::{AgentManifest, ClaudeMarketplaceConfig};
+```
+
+```rust
+#[derive(Debug, Serialize)]
+struct PluginState<'a> {
+    marketplaces: &'a [ClaudeMarketplaceConfig],
+    plugins: &'a [String],
+}
+```
+
+```rust
+        std::fs::write(
+            &plugins_json,
+            serde_json::to_string_pretty(&PluginState {
+                marketplaces: &manifest.claude.marketplaces,
+                plugins: &manifest.claude.plugins,
+            })?,
+        )?;
+```
+
+- [ ] **Step 4: Re-run the targeted test and verify it passes**
+
+Run:
+
+```bash
+cargo test prepares_plugins_json_with_marketplaces_for_runtime_bootstrap -- --exact
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the runtime-state change**
+
+```bash
+git add src/instance.rs
+git commit -m "feat: persist marketplace bootstrap state"
+```
+
+---
+
+### Task 3: Add Marketplace Bootstrap Commands and Cover Them with a Regression Test
+
+**Files:**
+- Create: `tests/install_plugins_bootstrap.rs`
+- Modify: `docker/construct/install-plugins.sh`
+
+- [ ] **Step 1: Write the failing integration test for the bootstrap script**
+
+Create `tests/install_plugins_bootstrap.rs`:
+
+```rust
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
+    let temp = tempdir().unwrap();
+    let plugins_file = temp.path().join("plugins.json");
+    fs::write(
+        &plugins_file,
+        r#"{
+  "marketplaces": [
+    {
+      "source": "obra/superpowers-marketplace",
+      "sparse": ["plugins", ".claude-plugin"]
+    },
+    {
+      "source": "donbeave/jackin-marketplace",
+      "sparse": []
+    }
+  ],
+  "plugins": [
+    "superpowers@superpowers-marketplace",
+    "jackin-dev@jackin-marketplace"
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let log_file = temp.path().join("claude.log");
+
+    let claude_path = bin_dir.join("claude");
+    fs::write(
+        &claude_path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            log_file.display()
+        ),
+    )
+    .unwrap();
+    let mut claude_perms = fs::metadata(&claude_path).unwrap().permissions();
+    claude_perms.set_mode(0o755);
+    fs::set_permissions(&claude_path, claude_perms).unwrap();
+
+    let jq_path = bin_dir.join("jq");
+    fs::write(
+        &jq_path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+if args and args[0] == "-r":
+    args = args[1:]
+flt = args[0]
+if len(args) > 1:
+    with open(args[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+else:
+    data = json.load(sys.stdin)
+
+if flt == ".marketplaces[]?":
+    for item in data.get("marketplaces", []):
+        print(json.dumps(item))
+elif flt == ".plugins[]?":
+    for item in data.get("plugins", []):
+        print(item)
+elif flt == ".source":
+    print(data["source"])
+elif flt == ".sparse[]?":
+    for item in data.get("sparse", []):
+        print(item)
+else:
+    raise SystemExit(f"unsupported filter: {flt}")
+"#,
+    )
+    .unwrap();
+    let mut jq_perms = fs::metadata(&jq_path).unwrap().permissions();
+    jq_perms.set_mode(0o755);
+    fs::set_permissions(&jq_path, jq_perms).unwrap();
+
+    let status = Command::new("bash")
+        .arg("docker/construct/install-plugins.sh")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("JACKIN_PLUGINS_FILE", &plugins_file)
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(log_file).unwrap(),
+        "plugin marketplace add anthropics/claude-plugins-official\n\
+plugin marketplace add obra/superpowers-marketplace --sparse plugins --sparse .claude-plugin\n\
+plugin marketplace add donbeave/jackin-marketplace\n\
+plugin install superpowers@superpowers-marketplace\n\
+plugin install jackin-dev@jackin-marketplace\n"
+    );
+}
+```
+
+- [ ] **Step 2: Run the integration test and verify it fails**
+
+Run:
+
+```bash
+cargo test install_plugins_script_adds_marketplaces_before_installing_plugins --test install_plugins_bootstrap -- --exact
+```
+
+Expected: FAIL because `install-plugins.sh` neither reads the test override path nor emits custom marketplace add commands.
+
+- [ ] **Step 3: Implement the bootstrap script changes with the smallest test seam**
+
+Update `docker/construct/install-plugins.sh` so it can be tested outside the container and so it adds marketplaces before installing plugins:
+
+```bash
+plugins_file="${JACKIN_PLUGINS_FILE:-/home/claude/.jackin/plugins.json}"
+```
+
+```bash
+jq -c '.marketplaces[]?' "$plugins_file" | while IFS= read -r marketplace; do
+    [ -n "$marketplace" ] || continue
+    source=$(printf '%s' "$marketplace" | jq -r '.source')
+    args=(claude plugin marketplace add "$source")
+    while IFS= read -r sparse; do
+        [ -n "$sparse" ] || continue
+        args+=(--sparse "$sparse")
+    done < <(printf '%s' "$marketplace" | jq -r '.sparse[]?')
+    run_maybe_quiet "${args[@]}"
+done
+
+jq -r '.plugins[]?' "$plugins_file" | while IFS= read -r plugin; do
+    [ -n "$plugin" ] || continue
+    run_maybe_quiet claude plugin install "$plugin"
+done
+```
+
+Keep the existing official marketplace bootstrap line:
+
+```bash
+run_maybe_quiet claude plugin marketplace add anthropics/claude-plugins-official || true
+```
+
+Do not add extra aliasing or plugin name rewriting logic.
+
+- [ ] **Step 4: Re-run the integration test and verify it passes**
+
+Run:
+
+```bash
+cargo test install_plugins_script_adds_marketplaces_before_installing_plugins --test install_plugins_bootstrap -- --exact
+```
+
+Expected: PASS, with the logged command order matching official marketplace add, custom marketplace adds, then plugin installs.
+
+- [ ] **Step 5: Commit the bootstrap change**
+
+```bash
+git add docker/construct/install-plugins.sh tests/install_plugins_bootstrap.rs
+git commit -m "feat: bootstrap custom Claude marketplaces"
+```
+
+---
+
+### Task 4: Update Docs and Resolve the TODO Item
+
+**Files:**
+- Modify: `docs/pages/developing/agent-manifest.mdx`
+- Modify: `docs/pages/developing/creating-agents.mdx`
+- Modify: `todo/custom-plugin-marketplace.md`
+- Modify: `TODO.md`
+- Modify: `docs/pages/reference/roadmap.mdx`
+
+- [ ] **Step 1: Update the manifest reference docs**
+
+In `docs/pages/developing/agent-manifest.mdx`, update the schema examples and the `[claude]` section to document marketplace blocks:
+
+```mdx
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+```
+
+Add a `[claude]` field table like this:
+
+```mdx
+| Field | Required | Description |
+|---|---|---|
+| `plugins` | No | List of Claude plugin identifiers to install at runtime |
+| `marketplaces` | No | List of marketplace registrations to add before plugin installation |
+```
+
+Add a short explanation for each marketplace block:
+
+```mdx
+Each `[[claude.marketplaces]]` block maps to `claude plugin marketplace add <source>`.
+Use `sparse` to pass one or more `--sparse` paths for monorepo-backed marketplaces.
+```
+
+- [ ] **Step 2: Update the agent creation guide with a custom marketplace example**
+
+In `docs/pages/developing/creating-agents.mdx`, replace the plugin example with one that shows both official-only and custom-marketplace usage:
+
+```toml [jackin.agent.toml]
+dockerfile = "Dockerfile"
+
+[claude]
+plugins = [
+  "superpowers@superpowers-marketplace",
+  "jackin-dev@jackin-marketplace",
+]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
+
+[identity]
+name = "My Agent"
+```
+
+Then add this sentence directly below the example:
+
+```text
+jackin adds each declared marketplace at container startup, then installs each plugin ID exactly as written.
+```
+
+- [ ] **Step 3: Mark the TODO item resolved and bring it into TODO-file convention**
+
+Rewrite `todo/custom-plugin-marketplace.md` to include the required sections:
+
+```md
+# Custom Plugin Marketplace Support in Agent Config
+
+## Status
+
+Resolved
+
+## Problem
+
+`jackin.agent.toml` could declare Claude plugin IDs, but the runtime bootstrap only added the official Anthropic marketplace. Custom marketplaces such as `donbeave/jackin-marketplace` still required manual `/plugin marketplace add` steps inside the container.
+
+## Why It Matters
+
+Agent repos need reproducible startup. Without manifest-declared marketplaces, project-specific plugins such as `jackin-dev` could not be installed automatically, which made agent setup less portable and less trustworthy.
+
+## Related Files
+
+- `src/manifest.rs`
+- `src/instance.rs`
+- `docker/construct/install-plugins.sh`
+- `docs/pages/developing/agent-manifest.mdx`
+- `docs/pages/developing/creating-agents.mdx`
+```
+
+- [ ] **Step 4: Move the item from open to resolved indexes**
+
+In `TODO.md`, remove the open-item bullet:
+
+```md
+- [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install GitHub-hosted plugins from `jackin.agent.toml`
+```
+
+and add a resolved section:
+
+```md
+## Resolved
+
+- [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`
+```
+
+In `docs/pages/reference/roadmap.mdx`, add a completed bullet:
+
+```mdx
+- Custom Claude plugin marketplaces in `jackin.agent.toml`
+```
+
+- [ ] **Step 5: Commit the docs and TODO updates**
+
+```bash
+git add docs/pages/developing/agent-manifest.mdx docs/pages/developing/creating-agents.mdx todo/custom-plugin-marketplace.md TODO.md docs/pages/reference/roadmap.mdx
+git commit -m "docs: document custom Claude marketplaces"
+```
+
+---
+
+### Task 5: Run Full Verification Before Declaring Success
+
+**Files:**
+- Modify: `src/manifest.rs` (formatting only if needed)
+- Modify: `src/instance.rs` (formatting only if needed)
+- Modify: `tests/install_plugins_bootstrap.rs` (formatting only if needed)
+
+- [ ] **Step 1: Run the formatter**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: command succeeds and rewrites Rust files only if formatting is needed.
+
+- [ ] **Step 2: Verify formatting stays clean**
+
+Run:
+
+```bash
+cargo fmt -- --check
+```
+
+Expected: PASS with no diff-producing formatting complaints.
+
+- [ ] **Step 3: Run clippy**
+
+Run:
+
+```bash
+cargo clippy
+```
+
+Expected: PASS with zero warnings promoted to failure.
+
+- [ ] **Step 4: Run the full Rust test suite**
+
+Run:
+
+```bash
+cargo nextest run
+```
+
+Expected: PASS for the existing suite plus the new marketplace coverage.
+
+- [ ] **Step 5: Build the docs site**
+
+Run:
+
+```bash
+bun run build
+```
+
+Run it from:
+
+```bash
+docs/
+```
+
+Expected: PASS, proving the updated MDX content still builds.
+
+- [ ] **Step 6: Commit formatting fixes if `cargo fmt` changed tracked files**
+
+If `git status --short` shows formatter-only changes, run:
+
+```bash
+git add src/manifest.rs src/instance.rs tests/install_plugins_bootstrap.rs
+git commit -m "style: format custom marketplace changes"
+```
+
+If `git status --short` is empty, do not create an extra commit.
+
+---
+
+## Self-Review
+
+- The plan covers the spec’s structured `[[claude.marketplaces]]` design, raw `[claude].plugins` strings, per-marketplace `sparse`, runtime-state serialization, startup bootstrap ordering, docs, and TODO/roadmap sync.
+- There are no `TODO`, `TBD`, or “implement later” placeholders in the tasks.
+- Type names and property names are consistent across tasks: `ClaudeMarketplaceConfig`, `marketplaces`, `source`, and `sparse` are used everywhere.

--- a/docs/superpowers/plans/2026-04-10-vocs-migration.md
+++ b/docs/superpowers/plans/2026-04-10-vocs-migration.md
@@ -416,8 +416,8 @@ jackin launch
 | Repository | Description |
 |---|---|
 | [jackin](https://github.com/jackin-project/jackin) | CLI source code |
-| [jackin-agent-smith](https://github.com/donbeave/jackin-agent-smith) | Default general-purpose agent |
-| [jackin-the-architect](https://github.com/donbeave/jackin-the-architect) | Rust development agent (used for jackin' development) |
+| [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose agent |
+| [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) | Rust development agent (used for jackin' development) |
 | [homebrew-tap](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for installing jackin' |
 ```
 

--- a/docs/superpowers/specs/2026-04-04-jackin-dev-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-04-jackin-dev-plugin-design.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin for simplifying jackin development. Provides skills for release management, with room to grow into other development workflows (testing, security review, Docker construct validation, etc.).
 
-Distributed as a standalone repository: `donbeave/jackin-dev`.
+Distributed as a standalone repository: `jackin-project/jackin-dev`.
 
 ## Platform Support
 
@@ -49,8 +49,8 @@ jackin-dev/
   "author": {
     "name": "Alexey Zhokhov"
   },
-  "homepage": "https://github.com/donbeave/jackin-dev",
-  "repository": "https://github.com/donbeave/jackin-dev",
+  "homepage": "https://github.com/jackin-project/jackin-dev",
+  "repository": "https://github.com/jackin-project/jackin-dev",
   "license": "Apache-2.0",
   "keywords": ["release", "changelog", "validation", "cargo-release", "rust"]
 }
@@ -105,10 +105,10 @@ jackin-dev/
    ## [Unreleased]
 
    ### Added
-   - Add TUI launcher for interactive agent selection ([#12](https://github.com/donbeave/jackin/pull/12))
+   - Add TUI launcher for interactive agent selection ([#12](https://github.com/jackin-project/jackin/pull/12))
 
    ### Fixed
-   - Fix symlink escape in container mounts ([#15](https://github.com/donbeave/jackin/pull/15))
+   - Fix symlink escape in container mounts ([#15](https://github.com/jackin-project/jackin/pull/15))
 
    ### Ungrouped commits (not from PRs)
    - `205875a` docs: fix resolve_agent_source references
@@ -181,7 +181,7 @@ Step 7: Post-release
 
 ## Changes Required in the jackin Repository
 
-These changes are prerequisites in the `donbeave/jackin` repo, not part of the plugin:
+These changes are prerequisites in the `jackin-project/jackin` repo, not part of the plugin:
 
 ### 1. New CI workflow: `.github/workflows/ci.yml`
 

--- a/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
+++ b/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
@@ -23,7 +23,6 @@ claude plugin install superpowers@superpowers-marketplace
 
 - Replacing Claude Code's own marketplace validation rules.
 - Introducing local aliases or renaming marketplaces inside `jackin`.
-- Supporting extra CLI flags such as `--sparse` in v1.
 - Reworking plugin installation into a separate build-time or image-baked
   system.
 
@@ -76,7 +75,7 @@ claude plugin marketplace add <source>
 If `sparse` is present, `jackin` should append the corresponding CLI flags:
 
 ```bash
-claude plugin marketplace add <source> --sparse <path1> --sparse <path2>
+claude plugin marketplace add <source> --sparse <path1> <path2>
 ```
 
 This keeps `jackin` as a thin wrapper around Claude Code rather than creating
@@ -217,7 +216,7 @@ The updated script behavior should be:
    where each marketplace entry expands to:
 
    - required source argument from `.source`
-   - zero or more `--sparse <path>` flags from `.sparse[]`
+   - an optional `--sparse <path1> <path2> ...` segment built from `.sparse[]`
 
 3. Read `.plugins[]` from `plugins.json` and run:
 

--- a/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
+++ b/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
@@ -62,7 +62,7 @@ source = "obra/superpowers-marketplace"
 sparse = ["plugins", ".claude-plugin"]
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 ```
 
 Each marketplace block maps to a `claude plugin marketplace add` invocation.
@@ -105,7 +105,7 @@ marketplace's own `.claude-plugin/marketplace.json`.
 For example, the source string may be:
 
 ```text
-donbeave/jackin-marketplace
+jackin-project/jackin-marketplace
 ```
 
 while the plugin ID remains:

--- a/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
+++ b/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
@@ -1,0 +1,277 @@
+# Custom Plugin Marketplaces In Agent Manifests
+
+This design extends `jackin.agent.toml` so agent repos can declare Claude Code
+plugin marketplaces in addition to plugin IDs.
+
+The goal is to let `jackin` automate the same workflow users already run
+manually inside the container:
+
+```bash
+claude plugin marketplace add obra/superpowers-marketplace
+claude plugin install superpowers@superpowers-marketplace
+```
+
+## Goals
+
+- Support custom Claude plugin marketplaces in `jackin.agent.toml`.
+- Keep the manifest aligned with Claude Code's existing CLI model.
+- Reuse `jackin`'s current runtime bootstrap path for plugin installation.
+- Allow agent repos to auto-install plugins from both the official marketplace
+  and additional GitHub-hosted marketplaces.
+
+## Non-Goals
+
+- Replacing Claude Code's own marketplace validation rules.
+- Introducing local aliases or renaming marketplaces inside `jackin`.
+- Supporting extra CLI flags such as `--sparse` in v1.
+- Reworking plugin installation into a separate build-time or image-baked
+  system.
+
+## Current Behavior
+
+Today, `jackin` already automates Claude plugin installation, but only for the
+official marketplace.
+
+- The manifest schema only accepts `[claude].plugins`.
+- Runtime state persists plugin IDs into `~/.jackin/plugins.json`.
+- Container startup runs `install-plugins.sh`.
+- The bootstrap script adds `anthropics/claude-plugins-official` and then runs
+  `claude plugin install <plugin>` for every configured plugin.
+
+This means plugins such as `superpowers@superpowers-marketplace` or
+`jackin-dev@jackin-marketplace` cannot work unless the marketplace has already
+been added manually inside the container.
+
+## Chosen Approach
+
+Add a `marketplaces` string list under `[claude]` and treat each entry as a raw
+Claude marketplace source.
+
+Example:
+
+```toml
+dockerfile = "Dockerfile"
+
+[claude]
+marketplaces = [
+  "obra/superpowers-marketplace",
+  "donbeave/jackin-marketplace",
+]
+plugins = [
+  "superpowers@superpowers-marketplace",
+  "jackin-dev@jackin-marketplace",
+]
+```
+
+Each string is passed directly to:
+
+```bash
+claude plugin marketplace add <source>
+```
+
+This keeps `jackin` as a thin wrapper around Claude Code rather than creating a
+new marketplace abstraction.
+
+## Why This Shape
+
+### Match The Existing Manual Workflow
+
+Users already think in terms of the two Claude commands:
+
+```bash
+claude plugin marketplace add <source>
+claude plugin install <plugin>@<marketplace-name>
+```
+
+Using raw marketplace source strings in the manifest mirrors that workflow
+exactly.
+
+### Avoid Alias Drift
+
+`jackin` should not invent marketplace aliases in TOML because Claude plugin
+installation already depends on the marketplace name declared in the
+marketplace's own `.claude-plugin/marketplace.json`.
+
+For example, the source string may be:
+
+```text
+donbeave/jackin-marketplace
+```
+
+while the plugin ID remains:
+
+```text
+jackin-dev@jackin-marketplace
+```
+
+The suffix comes from the marketplace's declared `name`, not from a local
+manifest alias.
+
+### Delegate Source Validation To Claude
+
+Claude Code already knows how to interpret marketplace sources such as GitHub
+shorthand. `jackin` should persist and pass through the source string, then let
+`claude plugin marketplace add` handle validation and errors.
+
+## Data Model Changes
+
+### Manifest Schema
+
+Extend `ClaudeConfig` with:
+
+- `marketplaces: Vec<String>`
+- `plugins: Vec<String>`
+
+Both fields default to empty lists.
+
+This preserves backwards compatibility for existing agent manifests that only
+declare plugins or no plugins at all.
+
+### Runtime State
+
+The runtime bootstrap JSON currently stores only plugins. It should store both
+marketplaces and plugins so the entrypoint has all Claude plugin setup inputs in
+one mounted file.
+
+Current shape:
+
+```json
+{
+  "plugins": ["code-review@claude-plugins-official"]
+}
+```
+
+New shape:
+
+```json
+{
+  "marketplaces": ["obra/superpowers-marketplace"],
+  "plugins": ["superpowers@superpowers-marketplace"]
+}
+```
+
+The file can keep its current location at `~/.jackin/plugins.json` to avoid a
+larger naming or mount refactor in this change.
+
+## Runtime Flow
+
+The existing startup flow remains intact:
+
+1. `jackin` parses `jackin.agent.toml`.
+2. `jackin` writes plugin bootstrap state into `~/.jackin/plugins.json` on the
+   host.
+3. `jackin` mounts that file into the container.
+4. The runtime entrypoint runs `install-plugins.sh`.
+5. The script adds marketplaces, then installs plugins.
+
+The updated script behavior should be:
+
+1. Add the official marketplace:
+
+   ```bash
+   claude plugin marketplace add anthropics/claude-plugins-official
+   ```
+
+2. Read `.marketplaces[]` from `plugins.json` and run:
+
+   ```bash
+   claude plugin marketplace add "$marketplace"
+   ```
+
+3. Read `.plugins[]` from `plugins.json` and run:
+
+   ```bash
+   claude plugin install "$plugin"
+   ```
+
+The ordering matters: marketplaces must be added before plugin installation.
+
+## Error Handling
+
+`jackin` should keep error handling simple in v1.
+
+- If a custom marketplace source is invalid or inaccessible, the bootstrap
+  command should fail the same way a manual Claude command would fail.
+- If a plugin references a marketplace name that has not been registered
+  successfully, `claude plugin install` should fail and surface the Claude
+  error.
+- `jackin` should not try to pre-validate whether a plugin suffix matches a
+  marketplace source, because that mapping is only known after Claude resolves
+  the marketplace metadata.
+
+This keeps the implementation small and avoids duplicating Claude behavior.
+
+## Testing Strategy
+
+Add focused regression tests at the existing state and manifest layers.
+
+### Manifest Tests
+
+- Parsing a manifest that omits `marketplaces` still yields an empty list.
+- Parsing a manifest with both `marketplaces` and `plugins` loads both fields.
+
+### Runtime State Tests
+
+- `AgentState::prepare` writes `plugins.json` with both arrays.
+
+### Runtime Command Tests
+
+The existing runtime tests already verify that `plugins.json` is mounted rather
+than that `claude plugin install` is run directly from Rust. Those tests should
+be updated only as needed to reflect the new JSON contents, not the shell
+script internals.
+
+## Documentation Changes
+
+Update the following docs to match the new manifest capability:
+
+- `docs/pages/developing/agent-manifest.mdx`
+- `docs/pages/developing/creating-agents.mdx`
+
+Also resolve the tracked TODO item and keep project planning docs aligned:
+
+- `todo/custom-plugin-marketplace.md`
+- `TODO.md`
+- `docs/pages/reference/roadmap.mdx`
+
+## Alternatives Considered
+
+### TOML Map Of Marketplace Aliases
+
+Example:
+
+```toml
+[claude.marketplaces]
+superpowers-marketplace = "obra/superpowers-marketplace"
+```
+
+Rejected because it duplicates marketplace naming already owned by Claude and
+creates room for mismatch between TOML keys and marketplace metadata.
+
+### Structured Marketplace Objects
+
+Example:
+
+```toml
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+```
+
+Rejected for v1 because the extra structure does not buy anything once we have
+decided not to support extra options such as `sparse` yet.
+
+### Writing Claude Settings Instead Of Using The CLI
+
+Rejected because `jackin` already has a working runtime bootstrap path that uses
+Claude CLI commands successfully. Extending that path is smaller and less risky
+than introducing a second configuration mechanism.
+
+## Rollout
+
+This change is safe to ship as an additive manifest feature.
+
+- Existing manifests remain valid.
+- Existing official marketplace plugin installs continue to work.
+- Agent repos can opt in by adding `[claude].marketplaces` entries.
+
+The TODO item should move to resolved once the code and docs ship.

--- a/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
+++ b/docs/superpowers/specs/2026-04-10-custom-plugin-marketplaces-design.md
@@ -44,8 +44,8 @@ been added manually inside the container.
 
 ## Chosen Approach
 
-Add a `marketplaces` string list under `[claude]` and treat each entry as a raw
-Claude marketplace source.
+Add structured `[[claude.marketplaces]]` blocks while keeping `[claude].plugins`
+as raw Claude plugin install strings.
 
 Example:
 
@@ -53,24 +53,34 @@ Example:
 dockerfile = "Dockerfile"
 
 [claude]
-marketplaces = [
-  "obra/superpowers-marketplace",
-  "donbeave/jackin-marketplace",
-]
 plugins = [
   "superpowers@superpowers-marketplace",
   "jackin-dev@jackin-marketplace",
 ]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
 ```
 
-Each string is passed directly to:
+Each marketplace block maps to a `claude plugin marketplace add` invocation.
+The `source` value is passed directly to:
 
 ```bash
 claude plugin marketplace add <source>
 ```
 
-This keeps `jackin` as a thin wrapper around Claude Code rather than creating a
-new marketplace abstraction.
+If `sparse` is present, `jackin` should append the corresponding CLI flags:
+
+```bash
+claude plugin marketplace add <source> --sparse <path1> --sparse <path2>
+```
+
+This keeps `jackin` as a thin wrapper around Claude Code rather than creating
+new marketplace naming or install rules.
 
 ## Why This Shape
 
@@ -83,8 +93,9 @@ claude plugin marketplace add <source>
 claude plugin install <plugin>@<marketplace-name>
 ```
 
-Using raw marketplace source strings in the manifest mirrors that workflow
-exactly.
+Using raw plugin install strings in the manifest mirrors the install workflow
+exactly, while marketplace blocks preserve the add workflow and its
+marketplace-specific options.
 
 ### Avoid Alias Drift
 
@@ -107,6 +118,20 @@ jackin-dev@jackin-marketplace
 The suffix comes from the marketplace's declared `name`, not from a local
 manifest alias.
 
+### Keep Marketplace Options Attached To The Marketplace
+
+The `sparse` option belongs to marketplace registration, not plugin
+installation. A flat `marketplaces = []` string list cannot express this cleanly
+without inventing a custom mini-language.
+
+Using `[[claude.marketplaces]]` blocks keeps marketplace-specific data together:
+
+```toml
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+```
+
 ### Delegate Source Validation To Claude
 
 Claude Code already knows how to interpret marketplace sources such as GitHub
@@ -119,10 +144,15 @@ shorthand. `jackin` should persist and pass through the source string, then let
 
 Extend `ClaudeConfig` with:
 
-- `marketplaces: Vec<String>`
 - `plugins: Vec<String>`
+- `marketplaces: Vec<ClaudeMarketplaceConfig>`
 
 Both fields default to empty lists.
+
+`ClaudeMarketplaceConfig` should contain:
+
+- `source: String`
+- `sparse: Vec<String>`
 
 This preserves backwards compatibility for existing agent manifests that only
 declare plugins or no plugins at all.
@@ -137,6 +167,7 @@ Current shape:
 
 ```json
 {
+  "marketplaces": [],
   "plugins": ["code-review@claude-plugins-official"]
 }
 ```
@@ -145,7 +176,12 @@ New shape:
 
 ```json
 {
-  "marketplaces": ["obra/superpowers-marketplace"],
+  "marketplaces": [
+    {
+      "source": "obra/superpowers-marketplace",
+      "sparse": ["plugins", ".claude-plugin"]
+    }
+  ],
   "plugins": ["superpowers@superpowers-marketplace"]
 }
 ```
@@ -172,11 +208,16 @@ The updated script behavior should be:
    claude plugin marketplace add anthropics/claude-plugins-official
    ```
 
-2. Read `.marketplaces[]` from `plugins.json` and run:
+2. Read `.marketplaces[]` from `plugins.json` and run one command per entry:
 
    ```bash
-   claude plugin marketplace add "$marketplace"
+   claude plugin marketplace add "$source"
    ```
+
+   where each marketplace entry expands to:
+
+   - required source argument from `.source`
+   - zero or more `--sparse <path>` flags from `.sparse[]`
 
 3. Read `.plugins[]` from `plugins.json` and run:
 
@@ -192,6 +233,8 @@ The ordering matters: marketplaces must be added before plugin installation.
 
 - If a custom marketplace source is invalid or inaccessible, the bootstrap
   command should fail the same way a manual Claude command would fail.
+- If a `sparse` path is invalid for a given marketplace, the Claude CLI command
+  should fail and surface the Claude error directly.
 - If a plugin references a marketplace name that has not been registered
   successfully, `claude plugin install` should fail and surface the Claude
   error.
@@ -208,11 +251,14 @@ Add focused regression tests at the existing state and manifest layers.
 ### Manifest Tests
 
 - Parsing a manifest that omits `marketplaces` still yields an empty list.
-- Parsing a manifest with both `marketplaces` and `plugins` loads both fields.
+- Parsing a manifest with marketplace blocks and plugins loads both fields.
+- Parsing a marketplace block without `sparse` yields an empty sparse list.
+- Parsing a marketplace block with `sparse` preserves the declared paths.
 
 ### Runtime State Tests
 
-- `AgentState::prepare` writes `plugins.json` with both arrays.
+- `AgentState::prepare` writes `plugins.json` with marketplace objects and the
+  plugin array.
 
 ### Runtime Command Tests
 
@@ -236,6 +282,18 @@ Also resolve the tracked TODO item and keep project planning docs aligned:
 
 ## Alternatives Considered
 
+### Flat `marketplaces = []` Strings
+
+Example:
+
+```toml
+[claude]
+marketplaces = ["obra/superpowers-marketplace"]
+```
+
+Rejected because it cannot naturally support marketplace-specific options such
+as `sparse`.
+
 ### TOML Map Of Marketplace Aliases
 
 Example:
@@ -248,17 +306,19 @@ superpowers-marketplace = "obra/superpowers-marketplace"
 Rejected because it duplicates marketplace naming already owned by Claude and
 creates room for mismatch between TOML keys and marketplace metadata.
 
-### Structured Marketplace Objects
+### Grouping Plugins Inside Marketplace Blocks
 
 Example:
 
 ```toml
 [[claude.marketplaces]]
 source = "obra/superpowers-marketplace"
+plugins = ["superpowers"]
 ```
 
-Rejected for v1 because the extra structure does not buy anything once we have
-decided not to support extra options such as `sparse` yet.
+Rejected because `jackin` would have to derive the final install string, such as
+`superpowers@superpowers-marketplace`, from marketplace metadata it does not own.
+Keeping `[claude].plugins` as raw Claude install strings avoids that coupling.
 
 ### Writing Claude Settings Instead Of Using The CLI
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,11 +10,11 @@ pub use crate::workspace::MountConfig;
 const BUILTIN_AGENTS: &[(&str, &str)] = &[
     (
         "agent-smith",
-        "https://github.com/donbeave/jackin-agent-smith.git",
+        "https://github.com/jackin-project/jackin-agent-smith.git",
     ),
     (
         "the-architect",
-        "https://github.com/donbeave/jackin-the-architect.git",
+        "https://github.com/jackin-project/jackin-the-architect.git",
     ),
 ];
 
@@ -411,11 +411,11 @@ mod tests {
 
         assert_eq!(
             config.agents.get("agent-smith").unwrap().git,
-            "https://github.com/donbeave/jackin-agent-smith.git"
+            "https://github.com/jackin-project/jackin-agent-smith.git"
         );
         assert_eq!(
             config.agents.get("the-architect").unwrap().git,
-            "https://github.com/donbeave/jackin-the-architect.git"
+            "https://github.com/jackin-project/jackin-the-architect.git"
         );
         assert!(paths.config_file.exists());
     }
@@ -442,12 +442,12 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
         // Built-in entries are corrected
         assert_eq!(
             config.agents.get("agent-smith").unwrap().git,
-            "https://github.com/donbeave/jackin-agent-smith.git"
+            "https://github.com/jackin-project/jackin-agent-smith.git"
         );
         // Missing built-in entries are added
         assert_eq!(
             config.agents.get("the-architect").unwrap().git,
-            "https://github.com/donbeave/jackin-the-architect.git"
+            "https://github.com/jackin-project/jackin-the-architect.git"
         );
         // User-added entries are preserved
         assert_eq!(
@@ -457,8 +457,8 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
 
         // Config file is updated on disk
         let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(persisted.contains("donbeave/jackin-agent-smith.git"));
-        assert!(persisted.contains("donbeave/jackin-the-architect.git"));
+        assert!(persisted.contains("jackin-project/jackin-agent-smith.git"));
+        assert!(persisted.contains("jackin-project/jackin-the-architect.git"));
         assert!(persisted.contains("chainargos/jackin-agent-brown.git"));
     }
 
@@ -517,7 +517,7 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
     fn deserializes_global_docker_mounts() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [docker.mounts]
 gradle-cache = { src = "~/.gradle/caches", dst = "/home/claude/.gradle/caches" }
@@ -543,7 +543,7 @@ gradle-wrapper = { src = "~/.gradle/wrapper", dst = "/home/claude/.gradle/wrappe
     fn deserializes_scoped_docker_mounts() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [docker.mounts."chainargos/*"]
 chainargos-secrets = { src = "~/.chainargos/secrets", dst = "/secrets", readonly = true }
@@ -575,7 +575,7 @@ brown-config = { src = "~/.chainargos/brown", dst = "/config" }
     fn deserializes_saved_workspaces() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [workspaces.big-monorepo]
 workdir = "/Users/donbeave/Projects/chainargos/big-monorepo"
@@ -680,7 +680,7 @@ readonly = true
             &paths.config_file,
             r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [workspaces.big-monorepo]
 workdir = "/workspace/project"
@@ -709,7 +709,7 @@ dst = "/workspace/src"
         let toml_str = format!(
             r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [workspaces.broken]
 workdir = "/workspace/project"
@@ -911,7 +911,7 @@ dst = "/workspace/src"
     fn resolve_mounts_collects_global_and_matching_scopes() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [docker.mounts]
 gradle-cache = { src = "/tmp/gradle-caches", dst = "/home/claude/.gradle/caches" }
@@ -950,7 +950,7 @@ other-data = { src = "/tmp/other", dst = "/other" }
     fn resolve_mounts_exact_overrides_global_with_same_name() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [docker.mounts]
 shared = { src = "/tmp/global", dst = "/data" }
@@ -1068,7 +1068,7 @@ shared = { src = "/tmp/specific", dst = "/data" }
     fn resolve_mounts_matches_exact_scope_for_unscoped_selector() {
         let toml_str = r#"
 [agents.agent-smith]
-git = "https://github.com/donbeave/jackin-agent-smith.git"
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
 [docker.mounts]
 global-data = { src = "/tmp/global", dst = "/global" }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,4 +1,4 @@
-use crate::manifest::AgentManifest;
+use crate::manifest::{AgentManifest, ClaudeMarketplaceConfig};
 use crate::paths::JackinPaths;
 use crate::selector::ClassSelector;
 use serde::Serialize;
@@ -16,6 +16,7 @@ pub struct AgentState {
 
 #[derive(Debug, Serialize)]
 struct PluginState<'a> {
+    marketplaces: &'a [ClaudeMarketplaceConfig],
     plugins: &'a [String],
 }
 
@@ -42,6 +43,7 @@ impl AgentState {
         std::fs::write(
             &plugins_json,
             serde_json::to_string_pretty(&PluginState {
+                marketplaces: &manifest.claude.marketplaces,
                 plugins: &manifest.claude.plugins,
             })?,
         )?;
@@ -94,6 +96,7 @@ mod tests {
     use super::*;
     use crate::paths::JackinPaths;
     use crate::selector::ClassSelector;
+    use serde_json::json;
     use tempfile::tempdir;
 
     #[test]
@@ -170,14 +173,59 @@ plugins = ["code-review@claude-plugins-official", "feature-dev@claude-plugins-of
         let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
 
         assert!(state.jackin_dir.is_dir());
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
+        assert_eq!(value["marketplaces"], json!([]));
         assert_eq!(
-            std::fs::read_to_string(&state.plugins_json).unwrap(),
-            r#"{
-  "plugins": [
-    "code-review@claude-plugins-official",
-    "feature-dev@claude-plugins-official"
-  ]
-}"#
+            value["plugins"],
+            json!([
+                "code-review@claude-plugins-official",
+                "feature-dev@claude-plugins-official"
+            ])
+        );
+    }
+
+    #[test]
+    fn prepares_plugins_json_with_marketplaces_for_runtime_bootstrap() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+
+        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
+        let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
+        assert_eq!(
+            value["marketplaces"],
+            json!([
+                {
+                    "source": "obra/superpowers-marketplace",
+                    "sparse": ["plugins", ".claude-plugin"]
+                }
+            ])
+        );
+        assert_eq!(
+            value["plugins"],
+            json!(["superpowers@superpowers-marketplace"])
         );
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -742,7 +742,7 @@ mod tests {
         config.agents.insert(
             "agent-smith".to_string(),
             crate::config::AgentSource {
-                git: "https://github.com/donbeave/jackin-agent-smith.git".to_string(),
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
             },
         );
         config.workspaces.insert(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -46,9 +46,19 @@ pub struct IdentityConfig {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ClaudeMarketplaceConfig {
+    pub source: String,
+    #[serde(default)]
+    pub sparse: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ClaudeConfig {
+    #[serde(default)]
+    pub marketplaces: Vec<ClaudeMarketplaceConfig>,
     #[serde(default)]
     pub plugins: Vec<String>,
 }
@@ -209,8 +219,92 @@ plugins = ["code-review@claude-plugins-official"]
         let manifest = AgentManifest::load(temp.path()).unwrap();
 
         assert_eq!(manifest.dockerfile, "Dockerfile");
+        assert!(manifest.claude.marketplaces.is_empty());
         assert_eq!(manifest.claude.plugins.len(), 1);
         assert!(manifest.identity.is_none());
+    }
+
+    #[test]
+    fn loads_manifest_with_marketplaces_and_plugins() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert_eq!(
+            manifest.claude.plugins,
+            vec!["superpowers@superpowers-marketplace"]
+        );
+        assert_eq!(manifest.claude.marketplaces.len(), 1);
+        assert_eq!(
+            manifest.claude.marketplaces[0],
+            ClaudeMarketplaceConfig {
+                source: "obra/superpowers-marketplace".to_string(),
+                sparse: vec!["plugins".to_string(), ".claude-plugin".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn loads_manifest_marketplace_without_sparse() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[[claude.marketplaces]]
+source = "donbeave/jackin-marketplace"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert_eq!(manifest.claude.marketplaces.len(), 1);
+        assert_eq!(
+            manifest.claude.marketplaces[0],
+            ClaudeMarketplaceConfig {
+                source: "donbeave/jackin-marketplace".to_string(),
+                sparse: vec![],
+            }
+        );
+        assert!(manifest.claude.plugins.is_empty());
+    }
+
+    #[test]
+    fn loads_manifest_without_plugins_defaults_to_empty() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+
+        assert!(manifest.claude.plugins.is_empty());
+        assert_eq!(manifest.claude.marketplaces.len(), 1);
     }
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -268,7 +268,7 @@ sparse = ["plugins", ".claude-plugin"]
 plugins = []
 
 [[claude.marketplaces]]
-source = "donbeave/jackin-marketplace"
+source = "jackin-project/jackin-marketplace"
 "#,
         )
         .unwrap();
@@ -279,7 +279,7 @@ source = "donbeave/jackin-marketplace"
         assert_eq!(
             manifest.claude.marketplaces[0],
             ClaudeMarketplaceConfig {
-                source: "donbeave/jackin-marketplace".to_string(),
+                source: "jackin-project/jackin-marketplace".to_string(),
                 sparse: vec![],
             }
         );

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -118,7 +118,7 @@ fn repo_matches(expected: &str, actual: &str) -> bool {
     }
 }
 
-/// Derive a short repository name from a git remote URL (e.g. `donbeave/jackin`).
+/// Derive a short repository name from a git remote URL (e.g. `jackin-project/jackin`).
 fn git_repo_name(dir: &std::path::Path, runner: &mut impl CommandRunner) -> Option<String> {
     let dir_str = dir.display().to_string();
     let url = try_capture(
@@ -1594,28 +1594,28 @@ plugins = []
     #[test]
     fn parse_repo_name_extracts_owner_repo_from_ssh_url() {
         assert_eq!(
-            parse_repo_name("git@github.com:donbeave/jackin.git"),
-            Some("donbeave/jackin".to_string())
+            parse_repo_name("git@github.com:jackin-project/jackin.git"),
+            Some("jackin-project/jackin".to_string())
         );
     }
 
     #[test]
     fn parse_repo_name_extracts_owner_repo_from_https_url() {
         assert_eq!(
-            parse_repo_name("https://github.com/donbeave/jackin.git"),
-            Some("donbeave/jackin".to_string())
+            parse_repo_name("https://github.com/jackin-project/jackin.git"),
+            Some("jackin-project/jackin".to_string())
         );
     }
 
     #[test]
     fn parse_repo_name_handles_url_without_git_suffix() {
         assert_eq!(
-            parse_repo_name("https://github.com/donbeave/jackin"),
-            Some("donbeave/jackin".to_string())
+            parse_repo_name("https://github.com/jackin-project/jackin"),
+            Some("jackin-project/jackin".to_string())
         );
         assert_eq!(
-            parse_repo_name("git@github.com:donbeave/jackin"),
-            Some("donbeave/jackin".to_string())
+            parse_repo_name("git@github.com:jackin-project/jackin"),
+            Some("jackin-project/jackin".to_string())
         );
     }
 
@@ -1654,7 +1654,7 @@ plugins = []
         let error = resolve_agent_repo(
             &paths,
             &selector,
-            "https://github.com/donbeave/jackin-agent-smith.git",
+            "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
         )
         .unwrap_err();
@@ -1689,13 +1689,13 @@ plugins = []
         .unwrap();
 
         let mut runner = FakeRunner::with_capture_queue([
-            "git@github.com:donbeave/jackin-agent-smith.git".to_string(),
+            "git@github.com:jackin-project/jackin-agent-smith.git".to_string(),
             "?? scratch.txt".to_string(),
         ]);
         let error = resolve_agent_repo(
             &paths,
             &selector,
-            "https://github.com/donbeave/jackin-agent-smith.git",
+            "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
         )
         .unwrap_err();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -481,7 +481,7 @@ mod tests {
         config.agents.insert(
             "agent-smith".to_string(),
             crate::config::AgentSource {
-                git: "https://github.com/donbeave/jackin-agent-smith.git".to_string(),
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
             },
         );
         config.workspaces.insert(
@@ -522,7 +522,7 @@ mod tests {
         config.agents.insert(
             "agent-smith".to_string(),
             crate::config::AgentSource {
-                git: "https://github.com/donbeave/jackin-agent-smith.git".to_string(),
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
             },
         );
         config.workspaces.insert(
@@ -627,7 +627,7 @@ mod tests {
         config.agents.insert(
             "agent-smith".to_string(),
             crate::config::AgentSource {
-                git: "https://github.com/donbeave/jackin-agent-smith.git".to_string(),
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
             },
         );
         config.workspaces.insert(

--- a/tests/install_plugins_bootstrap.rs
+++ b/tests/install_plugins_bootstrap.rs
@@ -61,7 +61,7 @@ fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
       "sparse": ["plugins", ".claude-plugin"]
     },
     {
-      "source": "donbeave/jackin-marketplace",
+      "source": "jackin-project/jackin-marketplace",
       "sparse": []
     }
   ],
@@ -106,7 +106,7 @@ fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
         fs::read_to_string(log_file).unwrap(),
         "plugin marketplace add anthropics/claude-plugins-official\n\
 plugin marketplace add obra/superpowers-marketplace --sparse plugins .claude-plugin\n\
-plugin marketplace add donbeave/jackin-marketplace\n\
+plugin marketplace add jackin-project/jackin-marketplace\n\
 plugin install superpowers@superpowers-marketplace\n\
 plugin install jackin-dev@jackin-marketplace\n"
     );

--- a/tests/install_plugins_bootstrap.rs
+++ b/tests/install_plugins_bootstrap.rs
@@ -1,0 +1,170 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+fn write_jq_stub(path: &Path) {
+    write_executable(
+        path,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+while args and args[0] in {"-r", "-c"}:
+    args = args[1:]
+flt = args[0]
+if len(args) > 1:
+    with open(args[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+else:
+    data = json.load(sys.stdin)
+
+if flt == ".marketplaces[]?":
+    for item in data.get("marketplaces", []):
+        print(json.dumps(item))
+elif flt == ".plugins[]?":
+    for item in data.get("plugins", []):
+        print(item)
+elif flt == ".source":
+    print(data["source"])
+elif flt == ".sparse[]?":
+    for item in data.get("sparse", []):
+        print(item)
+else:
+    raise SystemExit(f"unsupported filter: {flt}")
+"#,
+    );
+}
+
+#[test]
+fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
+    let temp = tempdir().unwrap();
+    let plugins_file = temp.path().join("plugins.json");
+    fs::write(
+        &plugins_file,
+        r#"{
+  "marketplaces": [
+    {
+      "source": "obra/superpowers-marketplace",
+      "sparse": ["plugins", ".claude-plugin"]
+    },
+    {
+      "source": "donbeave/jackin-marketplace",
+      "sparse": []
+    }
+  ],
+  "plugins": [
+    "superpowers@superpowers-marketplace",
+    "jackin-dev@jackin-marketplace"
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let log_file = temp.path().join("claude.log");
+
+    let claude_path = bin_dir.join("claude");
+    write_executable(
+        &claude_path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n",
+            log_file.display()
+        )
+        .as_str(),
+    );
+
+    let jq_path = bin_dir.join("jq");
+    write_jq_stub(&jq_path);
+
+    let status = Command::new("bash")
+        .arg("docker/construct/install-plugins.sh")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("JACKIN_PLUGINS_FILE", &plugins_file)
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(log_file).unwrap(),
+        "plugin marketplace add anthropics/claude-plugins-official\n\
+plugin marketplace add obra/superpowers-marketplace --sparse plugins .claude-plugin\n\
+plugin marketplace add donbeave/jackin-marketplace\n\
+plugin install superpowers@superpowers-marketplace\n\
+plugin install jackin-dev@jackin-marketplace\n"
+    );
+}
+
+#[test]
+fn install_plugins_script_surfaces_custom_marketplace_failures() {
+    let temp = tempdir().unwrap();
+    let plugins_file = temp.path().join("plugins.json");
+    fs::write(
+        &plugins_file,
+        r#"{
+  "marketplaces": [
+    {
+      "source": "obra/superpowers-marketplace",
+      "sparse": ["plugins", ".claude-plugin"]
+    }
+  ],
+  "plugins": [
+    "superpowers@superpowers-marketplace"
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let log_file = temp.path().join("claude.log");
+
+    let claude_path = bin_dir.join("claude");
+    write_executable(
+        &claude_path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"marketplace\" ] && [ \"$3\" = \"add\" ] && [ \"$4\" = \"obra/superpowers-marketplace\" ]; then\n  echo 'failed to add marketplace' >&2\n  exit 1\nfi\n",
+            log_file.display()
+        )
+        .as_str(),
+    );
+
+    let jq_path = bin_dir.join("jq");
+    write_jq_stub(&jq_path);
+
+    let output = Command::new("bash")
+        .arg("docker/construct/install-plugins.sh")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .env("JACKIN_PLUGINS_FILE", &plugins_file)
+        .env(
+            "PATH",
+            format!("{}:{}", bin_dir.display(), std::env::var("PATH").unwrap()),
+        )
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("failed to add marketplace"));
+    assert_eq!(
+        fs::read_to_string(log_file).unwrap(),
+        "plugin marketplace add anthropics/claude-plugins-official\n\
+plugin marketplace add obra/superpowers-marketplace --sparse plugins .claude-plugin\n"
+    );
+}

--- a/todo/custom-plugin-marketplace.md
+++ b/todo/custom-plugin-marketplace.md
@@ -1,42 +1,21 @@
 # Custom Plugin Marketplace Support in Agent Config
 
+## Status
+
+Resolved
+
 ## Problem
 
-`jackin.agent.toml` only supports plugins from `claude-plugins-official`. There is no way to declare custom or GitHub-hosted plugin marketplaces, so agents like `the-architect` cannot auto-install project-specific plugins like `jackin-dev`.
+`jackin.agent.toml` could declare Claude plugin IDs, but jackin only added the official Anthropic marketplace during runtime bootstrap. Custom marketplaces still required manual `/plugin marketplace add` commands inside the container before project-specific plugins could be installed.
 
-Currently, users must manually run `/plugin marketplace add` and `/plugin install` inside the container after launch.
+## Why It Matters
 
-## Desired Behavior
-
-Support a marketplace declaration in `jackin.agent.toml` so custom plugins are installed automatically at agent construction time:
-
-```toml
-[claude.marketplaces]
-jackin-marketplace = "donbeave/jackin-marketplace"
-
-[claude]
-plugins = [
-  "superpowers@claude-plugins-official",
-  "jackin-dev@jackin-marketplace",
-]
-```
-
-## Current Workaround
-
-From inside the container, run these Claude Code slash commands:
-
-```
-/plugin marketplace add donbeave/jackin-marketplace
-/plugin install jackin-dev@jackin-marketplace
-/reload-plugins
-```
-
-## Marketplace Repository
-
-The marketplace is at [donbeave/jackin-marketplace](https://github.com/donbeave/jackin-marketplace). It contains a `.claude-plugin/marketplace.json` that points to plugin repos via GitHub URLs, following the same pattern as [obra/superpowers-marketplace](https://github.com/obra/superpowers-marketplace).
+Agent repos need reproducible startup. Without manifest-declared marketplaces, teams could not ship a self-contained agent config that automatically installs project-specific plugins such as `jackin-dev`, especially when the marketplace lived in a monorepo and needed sparse checkout paths.
 
 ## Related Files
 
-- `src/agent.rs` — agent config parsing
-- `src/construct.rs` — agent image construction (where plugins are installed)
-- `jackin-the-architect` repo — `jackin.agent.toml` would be first consumer
+- `src/manifest.rs`
+- `src/instance.rs`
+- `docker/construct/install-plugins.sh`
+- `docs/pages/developing/agent-manifest.mdx`
+- `docs/pages/developing/creating-agents.mdx`


### PR DESCRIPTION
## Summary
- extend `jackin.agent.toml` to support `[[claude.marketplaces]]` entries with `source` and optional `sparse` paths
- persist marketplace data into runtime `plugins.json` and register custom marketplaces during container bootstrap before plugin installation
- add integration coverage for marketplace bootstrap ordering and docs/todo updates for the new manifest shape

## Test Plan
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo nextest run`
- `bun run build` (in `docs/`)
- manually verified with the real Claude CLI in isolated temp `HOME` directories that repeated `claude plugin marketplace add anthropics/claude-plugins-official` and `claude plugin marketplace add obra/superpowers-marketplace --sparse plugins .claude-plugin` both exit `0` on the second run and report `already on disk`
