### PR TITLE
feat: warn before mounting sensitive host paths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,11 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Migrate Docker CLI to Bollard API Client](todo/bollard-migration.md) — replace string-matched error handling with typed API
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
 - [Selectable Sandbox Backends: DinD and MicroVM](todo/selectable-sandbox-backends.md) — operator-selectable runtime modes with backend-neutral lifecycle design
-- [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
 - [Interactive Env Vars and Resolution](todo/env-var-interpolation.md) — interactive prompts, workspace overrides, and secret resolution for env vars
 
 ## Resolved
 
+- [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`
 - [Expose DinD Hostname as `JACKIN_DIND_HOSTNAME`](todo/dind-hostname-env-var.md) — agents can reach DinD-backed services without parsing `DOCKER_HOST`

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -62,12 +62,13 @@ jackin load agent-smith ~/app --mount ~/cache:/cache:ro
 
 1. Resolves the agent class and clones/updates its repository
 2. Validates the agent repo contract (`jackin.agent.toml` + Dockerfile) with strict manifest parsing
-3. Prompts for interactive environment variables declared in the manifest
-4. Generates and builds a derived Docker image (cached if unchanged)
-5. Creates a per-agent Docker network and DinD sidecar
-6. Launches the agent container with all resolved mounts and environment variables
-7. Runs the pre-launch hook if declared
-8. Starts Claude Code with `--dangerously-skip-permissions`
+3. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
+4. Prompts for interactive environment variables declared in the manifest
+5. Generates and builds a derived Docker image (cached if unchanged)
+6. Creates a per-agent Docker network and DinD sidecar
+7. Launches the agent container with all resolved mounts and environment variables
+8. Runs the pre-launch hook if declared
+9. Starts Claude Code with `--dangerously-skip-permissions`
 
 :::note
 If the agent manifest declares interactive environment variables, `jackin load` prompts for their values before building the Docker image. This ensures no build time is wasted if you cancel.

--- a/docs/pages/guides/mounts.mdx
+++ b/docs/pages/guides/mounts.mdx
@@ -125,6 +125,23 @@ When multiple mount sources are resolved, jackin' combines them in this order:
 If two mounts target the same container destination, jackin' stops with an error. It does not silently let the later mount win. This is deliberate because mounts are part of the security boundary.
 :::
 
+## Sensitive path warnings
+
+jackin' detects when a mount source matches a known sensitive directory and warns before proceeding:
+
+- `~/.ssh` — SSH keys and configuration
+- `~/.aws` — AWS credentials and configuration
+- `~/.gnupg` — GPG keys and trust database
+- `~/.config/gcloud` — Google Cloud credentials
+- `~/.kube` — Kubernetes credentials and configuration
+- `~/.docker` — Docker credentials and configuration
+
+When a sensitive path is detected, you'll see a warning explaining the risk and must confirm before the mount is applied. This applies to all mount types — load-time, workspace, and global mounts.
+
+:::warning
+The warning defaults to "no". If stdin is not a terminal (e.g. in a script), jackin' aborts rather than silently mounting sensitive paths.
+:::
+
 ## Best practices
 
 - **Mount only what the agent needs.** Don't mount your entire home directory. Be specific about which project directories the agent should access.

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -156,7 +156,7 @@ This is where people often over-claim container isolation. Don't do that. jackin
 
 1. **Mount the minimum necessary.** Smaller visibility is the biggest win.
 2. **Prefer read-only mounts.** If the agent only needs to inspect something, mount it as `:ro`.
-3. **Do not mount credential directories.** Avoid `~/.ssh`, `~/.aws`, `~/.gnupg`, and similar paths.
+3. **Do not mount credential directories.** Avoid `~/.ssh`, `~/.aws`, `~/.gnupg`, and similar paths. jackin' warns and asks for confirmation when it detects these, but avoiding them entirely is the safest approach.
 4. **Treat runtime login as sensitive.** If you authenticate inside the runtime, assume the agent can read that state.
 5. **Review agent repos before loading.** The Dockerfile defines what the runtime contains.
 6. **Split agent classes by scope.** Keep frontend, backend, infra, and review workflows in separate environments when appropriate.

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -25,6 +25,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Namespaced agent classes (e.g., `chainargos/frontend-engineer`)
 - Last-agent memory per workspace
 - Custom Claude plugin marketplaces in `jackin.agent.toml`
+- Sensitive mount path warnings (warn-and-confirm for `~/.ssh`, `~/.aws`, etc.)
 
 ## Planned
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,12 @@ pub fn run(cli: Cli) -> Result<()> {
                 workspace_input,
                 &ad_hoc_mounts,
             )?;
+
+            let sensitive = crate::workspace::find_sensitive_mounts(&resolved_workspace.mounts);
+            if !sensitive.is_empty() && !crate::workspace::confirm_sensitive_mounts(&sensitive)? {
+                anyhow::bail!("aborted — sensitive mount paths were not confirmed");
+            }
+
             let opts = runtime::LoadOptions {
                 no_intro: no_intro || debug,
                 debug,
@@ -281,6 +287,12 @@ pub fn run(cli: Cli) -> Result<()> {
         Command::Launch => {
             let cwd = std::env::current_dir()?;
             let (class, workspace) = crate::launch::run_launch(&config, &cwd)?;
+
+            let sensitive = crate::workspace::find_sensitive_mounts(&workspace.mounts);
+            if !sensitive.is_empty() && !crate::workspace::confirm_sensitive_mounts(&sensitive)? {
+                anyhow::bail!("aborted — sensitive mount paths were not confirmed");
+            }
+
             let opts = runtime::LoadOptions {
                 no_intro: false,
                 debug: false,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -149,6 +149,83 @@ pub fn validate_mounts(mounts: &[MountConfig]) -> anyhow::Result<()> {
     validate_mount_paths(mounts)
 }
 
+// ── Sensitive mount detection ────────────────────────────────────────────
+
+/// Path suffixes that indicate sensitive host directories. A mount source is
+/// considered sensitive when its resolved path ends with one of these suffixes
+/// (after tilde expansion).
+const SENSITIVE_SUFFIXES: &[(&str, &str)] = &[
+    ("/.ssh", "SSH keys and configuration"),
+    ("/.aws", "AWS credentials and configuration"),
+    ("/.gnupg", "GPG keys and trust database"),
+    ("/.config/gcloud", "Google Cloud credentials"),
+    ("/.kube", "Kubernetes credentials and configuration"),
+    ("/.docker", "Docker credentials and configuration"),
+];
+
+/// A mount source that matched a sensitive path pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SensitiveMount {
+    pub src: String,
+    pub reason: String,
+}
+
+/// Return any mounts whose source path matches a known sensitive pattern.
+pub fn find_sensitive_mounts(mounts: &[MountConfig]) -> Vec<SensitiveMount> {
+    let mut hits = Vec::new();
+    for mount in mounts {
+        let normalized = mount.src.trim_end_matches('/');
+        for &(suffix, reason) in SENSITIVE_SUFFIXES {
+            if normalized.ends_with(suffix) || normalized == suffix.trim_start_matches('/') {
+                hits.push(SensitiveMount {
+                    src: mount.src.clone(),
+                    reason: reason.to_string(),
+                });
+                break;
+            }
+        }
+    }
+    hits
+}
+
+/// Display a warning for sensitive mounts and ask the operator to confirm.
+/// Returns `Ok(true)` when the operator confirms, `Ok(false)` when they
+/// decline, and `Err` on I/O errors.
+pub fn confirm_sensitive_mounts(sensitive: &[SensitiveMount]) -> anyhow::Result<bool> {
+    use owo_colors::OwoColorize;
+    use std::io::IsTerminal;
+
+    if sensitive.is_empty() {
+        return Ok(true);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "sensitive mount paths detected but stdin is not a terminal — cannot prompt for confirmation"
+        );
+    }
+
+    eprintln!(
+        "\n{}",
+        "⚠  Sensitive host paths detected in mounts:"
+            .yellow()
+            .bold()
+    );
+    for hit in sensitive {
+        eprintln!("     {} — {}", hit.src.bold(), hit.reason);
+    }
+    eprintln!(
+        "   {}",
+        "These paths may expose credentials to the agent container.".dimmed()
+    );
+    eprintln!();
+
+    Ok(dialoguer::Confirm::new()
+        .with_prompt("Continue with these mounts?")
+        .default(false)
+        .interact()?)
+}
+
 pub fn validate_workspace_config(name: &str, workspace: &WorkspaceConfig) -> anyhow::Result<()> {
     if workspace.workdir.is_empty() {
         anyhow::bail!("workspace {name:?} must define workdir");
@@ -823,5 +900,93 @@ mod tests {
             last_agent: None,
         };
         validate_workspace_config("test", &ws).unwrap();
+    }
+
+    // -- find_sensitive_mounts ------------------------------------------------
+
+    fn mount(src: &str) -> MountConfig {
+        MountConfig {
+            src: src.to_string(),
+            dst: "/container/path".to_string(),
+            readonly: false,
+        }
+    }
+
+    #[test]
+    fn detects_ssh_mount() {
+        let mounts = vec![mount("/home/user/.ssh")];
+        let hits = find_sensitive_mounts(&mounts);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].src, "/home/user/.ssh");
+        assert!(hits[0].reason.contains("SSH"));
+    }
+
+    #[test]
+    fn detects_aws_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.aws")]);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].reason.contains("AWS"));
+    }
+
+    #[test]
+    fn detects_gnupg_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.gnupg")]);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].reason.contains("GPG"));
+    }
+
+    #[test]
+    fn detects_gcloud_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.config/gcloud")]);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].reason.contains("Google Cloud"));
+    }
+
+    #[test]
+    fn detects_kube_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.kube")]);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].reason.contains("Kubernetes"));
+    }
+
+    #[test]
+    fn detects_docker_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.docker")]);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].reason.contains("Docker"));
+    }
+
+    #[test]
+    fn ignores_safe_mounts() {
+        let mounts = vec![
+            mount("/home/user/projects"),
+            mount("/tmp/workspace"),
+            mount("/var/data"),
+        ];
+        assert!(find_sensitive_mounts(&mounts).is_empty());
+    }
+
+    #[test]
+    fn detects_multiple_sensitive_mounts() {
+        let mounts = vec![
+            mount("/home/user/.ssh"),
+            mount("/home/user/projects"),
+            mount("/home/user/.aws"),
+        ];
+        let hits = find_sensitive_mounts(&mounts);
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn handles_trailing_slash_on_sensitive_mount() {
+        let hits = find_sensitive_mounts(&[mount("/home/user/.ssh/")]);
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn does_not_match_partial_name() {
+        // ".sshd" should NOT match ".ssh"
+        let hits = find_sensitive_mounts(&[mount("/home/user/.sshd")]);
+        assert!(hits.is_empty());
     }
 }

--- a/todo/sensitive-mount-warnings.md
+++ b/todo/sensitive-mount-warnings.md
@@ -1,6 +1,6 @@
 # Sensitive Mount Path Warnings
 
-**Status**: Deferred — implement alongside the agent source trust model
+**Status**: Resolved
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Add warn-and-confirm flow when mount sources match known sensitive directories (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker`)
- Display a clear warning with per-mount reasons and require explicit confirmation before proceeding (defaults to "no"); non-interactive sessions bail with an error
- Document the feature across the mounts guide, security model, and load command reference
- Resolves the `sensitive-mount-warnings` TODO item and updates roadmap/tracking docs

## Changes

- **`src/workspace.rs`** — `find_sensitive_mounts()` (pure detection) + `confirm_sensitive_mounts()` (interactive warning) + 10 unit tests
- **`src/lib.rs`** — Wire check into both `Load` and `Launch` command paths, after workspace resolution
- **`docs/pages/guides/mounts.mdx`** — New "Sensitive path warnings" section with the full pattern list and behavior notes
- **`docs/pages/guides/security-model.mdx`** — Updated best practice #3 to mention the new warn-and-confirm flow
- **`docs/pages/commands/load.mdx`** — Added sensitive mount check as step 3 in the "What happens" sequence
- **`docs/pages/reference/roadmap.mdx`** — Moved to Completed section
- **`TODO.md`** / **`todo/sensitive-mount-warnings.md`** — Marked as resolved

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with zero warnings
- [x] `cargo test` — all 242 tests pass, including 10 new tests covering: each sensitive pattern, safe mounts, multiple hits, trailing slashes, and partial-name rejection (e.g. `.sshd` does not match `.ssh`)
- [ ] Manual: `jackin load <agent> --mount ~/.ssh:/container/.ssh` should display yellow warning and prompt for confirmation
- [ ] Manual: declining the prompt should abort with a clear error message

https://claude.ai/code/session_01VBhstT1HpiLTBkkQ8oeVQK