### PR TITLE
docs: expand reproducibility pinning TODO with versioning options

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Migrate Docker CLI to Bollard API Client](todo/bollard-migration.md) — replace string-matched error handling with typed API
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
 - [Selectable Sandbox Backends: DinD and MicroVM](todo/selectable-sandbox-backends.md) — operator-selectable runtime modes with backend-neutral lifecycle design
-- [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — commit SHA pinning for agent repos
+- [Reproducibility and Provenance Pinning](todo/reproducibility-pinning.md) — version pinning for agent repos (needs design)
 
 ## Resolved
 

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -51,7 +51,7 @@ jackin's architecture is runtime-agnostic. The construct and workspace system wo
 - **DinD TLS authentication** — secure the Docker-in-Docker daemon with auto-generated certificates
 - **Network policy controls** — outbound domain filtering per agent class, similar to Docker Sandboxes' network policies
 - **Credential proxy** — proxy-based credential injection to avoid storing tokens inside containers
-- **Runtime pinning and supply-chain hardening** — make agent runtime installation more reproducible and auditable
+- **Agent version pinning** — pin agent repos to tagged versions for reproducible builds, with explicit `--update` to advance (design in progress)
 - **Alternative isolation tiers** — explore stronger backends beyond plain container isolation for users who need them
 
 ### Infrastructure improvements

--- a/todo/reproducibility-pinning.md
+++ b/todo/reproducibility-pinning.md
@@ -1,27 +1,92 @@
 # Reproducibility and Provenance Pinning
 
-**Status**: Deferred — implement after agent source trust model
+**Status**: Needs design — brainstorming required before implementation
 
 ## Problem
 
-The current agent repo flow tracks moving branches (typically `main`) by default. There is no mechanism to pin to a specific commit, verify provenance, or control when updates are pulled.
+The current agent repo flow tracks moving branches (typically `main`) by default. There is no mechanism to pin to a specific version, verify provenance, or control when updates are pulled.
 
 ## Why It Matters
 
 - An agent's behavior can change between runs without the operator's knowledge
 - No way to reproduce a previous run's exact environment
-- No audit trail of which commit was used for a given session
+- No audit trail of which version was used for a given session
 
 ## Desired Behavior
 
-- Support lockfile-like pinning to commit SHAs in agent config
-- Display the resolved commit SHA during agent launch
+- Pin agents to a specific version so behavior is reproducible across runs
+- Display the resolved version during agent launch
 - Introduce explicit `--update` flag to pull latest (rather than auto-updating)
-- Record the commit SHA used in runtime state for audit/debugging
-- Integrate with the trust model: trust is granted at a specific commit, `--update` re-evaluates trust
+- Record the version used in runtime state for audit/debugging
+- Integrate with the trust model: trust is granted at a specific version, `--update` re-evaluates trust
+
+## Open Questions
+
+- What is the right unit of pinning — git tags (semantic versions) or raw commit SHAs?
+- Should `--update` advance to the latest tag, or to HEAD of the default branch?
+- How does this interact with built-in agents vs third-party agents?
+- Should the operator be able to pin to a specific version from the CLI (e.g. `--version v1.2.0`)?
+
+## Options
+
+### Option 1: Git Tag Versioning
+
+Agent repos use git tags (e.g. `v1.0.0`, `v1.2.3`) as the release mechanism. jackin' resolves and pins to tags rather than branches.
+
+- First load: resolve the latest tag, record it in config
+- Subsequent loads: check out the pinned tag (no auto-update)
+- `--update`: fetch tags, resolve latest, re-pin
+- Config: `version = "v1.2.3"` in `AgentSource`
+- Agents without tags fall back to branch tracking (current behavior)
+
+Pros:
+- Familiar model (Cargo, npm, Docker tags)
+- Human-readable versions in config and launch output
+- Agent authors can publish releases with changelogs
+- Natural integration with semver constraints in the future (e.g. `version = "^1.0"`)
+
+Cons:
+- Requires agent authors to tag releases — adds process
+- Need to decide how to handle repos with no tags
+- Tag-based resolution adds complexity (latest tag selection, pre-release handling)
+
+### Option 2: Commit SHA Pinning
+
+Lockfile-style pinning to raw commit SHAs, similar to `flake.lock` or Go module checksums.
+
+- First load: clone/pull, record HEAD SHA in config
+- Subsequent loads: fetch + checkout pinned SHA
+- `--update`: pull latest, re-pin to new HEAD
+- Config: `commit = "a1b2c3d4e5f6..."` in `AgentSource`
+
+Pros:
+- Works with any repo, no tagging discipline required
+- Exact reproducibility (SHAs are immutable)
+- Simple implementation
+
+Cons:
+- SHAs are opaque — no sense of "which version am I on" or "how far behind am I"
+- No concept of releases, changelogs, or upgrade paths
+- Harder for operators to reason about
+
+### Option 3: Hybrid
+
+Support both — prefer tags when available, fall back to commit SHAs.
+
+- If the repo has tags: resolve latest tag, pin by tag name, record the tag's SHA for verification
+- If the repo has no tags: fall back to commit SHA pinning
+- Config could store both: `version = "v1.2.3"` and `commit = "a1b2c3d..."` (tag + verification SHA)
+
+Pros:
+- Best of both worlds
+- Graceful degradation for untagged repos
+
+Cons:
+- More complex config and resolution logic
+- Two code paths to maintain
 
 ## Related Files
 
-- `src/config.rs` — `resolve_agent_source()`, agent config would need commit SHA field
+- `src/config.rs` — `resolve_agent_source()`, `AgentSource` would need version/commit fields
 - `src/runtime.rs` — repo checkout logic, calls `resolve_agent_source()`
 - `src/manifest.rs` — version/provenance metadata


### PR DESCRIPTION
## Summary

- Reframe the reproducibility pinning TODO around **git tag versioning** as the primary approach, with commit SHA pinning and a hybrid option as alternatives
- Update status from "Deferred" to **"Needs design — brainstorming required"**
- Add open questions and three design options with pros/cons
- Update `TODO.md` description and roadmap entry to reflect the versioning direction

## Changes

- `todo/reproducibility-pinning.md` — expanded with Options (tag versioning, SHA pinning, hybrid), Open Questions section
- `TODO.md` — updated item description
- `docs/pages/reference/roadmap.mdx` — updated roadmap entry

## Test plan

- [ ] Documentation-only change, no code changes to verify
- [ ] Confirm links in `TODO.md` still resolve correctly
- [ ] Confirm roadmap renders correctly

https://claude.ai/code/session_01Uy2aZT4BgXFcy9ybB6Yb9U