### PR TITLE
feat: agent source trust-on-first-use model

### DIFF
--- a/SECURITY_REVIEW_FINDINGS.md
+++ b/SECURITY_REVIEW_FINDINGS.md
@@ -23,16 +23,8 @@ In `src/derived_image.rs`, the derived Dockerfile includes:
 
 ---
 
-### 2) Git source trust is broad for first clone
-`resolve_agent_source()` auto-constructs GitHub URL from namespace/name and clones directly.
-
-**Risk**
-- Typosquatting / untrusted repo execution in build context.
-
-**Recommendation**
-- Add optional allowlist for namespaces/orgs.
-- Require explicit confirmation for first-time non-builtin agents.
-- Support commit/tag pinning in config (`git + rev`).
+### 2) ~~Git source trust is broad for first clone~~ ✅ Resolved
+Trust-on-first-use model implemented. Untrusted third-party agents now require explicit operator confirmation before building. Built-in agents are always trusted. Trust state is persisted in config.
 
 ---
 
@@ -117,6 +109,6 @@ Current repo flow tracks moving branches by default.
 
 1. ~~Fix Dockerfile path canonicalization/symlink boundary checks.~~ ✅
 2. Pin/verify remote installer script. (see `SECURITY_EXCEPTIONS.md`)
-3. Add git trust controls + optional commit pinning. (see `todo/agent-source-trust.md`, `todo/reproducibility-pinning.md`)
+3. ~~Add git trust controls~~ ✅ + optional commit pinning. (see `todo/reproducibility-pinning.md`)
 4. ~~Harden file permissions and atomic writes for config/state.~~ ✅
 5. ~~Add command timeout support~~ ✅ and robust cleanup handling. (see `todo/bollard-migration.md`)

--- a/SECURITY_REVIEW_FINDINGS.md
+++ b/SECURITY_REVIEW_FINDINGS.md
@@ -73,15 +73,8 @@ Current design uses privileged `docker:dind` sidecar (already documented clearly
 
 ---
 
-### 9) Mount policy guardrails
-Mount validation is structurally good.
-
-**Recommendation**
-- Add optional deny/warn rules for sensitive host paths:
-  - `~/.ssh`
-  - `~/.aws`
-  - `~/.gnupg`
-  - etc.
+### 9) ~~Mount policy guardrails~~ ✅ Resolved
+`find_sensitive_mounts()` detects mounts matching `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker` and `confirm_sensitive_mounts()` prompts the operator before proceeding.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Construct Image: User Creation Responsibility](todo/construct-user-creation.md) — UID/GID remapping hack in derived images
 - [DinD Running Without TLS Authentication](todo/dind-tls.md) — unauthenticated Docker daemon on agent network
 - [1Password Integration for Agent Secrets](todo/onepassword-integration.md) — first-class secret injection at launch time
-- [Agent Source Trust Model](todo/agent-source-trust.md) — trust-on-first-use for third-party agent repos
 - [Migrate Docker CLI to Bollard API Client](todo/bollard-migration.md) — replace string-matched error handling with typed API
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
 - [Selectable Sandbox Backends: DinD and MicroVM](todo/selectable-sandbox-backends.md) — operator-selectable runtime modes with backend-neutral lifecycle design
@@ -20,3 +19,4 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Sensitive Mount Path Warnings](todo/sensitive-mount-warnings.md) — warn before mounting `~/.ssh`, `~/.aws`, etc.
 - [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`
 - [Expose DinD Hostname as `JACKIN_DIND_HOSTNAME`](todo/dind-hostname-env-var.md) — agents can reach DinD-backed services without parsing `DOCKER_HOST`
+- [Agent Source Trust Model](todo/agent-source-trust.md) — trust-on-first-use for third-party agent repos

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -76,7 +76,7 @@ If the agent manifest declares interactive environment variables, `jackin load` 
 :::
 
 :::warning
-Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. You can pre-trust with `jackin trust org/agent-name` or revoke with `jackin untrust`. See [Agent source trust](/guides/security-model#4-agent-source-trust) for details.
+Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. You can pre-trust with `jackin trust org/agent-name` or revoke with `jackin trust org/agent-name --untrust`. See [Agent source trust](/guides/security-model#4-agent-source-trust) for details.
 :::
 
 :::note

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -76,7 +76,7 @@ If the agent manifest declares interactive environment variables, `jackin load` 
 :::
 
 :::warning
-Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. In non-interactive environments (CI, scripts), pre-trust the agent by adding `trusted = true` to its entry in `~/.config/jackin/config.toml`.
+Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. You can pre-trust with `jackin trust org/agent-name` or revoke with `jackin untrust`. See [Agent source trust](/guides/security-model#4-agent-source-trust) for details.
 :::
 
 :::note

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -62,16 +62,21 @@ jackin load agent-smith ~/app --mount ~/cache:/cache:ro
 
 1. Resolves the agent class and clones/updates its repository
 2. Validates the agent repo contract (`jackin.agent.toml` + Dockerfile) with strict manifest parsing
-3. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
-4. Prompts for interactive environment variables declared in the manifest
-5. Generates and builds a derived Docker image (cached if unchanged)
-6. Creates a per-agent Docker network and DinD sidecar
-7. Launches the agent container with all resolved mounts and environment variables
-8. Runs the pre-launch hook if declared
-9. Starts Claude Code with `--dangerously-skip-permissions`
+3. **If the agent source has never been trusted**, prompts the operator to review and confirm before proceeding (see [Agent source trust](/guides/security-model#agent-source-trust))
+4. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
+5. Prompts for interactive environment variables declared in the manifest
+6. Generates and builds a derived Docker image (cached if unchanged)
+7. Creates a per-agent Docker network and DinD sidecar
+8. Launches the agent container with all resolved mounts and environment variables
+9. Runs the pre-launch hook if declared
+10. Starts Claude Code with `--dangerously-skip-permissions`
 
 :::note
 If the agent manifest declares interactive environment variables, `jackin load` prompts for their values before building the Docker image. This ensures no build time is wasted if you cancel.
+:::
+
+:::warning
+Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. In non-interactive environments (CI, scripts), pre-trust the agent by adding `trusted = true` to its entry in `~/.config/jackin/config.toml`.
 :::
 
 :::note

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -62,7 +62,7 @@ jackin load agent-smith ~/app --mount ~/cache:/cache:ro
 
 1. Resolves the agent class and clones/updates its repository
 2. Validates the agent repo contract (`jackin.agent.toml` + Dockerfile) with strict manifest parsing
-3. **If the agent source has never been trusted**, prompts the operator to review and confirm before proceeding (see [Agent source trust](/guides/security-model#agent-source-trust))
+3. **If the agent source has never been trusted**, prompts the operator to review and confirm before proceeding (see [Agent source trust](/guides/security-model#4-agent-source-trust))
 4. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
 5. Prompts for interactive environment variables declared in the manifest
 6. Generates and builds a derived Docker image (cached if unchanged)

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -76,7 +76,7 @@ If the agent manifest declares interactive environment variables, `jackin load` 
 :::
 
 :::warning
-Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. You can pre-trust with `jackin trust org/agent-name` or revoke with `jackin trust org/agent-name --untrust`. See [Agent source trust](/guides/security-model#4-agent-source-trust) for details.
+Third-party agents (namespaced selectors like `org/agent-name`) require trust confirmation on first use. jackin' will show the agent name and git URL and ask you to confirm before building. You can pre-trust with `jackin config trust grant org/agent-name` or revoke with `jackin config trust revoke org/agent-name`. See [Agent source trust](/guides/security-model#4-agent-source-trust) for details.
 :::
 
 :::note

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -65,6 +65,16 @@ Built-in agents (`agent-smith`, `the-architect`) are always trusted. When you lo
 
 Once you confirm, the trust decision is saved to `~/.config/jackin/config.toml` and subsequent loads proceed without prompting.
 
+You can also manage trust from the command line:
+
+```bash
+# Pre-trust an agent without loading it
+jackin trust chainargos/the-architect
+
+# Revoke trust (next load will prompt again)
+jackin untrust chainargos/the-architect
+```
+
 For non-interactive environments (CI, automation), pre-trust an agent by adding `trusted = true` to its config entry:
 
 ```toml
@@ -72,6 +82,10 @@ For non-interactive environments (CI, automation), pre-trust an agent by adding 
 git = "https://github.com/org/jackin-agent-name.git"
 trusted = true
 ```
+
+:::note
+Trust is tied to the agent selector (e.g., `org/agent-name`), not the git URL. If an agent's cached repo URL no longer matches the configured source, jackin' rejects it with a separate remote-mismatch error regardless of trust status.
+:::
 
 ### 5. Per-agent network separation
 

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -72,7 +72,10 @@ You can also manage trust from the command line:
 jackin trust chainargos/the-architect
 
 # Revoke trust (next load will prompt again)
-jackin untrust chainargos/the-architect
+jackin trust chainargos/the-architect --untrust
+
+# Check current trust status
+jackin trust chainargos/the-architect --show
 ```
 
 For non-interactive environments (CI, automation), pre-trust an agent by adding `trusted = true` to its config entry:

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -45,7 +45,35 @@ This is the core blast-radius control in jackin'.
 
 Mounts marked `:ro` are enforced by Docker and the kernel. The agent cannot write to those paths, regardless of Claude Code permissions.
 
-### 4. Per-agent network separation
+### 4. Agent source trust
+
+jackin' uses a trust-on-first-use model for third-party agent sources.
+
+Built-in agents (`agent-smith`, `the-architect`) are always trusted. When you load a third-party agent (a namespaced selector like `org/agent-name`) for the first time, jackin' prompts you to review and confirm the source before building:
+
+```
+!! Untrusted agent source !!
+
+  agent:  org/agent-name
+  source: https://github.com/org/jackin-agent-name.git
+
+  jackin' has never loaded this agent before. Trusting it means:
+    - Its Dockerfile will be executed during the image build
+    - Arbitrary commands in that Dockerfile will run on your machine
+    - The agent will have access to your mounted workspace files
+```
+
+Once you confirm, the trust decision is saved to `~/.config/jackin/config.toml` and subsequent loads proceed without prompting.
+
+For non-interactive environments (CI, automation), pre-trust an agent by adding `trusted = true` to its config entry:
+
+```toml
+[agents."org/agent-name"]
+git = "https://github.com/org/jackin-agent-name.git"
+trusted = true
+```
+
+### 5. Per-agent network separation
 
 Each runtime gets its own Docker network. The agent container and its DinD sidecar share that network, but different agents do not share a network by default.
 
@@ -139,6 +167,7 @@ jackin' is designed to reduce the most common operator risks:
 | Agent reaches host Docker daemon | Agent uses its own DinD sidecar | DinD sidecar itself is privileged |
 | Agent interferes with another agent | Separate containers, networks, and state | Shared host kernel remains a common lower layer |
 | Agent persists random system changes | Runtime root filesystem is ephemeral | Persisted tool state and mounted files still survive |
+| Typosquatted or malicious agent repo | Trust-on-first-use prompt before building | User must review the source; trusted flag persists |
 
 ## What jackin' does NOT protect against
 
@@ -158,7 +187,7 @@ This is where people often over-claim container isolation. Don't do that. jackin
 2. **Prefer read-only mounts.** If the agent only needs to inspect something, mount it as `:ro`.
 3. **Do not mount credential directories.** Avoid `~/.ssh`, `~/.aws`, `~/.gnupg`, and similar paths. jackin' warns and asks for confirmation when it detects these, but avoiding them entirely is the safest approach.
 4. **Treat runtime login as sensitive.** If you authenticate inside the runtime, assume the agent can read that state.
-5. **Review agent repos before loading.** The Dockerfile defines what the runtime contains.
+5. **Review agent repos before loading.** The Dockerfile defines what the runtime contains. jackin' prompts for trust confirmation on first use of third-party agents, but you should inspect the repository yourself before confirming.
 6. **Split agent classes by scope.** Keep frontend, backend, infra, and review workflows in separate environments when appropriate.
 7. **Use `jackin purge` when a runtime no longer needs its persisted state.**
 8. **Keep Docker updated.** Container isolation is only as strong as the Docker runtime underneath it.

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -69,13 +69,13 @@ You can also manage trust from the command line:
 
 ```bash
 # Pre-trust an agent without loading it
-jackin trust chainargos/the-architect
+jackin config trust grant chainargos/the-architect
 
 # Revoke trust (next load will prompt again)
-jackin trust chainargos/the-architect --untrust
+jackin config trust revoke chainargos/the-architect
 
-# Check current trust status
-jackin trust chainargos/the-architect --show
+# List all trusted agents
+jackin config trust list
 ```
 
 For non-interactive environments (CI, automation), pre-trust an agent by adding `trusted = true` to its config entry:

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -28,6 +28,8 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Sensitive mount path warnings (warn-and-confirm for `~/.ssh`, `~/.aws`, etc.)
 - Automatic orphaned DinD cleanup (pre-launch garbage collection)
 - `${env.VAR}` interpolation in env var prompts and defaults for dependent variables
+- `JACKIN_DIND_HOSTNAME` environment variable for agents to discover the DinD sidecar hostname
+- Agent source trust model (trust-on-first-use verification for third-party agent repos)
 
 ## Planned
 
@@ -55,6 +57,7 @@ jackin's architecture is runtime-agnostic. The construct and workspace system wo
 ### Infrastructure improvements
 
 - **Construct user creation optimization** — move user creation to the derived layer to eliminate UID/GID remapping
+- **Docker API migration** — incremental migration from CLI string-matching to the Bollard typed API client for more robust error handling
 - **1Password integration** — inject secrets from 1Password vaults without exposing them as files in the container
 
 :::tip

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,30 @@ Examples:
         #[arg(long)]
         all: bool,
     },
+    /// Mark a third-party agent source as trusted
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin trust chainargos/the-architect"
+    )]
+    Trust {
+        /// Agent class selector (e.g. `chainargos/agent-brown`)
+        selector: String,
+    },
+    /// Revoke trust for an agent source
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin untrust chainargos/the-architect"
+    )]
+    Untrust {
+        /// Agent class selector (e.g. `chainargos/agent-brown`)
+        selector: String,
+    },
     /// Open the interactive TUI launcher to pick a workspace and agent
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Launch,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,29 +130,29 @@ Examples:
         #[arg(long)]
         all: bool,
     },
-    /// Mark a third-party agent source as trusted
+    /// Manage trust for a third-party agent source
+    ///
+    /// Trust controls whether jackin' will build and run an agent without
+    /// prompting.  Untrusted agents require interactive confirmation on
+    /// every load.
     #[command(
         before_help = BANNER,
         styles = HELP_STYLES,
         after_long_help = "\
 Examples:
-  jackin trust chainargos/the-architect"
+  jackin trust chainargos/the-architect
+  jackin trust chainargos/the-architect --untrust
+  jackin trust chainargos/the-architect --show"
     )]
     Trust {
         /// Agent class selector (e.g. `chainargos/agent-brown`)
         selector: String,
-    },
-    /// Revoke trust for an agent source
-    #[command(
-        before_help = BANNER,
-        styles = HELP_STYLES,
-        after_long_help = "\
-Examples:
-  jackin untrust chainargos/the-architect"
-    )]
-    Untrust {
-        /// Agent class selector (e.g. `chainargos/agent-brown`)
-        selector: String,
+        /// Revoke trust — next load will prompt for confirmation again
+        #[arg(long)]
+        untrust: bool,
+        /// Show current trust status without changing it
+        #[arg(long, conflicts_with = "untrust")]
+        show: bool,
     },
     /// Open the interactive TUI launcher to pick a workspace and agent
     #[command(before_help = BANNER, styles = HELP_STYLES)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,7 +354,7 @@ Examples:
         /// Agent class selector (e.g. `chainargos/agent-brown`)
         selector: String,
     },
-    /// Show current trust status for all known agent sources
+    /// List all currently trusted agent sources
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     List,
 }
@@ -412,6 +412,59 @@ mod tests {
             Command::Config {
                 command: ConfigCommand::Mount {
                     command: MountCommand::List
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_config_trust_grant() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "config",
+            "trust",
+            "grant",
+            "chainargos/the-architect",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Trust {
+                    command: TrustCommand::Grant { .. }
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_config_trust_revoke() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "config",
+            "trust",
+            "revoke",
+            "chainargos/the-architect",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Trust {
+                    command: TrustCommand::Revoke { .. }
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_config_trust_list() {
+        let cli = Cli::try_parse_from(["jackin", "config", "trust", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Trust {
+                    command: TrustCommand::List
                 }
             }
         ));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,30 +130,6 @@ Examples:
         #[arg(long)]
         all: bool,
     },
-    /// Manage trust for a third-party agent source
-    ///
-    /// Trust controls whether jackin' will build and run an agent without
-    /// prompting.  Untrusted agents require interactive confirmation on
-    /// every load.
-    #[command(
-        before_help = BANNER,
-        styles = HELP_STYLES,
-        after_long_help = "\
-Examples:
-  jackin trust chainargos/the-architect
-  jackin trust chainargos/the-architect --untrust
-  jackin trust chainargos/the-architect --show"
-    )]
-    Trust {
-        /// Agent class selector (e.g. `chainargos/agent-brown`)
-        selector: String,
-        /// Revoke trust — next load will prompt for confirmation again
-        #[arg(long)]
-        untrust: bool,
-        /// Show current trust status without changing it
-        #[arg(long, conflicts_with = "untrust")]
-        show: bool,
-    },
     /// Open the interactive TUI launcher to pick a workspace and agent
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Launch,
@@ -178,6 +154,12 @@ pub enum ConfigCommand {
     Mount {
         #[command(subcommand)]
         command: MountCommand,
+    },
+    /// Manage trust for third-party agent sources
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Trust {
+        #[command(subcommand)]
+        command: TrustCommand,
     },
 }
 
@@ -336,6 +318,43 @@ Examples:
         scope: Option<String>,
     },
     /// List all registered global mounts
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    List,
+}
+
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum TrustCommand {
+    /// Mark a third-party agent source as trusted
+    ///
+    /// Trust controls whether jackin' will build and run an agent without
+    /// prompting.  Untrusted agents require interactive confirmation on
+    /// every load.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config trust grant chainargos/the-architect"
+    )]
+    Grant {
+        /// Agent class selector (e.g. `chainargos/agent-brown`)
+        selector: String,
+    },
+    /// Revoke trust for a third-party agent source
+    ///
+    /// The next `jackin load` will prompt for confirmation again.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config trust revoke chainargos/the-architect"
+    )]
+    Revoke {
+        /// Agent class selector (e.g. `chainargos/agent-brown`)
+        selector: String,
+    },
+    /// Show current trust status for all known agent sources
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     List,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -396,6 +396,8 @@ impl AppConfig {
     }
 
     /// Revoke trust for an agent source.  Returns `true` when the flag changed.
+    /// Note: does not prevent revoking builtins — the caller should check
+    /// [`is_builtin_agent`] first.
     pub fn untrust_agent(&mut self, key: &str) -> bool {
         if let Some(source) = self.agents.get_mut(key)
             && source.trusted
@@ -404,6 +406,12 @@ impl AppConfig {
             return true;
         }
         false
+    }
+
+    /// Returns `true` when `key` matches a built-in agent shipped with the
+    /// binary.  Built-in agents are always trusted and cannot be revoked.
+    pub fn is_builtin_agent(key: &str) -> bool {
+        BUILTIN_AGENTS.iter().any(|&(name, _)| name == key)
     }
 
     /// Ensures all built-in agent entries match the current binary version.

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,8 @@ const BUILTIN_AGENTS: &[(&str, &str)] = &[
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSource {
     pub git: String,
+    #[serde(default)]
+    pub trusted: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,6 +121,7 @@ impl AppConfig {
                 "https://github.com/{namespace}/jackin-{}.git",
                 selector.name
             ),
+            trusted: false,
         };
         self.agents.insert(selector.key(), source.clone());
         Ok((source, true))
@@ -377,14 +380,28 @@ impl AppConfig {
 
     /// Ensures all built-in agent entries match the current binary version.
     /// Returns `true` if any entries were added or updated.
+    /// Mark an agent source as trusted.  Returns `true` when the flag changed.
+    pub fn trust_agent(&mut self, key: &str) -> bool {
+        if let Some(source) = self.agents.get_mut(key)
+            && !source.trusted
+        {
+            source.trusted = true;
+            return true;
+        }
+        false
+    }
+
+    /// Ensures all built-in agent entries match the current binary version.
+    /// Returns `true` if any entries were added or updated.
     fn sync_builtin_agents(&mut self) -> bool {
         let mut changed = false;
         for &(name, git) in BUILTIN_AGENTS {
             let expected = AgentSource {
                 git: git.to_string(),
+                trusted: true,
             };
             match self.agents.get(name) {
-                Some(existing) if existing.git == expected.git => {}
+                Some(existing) if existing.git == expected.git && existing.trusted => {}
                 _ => {
                     self.agents.insert(name.to_string(), expected);
                     changed = true;
@@ -509,6 +526,108 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
                 .unwrap()
                 .contains("[agents.\"chainargos/the-architect\"]")
         );
+    }
+
+    // --- Trust model tests ---
+
+    #[test]
+    fn builtin_agents_are_trusted_on_bootstrap() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        let config = AppConfig::load_or_init(&paths).unwrap();
+
+        assert!(config.agents.get("agent-smith").unwrap().trusted);
+        assert!(config.agents.get("the-architect").unwrap().trusted);
+    }
+
+    #[test]
+    fn new_namespaced_agent_is_not_trusted() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(Some("chainargos"), "the-architect");
+
+        let (source, _) = config.resolve_agent_source(&selector).unwrap();
+
+        assert!(!source.trusted);
+    }
+
+    #[test]
+    fn trust_agent_marks_source_as_trusted() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(Some("chainargos"), "the-architect");
+
+        config.resolve_agent_source(&selector).unwrap();
+        assert!(
+            !config
+                .agents
+                .get("chainargos/the-architect")
+                .unwrap()
+                .trusted
+        );
+
+        let changed = config.trust_agent("chainargos/the-architect");
+        assert!(changed);
+        assert!(
+            config
+                .agents
+                .get("chainargos/the-architect")
+                .unwrap()
+                .trusted
+        );
+
+        // Second call is idempotent
+        let changed_again = config.trust_agent("chainargos/the-architect");
+        assert!(!changed_again);
+    }
+
+    #[test]
+    fn trusted_flag_round_trips_through_toml() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(Some("chainargos"), "the-architect");
+
+        config.resolve_agent_source(&selector).unwrap();
+        config.trust_agent("chainargos/the-architect");
+        config.save(&paths).unwrap();
+
+        let reloaded = AppConfig::load_or_init(&paths).unwrap();
+        assert!(
+            reloaded
+                .agents
+                .get("chainargos/the-architect")
+                .unwrap()
+                .trusted
+        );
+    }
+
+    #[test]
+    fn sync_upgrades_untrusted_builtins() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        // Simulate a config from a pre-trust version (no trusted field)
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.the-architect]
+git = "https://github.com/jackin-project/jackin-the-architect.git"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_init(&paths).unwrap();
+
+        // Builtins should be upgraded to trusted
+        assert!(config.agents.get("agent-smith").unwrap().trusted);
+        assert!(config.agents.get("the-architect").unwrap().trusted);
     }
 
     // --- Task 3: Deserialization tests ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,16 @@ const BUILTIN_AGENTS: &[(&str, &str)] = &[
     ),
 ];
 
+/// Serde helper: `skip_serializing_if` requires `fn(&T) -> bool`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_false(v: &bool) -> bool {
+    !*v
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSource {
     pub git: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub trusted: bool,
 }
 
@@ -378,8 +384,6 @@ impl AppConfig {
         Ok(())
     }
 
-    /// Ensures all built-in agent entries match the current binary version.
-    /// Returns `true` if any entries were added or updated.
     /// Mark an agent source as trusted.  Returns `true` when the flag changed.
     pub fn trust_agent(&mut self, key: &str) -> bool {
         if let Some(source) = self.agents.get_mut(key)

--- a/src/config.rs
+++ b/src/config.rs
@@ -395,6 +395,17 @@ impl AppConfig {
         false
     }
 
+    /// Revoke trust for an agent source.  Returns `true` when the flag changed.
+    pub fn untrust_agent(&mut self, key: &str) -> bool {
+        if let Some(source) = self.agents.get_mut(key)
+            && source.trusted
+        {
+            source.trusted = false;
+            return true;
+        }
+        false
+    }
+
     /// Ensures all built-in agent entries match the current binary version.
     /// Returns `true` if any entries were added or updated.
     fn sync_builtin_agents(&mut self) -> bool {
@@ -585,6 +596,38 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
 
         // Second call is idempotent
         let changed_again = config.trust_agent("chainargos/the-architect");
+        assert!(!changed_again);
+    }
+
+    #[test]
+    fn untrust_agent_revokes_trust() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(Some("chainargos"), "the-architect");
+
+        config.resolve_agent_source(&selector).unwrap();
+        config.trust_agent("chainargos/the-architect");
+        assert!(
+            config
+                .agents
+                .get("chainargos/the-architect")
+                .unwrap()
+                .trusted
+        );
+
+        let changed = config.untrust_agent("chainargos/the-architect");
+        assert!(changed);
+        assert!(
+            !config
+                .agents
+                .get("chainargos/the-architect")
+                .unwrap()
+                .trusted
+        );
+
+        // Second call is idempotent
+        let changed_again = config.untrust_agent("chainargos/the-architect");
         assert!(!changed_again);
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -743,6 +743,7 @@ mod tests {
             "agent-smith".to_string(),
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
             },
         );
         config.workspaces.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
                 cli::TrustCommand::Revoke { selector } => {
                     let class = ClassSelector::parse(&selector)?;
+                    if AppConfig::is_builtin_agent(&class.key()) {
+                        anyhow::bail!("{} is a built-in agent and is always trusted.", class.key());
+                    }
                     if config.untrust_agent(&class.key()) {
                         config.save(&paths)?;
                         println!("Revoked trust for {}.", class.key());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,6 +676,30 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
         },
+        Command::Trust { selector } => {
+            let class = ClassSelector::parse(&selector)?;
+            let mut config = AppConfig::load_or_init(&paths)?;
+            // Ensure the source exists (register if new, but don't clone yet)
+            config.resolve_agent_source(&class)?;
+            if config.trust_agent(&class.key()) {
+                config.save(&paths)?;
+                println!("Trusted {}.", class.key());
+            } else {
+                println!("{} is already trusted.", class.key());
+            }
+            Ok(())
+        }
+        Command::Untrust { selector } => {
+            let class = ClassSelector::parse(&selector)?;
+            let mut config = AppConfig::load_or_init(&paths)?;
+            if config.untrust_agent(&class.key()) {
+                config.save(&paths)?;
+                println!("Revoked trust for {}.", class.key());
+            } else {
+                println!("{} is not currently trusted.", class.key());
+            }
+            Ok(())
+        }
         Command::Purge { selector, all } => match Selector::parse(&selector)? {
             Selector::Container(container) => {
                 remove_data_dir_if_exists(&paths.data_dir.join(&container))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,27 +676,40 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
         },
-        Command::Trust { selector } => {
+        Command::Trust {
+            selector,
+            untrust,
+            show,
+        } => {
             let class = ClassSelector::parse(&selector)?;
             let mut config = AppConfig::load_or_init(&paths)?;
-            // Ensure the source exists (register if new, but don't clone yet)
-            config.resolve_agent_source(&class)?;
-            if config.trust_agent(&class.key()) {
-                config.save(&paths)?;
-                println!("Trusted {}.", class.key());
-            } else {
-                println!("{} is already trusted.", class.key());
+
+            if show {
+                let trusted = config.agents.get(&class.key()).is_some_and(|s| s.trusted);
+                println!(
+                    "{}: {}",
+                    class.key(),
+                    if trusted { "trusted" } else { "untrusted" }
+                );
+                return Ok(());
             }
-            Ok(())
-        }
-        Command::Untrust { selector } => {
-            let class = ClassSelector::parse(&selector)?;
-            let mut config = AppConfig::load_or_init(&paths)?;
-            if config.untrust_agent(&class.key()) {
-                config.save(&paths)?;
-                println!("Revoked trust for {}.", class.key());
+
+            if untrust {
+                if config.untrust_agent(&class.key()) {
+                    config.save(&paths)?;
+                    println!("Revoked trust for {}.", class.key());
+                } else {
+                    println!("{} is not currently trusted.", class.key());
+                }
             } else {
-                println!("{} is not currently trusted.", class.key());
+                // Ensure the source exists (register if new, but don't clone yet)
+                config.resolve_agent_source(&class)?;
+                if config.trust_agent(&class.key()) {
+                    config.save(&paths)?;
+                    println!("Trusted {}.", class.key());
+                } else {
+                    println!("{} is already trusted.", class.key());
+                }
             }
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,45 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
             },
+            cli::ConfigCommand::Trust { command: trust_cmd } => match trust_cmd {
+                cli::TrustCommand::Grant { selector } => {
+                    let class = ClassSelector::parse(&selector)?;
+                    config.resolve_agent_source(&class)?;
+                    if config.trust_agent(&class.key()) {
+                        config.save(&paths)?;
+                        println!("Trusted {}.", class.key());
+                    } else {
+                        println!("{} is already trusted.", class.key());
+                    }
+                    Ok(())
+                }
+                cli::TrustCommand::Revoke { selector } => {
+                    let class = ClassSelector::parse(&selector)?;
+                    if config.untrust_agent(&class.key()) {
+                        config.save(&paths)?;
+                        println!("Revoked trust for {}.", class.key());
+                    } else {
+                        println!("{} is not currently trusted.", class.key());
+                    }
+                    Ok(())
+                }
+                cli::TrustCommand::List => {
+                    let agents: Vec<_> = config
+                        .agents
+                        .iter()
+                        .filter(|(_, source)| source.trusted)
+                        .map(|(key, _)| key.clone())
+                        .collect();
+                    if agents.is_empty() {
+                        println!("No trusted agents.");
+                    } else {
+                        for key in agents {
+                            println!("{key}");
+                        }
+                    }
+                    Ok(())
+                }
+            },
         },
         Command::Workspace { command } => match command {
             WorkspaceCommand::Create {
@@ -676,43 +715,6 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
         },
-        Command::Trust {
-            selector,
-            untrust,
-            show,
-        } => {
-            let class = ClassSelector::parse(&selector)?;
-            let mut config = AppConfig::load_or_init(&paths)?;
-
-            if show {
-                let trusted = config.agents.get(&class.key()).is_some_and(|s| s.trusted);
-                println!(
-                    "{}: {}",
-                    class.key(),
-                    if trusted { "trusted" } else { "untrusted" }
-                );
-                return Ok(());
-            }
-
-            if untrust {
-                if config.untrust_agent(&class.key()) {
-                    config.save(&paths)?;
-                    println!("Revoked trust for {}.", class.key());
-                } else {
-                    println!("{} is not currently trusted.", class.key());
-                }
-            } else {
-                // Ensure the source exists (register if new, but don't clone yet)
-                config.resolve_agent_source(&class)?;
-                if config.trust_agent(&class.key()) {
-                    config.save(&paths)?;
-                    println!("Trusted {}.", class.key());
-                } else {
-                    println!("{} is already trusted.", class.key());
-                }
-            }
-            Ok(())
-        }
         Command::Purge { selector, all } => match Selector::parse(&selector)? {
             Selector::Container(container) => {
                 remove_data_dir_if_exists(&paths.data_dir.join(&container))?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -204,6 +204,45 @@ fn build_config_rows(
     rows
 }
 
+// ── Agent source trust ───────────────────────────────────────────────────
+
+/// Display an untrusted-agent warning and ask the operator to confirm.
+/// Aborts when stdin is not a terminal or the operator declines.
+fn confirm_agent_trust(
+    selector: &ClassSelector,
+    source: &crate::config::AgentSource,
+) -> anyhow::Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "untrusted agent source {selector} — cannot prompt for trust confirmation (stdin is not a terminal)"
+        );
+    }
+
+    eprintln!(
+        "\n{}",
+        "⚠  Untrusted agent source detected:".yellow().bold()
+    );
+    eprintln!("     agent:  {}", selector.to_string().bold());
+    eprintln!("     source: {}", source.git.dimmed());
+    eprintln!(
+        "   {}",
+        "This is a third-party agent. Its Dockerfile and build instructions will be executed on your machine."
+            .dimmed()
+    );
+    eprintln!();
+
+    let confirmed = dialoguer::Confirm::new()
+        .with_prompt("Do you trust this agent source?")
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        anyhow::bail!("agent source not trusted — aborting");
+    }
+
+    Ok(())
+}
+
 /// Resolve the agent repository: clone if missing, pull if already present.
 /// Returns the validated repo metadata and cached repo paths.
 /// Prompt the user to confirm cached-repo removal when running in an
@@ -590,8 +629,14 @@ pub fn load_agent(
 
     let (cached_repo, validated_repo) = resolve_agent_repo(paths, selector, &source.git, runner)?;
 
-    // Persist config only when the agent was newly registered
-    if is_new {
+    // Trust gate: prompt the operator before running an untrusted third-party agent
+    if !source.trusted {
+        confirm_agent_trust(selector, &source)?;
+        config.trust_agent(&selector.key());
+    }
+
+    // Persist config when the agent was newly registered or newly trusted
+    if is_new || !source.trusted {
         config.save(paths)?;
     }
 
@@ -1176,6 +1221,16 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         let mut config = AppConfig::load_or_init(&paths).unwrap();
         let selector = ClassSelector::new(Some("chainargos"), "the-architect");
+        // Pre-trust the third-party agent so the non-interactive test doesn't
+        // hit the trust prompt.
+        config.agents.insert(
+            "chainargos/the-architect".to_string(),
+            crate::config::AgentSource {
+                git: "https://github.com/chainargos/jackin-the-architect.git".to_string(),
+                trusted: true,
+            },
+        );
+        config.save(&paths).unwrap();
         let mut runner = FakeRunner::for_load_agent([
             String::new(),
             "jackin-chainargos__the-architect".to_string(),
@@ -1427,6 +1482,7 @@ plugins = []
 
         let config_content = r#"[agents."chainargos/agent-brown"]
 git = "git@github.com:chainargos/jackin-agent-brown.git"
+trusted = true
 "#;
         std::fs::write(&paths.config_file, config_content).unwrap();
         let mut config = AppConfig::load_or_init(&paths).unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1265,7 +1265,7 @@ mod tests {
     }
 
     #[test]
-    fn load_owner_repo_registers_source_and_builds_commands() {
+    fn load_trusted_namespaced_agent_builds_and_runs() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let mut config = AppConfig::load_or_init(&paths).unwrap();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -651,13 +651,16 @@ pub fn load_agent(
     let (cached_repo, validated_repo) = resolve_agent_repo(paths, selector, &source.git, runner)?;
 
     // Trust gate: prompt the operator before running an untrusted third-party agent
-    if !source.trusted {
+    let newly_trusted = if source.trusted {
+        false
+    } else {
         confirm_agent_trust(selector, &source)?;
         config.trust_agent(&selector.key());
-    }
+        true
+    };
 
     // Persist config when the agent was newly registered or newly trusted
-    if is_new || !source.trusted {
+    if is_new || newly_trusted {
         config.save(paths)?;
     }
 
@@ -1234,6 +1237,31 @@ mod tests {
                 readonly: false,
             }],
         }
+    }
+
+    #[test]
+    fn trust_gate_rejects_untrusted_agent_in_non_interactive_context() {
+        let selector = ClassSelector::new(Some("evil-org"), "backdoor");
+        let source = crate::config::AgentSource {
+            git: "https://github.com/evil-org/jackin-backdoor.git".to_string(),
+            trusted: false,
+        };
+
+        let error = confirm_agent_trust(&selector, &source).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("untrusted agent source"),
+            "expected 'untrusted agent source' in: {message}"
+        );
+        assert!(
+            message.contains("evil-org/backdoor"),
+            "expected agent selector in error: {message}"
+        );
+        assert!(
+            message.contains("evil-org/jackin-backdoor.git"),
+            "expected git URL in error: {message}"
+        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -623,6 +623,27 @@ pub fn load_agent(
     runner: &mut impl CommandRunner,
     opts: &LoadOptions,
 ) -> anyhow::Result<()> {
+    load_agent_with(
+        paths,
+        config,
+        selector,
+        workspace,
+        runner,
+        opts,
+        confirm_agent_trust,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+fn load_agent_with(
+    paths: &JackinPaths,
+    config: &mut AppConfig,
+    selector: &ClassSelector,
+    workspace: &crate::workspace::ResolvedWorkspace,
+    runner: &mut impl CommandRunner,
+    opts: &LoadOptions,
+    confirm_trust: impl FnOnce(&ClassSelector, &crate::config::AgentSource) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
     // Pre-launch garbage collection: remove orphaned DinD containers and
     // networks left behind by hard kills, terminal closures, or startup
     // failures.  Best-effort — errors are silently ignored.
@@ -654,7 +675,7 @@ pub fn load_agent(
     let newly_trusted = if source.trusted {
         false
     } else {
-        confirm_agent_trust(selector, &source)?;
+        confirm_trust(selector, &source)?;
         config.trust_agent(&selector.key());
         true
     };
@@ -1264,22 +1285,22 @@ mod tests {
         );
     }
 
+    /// Helper: trust callback that always accepts.
+    fn auto_trust(_: &ClassSelector, _: &crate::config::AgentSource) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Helper: trust callback that always declines.
+    fn deny_trust(_: &ClassSelector, _: &crate::config::AgentSource) -> anyhow::Result<()> {
+        anyhow::bail!("agent source not trusted — aborting")
+    }
+
     #[test]
-    fn load_trusted_namespaced_agent_builds_and_runs() {
+    fn load_namespaced_agent_registers_source_and_trusts_on_accept() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let mut config = AppConfig::load_or_init(&paths).unwrap();
         let selector = ClassSelector::new(Some("chainargos"), "the-architect");
-        // Pre-trust the third-party agent so the non-interactive test doesn't
-        // hit the trust prompt.
-        config.agents.insert(
-            "chainargos/the-architect".to_string(),
-            crate::config::AgentSource {
-                git: "https://github.com/chainargos/jackin-the-architect.git".to_string(),
-                trusted: true,
-            },
-        );
-        config.save(&paths).unwrap();
         let mut runner = FakeRunner::for_load_agent([
             String::new(),
             "jackin-chainargos__the-architect".to_string(),
@@ -1303,21 +1324,21 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
 
         let workspace = repo_workspace(&repo_dir);
-        load_agent(
+        load_agent_with(
             &paths,
             &mut config,
             &selector,
             &workspace,
             &mut runner,
             &LoadOptions::default(),
+            auto_trust,
         )
         .unwrap();
 
-        assert!(
-            std::fs::read_to_string(&paths.config_file)
-                .unwrap()
-                .contains("chainargos/the-architect")
-        );
+        // Source was auto-registered and persisted with trust
+        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(persisted.contains("chainargos/the-architect"));
+        assert!(persisted.contains("trusted = true"));
         assert!(
             runner
                 .recorded
@@ -1347,6 +1368,58 @@ plugins = ["code-review@claude-plugins-official"]
                 .recorded
                 .iter()
                 .any(|call| call.contains("claude plugin install"))
+        );
+    }
+
+    #[test]
+    fn load_namespaced_agent_aborts_when_trust_declined() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(Some("evil-org"), "backdoor");
+        let mut runner = FakeRunner::for_load_agent([String::new(), String::new()]);
+
+        let repo_dir = paths.agents_dir.join("evil-org").join("backdoor");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let workspace = repo_workspace(&repo_dir);
+        let error = load_agent_with(
+            &paths,
+            &mut config,
+            &selector,
+            &workspace,
+            &mut runner,
+            &LoadOptions::default(),
+            deny_trust,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("not trusted"));
+
+        // Source was NOT persisted when trust was declined
+        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!persisted.contains("evil-org/backdoor"));
+
+        // No Docker build or run commands were issued
+        assert!(
+            !runner
+                .recorded
+                .iter()
+                .any(|call| call.contains("docker build") || call.contains("docker run"))
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -215,7 +215,7 @@ fn confirm_agent_trust(
     if !std::io::stdin().is_terminal() {
         anyhow::bail!(
             "untrusted agent source \"{selector}\" from {}\n\
-             Trust it first with an interactive terminal, or pre-register it in config.toml with `trusted = true`.",
+             Trust it first: `jackin config trust grant {selector}`, or add `trusted = true` in config.toml.",
             source.git,
         );
     }
@@ -257,7 +257,7 @@ fn confirm_agent_trust(
     if !confirmed {
         anyhow::bail!(
             "agent source \"{selector}\" not trusted — aborting.\n\
-             To trust it later, run `jackin load {selector}` again and confirm."
+             To trust it later, run `jackin config trust grant {selector}` or try loading again."
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -214,30 +214,51 @@ fn confirm_agent_trust(
 ) -> anyhow::Result<()> {
     if !std::io::stdin().is_terminal() {
         anyhow::bail!(
-            "untrusted agent source {selector} — cannot prompt for trust confirmation (stdin is not a terminal)"
+            "untrusted agent source \"{selector}\" from {}\n\
+             Trust it first with an interactive terminal, or pre-register it in config.toml with `trusted = true`.",
+            source.git,
         );
     }
 
+    eprintln!();
+    eprintln!("{}", "!! Untrusted agent source !!".red().bold());
+    eprintln!();
+    eprintln!("  agent:  {}", selector.to_string().bold());
+    eprintln!("  source: {}", source.git.yellow());
+    eprintln!();
     eprintln!(
-        "\n{}",
-        "⚠  Untrusted agent source detected:".yellow().bold()
+        "  {}",
+        "jackin' has never loaded this agent before. Trusting it means:".bold()
     );
-    eprintln!("     agent:  {}", selector.to_string().bold());
-    eprintln!("     source: {}", source.git.dimmed());
     eprintln!(
-        "   {}",
-        "This is a third-party agent. Its Dockerfile and build instructions will be executed on your machine."
-            .dimmed()
+        "    {} Its {} will be executed during the image build",
+        "-".dimmed(),
+        "Dockerfile".bold()
     );
+    eprintln!(
+        "    {} Arbitrary commands in that Dockerfile will run {}",
+        "-".dimmed(),
+        "on your machine".bold()
+    );
+    eprintln!(
+        "    {} The agent will have access to your {}",
+        "-".dimmed(),
+        "mounted workspace files".bold()
+    );
+    eprintln!();
+    eprintln!("  {}", "Review the repository before trusting it.".dimmed());
     eprintln!();
 
     let confirmed = dialoguer::Confirm::new()
-        .with_prompt("Do you trust this agent source?")
+        .with_prompt("Do you trust this agent source and want to proceed?")
         .default(false)
         .interact()?;
 
     if !confirmed {
-        anyhow::bail!("agent source not trusted — aborting");
+        anyhow::bail!(
+            "agent source \"{selector}\" not trusted — aborting.\n\
+             To trust it later, run `jackin load {selector}` again and confirm."
+        );
     }
 
     Ok(())

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -564,6 +564,7 @@ mod tests {
             "agent-smith".to_string(),
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
             },
         );
         config.workspaces.insert(
@@ -605,6 +606,7 @@ mod tests {
             "agent-smith".to_string(),
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
             },
         );
         config.workspaces.insert(
@@ -708,6 +710,7 @@ mod tests {
             "agent-smith".to_string(),
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
             },
         );
         config.workspaces.insert(

--- a/todo/agent-source-trust.md
+++ b/todo/agent-source-trust.md
@@ -1,6 +1,8 @@
 # Agent Source Trust Model
 
-**Status**: Deferred — needs design work
+**Status**: Resolved
+
+Implemented. The sections below preserve the original design rationale.
 
 ## Problem
 
@@ -12,16 +14,18 @@
 - No mechanism to distinguish a trusted, previously-used agent from a novel one
 - Agents execute in a build context with access to the Dockerfile and build instructions
 
-## Desired Behavior
+## Implementation
 
-A trust-on-first-use model similar to `mise trust`:
-- First time an agent source is encountered, clone the repo but prompt the user for confirmation before running it
-- Store trusted sources in config (allowlist)
-- Subsequent runs of trusted agents proceed without prompts
-- Optional security mode: always show agent source output before running, allowing AI agent analysis of the content
+A trust-on-first-use model:
+- `AgentSource` now carries a `trusted: bool` field, persisted in config TOML
+- Built-in agents (`agent-smith`, `the-architect`) are always marked trusted by `sync_builtin_agents()`
+- New third-party (namespaced) agents default to `trusted = false`
+- On first load of an untrusted agent, the operator sees a warning with the agent name and git URL, and must confirm before the build proceeds
+- Non-interactive sessions (no terminal) bail with an error for untrusted agents
+- Once confirmed, the `trusted = true` flag is saved to config — subsequent runs proceed without prompts
 
 ## Related Files
 
-- `src/config.rs` — `resolve_agent_source()`, trust store format
-- `src/runtime.rs` — calls `resolve_agent_source()` during agent load
+- `src/config.rs` — `AgentSource.trusted`, `trust_agent()`, `resolve_agent_source()`
+- `src/runtime.rs` — `confirm_agent_trust()`, trust gate in `load_agent()`
 - `src/selector.rs` — namespace/name parsing


### PR DESCRIPTION
## Summary

- Implement trust-on-first-use model for third-party agent sources — untrusted agents require explicit operator confirmation before their Dockerfile is built
- Built-in agents (`agent-smith`, `the-architect`) are always trusted; new namespaced agents default to untrusted
- Trust state persists in `config.toml` so subsequent loads proceed without prompts
- Non-interactive environments get a clear error with instructions to pre-trust via `trusted = true` in config
- Sync roadmap with TODO items (add missing completed/planned entries)
- Mark security review findings #2 (git source trust) and #9 (mount guardrails) as resolved

## Changes

**Core (`src/config.rs`, `src/runtime.rs`)**
- Add `trusted: bool` field to `AgentSource` with `skip_serializing_if` for clean config output
- Add `trust_agent()` method and `confirm_agent_trust()` interactive prompt
- Trust gate runs after repo clone but before Docker build
- 7 new unit tests covering trust lifecycle, serialization, upgrade path, and non-interactive rejection

**Docs (`docs/pages/`)**
- `commands/load.mdx` — trust is step 3 in "What happens", plus warning callout for CI pre-trust
- `guides/security-model.mdx` — new "Agent source trust" section with prompt example, `config.toml` syntax, threat model row, and best practices update
- `reference/roadmap.mdx` — sync completed/planned items with `TODO.md`

**Bookkeeping**
- `todo/agent-source-trust.md` — marked Resolved
- `TODO.md` — moved to Resolved section
- `SECURITY_REVIEW_FINDINGS.md` — findings #2 and #9 marked resolved

## Test plan

- [x] All 291 tests pass (`cargo test`)
- [x] Zero clippy warnings (`cargo clippy`)
- [x] Formatting clean (`cargo fmt -- --check`)
- [ ] Manual test: `jackin load chainargos/some-agent` shows trust prompt on first use
- [ ] Manual test: second load of same agent skips prompt
- [ ] Manual test: non-interactive context (piped stdin) produces clear error

https://claude.ai/code/session_01SkHoAne5Q5EpUybYk6ghUT