### PR TITLE
feat: ${env.VAR} interpolation in env var prompts and defaults

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
 ## Resolved
 
-- [Interactive Env Var Interpolation](todo/env-var-interpolation.md) — `${VAR_NAME}` interpolation in prompt and default fields for dependent env vars
+- [Interactive Env Var Interpolation](todo/env-var-interpolation.md) — `${env.VAR}` interpolation in prompt and default fields for dependent env vars
 - [Orphaned DinD Container Cleanup](todo/orphaned-dind-cleanup.md) — automatic pre-launch GC for orphaned DinD sidecars and networks
 - [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
 - [Selectable Sandbox Backends: DinD and MicroVM](todo/selectable-sandbox-backends.md) — operator-selectable runtime modes with backend-neutral lifecycle design
 - [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
+
 ## Resolved
 
 - [Interactive Env Var Interpolation](todo/env-var-interpolation.md) — `${env.VAR}` interpolation in prompt and default fields for dependent env vars

--- a/TODO.md
+++ b/TODO.md
@@ -12,10 +12,9 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
 - [Selectable Sandbox Backends: DinD and MicroVM](todo/selectable-sandbox-backends.md) — operator-selectable runtime modes with backend-neutral lifecycle design
 - [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
-- [Interactive Env Vars and Resolution](todo/env-var-interpolation.md) — interactive prompts, workspace overrides, and secret resolution for env vars
-
 ## Resolved
 
+- [Interactive Env Var Interpolation](todo/env-var-interpolation.md) — `${VAR_NAME}` interpolation in prompt and default fields for dependent env vars
 - [Orphaned DinD Container Cleanup](todo/orphaned-dind-cleanup.md) — automatic pre-launch GC for orphaned DinD sidecars and networks
 - [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -44,8 +44,8 @@ prompt = "Select a project:"
 [env.BRANCH]
 interactive = true
 depends_on = ["env.PROJECT"]
-prompt = "Branch name:"
-default = "main"
+prompt = "Branch for ${env.PROJECT}:"
+default = "feature/${env.PROJECT}"
 ```
 
 ## Top-level fields
@@ -326,13 +326,13 @@ prompt = "Context7 API key:"
 [env.PROJECT]
 interactive = true
 options = ["frontend", "backend", "infra"]
-prompt = "Select a project to clone"
+prompt = "Select a project to clone:"
 
 [env.BRANCH]
 interactive = true
 depends_on = ["env.PROJECT"]
-prompt = "Branch name:"
-default = "main"
+prompt = "Branch for ${env.PROJECT}:"
+default = "feature/${env.PROJECT}"
 ```
 
 :::tip

--- a/docs/pages/developing/agent-manifest.mdx
+++ b/docs/pages/developing/agent-manifest.mdx
@@ -176,10 +176,13 @@ Declare environment variables that the agent needs at runtime. Each variable is 
 
 ### Validation rules
 
+- Variable names must contain only ASCII letters, digits, and underscores, and cannot start with a digit
 - A non-interactive variable **must** have a `default` value
 - `options` requires `interactive = true`
+- `options` cannot contain `${env.*}` interpolation — options are always static
 - `depends_on` entries must use the `env.` prefix (e.g., `"env.PROJECT"`)
 - `depends_on` must reference variables declared in the same manifest
+- `${env.*}` references in `prompt` and `default` must point to declared variables that are listed in `depends_on`
 - `JACKIN_CLAUDE_ENV` is reserved for jackin and cannot be declared in `[env]`
 - `JACKIN_DIND_HOSTNAME` is reserved for jackin and cannot be declared in `[env]`
 - Circular dependencies are rejected
@@ -247,6 +250,32 @@ default = "main"
 ```
 
 If a skippable variable is skipped, all variables that depend on it are also skipped — regardless of their own `skippable` setting.
+
+### Interpolation
+
+Use `${env.VAR_NAME}` in `prompt` and `default` fields to reference the resolved value of a dependency:
+
+```toml
+[env.PROJECT]
+interactive = true
+options = ["frontend", "backend"]
+prompt = "Select a project:"
+
+[env.BRANCH]
+interactive = true
+depends_on = ["env.PROJECT"]
+prompt = "Branch for ${env.PROJECT}:"
+default = "feature/${env.PROJECT}"
+```
+
+When the user selects `frontend`, the branch prompt becomes `"Branch for frontend:"` with default `"feature/frontend"`.
+
+Interpolation rules:
+
+- Only `${env.*}` references are resolved — other `${...}` forms are preserved as-is
+- Every `${env.*}` reference must point to a variable declared in the same manifest **and** listed in `depends_on`
+- `options` arrays cannot contain `${env.*}` references — options are always static
+- Resolved values are never re-interpreted, so a value containing `${env.*}` is treated as literal text
 
 :::tip
 Interactive prompts happen before the Docker image build, so you won't wait through a build before being asked questions. If you cancel, no build resources are wasted.

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -27,7 +27,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Custom Claude plugin marketplaces in `jackin.agent.toml`
 - Sensitive mount path warnings (warn-and-confirm for `~/.ssh`, `~/.aws`, etc.)
 - Automatic orphaned DinD cleanup (pre-launch garbage collection)
-- `${VAR_NAME}` interpolation in env var prompts and defaults for dependent variables
+- `${env.VAR}` interpolation in env var prompts and defaults for dependent variables
 
 ## Planned
 

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -27,6 +27,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Custom Claude plugin marketplaces in `jackin.agent.toml`
 - Sensitive mount path warnings (warn-and-confirm for `~/.ssh`, `~/.aws`, etc.)
 - Automatic orphaned DinD cleanup (pre-launch garbage collection)
+- `${VAR_NAME}` interpolation in env var prompts and defaults for dependent variables
 
 ## Planned
 

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -21,6 +21,33 @@ pub trait EnvPrompter {
     ) -> PromptResult;
 }
 
+/// Extract env var names from `${env.VAR_NAME}` interpolation placeholders.
+///
+/// Returns the var name portion (after `env.`) for each match.  Non-`env.`
+/// references like `${other.FOO}` are ignored — only the `env` namespace is
+/// recognised for interpolation.
+///
+/// The scanning logic here mirrors [`interpolate`] — both parse `${...}` the
+/// same way so that validation and runtime resolution agree on what constitutes
+/// a reference.
+pub(crate) fn extract_interpolation_refs(s: &str) -> Vec<&str> {
+    let mut refs = Vec::new();
+    let mut rest = s;
+    while let Some(start) = rest.find("${") {
+        let after_open = &rest[start + 2..];
+        if let Some(end) = after_open.find('}') {
+            let ref_expr = &after_open[..end];
+            if let Some(var_name) = ref_expr.strip_prefix("env.") {
+                refs.push(var_name);
+            }
+            rest = &after_open[end + 1..];
+        } else {
+            break;
+        }
+    }
+    refs
+}
+
 /// Replace `${env.VAR_NAME}` placeholders with values from already-resolved vars.
 ///
 /// Uses a single left-to-right scan so that replacement values containing `${...}`
@@ -180,6 +207,43 @@ fn topological_sort(declarations: &BTreeMap<String, EnvVarDecl>) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_interpolation_refs_finds_single_ref() {
+        assert_eq!(
+            extract_interpolation_refs("Branch for ${env.PROJECT}:"),
+            vec!["PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_finds_multiple_refs() {
+        assert_eq!(
+            extract_interpolation_refs("${env.TEAM}/${env.PROJECT}"),
+            vec!["TEAM", "PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_returns_empty_for_no_refs() {
+        assert!(extract_interpolation_refs("plain text").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_ignores_non_env_namespace() {
+        assert!(extract_interpolation_refs("${other.FOO}").is_empty());
+        assert!(extract_interpolation_refs("${FOO}").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_returns_empty_name_for_empty_env_ref() {
+        assert_eq!(extract_interpolation_refs("${env.}"), vec![""]);
+    }
+
+    #[test]
+    fn extract_interpolation_refs_handles_unclosed_brace() {
+        assert!(extract_interpolation_refs("${env.OPEN").is_empty());
+    }
 
     struct MockPrompter {
         responses: std::cell::RefCell<Vec<PromptResult>>,

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -21,10 +21,11 @@ pub trait EnvPrompter {
     ) -> PromptResult;
 }
 
-/// Replace `${VAR_NAME}` placeholders with values from already-resolved vars.
+/// Replace `${env.VAR_NAME}` placeholders with values from already-resolved vars.
 ///
 /// Uses a single left-to-right scan so that replacement values containing `${...}`
-/// are never re-interpreted as placeholders.
+/// are never re-interpreted as placeholders.  Only `${env.*}` references are
+/// resolved; other `${...}` forms are preserved as-is.
 fn interpolate(template: &str, resolved: &[(String, String)]) -> String {
     let resolved_map: std::collections::HashMap<&str, &str> = resolved
         .iter()
@@ -38,11 +39,16 @@ fn interpolate(template: &str, resolved: &[(String, String)]) -> String {
         result.push_str(&rest[..start]);
         let after_open = &rest[start + 2..];
         if let Some(end) = after_open.find('}') {
-            let var_name = &after_open[..end];
-            if let Some(&value) = resolved_map.get(var_name) {
-                result.push_str(value);
+            let ref_expr = &after_open[..end];
+            if let Some(var_name) = ref_expr.strip_prefix("env.") {
+                if let Some(&value) = resolved_map.get(var_name) {
+                    result.push_str(value);
+                } else {
+                    // Known namespace but unknown var — preserve as-is
+                    result.push_str(&rest[start..=start + 2 + end]);
+                }
             } else {
-                // Unknown placeholder — preserve as-is
+                // Not an env. reference — preserve as-is
                 result.push_str(&rest[start..=start + 2 + end]);
             }
             rest = &after_open[end + 1..];
@@ -409,7 +415,7 @@ mod tests {
             interactive_select("Select a project:", vec!["alpha", "beta"]),
         );
 
-        let mut branch = interactive_text("Branch for ${PROJECT}:");
+        let mut branch = interactive_text("Branch for ${env.PROJECT}:");
         branch.depends_on = vec!["env.PROJECT".to_string()];
         decls.insert("BRANCH".to_string(), branch);
 
@@ -433,7 +439,7 @@ mod tests {
         );
 
         let branch = EnvVarDecl {
-            default_value: Some("feature/${PROJECT}".to_string()),
+            default_value: Some("feature/${env.PROJECT}".to_string()),
             interactive: true,
             skippable: false,
             prompt: Some("Branch:".to_string()),
@@ -462,7 +468,7 @@ mod tests {
         );
 
         let derived = EnvVarDecl {
-            default_value: Some("${PROJECT}-derived".to_string()),
+            default_value: Some("${env.PROJECT}-derived".to_string()),
             interactive: false,
             skippable: false,
             prompt: None,
@@ -494,10 +500,10 @@ mod tests {
         );
 
         let label = EnvVarDecl {
-            default_value: Some("${TEAM}/${PROJECT}".to_string()),
+            default_value: Some("${env.TEAM}/${env.PROJECT}".to_string()),
             interactive: true,
             skippable: false,
-            prompt: Some("Label for ${TEAM}/${PROJECT}:".to_string()),
+            prompt: Some("Label for ${env.TEAM}/${env.PROJECT}:".to_string()),
             options: vec![],
             depends_on: vec!["env.TEAM".to_string(), "env.PROJECT".to_string()],
         };
@@ -522,11 +528,11 @@ mod tests {
         let mut decls = BTreeMap::new();
 
         // A resolves to a value that looks like an interpolation placeholder
-        decls.insert("A".to_string(), static_var("${B}"));
+        decls.insert("A".to_string(), static_var("${env.B}"));
         decls.insert("B".to_string(), static_var("secret"));
 
         let c = EnvVarDecl {
-            default_value: Some("prefix-${A}-suffix".to_string()),
+            default_value: Some("prefix-${env.A}-suffix".to_string()),
             interactive: false,
             skippable: false,
             prompt: None,
@@ -539,9 +545,9 @@ mod tests {
 
         let resolved = resolve_env(&decls, &prompter).unwrap();
 
-        // C should be "prefix-${B}-suffix" (literal), NOT "prefix-secret-suffix"
+        // C should be "prefix-${env.B}-suffix" (literal), NOT "prefix-secret-suffix"
         let c_value = resolved.vars.iter().find(|(k, _)| k == "C").unwrap();
-        assert_eq!(c_value.1, "prefix-${B}-suffix");
+        assert_eq!(c_value.1, "prefix-${env.B}-suffix");
     }
 
     #[test]

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -21,6 +21,18 @@ pub trait EnvPrompter {
     ) -> PromptResult;
 }
 
+/// Replace `${VAR_NAME}` placeholders with values from already-resolved vars.
+fn interpolate(template: &str, resolved: &[(String, String)]) -> String {
+    let mut result = template.to_string();
+    for (name, value) in resolved {
+        let placeholder = format!("${{{name}}}");
+        if result.contains(&placeholder) {
+            result = result.replace(&placeholder, value);
+        }
+    }
+    result
+}
+
 pub fn resolve_env(
     declarations: &BTreeMap<String, EnvVarDecl>,
     prompter: &impl EnvPrompter,
@@ -43,24 +55,28 @@ pub fn resolve_env(
             continue;
         }
 
+        // Interpolate prompt and default_value using already-resolved vars
+        let interpolated_default = decl.default_value.as_deref().map(|d| interpolate(d, &vars));
+
         if !decl.interactive {
             // Static var — use default
-            if let Some(ref default) = decl.default_value {
-                vars.push((name.clone(), default.clone()));
+            if let Some(default) = interpolated_default {
+                vars.push((name.clone(), default));
             }
             continue;
         }
 
-        // Interactive var — prompt
-        let title = decl.prompt.as_deref().unwrap_or(name.as_str());
+        // Interactive var — prompt with interpolated fields
+        let raw_title = decl.prompt.as_deref().unwrap_or(name.as_str());
+        let title = interpolate(raw_title, &vars);
 
         let result = if decl.options.is_empty() {
-            prompter.prompt_text(title, decl.default_value.as_deref(), decl.skippable)
+            prompter.prompt_text(&title, interpolated_default.as_deref(), decl.skippable)
         } else {
             prompter.prompt_select(
-                title,
+                &title,
                 &decl.options,
-                decl.default_value.as_deref(),
+                interpolated_default.as_deref(),
                 decl.skippable,
             )
         };
@@ -137,12 +153,16 @@ mod tests {
 
     struct MockPrompter {
         responses: std::cell::RefCell<Vec<PromptResult>>,
+        captured_titles: std::cell::RefCell<Vec<String>>,
+        captured_defaults: std::cell::RefCell<Vec<Option<String>>>,
     }
 
     impl MockPrompter {
         fn new(responses: Vec<PromptResult>) -> Self {
             Self {
                 responses: std::cell::RefCell::new(responses),
+                captured_titles: std::cell::RefCell::new(vec![]),
+                captured_defaults: std::cell::RefCell::new(vec![]),
             }
         }
     }
@@ -150,20 +170,28 @@ mod tests {
     impl EnvPrompter for MockPrompter {
         fn prompt_text(
             &self,
-            _title: &str,
-            _default: Option<&str>,
+            title: &str,
+            default: Option<&str>,
             _skippable: bool,
         ) -> PromptResult {
+            self.captured_titles.borrow_mut().push(title.to_string());
+            self.captured_defaults
+                .borrow_mut()
+                .push(default.map(String::from));
             self.responses.borrow_mut().remove(0)
         }
 
         fn prompt_select(
             &self,
-            _title: &str,
+            title: &str,
             _options: &[String],
-            _default: Option<&str>,
+            default: Option<&str>,
             _skippable: bool,
         ) -> PromptResult {
+            self.captured_titles.borrow_mut().push(title.to_string());
+            self.captured_defaults
+                .borrow_mut()
+                .push(default.map(String::from));
             self.responses.borrow_mut().remove(0)
         }
     }
@@ -347,5 +375,134 @@ mod tests {
         let resolved = resolve_env(&decls, &prompter).unwrap();
 
         assert!(resolved.vars.is_empty());
+    }
+
+    #[test]
+    fn interpolates_prompt_with_resolved_value() {
+        let mut decls = BTreeMap::new();
+        decls.insert(
+            "PROJECT".to_string(),
+            interactive_select("Select a project:", vec!["alpha", "beta"]),
+        );
+
+        let mut branch = interactive_text("Branch for ${PROJECT}:");
+        branch.depends_on = vec!["env.PROJECT".to_string()];
+        decls.insert("BRANCH".to_string(), branch);
+
+        let prompter = MockPrompter::new(vec![
+            PromptResult::Value("alpha".to_string()),
+            PromptResult::Value("main".to_string()),
+        ]);
+
+        resolve_env(&decls, &prompter).unwrap();
+
+        let titles = prompter.captured_titles.borrow();
+        assert_eq!(titles[1], "Branch for alpha:");
+    }
+
+    #[test]
+    fn interpolates_default_value_with_resolved_value() {
+        let mut decls = BTreeMap::new();
+        decls.insert(
+            "PROJECT".to_string(),
+            interactive_select("Select:", vec!["proj1", "proj2"]),
+        );
+
+        let branch = EnvVarDecl {
+            default_value: Some("feature/${PROJECT}".to_string()),
+            interactive: true,
+            skippable: false,
+            prompt: Some("Branch:".to_string()),
+            options: vec![],
+            depends_on: vec!["env.PROJECT".to_string()],
+        };
+        decls.insert("BRANCH".to_string(), branch);
+
+        let prompter = MockPrompter::new(vec![
+            PromptResult::Value("proj1".to_string()),
+            PromptResult::Value("feature/proj1".to_string()),
+        ]);
+
+        resolve_env(&decls, &prompter).unwrap();
+
+        let defaults = prompter.captured_defaults.borrow();
+        assert_eq!(defaults[1], Some("feature/proj1".to_string()));
+    }
+
+    #[test]
+    fn interpolates_static_default_value() {
+        let mut decls = BTreeMap::new();
+        decls.insert(
+            "PROJECT".to_string(),
+            interactive_select("Select:", vec!["proj1", "proj2"]),
+        );
+
+        let derived = EnvVarDecl {
+            default_value: Some("${PROJECT}-derived".to_string()),
+            interactive: false,
+            skippable: false,
+            prompt: None,
+            options: vec![],
+            depends_on: vec!["env.PROJECT".to_string()],
+        };
+        decls.insert("DERIVED".to_string(), derived);
+
+        let prompter = MockPrompter::new(vec![PromptResult::Value("proj1".to_string())]);
+
+        let resolved = resolve_env(&decls, &prompter).unwrap();
+
+        assert_eq!(
+            resolved.vars,
+            vec![
+                ("PROJECT".to_string(), "proj1".to_string()),
+                ("DERIVED".to_string(), "proj1-derived".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn interpolates_multiple_refs_in_one_field() {
+        let mut decls = BTreeMap::new();
+        decls.insert("TEAM".to_string(), static_var("backend"));
+        decls.insert(
+            "PROJECT".to_string(),
+            interactive_select("Select:", vec!["api", "web"]),
+        );
+
+        let label = EnvVarDecl {
+            default_value: Some("${TEAM}/${PROJECT}".to_string()),
+            interactive: true,
+            skippable: false,
+            prompt: Some("Label for ${TEAM}/${PROJECT}:".to_string()),
+            options: vec![],
+            depends_on: vec!["env.TEAM".to_string(), "env.PROJECT".to_string()],
+        };
+        decls.insert("LABEL".to_string(), label);
+
+        let prompter = MockPrompter::new(vec![
+            PromptResult::Value("api".to_string()),
+            PromptResult::Value("backend/api".to_string()),
+        ]);
+
+        resolve_env(&decls, &prompter).unwrap();
+
+        let titles = prompter.captured_titles.borrow();
+        let defaults = prompter.captured_defaults.borrow();
+        // LABEL is the second prompt (PROJECT is first, TEAM is static)
+        assert_eq!(titles[1], "Label for backend/api:");
+        assert_eq!(defaults[1], Some("backend/api".to_string()));
+    }
+
+    #[test]
+    fn no_interpolation_without_placeholders() {
+        let mut decls = BTreeMap::new();
+        decls.insert("BRANCH".to_string(), interactive_text("Branch name:"));
+
+        let prompter = MockPrompter::new(vec![PromptResult::Value("main".to_string())]);
+
+        resolve_env(&decls, &prompter).unwrap();
+
+        let titles = prompter.captured_titles.borrow();
+        assert_eq!(titles[0], "Branch name:");
     }
 }

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -22,14 +22,38 @@ pub trait EnvPrompter {
 }
 
 /// Replace `${VAR_NAME}` placeholders with values from already-resolved vars.
+///
+/// Uses a single left-to-right scan so that replacement values containing `${...}`
+/// are never re-interpreted as placeholders.
 fn interpolate(template: &str, resolved: &[(String, String)]) -> String {
-    let mut result = template.to_string();
-    for (name, value) in resolved {
-        let placeholder = format!("${{{name}}}");
-        if result.contains(&placeholder) {
-            result = result.replace(&placeholder, value);
+    let resolved_map: std::collections::HashMap<&str, &str> = resolved
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let mut result = String::with_capacity(template.len());
+    let mut rest = template;
+
+    while let Some(start) = rest.find("${") {
+        result.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+        if let Some(end) = after_open.find('}') {
+            let var_name = &after_open[..end];
+            if let Some(&value) = resolved_map.get(var_name) {
+                result.push_str(value);
+            } else {
+                // Unknown placeholder — preserve as-is
+                result.push_str(&rest[start..=start + 2 + end]);
+            }
+            rest = &after_open[end + 1..];
+        } else {
+            // Unclosed `${` — preserve rest as-is
+            result.push_str(&rest[start..]);
+            rest = "";
+            break;
         }
     }
+    result.push_str(rest);
     result
 }
 
@@ -491,6 +515,33 @@ mod tests {
         // LABEL is the second prompt (PROJECT is first, TEAM is static)
         assert_eq!(titles[1], "Label for backend/api:");
         assert_eq!(defaults[1], Some("backend/api".to_string()));
+    }
+
+    #[test]
+    fn resolved_values_containing_dollar_brace_are_not_re_interpolated() {
+        let mut decls = BTreeMap::new();
+
+        // A resolves to a value that looks like an interpolation placeholder
+        decls.insert("A".to_string(), static_var("${B}"));
+        decls.insert("B".to_string(), static_var("secret"));
+
+        let c = EnvVarDecl {
+            default_value: Some("prefix-${A}-suffix".to_string()),
+            interactive: false,
+            skippable: false,
+            prompt: None,
+            options: vec![],
+            depends_on: vec!["env.A".to_string()],
+        };
+        decls.insert("C".to_string(), c);
+
+        let prompter = MockPrompter::new(vec![]);
+
+        let resolved = resolve_env(&decls, &prompter).unwrap();
+
+        // C should be "prefix-${B}-suffix" (literal), NOT "prefix-secret-suffix"
+        let c_value = resolved.vars.iter().find(|(k, _)| k == "C").unwrap();
+        assert_eq!(c_value.1, "prefix-${B}-suffix");
     }
 
     #[test]

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -527,8 +527,8 @@ mod tests {
     fn resolved_values_containing_dollar_brace_are_not_re_interpolated() {
         let mut decls = BTreeMap::new();
 
-        // A resolves to a value that looks like an interpolation placeholder
-        decls.insert("A".to_string(), static_var("${env.B}"));
+        // User types a value that looks like an interpolation placeholder
+        decls.insert("A".to_string(), interactive_text("Enter A:"));
         decls.insert("B".to_string(), static_var("secret"));
 
         let c = EnvVarDecl {
@@ -541,7 +541,8 @@ mod tests {
         };
         decls.insert("C".to_string(), c);
 
-        let prompter = MockPrompter::new(vec![]);
+        // User enters a value that looks like an interpolation ref
+        let prompter = MockPrompter::new(vec![PromptResult::Value("${env.B}".to_string())]);
 
         let resolved = resolve_env(&decls, &prompter).unwrap();
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -182,6 +182,7 @@ impl AgentManifest {
         }
 
         // Validate depends_on entries
+        let mut seen_deps: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for dep in &decl.depends_on {
             let Some(dep_name) = dep.strip_prefix("env.") else {
                 anyhow::bail!(
@@ -191,6 +192,10 @@ impl AgentManifest {
 
             if dep_name == name {
                 anyhow::bail!("env var {name}: depends_on cannot reference self");
+            }
+
+            if !seen_deps.insert(dep_name) {
+                anyhow::bail!("env var {name}: depends_on contains duplicate entry \"{dep_name}\"");
             }
 
             self.validate_env_ref(name, "depends_on", dep_name)?;
@@ -1458,5 +1463,35 @@ prompt = "Value:"
                 .to_string()
                 .contains("invalid env var name")
         );
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_depends_on() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Select:"
+
+[env.BRANCH]
+interactive = true
+depends_on = ["env.PROJECT", "env.PROJECT"]
+prompt = "Branch:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("duplicate"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -82,32 +82,21 @@ fn is_valid_env_var_name(name: &str) -> bool {
         && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
-/// Detect bare `$VAR` references (single dollar without braces).
+/// Extract env var names from `${env.VAR_NAME}` interpolation placeholders.
 ///
-/// Matches `$` followed by an ASCII letter or underscore (the start of a valid
-/// env var name), but NOT followed by `{` (which is the `${VAR}` interpolation syntax).
-fn contains_bare_dollar_ref(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    for i in 0..bytes.len().saturating_sub(1) {
-        if bytes[i] == b'$'
-            && bytes[i + 1] != b'{'
-            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
-        {
-            return true;
-        }
-    }
-    false
-}
-
-/// Extract variable names from `${VAR_NAME}` interpolation placeholders in a string.
+/// Returns the var name portion (after `env.`) for each match.  Non-`env.`
+/// references like `${other.FOO}` are ignored — only the `env` namespace is
+/// recognised for interpolation.
 fn extract_interpolation_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();
     let mut rest = s;
     while let Some(start) = rest.find("${") {
         let after_open = &rest[start + 2..];
         if let Some(end) = after_open.find('}') {
-            let var_name = &after_open[..end];
-            if !var_name.is_empty() {
+            let ref_expr = &after_open[..end];
+            if let Some(var_name) = ref_expr.strip_prefix("env.")
+                && !var_name.is_empty()
+            {
                 refs.push(var_name);
             }
             rest = &after_open[end + 1..];
@@ -181,7 +170,7 @@ impl AgentManifest {
                 });
             }
 
-            self.validate_env_interpolation(name, decl, &mut warnings)?;
+            self.validate_env_interpolation(name, decl)?;
         }
 
         // Cycle detection via topological sort (Kahn's algorithm)
@@ -190,36 +179,13 @@ impl AgentManifest {
         Ok(warnings)
     }
 
-    fn validate_env_interpolation(
-        &self,
-        name: &str,
-        decl: &EnvVarDecl,
-        warnings: &mut Vec<ManifestWarning>,
-    ) -> anyhow::Result<()> {
+    fn validate_env_interpolation(&self, name: &str, decl: &EnvVarDecl) -> anyhow::Result<()> {
         // Reject ${...} interpolation placeholders in options (options are always static)
         for option in &decl.options {
             if !extract_interpolation_refs(option).is_empty() {
                 anyhow::bail!(
                     "env var {name}: options cannot contain interpolation placeholders — options are static"
                 );
-            }
-        }
-
-        // Warn on bare $VAR (no braces) in prompt and default — reserved for future
-        // host env passthrough syntax, currently has no effect
-        for (field, value) in [
-            ("prompt", decl.prompt.as_deref()),
-            ("default", decl.default_value.as_deref()),
-        ] {
-            if let Some(v) = value
-                && contains_bare_dollar_ref(v)
-            {
-                warnings.push(ManifestWarning {
-                    message: format!(
-                        "env var {name}: {field} contains bare $VAR reference — \
-                         use ${{VAR}} for interpolation; bare $VAR is reserved for future host env passthrough"
-                    ),
-                });
             }
         }
 
@@ -264,12 +230,12 @@ impl AgentManifest {
             for ref_name in extract_interpolation_refs(value) {
                 if !self.env.contains_key(ref_name) {
                     anyhow::bail!(
-                        "env var {name}: {field} references unknown env var \"${{{ref_name}}}\""
+                        "env var {name}: {field} references unknown env var \"${{env.{ref_name}}}\""
                     );
                 }
                 if !dep_names.contains(ref_name) {
                     anyhow::bail!(
-                        "env var {name}: {field} references \"${{{ref_name}}}\" which is not listed in depends_on"
+                        "env var {name}: {field} references \"${{env.{ref_name}}}\" which is not listed in depends_on"
                     );
                 }
             }
@@ -352,30 +318,9 @@ mod tests {
     }
 
     #[test]
-    fn contains_bare_dollar_ref_detects_simple_cases() {
-        assert!(contains_bare_dollar_ref("$HOME"));
-        assert!(contains_bare_dollar_ref("prefix-$VAR-suffix"));
-        assert!(contains_bare_dollar_ref("$_PRIVATE"));
-    }
-
-    #[test]
-    fn contains_bare_dollar_ref_ignores_braced_syntax() {
-        assert!(!contains_bare_dollar_ref("${VAR}"));
-        assert!(!contains_bare_dollar_ref("prefix-${VAR}-suffix"));
-    }
-
-    #[test]
-    fn contains_bare_dollar_ref_ignores_dollar_without_identifier() {
-        assert!(!contains_bare_dollar_ref("$"));
-        assert!(!contains_bare_dollar_ref("$$"));
-        assert!(!contains_bare_dollar_ref("$1"));
-        assert!(!contains_bare_dollar_ref("price is $5"));
-    }
-
-    #[test]
     fn extract_interpolation_refs_finds_single_ref() {
         assert_eq!(
-            extract_interpolation_refs("Branch for ${PROJECT}:"),
+            extract_interpolation_refs("Branch for ${env.PROJECT}:"),
             vec!["PROJECT"]
         );
     }
@@ -383,7 +328,7 @@ mod tests {
     #[test]
     fn extract_interpolation_refs_finds_multiple_refs() {
         assert_eq!(
-            extract_interpolation_refs("${TEAM}/${PROJECT}"),
+            extract_interpolation_refs("${env.TEAM}/${env.PROJECT}"),
             vec!["TEAM", "PROJECT"]
         );
     }
@@ -394,13 +339,19 @@ mod tests {
     }
 
     #[test]
-    fn extract_interpolation_refs_skips_empty_braces() {
-        assert!(extract_interpolation_refs("${}").is_empty());
+    fn extract_interpolation_refs_ignores_non_env_namespace() {
+        assert!(extract_interpolation_refs("${other.FOO}").is_empty());
+        assert!(extract_interpolation_refs("${FOO}").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_skips_empty_env_ref() {
+        assert!(extract_interpolation_refs("${env.}").is_empty());
     }
 
     #[test]
     fn extract_interpolation_refs_handles_unclosed_brace() {
-        assert!(extract_interpolation_refs("${OPEN").is_empty());
+        assert!(extract_interpolation_refs("${env.OPEN").is_empty());
     }
 
     #[test]
@@ -1144,8 +1095,8 @@ prompt = "Select a project:"
 [env.BRANCH]
 interactive = true
 depends_on = ["env.PROJECT"]
-prompt = "Branch name for ${PROJECT}:"
-default = "feature/${PROJECT}"
+prompt = "Branch name for ${env.PROJECT}:"
+default = "feature/${env.PROJECT}"
 "#,
         )
         .unwrap();
@@ -1169,7 +1120,7 @@ plugins = []
 [env.BRANCH]
 interactive = true
 depends_on = []
-prompt = "Branch for ${NONEXISTENT}:"
+prompt = "Branch for ${env.NONEXISTENT}:"
 "#,
         )
         .unwrap();
@@ -1198,7 +1149,7 @@ prompt = "Select:"
 
 [env.BRANCH]
 interactive = true
-prompt = "Branch for ${PROJECT}:"
+prompt = "Branch for ${env.PROJECT}:"
 "#,
         )
         .unwrap();
@@ -1225,7 +1176,7 @@ plugins = []
 [env.BRANCH]
 interactive = true
 depends_on = []
-default = "feature/${GHOST}"
+default = "feature/${env.GHOST}"
 prompt = "Branch:"
 "#,
         )
@@ -1330,7 +1281,7 @@ prompt = "Pick:"
 [env.BRANCH]
 interactive = true
 depends_on = ["env.PROJECT"]
-options = ["${PROJECT}-main", "${PROJECT}-dev"]
+options = ["${env.PROJECT}-main", "${env.PROJECT}-dev"]
 prompt = "Branch:"
 "#,
         )
@@ -1349,31 +1300,7 @@ prompt = "Branch:"
     }
 
     #[test]
-    fn validate_warns_on_bare_dollar_var_in_prompt() {
-        let temp = tempdir().unwrap();
-        std::fs::write(
-            temp.path().join("jackin.agent.toml"),
-            r#"dockerfile = "Dockerfile"
-
-[claude]
-plugins = []
-
-[env.API_KEY]
-interactive = true
-prompt = "Key for $SERVICE:"
-"#,
-        )
-        .unwrap();
-
-        let manifest = AgentManifest::load(temp.path()).unwrap();
-        let warnings = manifest.validate().unwrap();
-
-        assert!(!warnings.is_empty());
-        assert!(warnings[0].message.contains("bare $VAR"));
-    }
-
-    #[test]
-    fn validate_warns_on_bare_dollar_var_in_default() {
+    fn validate_ignores_non_env_namespace_in_interpolation() {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.agent.toml"),
@@ -1383,7 +1310,8 @@ prompt = "Key for $SERVICE:"
 plugins = []
 
 [env.FOO]
-default = "$HOME/projects"
+interactive = true
+prompt = "Value (use ${other.THING} for other):"
 "#,
         )
         .unwrap();
@@ -1391,37 +1319,7 @@ default = "$HOME/projects"
         let manifest = AgentManifest::load(temp.path()).unwrap();
         let warnings = manifest.validate().unwrap();
 
-        assert!(!warnings.is_empty());
-        assert!(warnings[0].message.contains("bare $VAR"));
-    }
-
-    #[test]
-    fn validate_does_not_warn_on_braced_interpolation() {
-        let temp = tempdir().unwrap();
-        std::fs::write(
-            temp.path().join("jackin.agent.toml"),
-            r#"dockerfile = "Dockerfile"
-
-[claude]
-plugins = []
-
-[env.PROJECT]
-interactive = true
-options = ["a", "b"]
-prompt = "Pick:"
-
-[env.BRANCH]
-interactive = true
-depends_on = ["env.PROJECT"]
-prompt = "Branch for ${PROJECT}:"
-default = "feature/${PROJECT}"
-"#,
-        )
-        .unwrap();
-
-        let manifest = AgentManifest::load(temp.path()).unwrap();
-        let warnings = manifest.validate().unwrap();
-
+        // ${other.THING} is not an env. ref, so no error or warning
         assert!(warnings.is_empty());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -177,8 +177,24 @@ impl AgentManifest {
         Ok(warnings)
     }
 
+    /// Validate a single `env.VAR_NAME` reference: non-empty, valid name, and declared.
+    fn validate_env_ref(&self, owner: &str, context: &str, ref_name: &str) -> anyhow::Result<()> {
+        if ref_name.is_empty() {
+            anyhow::bail!("env var {owner}: {context} contains empty env reference \"env.\"");
+        }
+        if !is_valid_env_var_name(ref_name) {
+            anyhow::bail!(
+                "env var {owner}: {context} contains invalid env var name \"{ref_name}\""
+            );
+        }
+        if !self.env.contains_key(ref_name) {
+            anyhow::bail!("env var {owner}: {context} references unknown env var \"{ref_name}\"");
+        }
+        Ok(())
+    }
+
     fn validate_env_interpolation(&self, name: &str, decl: &EnvVarDecl) -> anyhow::Result<()> {
-        // Reject ${...} interpolation placeholders in options (options are always static)
+        // Reject ${env.*} interpolation placeholders in options (options are always static)
         for option in &decl.options {
             if !extract_interpolation_refs(option).is_empty() {
                 anyhow::bail!(
@@ -189,35 +205,16 @@ impl AgentManifest {
 
         // Validate depends_on entries
         for dep in &decl.depends_on {
-            // Must have env. prefix
             let Some(dep_name) = dep.strip_prefix("env.") else {
                 anyhow::bail!(
                     "env var {name}: depends_on entry \"{dep}\" must use env. prefix (e.g., \"env.{dep}\")"
                 );
             };
 
-            // Empty name
-            if dep_name.is_empty() {
-                anyhow::bail!("env var {name}: depends_on contains empty reference \"env.\"");
-            }
+            self.validate_env_ref(name, "depends_on", dep_name)?;
 
-            // Invalid name
-            if !is_valid_env_var_name(dep_name) {
-                anyhow::bail!(
-                    "env var {name}: depends_on contains invalid env var name \"{dep_name}\""
-                );
-            }
-
-            // Self-reference
             if dep_name == name {
                 anyhow::bail!("env var {name}: depends_on cannot reference self");
-            }
-
-            // Must exist
-            if !self.env.contains_key(dep_name) {
-                anyhow::bail!(
-                    "env var {name}: depends_on references unknown env var \"{dep_name}\""
-                );
             }
         }
 
@@ -228,35 +225,18 @@ impl AgentManifest {
             .filter_map(|d| d.strip_prefix("env."))
             .collect();
 
-        let fields_to_check: Vec<(&str, &str)> = [
-            decl.prompt.as_deref().map(|v| ("prompt", v)),
-            decl.default_value.as_deref().map(|v| ("default", v)),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        for (field, value) in fields_to_check {
-            for ref_name in extract_interpolation_refs(value) {
-                if ref_name.is_empty() {
-                    anyhow::bail!(
-                        "env var {name}: {field} contains empty interpolation reference \"${{env.}}\""
-                    );
-                }
-                if !is_valid_env_var_name(ref_name) {
-                    anyhow::bail!(
-                        "env var {name}: {field} contains invalid env var name in \"${{env.{ref_name}}}\""
-                    );
-                }
-                if !self.env.contains_key(ref_name) {
-                    anyhow::bail!(
-                        "env var {name}: {field} references unknown env var \"${{env.{ref_name}}}\""
-                    );
-                }
-                if !dep_names.contains(ref_name) {
-                    anyhow::bail!(
-                        "env var {name}: {field} references \"${{env.{ref_name}}}\" which is not listed in depends_on"
-                    );
+        for (field, value) in [
+            ("prompt", decl.prompt.as_deref()),
+            ("default", decl.default_value.as_deref()),
+        ] {
+            if let Some(v) = value {
+                for ref_name in extract_interpolation_refs(v) {
+                    self.validate_env_ref(name, field, ref_name)?;
+                    if !dep_names.contains(ref_name) {
+                        anyhow::bail!(
+                            "env var {name}: {field} references \"{ref_name}\" which is not listed in depends_on"
+                        );
+                    }
                 }
             }
         }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -209,7 +209,7 @@ impl AgentManifest {
             }
         }
 
-        // Validate ${VAR_NAME} interpolation references in prompt and default_value
+        // Validate ${env.VAR_NAME} interpolation references in prompt and default_value
         let dep_names: std::collections::HashSet<&str> = decl
             .depends_on
             .iter()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,3 +1,4 @@
+use crate::env_resolver::extract_interpolation_refs;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -80,29 +81,6 @@ fn is_valid_env_var_name(name: &str) -> bool {
         && name.is_ascii()
         && !name.as_bytes()[0].is_ascii_digit()
         && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
-}
-
-/// Extract env var names from `${env.VAR_NAME}` interpolation placeholders.
-///
-/// Returns the var name portion (after `env.`) for each match.  Non-`env.`
-/// references like `${other.FOO}` are ignored — only the `env` namespace is
-/// recognised for interpolation.
-fn extract_interpolation_refs(s: &str) -> Vec<&str> {
-    let mut refs = Vec::new();
-    let mut rest = s;
-    while let Some(start) = rest.find("${") {
-        let after_open = &rest[start + 2..];
-        if let Some(end) = after_open.find('}') {
-            let ref_expr = &after_open[..end];
-            if let Some(var_name) = ref_expr.strip_prefix("env.") {
-                refs.push(var_name);
-            }
-            rest = &after_open[end + 1..];
-        } else {
-            break;
-        }
-    }
-    refs
 }
 
 impl AgentManifest {
@@ -211,11 +189,11 @@ impl AgentManifest {
                 );
             };
 
-            self.validate_env_ref(name, "depends_on", dep_name)?;
-
             if dep_name == name {
                 anyhow::bail!("env var {name}: depends_on cannot reference self");
             }
+
+            self.validate_env_ref(name, "depends_on", dep_name)?;
         }
 
         // Validate ${env.VAR_NAME} interpolation references in prompt and default_value
@@ -315,43 +293,6 @@ mod tests {
         assert!(!is_valid_env_var_name("MY.VAR"));
         assert!(!is_valid_env_var_name("MY$VAR"));
         assert!(!is_valid_env_var_name("A}B"));
-    }
-
-    #[test]
-    fn extract_interpolation_refs_finds_single_ref() {
-        assert_eq!(
-            extract_interpolation_refs("Branch for ${env.PROJECT}:"),
-            vec!["PROJECT"]
-        );
-    }
-
-    #[test]
-    fn extract_interpolation_refs_finds_multiple_refs() {
-        assert_eq!(
-            extract_interpolation_refs("${env.TEAM}/${env.PROJECT}"),
-            vec!["TEAM", "PROJECT"]
-        );
-    }
-
-    #[test]
-    fn extract_interpolation_refs_returns_empty_for_no_refs() {
-        assert!(extract_interpolation_refs("plain text").is_empty());
-    }
-
-    #[test]
-    fn extract_interpolation_refs_ignores_non_env_namespace() {
-        assert!(extract_interpolation_refs("${other.FOO}").is_empty());
-        assert!(extract_interpolation_refs("${FOO}").is_empty());
-    }
-
-    #[test]
-    fn extract_interpolation_refs_returns_empty_name_for_empty_env_ref() {
-        assert_eq!(extract_interpolation_refs("${env.}"), vec![""]);
-    }
-
-    #[test]
-    fn extract_interpolation_refs_handles_unclosed_brace() {
-        assert!(extract_interpolation_refs("${env.OPEN").is_empty());
     }
 
     #[test]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -94,9 +94,7 @@ fn extract_interpolation_refs(s: &str) -> Vec<&str> {
         let after_open = &rest[start + 2..];
         if let Some(end) = after_open.find('}') {
             let ref_expr = &after_open[..end];
-            if let Some(var_name) = ref_expr.strip_prefix("env.")
-                && !var_name.is_empty()
-            {
+            if let Some(var_name) = ref_expr.strip_prefix("env.") {
                 refs.push(var_name);
             }
             rest = &after_open[end + 1..];
@@ -228,6 +226,16 @@ impl AgentManifest {
 
         for (field, value) in fields_to_check {
             for ref_name in extract_interpolation_refs(value) {
+                if ref_name.is_empty() {
+                    anyhow::bail!(
+                        "env var {name}: {field} contains empty interpolation reference \"${{env.}}\""
+                    );
+                }
+                if !is_valid_env_var_name(ref_name) {
+                    anyhow::bail!(
+                        "env var {name}: {field} contains invalid env var name in \"${{env.{ref_name}}}\""
+                    );
+                }
                 if !self.env.contains_key(ref_name) {
                     anyhow::bail!(
                         "env var {name}: {field} references unknown env var \"${{env.{ref_name}}}\""
@@ -345,8 +353,8 @@ mod tests {
     }
 
     #[test]
-    fn extract_interpolation_refs_skips_empty_env_ref() {
-        assert!(extract_interpolation_refs("${env.}").is_empty());
+    fn extract_interpolation_refs_returns_empty_name_for_empty_env_ref() {
+        assert_eq!(extract_interpolation_refs("${env.}"), vec![""]);
     }
 
     #[test]
@@ -1383,5 +1391,84 @@ prompt = "Label for ${env.PROJECT} in ${env.MISSING}:"
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("MISSING"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_env_ref_in_prompt() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+interactive = true
+prompt = "Value: ${env.}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_var_name_in_interpolation_ref() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+interactive = true
+depends_on = []
+prompt = "Value: ${env.MY-VAR}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid env var name")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_env_ref_in_default() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+interactive = true
+prompt = "Value:"
+default = "prefix-${env.}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -74,6 +74,25 @@ pub struct ManifestWarning {
     pub message: String,
 }
 
+/// Extract variable names from `${VAR_NAME}` interpolation placeholders in a string.
+fn extract_interpolation_refs(s: &str) -> Vec<&str> {
+    let mut refs = Vec::new();
+    let mut rest = s;
+    while let Some(start) = rest.find("${") {
+        let after_open = &rest[start + 2..];
+        if let Some(end) = after_open.find('}') {
+            let var_name = &after_open[..end];
+            if !var_name.is_empty() {
+                refs.push(var_name);
+            }
+            rest = &after_open[end + 1..];
+        } else {
+            break;
+        }
+    }
+    refs
+}
+
 impl AgentManifest {
     pub fn load(repo_dir: &Path) -> anyhow::Result<Self> {
         let manifest_path = repo_dir.join("jackin.agent.toml");
@@ -151,6 +170,36 @@ impl AgentManifest {
                     );
                 }
             }
+
+            // Validate ${VAR_NAME} interpolation references in prompt and default_value
+            let dep_names: std::collections::HashSet<&str> = decl
+                .depends_on
+                .iter()
+                .filter_map(|d| d.strip_prefix("env."))
+                .collect();
+
+            let fields_to_check: Vec<(&str, &str)> = [
+                decl.prompt.as_deref().map(|v| ("prompt", v)),
+                decl.default_value.as_deref().map(|v| ("default", v)),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+
+            for (field, value) in fields_to_check {
+                for ref_name in extract_interpolation_refs(value) {
+                    if !self.env.contains_key(ref_name) {
+                        anyhow::bail!(
+                            "env var {name}: {field} references unknown env var \"${{{ref_name}}}\""
+                        );
+                    }
+                    if !dep_names.contains(ref_name) {
+                        anyhow::bail!(
+                            "env var {name}: {field} references \"${{{ref_name}}}\" which is not listed in depends_on"
+                        );
+                    }
+                }
+            }
         }
 
         // Cycle detection via topological sort (Kahn's algorithm)
@@ -213,6 +262,37 @@ impl AgentManifest {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn extract_interpolation_refs_finds_single_ref() {
+        assert_eq!(
+            extract_interpolation_refs("Branch for ${PROJECT}:"),
+            vec!["PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_finds_multiple_refs() {
+        assert_eq!(
+            extract_interpolation_refs("${TEAM}/${PROJECT}"),
+            vec!["TEAM", "PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_returns_empty_for_no_refs() {
+        assert!(extract_interpolation_refs("plain text").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_skips_empty_braces() {
+        assert!(extract_interpolation_refs("${}").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_handles_unclosed_brace() {
+        assert!(extract_interpolation_refs("${OPEN").is_empty());
+    }
 
     #[test]
     fn loads_manifest_with_plugins() {
@@ -935,5 +1015,117 @@ skippable = true
 
         assert!(!warnings.is_empty());
         assert!(warnings[0].message.contains("skippable"));
+    }
+
+    #[test]
+    fn validate_accepts_interpolation_in_prompt_and_default() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["project1", "project2"]
+prompt = "Select a project:"
+
+[env.BRANCH]
+interactive = true
+depends_on = ["env.PROJECT"]
+prompt = "Branch name for ${PROJECT}:"
+default = "feature/${PROJECT}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let warnings = manifest.validate().unwrap();
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn validate_rejects_interpolation_referencing_unknown_var() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.BRANCH]
+interactive = true
+depends_on = []
+prompt = "Branch for ${NONEXISTENT}:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("NONEXISTENT"));
+    }
+
+    #[test]
+    fn validate_rejects_interpolation_not_in_depends_on() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Select:"
+
+[env.BRANCH]
+interactive = true
+prompt = "Branch for ${PROJECT}:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("PROJECT"));
+        assert!(msg.contains("depends_on"));
+    }
+
+    #[test]
+    fn validate_rejects_interpolation_in_default_referencing_unknown_var() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.BRANCH]
+interactive = true
+depends_on = []
+default = "feature/${GHOST}"
+prompt = "Branch:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("GHOST"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1322,4 +1322,66 @@ prompt = "Value (use ${other.THING} for other):"
         // ${other.THING} is not an env. ref, so no error or warning
         assert!(warnings.is_empty());
     }
+
+    #[test]
+    fn validate_rejects_interpolation_in_default_not_in_depends_on() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Select:"
+
+[env.BRANCH]
+interactive = true
+prompt = "Branch:"
+default = "feature/${env.PROJECT}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("PROJECT"));
+        assert!(msg.contains("depends_on"));
+    }
+
+    #[test]
+    fn validate_rejects_when_one_of_multiple_refs_is_invalid() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Select:"
+
+[env.LABEL]
+interactive = true
+depends_on = ["env.PROJECT"]
+prompt = "Label for ${env.PROJECT} in ${env.MISSING}:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("MISSING"));
+    }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -74,6 +74,31 @@ pub struct ManifestWarning {
     pub message: String,
 }
 
+/// Check that an env var name contains only `[A-Za-z0-9_]` and doesn't start with a digit.
+fn is_valid_env_var_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.is_ascii()
+        && !name.as_bytes()[0].is_ascii_digit()
+        && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+/// Detect bare `$VAR` references (single dollar without braces).
+///
+/// Matches `$` followed by an ASCII letter or underscore (the start of a valid
+/// env var name), but NOT followed by `{` (which is the `${VAR}` interpolation syntax).
+fn contains_bare_dollar_ref(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    for i in 0..bytes.len().saturating_sub(1) {
+        if bytes[i] == b'$'
+            && bytes[i + 1] != b'{'
+            && (bytes[i + 1].is_ascii_alphabetic() || bytes[i + 1] == b'_')
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Extract variable names from `${VAR_NAME}` interpolation placeholders in a string.
 fn extract_interpolation_refs(s: &str) -> Vec<&str> {
     let mut refs = Vec::new();
@@ -110,6 +135,13 @@ impl AgentManifest {
         let mut warnings = Vec::new();
 
         for (name, decl) in &self.env {
+            // Env var names must be valid identifiers: [A-Za-z_][A-Za-z0-9_]*
+            if !is_valid_env_var_name(name) {
+                anyhow::bail!(
+                    "env var \"{name}\": name must contain only ASCII letters, digits, and underscores, and cannot start with a digit"
+                );
+            }
+
             if let Some((_, value)) = RESERVED_RUNTIME_ENV_VARS
                 .iter()
                 .find(|(reserved, _)| name == reserved)
@@ -149,63 +181,101 @@ impl AgentManifest {
                 });
             }
 
-            // Validate depends_on entries
-            for dep in &decl.depends_on {
-                // Must have env. prefix
-                let Some(dep_name) = dep.strip_prefix("env.") else {
-                    anyhow::bail!(
-                        "env var {name}: depends_on entry \"{dep}\" must use env. prefix (e.g., \"env.{dep}\")"
-                    );
-                };
-
-                // Self-reference
-                if dep_name == name {
-                    anyhow::bail!("env var {name}: depends_on cannot reference self");
-                }
-
-                // Dangling reference
-                if !self.env.contains_key(dep_name) {
-                    anyhow::bail!(
-                        "env var {name}: depends_on references unknown env var \"{dep_name}\""
-                    );
-                }
-            }
-
-            // Validate ${VAR_NAME} interpolation references in prompt and default_value
-            let dep_names: std::collections::HashSet<&str> = decl
-                .depends_on
-                .iter()
-                .filter_map(|d| d.strip_prefix("env."))
-                .collect();
-
-            let fields_to_check: Vec<(&str, &str)> = [
-                decl.prompt.as_deref().map(|v| ("prompt", v)),
-                decl.default_value.as_deref().map(|v| ("default", v)),
-            ]
-            .into_iter()
-            .flatten()
-            .collect();
-
-            for (field, value) in fields_to_check {
-                for ref_name in extract_interpolation_refs(value) {
-                    if !self.env.contains_key(ref_name) {
-                        anyhow::bail!(
-                            "env var {name}: {field} references unknown env var \"${{{ref_name}}}\""
-                        );
-                    }
-                    if !dep_names.contains(ref_name) {
-                        anyhow::bail!(
-                            "env var {name}: {field} references \"${{{ref_name}}}\" which is not listed in depends_on"
-                        );
-                    }
-                }
-            }
+            self.validate_env_interpolation(name, decl, &mut warnings)?;
         }
 
         // Cycle detection via topological sort (Kahn's algorithm)
         self.detect_env_cycles()?;
 
         Ok(warnings)
+    }
+
+    fn validate_env_interpolation(
+        &self,
+        name: &str,
+        decl: &EnvVarDecl,
+        warnings: &mut Vec<ManifestWarning>,
+    ) -> anyhow::Result<()> {
+        // Reject ${...} interpolation placeholders in options (options are always static)
+        for option in &decl.options {
+            if !extract_interpolation_refs(option).is_empty() {
+                anyhow::bail!(
+                    "env var {name}: options cannot contain interpolation placeholders — options are static"
+                );
+            }
+        }
+
+        // Warn on bare $VAR (no braces) in prompt and default — reserved for future
+        // host env passthrough syntax, currently has no effect
+        for (field, value) in [
+            ("prompt", decl.prompt.as_deref()),
+            ("default", decl.default_value.as_deref()),
+        ] {
+            if let Some(v) = value
+                && contains_bare_dollar_ref(v)
+            {
+                warnings.push(ManifestWarning {
+                    message: format!(
+                        "env var {name}: {field} contains bare $VAR reference — \
+                         use ${{VAR}} for interpolation; bare $VAR is reserved for future host env passthrough"
+                    ),
+                });
+            }
+        }
+
+        // Validate depends_on entries
+        for dep in &decl.depends_on {
+            // Must have env. prefix
+            let Some(dep_name) = dep.strip_prefix("env.") else {
+                anyhow::bail!(
+                    "env var {name}: depends_on entry \"{dep}\" must use env. prefix (e.g., \"env.{dep}\")"
+                );
+            };
+
+            // Self-reference
+            if dep_name == name {
+                anyhow::bail!("env var {name}: depends_on cannot reference self");
+            }
+
+            // Dangling reference
+            if !self.env.contains_key(dep_name) {
+                anyhow::bail!(
+                    "env var {name}: depends_on references unknown env var \"{dep_name}\""
+                );
+            }
+        }
+
+        // Validate ${VAR_NAME} interpolation references in prompt and default_value
+        let dep_names: std::collections::HashSet<&str> = decl
+            .depends_on
+            .iter()
+            .filter_map(|d| d.strip_prefix("env."))
+            .collect();
+
+        let fields_to_check: Vec<(&str, &str)> = [
+            decl.prompt.as_deref().map(|v| ("prompt", v)),
+            decl.default_value.as_deref().map(|v| ("default", v)),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        for (field, value) in fields_to_check {
+            for ref_name in extract_interpolation_refs(value) {
+                if !self.env.contains_key(ref_name) {
+                    anyhow::bail!(
+                        "env var {name}: {field} references unknown env var \"${{{ref_name}}}\""
+                    );
+                }
+                if !dep_names.contains(ref_name) {
+                    anyhow::bail!(
+                        "env var {name}: {field} references \"${{{ref_name}}}\" which is not listed in depends_on"
+                    );
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn detect_env_cycles(&self) -> anyhow::Result<()> {
@@ -262,6 +332,45 @@ impl AgentManifest {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn is_valid_env_var_name_accepts_standard_names() {
+        assert!(is_valid_env_var_name("FOO"));
+        assert!(is_valid_env_var_name("_PRIVATE"));
+        assert!(is_valid_env_var_name("FOO_BAR_123"));
+        assert!(is_valid_env_var_name("mixedCase"));
+    }
+
+    #[test]
+    fn is_valid_env_var_name_rejects_invalid_names() {
+        assert!(!is_valid_env_var_name(""));
+        assert!(!is_valid_env_var_name("1FOO"));
+        assert!(!is_valid_env_var_name("MY-VAR"));
+        assert!(!is_valid_env_var_name("MY.VAR"));
+        assert!(!is_valid_env_var_name("MY$VAR"));
+        assert!(!is_valid_env_var_name("A}B"));
+    }
+
+    #[test]
+    fn contains_bare_dollar_ref_detects_simple_cases() {
+        assert!(contains_bare_dollar_ref("$HOME"));
+        assert!(contains_bare_dollar_ref("prefix-$VAR-suffix"));
+        assert!(contains_bare_dollar_ref("$_PRIVATE"));
+    }
+
+    #[test]
+    fn contains_bare_dollar_ref_ignores_braced_syntax() {
+        assert!(!contains_bare_dollar_ref("${VAR}"));
+        assert!(!contains_bare_dollar_ref("prefix-${VAR}-suffix"));
+    }
+
+    #[test]
+    fn contains_bare_dollar_ref_ignores_dollar_without_identifier() {
+        assert!(!contains_bare_dollar_ref("$"));
+        assert!(!contains_bare_dollar_ref("$$"));
+        assert!(!contains_bare_dollar_ref("$1"));
+        assert!(!contains_bare_dollar_ref("price is $5"));
+    }
 
     #[test]
     fn extract_interpolation_refs_finds_single_ref() {
@@ -1127,5 +1236,192 @@ prompt = "Branch:"
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("GHOST"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_env_var_name() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env."MY-VAR"]
+default = "value"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("MY-VAR"));
+    }
+
+    #[test]
+    fn validate_rejects_env_var_name_starting_with_digit() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env."1FOO"]
+default = "value"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("1FOO"));
+    }
+
+    #[test]
+    fn validate_accepts_valid_env_var_names() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env._PRIVATE]
+default = "a"
+
+[env.UPPER_CASE_123]
+default = "b"
+
+[env.mixedCase]
+default = "c"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_interpolation_in_options() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Pick:"
+
+[env.BRANCH]
+interactive = true
+depends_on = ["env.PROJECT"]
+options = ["${PROJECT}-main", "${PROJECT}-dev"]
+prompt = "Branch:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("options cannot contain interpolation")
+        );
+    }
+
+    #[test]
+    fn validate_warns_on_bare_dollar_var_in_prompt() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.API_KEY]
+interactive = true
+prompt = "Key for $SERVICE:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let warnings = manifest.validate().unwrap();
+
+        assert!(!warnings.is_empty());
+        assert!(warnings[0].message.contains("bare $VAR"));
+    }
+
+    #[test]
+    fn validate_warns_on_bare_dollar_var_in_default() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+default = "$HOME/projects"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let warnings = manifest.validate().unwrap();
+
+        assert!(!warnings.is_empty());
+        assert!(warnings[0].message.contains("bare $VAR"));
+    }
+
+    #[test]
+    fn validate_does_not_warn_on_braced_interpolation() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.PROJECT]
+interactive = true
+options = ["a", "b"]
+prompt = "Pick:"
+
+[env.BRANCH]
+interactive = true
+depends_on = ["env.PROJECT"]
+prompt = "Branch for ${PROJECT}:"
+default = "feature/${PROJECT}"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let warnings = manifest.validate().unwrap();
+
+        assert!(warnings.is_empty());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -196,12 +196,24 @@ impl AgentManifest {
                 );
             };
 
+            // Empty name
+            if dep_name.is_empty() {
+                anyhow::bail!("env var {name}: depends_on contains empty reference \"env.\"");
+            }
+
+            // Invalid name
+            if !is_valid_env_var_name(dep_name) {
+                anyhow::bail!(
+                    "env var {name}: depends_on contains invalid env var name \"{dep_name}\""
+                );
+            }
+
             // Self-reference
             if dep_name == name {
                 anyhow::bail!("env var {name}: depends_on cannot reference self");
             }
 
-            // Dangling reference
+            // Must exist
             if !self.env.contains_key(dep_name) {
                 anyhow::bail!(
                     "env var {name}: depends_on references unknown env var \"{dep_name}\""
@@ -1470,5 +1482,60 @@ default = "prefix-${env.}"
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_depends_on_name() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+interactive = true
+depends_on = ["env."]
+prompt = "Value:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_depends_on_name() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.FOO]
+interactive = true
+depends_on = ["env.MY-VAR"]
+prompt = "Value:"
+"#,
+        )
+        .unwrap();
+
+        let manifest = AgentManifest::load(temp.path()).unwrap();
+        let result = manifest.validate();
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid env var name")
+        );
     }
 }

--- a/todo/env-var-interpolation.md
+++ b/todo/env-var-interpolation.md
@@ -61,7 +61,7 @@ Env vars declared in the agent manifest need to be overridable at multiple level
    ```toml
    [env]
    JACKIN_CLAUDE_ENV = "docker-staging"
-   CONTEXT7_API_KEY = "$CONTEXT7_API_KEY"   # host env passthrough
+   CONTEXT7_API_KEY = "sk-..."              # literal value
    ```
 3. **Agent manifest default** (`jackin.agent.toml`):
    ```toml

--- a/todo/env-var-interpolation.md
+++ b/todo/env-var-interpolation.md
@@ -1,6 +1,6 @@
 # Interactive Env Vars and Resolution
 
-**Status**: Resolved — `${VAR_NAME}` interpolation implemented; operator-side resolution and secret backends remain future work
+**Status**: Resolved — `${env.VAR}` interpolation implemented; operator-side resolution and secret backends remain future work
 
 ## Problem
 
@@ -14,7 +14,7 @@ When an agent manifest declares interactive environment variables with `depends_
 
 ## Implementation
 
-`${VAR_NAME}` syntax is now supported in `prompt` and `default_value` fields of `[env.*]` entries in `jackin.agent.toml`:
+`${env.VAR_NAME}` syntax is now supported in `prompt` and `default` fields of `[env.*]` entries in `jackin.agent.toml`. The `env.` prefix is consistent with the `depends_on` syntax and creates a clear namespace for future expansion (e.g., `${host.VAR}`, `${secret.VAR}`).
 
 ```toml
 [env.PROJECT_TO_CLONE]
@@ -25,27 +25,26 @@ prompt = "Select a project:"
 [env.BRANCH_TO_CREATE]
 interactive = true
 depends_on = ["env.PROJECT_TO_CLONE"]
-prompt = "Branch name for ${PROJECT_TO_CLONE}:"
-default = "feature/${PROJECT_TO_CLONE}"
+prompt = "Branch name for ${env.PROJECT_TO_CLONE}:"
+default = "feature/${env.PROJECT_TO_CLONE}"
 ```
 
-Interpolation is limited to `prompt` and `default` fields only. Options arrays remain static.
+Interpolation is limited to `prompt` and `default` fields only. Options arrays remain static. Non-`env.` namespaces (e.g., `${other.FOO}`) are preserved as-is.
 
 ### Validation
 
-The manifest validator ensures that `${VAR_NAME}` references:
+The manifest validator ensures that `${env.VAR_NAME}` references:
 - Point to declared env vars (rejects unknown references)
 - Are listed in `depends_on` (guarantees topological ordering so the value is available at prompt time)
 
 Additional safety checks:
 - **Env var names** must match `[A-Za-z_][A-Za-z0-9_]*` — prevents parser ambiguity from special characters like `$`, `{`, `}`
-- **Options arrays** reject `${...}` placeholders — options are always static to keep validation possible
-- **Bare `$VAR` syntax** (no braces) in `prompt` and `default` triggers a warning — reserves the syntax for future host env passthrough without breaking existing manifests
+- **Options arrays** reject `${env.*}` placeholders — options are always static to keep validation possible
 - **No re-interpolation** — the interpolation engine uses a single left-to-right scan, so resolved values containing `${...}` are never re-interpreted as placeholders
 
 ### How It Works
 
-Since env vars are already resolved in topological (dependency) order, the `resolve_env` function interpolates `${VAR_NAME}` placeholders in `prompt` and `default` fields using already-resolved values before presenting the prompt to the user. Static (non-interactive) vars also have their `default` values interpolated.
+Since env vars are already resolved in topological (dependency) order, the `resolve_env` function interpolates `${env.VAR_NAME}` placeholders in `prompt` and `default` fields using already-resolved values before presenting the prompt to the user. Static (non-interactive) vars also have their `default` values interpolated.
 
 ## Remaining Work
 

--- a/todo/env-var-interpolation.md
+++ b/todo/env-var-interpolation.md
@@ -9,7 +9,7 @@ When an agent manifest declares interactive environment variables with `depends_
 ## Why It Matters
 
 - A prompt like "Branch name for project2:" is more contextual than "Branch name for this project:"
-- Default values that derive from prior selections (e.g., `feature/${PROJECT_TO_CLONE}`) reduce typing and enforce conventions
+- Default values that derive from prior selections (e.g., `feature/${env.PROJECT_TO_CLONE}`) reduce typing and enforce conventions
 - The dependency chain already implies a relationship — interpolation makes it explicit in the UI
 
 ## Implementation
@@ -66,10 +66,10 @@ Env vars declared in the agent manifest need to be overridable at multiple level
 3. **Agent manifest default** (`jackin.agent.toml`):
    ```toml
    [env.JACKIN_CLAUDE_ENV]
-   default_value = "docker"
+   default = "docker"
    ```
 
-The `$VAR` syntax (single dollar, no braces) means "resolve from host environment at launch time," mirroring `docker run -e` behavior.
+Host env passthrough syntax is TBD — could use `${host.VAR}` to stay consistent with the `${env.VAR}` namespace convention.
 
 ### Secret Resolution (Future)
 
@@ -83,6 +83,6 @@ This needs its own design pass — see [1Password Integration](onepassword-integ
 ## Related Files
 
 - `src/manifest.rs` — env var declaration parsing and interpolation validation
-- `src/env_resolver.rs` — launch-time env var resolution with `${VAR_NAME}` interpolation
+- `src/env_resolver.rs` — launch-time env var resolution with `${env.VAR}` interpolation
 - `src/config.rs` — operator config and workspace config
 - `src/workspace.rs` — workspace-level overrides

--- a/todo/env-var-interpolation.md
+++ b/todo/env-var-interpolation.md
@@ -37,6 +37,12 @@ The manifest validator ensures that `${VAR_NAME}` references:
 - Point to declared env vars (rejects unknown references)
 - Are listed in `depends_on` (guarantees topological ordering so the value is available at prompt time)
 
+Additional safety checks:
+- **Env var names** must match `[A-Za-z_][A-Za-z0-9_]*` — prevents parser ambiguity from special characters like `$`, `{`, `}`
+- **Options arrays** reject `${...}` placeholders — options are always static to keep validation possible
+- **Bare `$VAR` syntax** (no braces) in `prompt` and `default` triggers a warning — reserves the syntax for future host env passthrough without breaking existing manifests
+- **No re-interpolation** — the interpolation engine uses a single left-to-right scan, so resolved values containing `${...}` are never re-interpreted as placeholders
+
 ### How It Works
 
 Since env vars are already resolved in topological (dependency) order, the `resolve_env` function interpolates `${VAR_NAME}` placeholders in `prompt` and `default` fields using already-resolved values before presenting the prompt to the user. Static (non-interactive) vars also have their `default` values interpolated.

--- a/todo/env-var-interpolation.md
+++ b/todo/env-var-interpolation.md
@@ -1,6 +1,6 @@
 # Interactive Env Vars and Resolution
 
-**Status**: Deferred — future enhancement to env var system
+**Status**: Resolved — `${VAR_NAME}` interpolation implemented; operator-side resolution and secret backends remain future work
 
 ## Problem
 
@@ -12,26 +12,38 @@ When an agent manifest declares interactive environment variables with `depends_
 - Default values that derive from prior selections (e.g., `feature/${PROJECT_TO_CLONE}`) reduce typing and enforce conventions
 - The dependency chain already implies a relationship — interpolation makes it explicit in the UI
 
-## Proposed Design
+## Implementation
 
-Allow `${VAR_NAME}` syntax in `title` and `default_value` fields of `[env.*]` entries in `jackin.agent.toml`:
+`${VAR_NAME}` syntax is now supported in `prompt` and `default_value` fields of `[env.*]` entries in `jackin.agent.toml`:
 
 ```toml
 [env.PROJECT_TO_CLONE]
 interactive = true
 options = ["project1", "project2"]
-title = "Select a project:"
+prompt = "Select a project:"
 
 [env.BRANCH_TO_CREATE]
 interactive = true
 depends_on = ["env.PROJECT_TO_CLONE"]
-title = "Branch name for ${PROJECT_TO_CLONE}:"
-default_value = "feature/${PROJECT_TO_CLONE}"
+prompt = "Branch name for ${PROJECT_TO_CLONE}:"
+default = "feature/${PROJECT_TO_CLONE}"
 ```
 
-Interpolation would be limited to `title` and `default_value` fields only. Options arrays remain static.
+Interpolation is limited to `prompt` and `default` fields only. Options arrays remain static.
 
-## Operator-Side Resolution and Overrides
+### Validation
+
+The manifest validator ensures that `${VAR_NAME}` references:
+- Point to declared env vars (rejects unknown references)
+- Are listed in `depends_on` (guarantees topological ordering so the value is available at prompt time)
+
+### How It Works
+
+Since env vars are already resolved in topological (dependency) order, the `resolve_env` function interpolates `${VAR_NAME}` placeholders in `prompt` and `default` fields using already-resolved values before presenting the prompt to the user. Static (non-interactive) vars also have their `default` values interpolated.
+
+## Remaining Work
+
+### Operator-Side Resolution and Overrides
 
 Env vars declared in the agent manifest need to be overridable at multiple levels. Proposed resolution order (highest priority wins):
 
@@ -65,7 +77,7 @@ This needs its own design pass — see [1Password Integration](onepassword-integ
 
 ## Related Files
 
-- `src/manifest.rs` — env var declaration parsing
-- `src/runtime.rs` — launch-time env var resolution
+- `src/manifest.rs` — env var declaration parsing and interpolation validation
+- `src/env_resolver.rs` — launch-time env var resolution with `${VAR_NAME}` interpolation
 - `src/config.rs` — operator config and workspace config
 - `src/workspace.rs` — workspace-level overrides


### PR DESCRIPTION
## Summary

- Support `${env.VAR}` syntax in `prompt` and `default` fields of `[env.*]` entries in `jackin.agent.toml`, so dependent env vars can reference resolved values from their dependencies
- The `env.` prefix is consistent with the existing `depends_on` syntax and reserves other namespaces for future expansion (e.g. `${host.VAR}`, `${secret.VAR}`)
- Harden the interpolation engine against edge cases: no re-interpolation of resolved values, env var name validation, and rejection of `${env.*}` in options arrays

## Example

```toml
[env.PROJECT]
interactive = true
options = ["project1", "project2"]
prompt = "Select a project:"

[env.BRANCH]
interactive = true
depends_on = ["env.PROJECT"]
prompt = "Branch name for ${env.PROJECT}:"
default = "feature/${env.PROJECT}"
```

When the user selects `project1`, the branch prompt becomes `"Branch name for project1:"` with default `"feature/project1"`.

## Safety measures

| Concern | Protection |
|---|---|
| Resolved value contains `${...}` | Single left-to-right scan — no re-interpretation |
| Env var name with `$`, `{`, `}` chars | Names must match `[A-Za-z_][A-Za-z0-9_]*` |
| `${env.*}` in options array | Hard error — options are always static |
| Reference to undeclared var | Hard error at manifest validation |
| Reference not in `depends_on` | Hard error — guarantees topological ordering |
| Non-`env.` namespaces (e.g. `${other.FOO}`) | Preserved as-is — reserved for future use |

## Test plan

- [x] Interpolation of prompt field with resolved dependency value
- [x] Interpolation of default field with resolved dependency value
- [x] Static (non-interactive) vars get their defaults interpolated
- [x] Multiple `${env.*}` refs in a single field
- [x] No-op when no placeholders are present
- [x] Resolved values containing `${...}` are NOT re-interpolated
- [x] Non-`env.` namespaces ignored (preserved as-is)
- [x] Env var name validation (accepts valid, rejects hyphens/digits-first/special chars)
- [x] `${env.*}` in options rejected
- [x] Unknown interpolation ref in prompt/default rejected
- [x] Interpolation ref not in `depends_on` rejected
- [x] All 270 tests passing, zero clippy warnings

https://claude.ai/code/session_01HbstumtnvKAjStrX1xTvcv