### PR TITLE
feat: enable TLS authentication for DinD sidecar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 ## Open Items
 
 - [Construct Image: User Creation Responsibility](todo/construct-user-creation.md) — UID/GID remapping hack in derived images
-- [DinD Running Without TLS Authentication](todo/dind-tls.md) — unauthenticated Docker daemon on agent network
 - [1Password Integration for Agent Secrets](todo/onepassword-integration.md) — first-class secret injection at launch time
 - [Migrate Docker CLI to Bollard API Client](todo/bollard-migration.md) — replace string-matched error handling with typed API
 - [Rootless DinD Research](todo/rootless-dind.md) — reduce privileged container attack surface
@@ -20,3 +19,4 @@ Individual items are tracked in [`todo/`](todo/). Each file is a self-contained 
 - [Custom Plugin Marketplace Support](todo/custom-plugin-marketplace.md) — auto-install custom Claude marketplaces and plugins from `jackin.agent.toml`
 - [Expose DinD Hostname as `JACKIN_DIND_HOSTNAME`](todo/dind-hostname-env-var.md) — agents can reach DinD-backed services without parsing `DOCKER_HOST`
 - [Agent Source Trust Model](todo/agent-source-trust.md) — trust-on-first-use for third-party agent repos
+- [DinD TLS Authentication](todo/dind-tls.md) — TLS with auto-generated certificates for DinD sidecar

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -153,9 +153,9 @@ These are the parts of the security story that should be stated bluntly.
 
 ### Privileged DinD sidecar
 
-jackin' launches a privileged `docker:dind` sidecar per agent. The agent talks to it over plain TCP inside the per-agent network.
+jackin' launches a privileged `docker:dind` sidecar per agent. The sidecar auto-generates TLS certificates at startup and shares client certs with the agent container via a Docker volume. The agent connects over TLS-authenticated TCP (`DOCKER_HOST=tcp://...:2376` with `DOCKER_TLS_VERIFY=1`).
 
-That keeps the agent away from your host Docker daemon, which is good. But it is still a privileged sidecar, and DinD TLS is not implemented yet.
+That keeps the agent away from your host Docker daemon and prevents unauthenticated access to the DinD daemon on the per-agent network. But it is still a privileged sidecar, and the auto-generated certificates are session-scoped (not pinned to an external CA).
 
 ### Open outbound network by default
 

--- a/docs/pages/reference/architecture.mdx
+++ b/docs/pages/reference/architecture.mdx
@@ -26,7 +26,7 @@ description: How jackin' orchestrates containers, networks, and persisted state
 │  │  │  │ Container     │  │ (docker:dind)   │  │  │     │
 │  │  │  │               │  │                 │  │  │     │
 │  │  │  │ Claude Code   │──│ Docker daemon   │  │  │     │
-│  │  │  │ Agent tools   │  │ tcp://...:2375  │  │  │     │
+│  │  │  │ Agent tools   │  │ tcp://...:2376  │  │  │     │
 │  │  │  │ Mounted dirs  │  │                 │  │  │     │
 │  │  │  └──────────────┘  └─────────────────┘  │  │     │
 │  │  └─────────────────────────────────────────┘  │     │
@@ -96,8 +96,8 @@ That means an agent class defines the tools and conventions, while jackin' injec
 4. **Generate a derived build context** — copy the repo, inject runtime assets (entrypoint + pre-launch hook), and render a derived Dockerfile
 5. **Build the image on the host Docker engine** — reusing host-side Docker cache where possible
 6. **Create a per-agent Docker network**
-7. **Start a privileged `docker:dind` sidecar**
-8. **Start the agent container** — mounts, resolved env vars, labels, and `DOCKER_HOST` all point at the sidecar
+7. **Start a privileged `docker:dind` sidecar** with TLS enabled and a shared certificate volume
+8. **Start the agent container** — mounts, resolved env vars, TLS client certs, labels, and `DOCKER_HOST` all point at the sidecar
 9. **Run Claude Code with full permissions inside that boundary**
 
 ### Reconnecting
@@ -120,13 +120,11 @@ Each agent gets an isolated Docker network:
 
 - network name is derived from the runtime container name
 - the agent container and DinD sidecar share that network
-- the agent reaches the daemon through `DOCKER_HOST=tcp://{dind}:2375`
+- the agent reaches the daemon through `DOCKER_HOST=tcp://{dind}:2376` with TLS mutual authentication
 - the agent reaches published services launched via DinD through `JACKIN_DIND_HOSTNAME={dind}`
 - different agents do not share a network by default
 
-:::note
-The DinD sidecar currently runs without TLS. Any container on that per-agent network can reach the daemon. TLS support is on the roadmap.
-:::
+The DinD sidecar auto-generates TLS certificates at startup into a shared Docker volume. The agent container mounts the client certificates read-only and sets `DOCKER_TLS_VERIFY=1` so all Docker CLI commands are authenticated.
 
 ## State management
 
@@ -183,7 +181,7 @@ If the main thing you need is the strongest local boundary for autonomous agents
 
 ## Current technical debt and limitations
 
-- **DinD transport is not authenticated.** The runtime reaches the sidecar over plain TCP.
+- **DinD transport uses auto-generated TLS certificates.** The certificates are generated per-session and not pinned to a CA chain you control.
 - **Claude installation is not fully pinned.** The derived image installs Claude Code from the upstream installer.
 - **Derived build context rejects symlinks.** Agent repos with symlink-heavy layouts are not supported yet.
 - **Cached agent repos must stay clean.** jackin' refuses to build from a dirty or origin-mismatched cache.

--- a/docs/pages/reference/roadmap.mdx
+++ b/docs/pages/reference/roadmap.mdx
@@ -30,6 +30,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - `${env.VAR}` interpolation in env var prompts and defaults for dependent variables
 - `JACKIN_DIND_HOSTNAME` environment variable for agents to discover the DinD sidecar hostname
 - Agent source trust model (trust-on-first-use verification for third-party agent repos)
+- DinD TLS authentication with auto-generated certificates
 
 ## Planned
 
@@ -48,7 +49,6 @@ jackin's architecture is runtime-agnostic. The construct and workspace system wo
 
 ### Security improvements
 
-- **DinD TLS authentication** — secure the Docker-in-Docker daemon with auto-generated certificates
 - **Network policy controls** — outbound domain filtering per agent class, similar to Docker Sandboxes' network policies
 - **Credential proxy** — proxy-based credential injection to avoid storing tokens inside containers
 - **Agent version pinning** — pin agent repos to tagged versions for reproducible builds, with explicit `--update` to advance (design in progress)

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,6 +10,10 @@ pub const JACKIN_DIND_HOSTNAME_ENV_NAME: &str = "JACKIN_DIND_HOSTNAME";
 const RESERVED_RUNTIME_ENV_VARS: &[(&str, Option<&str>)] = &[
     (JACKIN_RUNTIME_ENV_NAME, Some(JACKIN_RUNTIME_ENV_VALUE)),
     (JACKIN_DIND_HOSTNAME_ENV_NAME, None),
+    // Docker TLS vars injected by jackin — must not be overridden by manifests.
+    ("DOCKER_HOST", None),
+    ("DOCKER_TLS_VERIFY", None),
+    ("DOCKER_CERT_PATH", None),
 ];
 
 #[derive(Debug, Clone, Deserialize)]
@@ -973,6 +977,36 @@ default = "sidecar"
                 .to_string()
                 .contains("JACKIN_DIND_HOSTNAME")
         );
+    }
+
+    #[test]
+    fn validate_rejects_reserved_docker_tls_env_vars() {
+        for var in ["DOCKER_HOST", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"] {
+            let temp = tempdir().unwrap();
+            std::fs::write(
+                temp.path().join("jackin.agent.toml"),
+                format!(
+                    r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[env.{var}]
+default = "override"
+"#
+                ),
+            )
+            .unwrap();
+
+            let manifest = AgentManifest::load(temp.path()).unwrap();
+            let result = manifest.validate();
+
+            assert!(result.is_err(), "{var} should be rejected as reserved");
+            assert!(
+                result.unwrap_err().to_string().contains(var),
+                "error message should mention {var}"
+            );
+        }
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -23,6 +23,13 @@ const FILTER_MANAGED: &str = "label=jackin.managed=true";
 /// Filter expression for `docker ps --filter` to find `DinD` sidecars.
 const FILTER_ROLE_DIND: &str = "label=jackin.role=dind";
 
+/// Environment variables owned by the jackin runtime that must not be
+/// overridden by agent manifests.  These are injected as `-e` flags in
+/// `launch_agent_runtime` and are silently skipped if a manifest declares them.
+/// The corresponding manifest-time validation lives in
+/// `manifest::RESERVED_RUNTIME_ENV_VARS`.
+const RUNTIME_OWNED_ENV_VARS: &[&str] = &["DOCKER_HOST", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"];
+
 pub struct LoadOptions {
     pub no_intro: bool,
     pub debug: bool,
@@ -586,6 +593,7 @@ fn launch_agent_runtime(
     for (key, value) in &resolved_env.vars {
         if key == crate::manifest::JACKIN_RUNTIME_ENV_NAME
             || key == crate::manifest::JACKIN_DIND_HOSTNAME_ENV_NAME
+            || RUNTIME_OWNED_ENV_VARS.contains(&key.as_str())
         {
             continue;
         }
@@ -1049,9 +1057,9 @@ fn collect_orphaned_dind(runner: &mut impl CommandRunner) -> anyhow::Result<Vec<
         .collect())
 }
 
-/// Remove orphaned `DinD` containers, their associated agent containers, and
-/// networks.  Errors are logged but do not abort the launch — GC is
-/// best-effort.
+/// Remove orphaned `DinD` containers, their associated agent containers, cert
+/// volumes, and networks.  Errors are logged but do not abort the launch — GC
+/// is best-effort.
 fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
     let Ok(orphaned) = collect_orphaned_dind(runner) else {
         return;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -842,16 +842,7 @@ fn wait_for_dind(
     runner
         .capture(
             "docker",
-            &[
-                "run",
-                "--rm",
-                "-v",
-                &format!("{certs_volume}:/certs/client:ro"),
-                "docker:dind",
-                "test",
-                "-f",
-                "/certs/client/ca.pem",
-            ],
+            &["exec", dind_name, "test", "-f", "/certs/client/ca.pem"],
             None,
         )
         .map_err(|_| {
@@ -2093,6 +2084,105 @@ plugins = []
             .position(|call| call.contains("docker exec jackin-agent-smith-dind docker info"))
             .unwrap();
         assert!(dind_start < dind_check);
+
+        // TLS cert verification runs after docker info check
+        assert!(runner.recorded.iter().any(|call| {
+            call.contains("docker exec jackin-agent-smith-dind test -f /certs/client/ca.pem")
+        }));
+    }
+
+    #[test]
+    fn dind_certs_volume_derives_from_container_name() {
+        assert_eq!(
+            dind_certs_volume("jackin-agent-smith"),
+            "jackin-agent-smith-dind-certs"
+        );
+        assert_eq!(
+            dind_certs_volume("jackin-chainargos__the-architect-clone-2"),
+            "jackin-chainargos__the-architect-clone-2-dind-certs"
+        );
+    }
+
+    #[test]
+    fn load_agent_configures_dind_with_tls() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = ClassSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "jackin-agent-smith".to_string(),
+        ]);
+
+        let repo_dir = paths.agents_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let workspace = repo_workspace(&repo_dir);
+        load_agent(
+            &paths,
+            &mut config,
+            &selector,
+            &workspace,
+            &mut runner,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+
+        // DinD sidecar: TLS enabled with cert volume
+        let dind_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker run -d --name jackin-agent-smith-dind"))
+            .unwrap();
+        assert!(
+            dind_cmd.contains("DOCKER_TLS_CERTDIR=/certs"),
+            "DinD must enable TLS cert generation"
+        );
+        assert!(
+            dind_cmd.contains("jackin-agent-smith-dind-certs:/certs/client"),
+            "DinD must mount cert volume"
+        );
+
+        // Agent container: TLS client config
+        let run_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker run -it"))
+            .unwrap();
+        assert!(
+            run_cmd.contains("DOCKER_HOST=tcp://jackin-agent-smith-dind:2376"),
+            "agent must use TLS port 2376"
+        );
+        assert!(
+            run_cmd.contains("DOCKER_TLS_VERIFY=1"),
+            "agent must verify TLS"
+        );
+        assert!(
+            run_cmd.contains("DOCKER_CERT_PATH=/certs/client"),
+            "agent must know cert path"
+        );
+        assert!(
+            run_cmd.contains("jackin-agent-smith-dind-certs:/certs/client:ro"),
+            "agent must mount cert volume read-only"
+        );
     }
 
     #[test]
@@ -2621,6 +2711,12 @@ plugins = []
             runner
                 .recorded
                 .iter()
+                .any(|c| c.contains("docker volume rm jackin-agent-smith-dind-certs"))
+        );
+        assert!(
+            runner
+                .recorded
+                .iter()
                 .any(|c| c.contains("docker network rm jackin-agent-smith-net"))
         );
     }
@@ -2704,7 +2800,19 @@ plugins = []
             runner
                 .recorded
                 .iter()
+                .any(|c| c.contains("docker volume rm jackin-agent-smith-dind-certs"))
+        );
+        assert!(
+            runner
+                .recorded
+                .iter()
                 .any(|c| c.contains("docker rm -f jackin-neo-dind"))
+        );
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker volume rm jackin-neo-dind-certs"))
         );
         assert!(
             runner

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -474,8 +474,10 @@ fn launch_agent_runtime(
     } = ctx;
     // Clean up stale resources from a previous run that wasn't cleaned up
     // (e.g. terminal closed, process killed, Ctrl+C during docker run)
+    let certs_volume = dind_certs_volume(container_name);
     let _ = run_cleanup_command(runner, &["rm", "-f", container_name]);
     let _ = run_cleanup_command(runner, &["rm", "-f", dind]);
+    let _ = run_cleanup_command(runner, &["volume", "rm", &certs_volume]);
     let _ = run_cleanup_command(runner, &["network", "rm", network]);
 
     // Create Docker network
@@ -494,7 +496,8 @@ fn launch_agent_runtime(
         None,
     )?;
 
-    // Start Docker-in-Docker
+    // Start Docker-in-Docker with TLS
+    let certs_dind_mount = format!("{certs_volume}:/certs/client");
     let dind_args: Vec<&str> = vec![
         "run",
         "-d",
@@ -510,12 +513,14 @@ fn launch_agent_runtime(
         "--label",
         &agent_label,
         "-e",
-        "DOCKER_TLS_CERTDIR=",
+        "DOCKER_TLS_CERTDIR=/certs",
+        "-v",
+        &certs_dind_mount,
         "docker:dind",
     ];
     runner.capture("docker", &dind_args, None)?;
 
-    wait_for_dind(dind, runner, *debug)?;
+    wait_for_dind(dind, &certs_volume, runner, *debug)?;
 
     // Step 4: Mount volumes and launch
     steps.next("Launching agent");
@@ -525,7 +530,7 @@ fn launch_agent_runtime(
 
     let class_label = format!("jackin.class={}", selector.key());
     let display_label = format!("jackin.display_name={agent_display_name}");
-    let docker_host = format!("DOCKER_HOST=tcp://{dind}:2375");
+    let docker_host = format!("DOCKER_HOST=tcp://{dind}:2376");
     let dind_hostname = format!("{}={dind}", crate::manifest::JACKIN_DIND_HOSTNAME_ENV_NAME);
     let git_author_name = format!("GIT_AUTHOR_NAME={}", git.user_name);
     let git_author_email = format!("GIT_AUTHOR_EMAIL={}", git.user_email);
@@ -536,6 +541,7 @@ fn launch_agent_runtime(
         "{}:/home/claude/.jackin/plugins.json:ro",
         state.plugins_json.display()
     );
+    let certs_agent_mount = format!("{certs_volume}:/certs/client:ro");
 
     let mut run_args: Vec<&str> = vec![
         "run",
@@ -557,6 +563,10 @@ fn launch_agent_runtime(
         // JACKIN_* runtime metadata is injected by jackin, not declared in agent manifests.
         "-e",
         &docker_host,
+        "-e",
+        "DOCKER_TLS_VERIFY=1",
+        "-e",
+        "DOCKER_CERT_PATH=/certs/client",
         "-e",
         &dind_hostname,
         "-e",
@@ -586,6 +596,8 @@ fn launch_agent_runtime(
         run_args.push(env_str);
     }
     run_args.extend_from_slice(&[
+        "-v",
+        &certs_agent_mount,
         "-v",
         &claude_dir_mount,
         "-v",
@@ -720,7 +732,13 @@ fn load_agent_with(
         crate::env_resolver::resolve_env(&validated_repo.manifest.env, &prompter)?
     };
 
-    let mut cleanup = LoadCleanup::new(container_name.clone(), dind.clone(), network.clone());
+    let certs_volume = dind_certs_volume(&container_name);
+    let mut cleanup = LoadCleanup::new(
+        container_name.clone(),
+        dind.clone(),
+        certs_volume,
+        network.clone(),
+    );
     let load_result = (|| -> anyhow::Result<()> {
         // Step 2: Build Docker image
         let rebuild = opts.rebuild || {
@@ -801,9 +819,11 @@ pub fn hardline_agent(container_name: &str, runner: &mut impl CommandRunner) -> 
 
 fn wait_for_dind(
     dind_name: &str,
+    certs_volume: &str,
     runner: &mut impl CommandRunner,
     _debug: bool,
 ) -> anyhow::Result<()> {
+    // Wait for the DinD daemon to become ready (TLS handshake included).
     tui::spin_wait(
         "Waiting for Docker-in-Docker to be ready",
         30,
@@ -814,7 +834,34 @@ fn wait_for_dind(
                 .map(|_| ())
         },
     )
-    .map_err(|_| anyhow::anyhow!("timed out waiting for Docker-in-Docker sidecar {dind_name}"))
+    .map_err(|_| anyhow::anyhow!("timed out waiting for Docker-in-Docker sidecar {dind_name}"))?;
+
+    // Verify TLS client certificates were generated on the shared volume.
+    // The DinD entrypoint writes certs before starting dockerd, so this
+    // should succeed immediately after `docker info` passes.
+    runner
+        .capture(
+            "docker",
+            &[
+                "run",
+                "--rm",
+                "-v",
+                &format!("{certs_volume}:/certs/client:ro"),
+                "docker:dind",
+                "test",
+                "-f",
+                "/certs/client/ca.pem",
+            ],
+            None,
+        )
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "DinD TLS client certificates not found on volume {certs_volume} — \
+                 the DinD sidecar may have started without generating certificates"
+            )
+        })?;
+
+    Ok(())
 }
 
 pub fn list_running_agent_names(runner: &mut impl CommandRunner) -> anyhow::Result<Vec<String>> {
@@ -931,10 +978,12 @@ pub fn purge_class_data(paths: &JackinPaths, selector: &ClassSelector) -> anyhow
 
 pub fn eject_agent(container_name: &str, runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     let dind = format!("{container_name}-dind");
+    let certs_volume = dind_certs_volume(container_name);
     let network = format!("{container_name}-net");
 
     run_cleanup_command(runner, &["rm", "-f", container_name])?;
     run_cleanup_command(runner, &["rm", "-f", &dind])?;
+    run_cleanup_command(runner, &["volume", "rm", &certs_volume])?;
     run_cleanup_command(runner, &["network", "rm", &network])?;
 
     Ok(())
@@ -950,7 +999,9 @@ fn run_cleanup_command(runner: &mut impl CommandRunner, args: &[&str]) -> anyhow
 
 fn is_missing_cleanup_error(error: &anyhow::Error) -> bool {
     let message = error.to_string();
-    message.contains("No such container") || message.contains("No such network")
+    message.contains("No such container")
+        || message.contains("No such volume")
+        || message.contains("No such network")
 }
 
 // ── Orphaned resource garbage collection ─────────────────────────────────
@@ -1016,11 +1067,13 @@ fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
     };
 
     for info in &orphaned {
+        let certs_volume = dind_certs_volume(&info.agent);
         let network = format!("{}-net", info.agent);
 
-        // Remove stopped agent container, DinD sidecar, and network.
+        // Remove stopped agent container, DinD sidecar, cert volume, and network.
         let _ = run_cleanup_command(runner, &["rm", "-f", &info.agent]);
         let _ = run_cleanup_command(runner, &["rm", "-f", &info.name]);
+        let _ = run_cleanup_command(runner, &["volume", "rm", &certs_volume]);
         let _ = run_cleanup_command(runner, &["network", "rm", &network]);
 
         eprintln!(
@@ -1088,18 +1141,31 @@ fn image_name(selector: &ClassSelector) -> String {
     format!("jackin-{}", crate::instance::runtime_slug(selector))
 }
 
+/// Docker volume name for the TLS client certificates shared between the
+/// `DinD` sidecar (writer) and the agent container (reader).
+fn dind_certs_volume(container_name: &str) -> String {
+    format!("{container_name}-dind-certs")
+}
+
 struct LoadCleanup {
     container_name: String,
     dind: String,
+    certs_volume: String,
     network: String,
     armed: bool,
 }
 
 impl LoadCleanup {
-    const fn new(container_name: String, dind: String, network: String) -> Self {
+    const fn new(
+        container_name: String,
+        dind: String,
+        certs_volume: String,
+        network: String,
+    ) -> Self {
         Self {
             container_name,
             dind,
+            certs_volume,
             network,
             armed: true,
         }
@@ -1119,6 +1185,9 @@ impl LoadCleanup {
         }
         if let Err(e) = run_cleanup_command(runner, &["rm", "-f", &self.dind]) {
             tui::step_fail(&format!("cleanup failed (dind): {e}"));
+        }
+        if let Err(e) = run_cleanup_command(runner, &["volume", "rm", &self.certs_volume]) {
+            tui::step_fail(&format!("cleanup failed (certs volume): {e}"));
         }
         if let Err(e) = run_cleanup_command(runner, &["network", "rm", &self.network]) {
             tui::step_fail(&format!("cleanup failed (network): {e}"));
@@ -1472,6 +1541,7 @@ plugins = []
             vec![
                 "docker rm -f jackin-agent-smith",
                 "docker rm -f jackin-agent-smith-dind",
+                "docker volume rm jackin-agent-smith-dind-certs",
                 "docker network rm jackin-agent-smith-net",
             ]
         );
@@ -1491,6 +1561,11 @@ plugins = []
                         .to_string(),
                 ),
                 (
+                    "docker volume rm jackin-agent-smith-dind-certs".to_string(),
+                    "Error response from daemon: No such volume: jackin-agent-smith-dind-certs"
+                        .to_string(),
+                ),
+                (
                     "docker network rm jackin-agent-smith-net".to_string(),
                     "Error response from daemon: No such network: jackin-agent-smith-net"
                         .to_string(),
@@ -1506,6 +1581,7 @@ plugins = []
             vec![
                 "docker rm -f jackin-agent-smith",
                 "docker rm -f jackin-agent-smith-dind",
+                "docker volume rm jackin-agent-smith-dind-certs",
                 "docker network rm jackin-agent-smith-net",
             ]
         );
@@ -1525,9 +1601,11 @@ jackin-agent-smith-clone-1"#
                 "docker ps -a --filter label=jackin.managed=true --format {{.Names}}",
                 "docker rm -f jackin-agent-smith",
                 "docker rm -f jackin-agent-smith-dind",
+                "docker volume rm jackin-agent-smith-dind-certs",
                 "docker network rm jackin-agent-smith-net",
                 "docker rm -f jackin-agent-smith-clone-1",
                 "docker rm -f jackin-agent-smith-clone-1-dind",
+                "docker volume rm jackin-agent-smith-clone-1-dind-certs",
                 "docker network rm jackin-agent-smith-clone-1-net",
             ]
         );
@@ -1563,9 +1641,11 @@ jackin-agent-smith-clone-1"#
                 "docker ps -a --filter label=jackin.managed=true --format {{.Names}}",
                 "docker rm -f jackin-agent-smith",
                 "docker rm -f jackin-agent-smith-dind",
+                "docker volume rm jackin-agent-smith-dind-certs",
                 "docker network rm jackin-agent-smith-net",
                 "docker rm -f jackin-agent-smith-clone-1",
                 "docker rm -f jackin-agent-smith-clone-1-dind",
+                "docker volume rm jackin-agent-smith-clone-1-dind-certs",
                 "docker network rm jackin-agent-smith-clone-1-net",
             ]
         );
@@ -1935,6 +2015,12 @@ plugins = ["code-review@claude-plugins-official"]
                 .recorded
                 .iter()
                 .any(|call| call == "docker rm -f jackin-agent-smith-dind")
+        );
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|call| call == "docker volume rm jackin-agent-smith-dind-certs")
         );
         assert!(
             runner

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2104,6 +2104,23 @@ plugins = []
     }
 
     #[test]
+    fn is_missing_cleanup_error_tolerates_all_resource_types() {
+        let container_err =
+            anyhow::anyhow!("Error response from daemon: No such container: jackin-agent-smith");
+        let volume_err = anyhow::anyhow!(
+            "Error response from daemon: No such volume: jackin-agent-smith-dind-certs"
+        );
+        let network_err =
+            anyhow::anyhow!("Error response from daemon: No such network: jackin-agent-smith-net");
+        let real_err = anyhow::anyhow!("Error response from daemon: permission denied");
+
+        assert!(is_missing_cleanup_error(&container_err));
+        assert!(is_missing_cleanup_error(&volume_err));
+        assert!(is_missing_cleanup_error(&network_err));
+        assert!(!is_missing_cleanup_error(&real_err));
+    }
+
+    #[test]
     fn load_agent_configures_dind_with_tls() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());

--- a/todo/dind-hostname-env-var.md
+++ b/todo/dind-hostname-env-var.md
@@ -26,7 +26,7 @@ Export `JACKIN_DIND_HOSTNAME` with the DinD container's hostname on the shared n
 
 ```rust
 let dind = format!("{container_name}-dind");
-let docker_host = format!("DOCKER_HOST=tcp://{dind}:2375");
+let docker_host = format!("DOCKER_HOST=tcp://{dind}:2376");
 let dind_hostname = format!("JACKIN_DIND_HOSTNAME={dind}");  // new
 ```
 
@@ -46,7 +46,7 @@ export POSTGRESQL_DB_HOST="$JACKIN_DIND_HOSTNAME"
 
 ## What NOT to add
 
-- `JACKIN_DIND_PORT` — always 2375, already in `DOCKER_HOST`, no standalone use case
+- `JACKIN_DIND_PORT` — always 2376 (TLS), already in `DOCKER_HOST`, no standalone use case
 - `JACKIN_NETWORK_NAME` — internal Docker plumbing, agents shouldn't need it
 - Domain-specific vars like `POSTGRESQL_DB_HOST` — that's the agent's responsibility
 

--- a/todo/dind-tls.md
+++ b/todo/dind-tls.md
@@ -1,6 +1,6 @@
 # DinD Running Without TLS Authentication
 
-**Status**: Deferred — option 1 (TLS with auto-generated certs) is the correct long-term solution
+**Status**: Resolved — option 1 (TLS with auto-generated certs) implemented
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Enable TLS authentication for the Docker-in-Docker sidecar using auto-generated certificates (Option 1 from `todo/dind-tls.md`)
- The DinD daemon now listens exclusively on port 2376 with `--tlsverify` — port 2375 (unencrypted) is no longer opened
- Client certificates are shared via a per-agent Docker volume mounted read-only into the agent container

## Problem

The DinD sidecar previously ran with `DOCKER_TLS_CERTDIR=` (empty, disabling TLS) and listened on `tcp://0.0.0.0:2375` without authentication. Any container on the per-agent Docker network had unauthenticated root access to the DinD daemon. Docker has warned this will become a hard failure in a future release.

## Changes

### `src/runtime.rs` (core)

- **DinD sidecar** starts with `DOCKER_TLS_CERTDIR=/certs` and a named volume (`<container>-dind-certs`) mounted at `/certs/client`
- **Agent container** gets `DOCKER_HOST=tcp://<dind>:2376`, `DOCKER_TLS_VERIFY=1`, `DOCKER_CERT_PATH=/certs/client`, and the cert volume mounted `:ro`
- **`wait_for_dind`** verifies TLS client certs exist via `docker exec <dind> test -f /certs/client/ca.pem` after daemon readiness
- **Cleanup** — cert volume removed in all 4 cleanup paths: `eject_agent`, `LoadCleanup::run` (rollback), `gc_orphaned_resources` (pre-launch GC), and stale resource cleanup in `launch_agent_runtime`
- **`is_missing_cleanup_error`** now tolerates `"No such volume"` alongside container and network errors
- **`dind_certs_volume`** helper for consistent volume naming

### Documentation

- `architecture.mdx` — updated diagram (port 2376), lifecycle steps, networking section, tech debt
- `security-model.mdx` — updated DinD sidecar section from "plain TCP" to "TLS-authenticated"
- `roadmap.mdx` — moved DinD TLS from planned to completed

### TODO tracking

- `todo/dind-tls.md` — status changed to Resolved
- `TODO.md` — moved from Open Items to Resolved
- `todo/dind-hostname-env-var.md` — port references updated from 2375 to 2376

## Security notes

Verified against the [official `docker:dind` entrypoint](https://github.com/docker-library/docker/blob/master/dockerd-entrypoint.sh):

- When `DOCKER_TLS_CERTDIR=/certs`, the entrypoint starts dockerd with **only** `--host=tcp://0.0.0.0:2376 --tlsverify`. Port 2375 is never opened (strict if/else in the entrypoint).
- Mounting only `/certs/client` as a volume is valid — CA and server certs go to the container writable layer (ephemeral), client certs go to the shared volume.
- `/certs/client/` contains `ca.pem`, `cert.pem`, `key.pem` — exactly what the Docker client needs.
- Certificates are auto-generated per session (not pinned to an external CA). The CA private key lives only in the DinD container's ephemeral writable layer.

## Test plan

- [x] `load_agent_configures_dind_with_tls` — verifies DinD gets `DOCKER_TLS_CERTDIR=/certs` + cert volume; agent gets port 2376, `DOCKER_TLS_VERIFY=1`, `DOCKER_CERT_PATH`, cert volume `:ro`
- [x] `dind_certs_volume_derives_from_container_name` — volume naming helper
- [x] `is_missing_cleanup_error_tolerates_all_resource_types` — direct unit test for container/volume/network error tolerance + negative case
- [x] `load_agent_checks_dind_readiness` — extended to verify TLS cert file check
- [x] `gc_removes_orphaned_dind_and_network` — extended to assert cert volume cleanup
- [x] `gc_cleans_multiple_orphans` — extended to assert cert volume cleanup for multiple orphans
- [x] `eject_agent_removes_container_dind_and_network` — includes volume cleanup step
- [x] `eject_agent_ignores_missing_runtime_resources` — tolerates missing volume
- [x] `load_agent_rolls_back_runtime_on_attached_run_failure` — asserts volume cleanup on rollback
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes
- [x] All 41 runtime tests pass (up from 38 on main)

https://claude.ai/code/session_01SeWvr3QqvP33MfudM5pis9