### PR TITLE
Improve jackin load docker build failures

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -8,6 +8,14 @@ const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub trait CommandRunner {
     fn run(&mut self, program: &str, args: &[&str], cwd: Option<&Path>) -> anyhow::Result<()>;
+    fn run_capture_stderr(
+        &mut self,
+        program: &str,
+        args: &[&str],
+        cwd: Option<&Path>,
+    ) -> anyhow::Result<()> {
+        self.run(program, args, cwd)
+    }
     fn capture(
         &mut self,
         program: &str,
@@ -89,6 +97,56 @@ impl CommandRunner for ShellRunner {
         Ok(())
     }
 
+    fn run_capture_stderr(
+        &mut self,
+        program: &str,
+        args: &[&str],
+        cwd: Option<&Path>,
+    ) -> anyhow::Result<()> {
+        self.log_command(program, args, cwd);
+        let timeout = self.capture_timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT);
+        let mut child = Self::build_command(program, args, cwd)
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            anyhow::anyhow!(
+                "failed to capture stderr for {} {}",
+                program,
+                args.join(" ")
+            )
+        })?;
+        let stderr_handle = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
+            let mut reader = std::io::BufReader::new(stderr);
+            let mut output = Vec::new();
+            let mut buf = [0_u8; 8192];
+            let mut writer = std::io::stderr().lock();
+            loop {
+                let read = reader.read(&mut buf)?;
+                if read == 0 {
+                    break;
+                }
+                std::io::Write::write_all(&mut writer, &buf[..read])?;
+                output.extend_from_slice(&buf[..read]);
+            }
+            Ok(output)
+        });
+        let status = Self::wait_with_timeout(&mut child, timeout, program, args)?;
+        let stderr = stderr_handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("stderr reader thread panicked"))??;
+        if !status.success() {
+            if String::from_utf8_lossy(&stderr).trim().is_empty() {
+                anyhow::bail!("command failed: {} {}", program, args.join(" "));
+            }
+            anyhow::bail!(
+                "command failed: {} {} (see stderr above)",
+                program,
+                args.join(" ")
+            );
+        }
+        Ok(())
+    }
+
     fn capture(
         &mut self,
         program: &str,
@@ -153,6 +211,18 @@ impl CommandRunner for ShellRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn run_capture_stderr_returns_hint_after_streaming_stderr() {
+        let mut runner = ShellRunner::default();
+
+        let error = runner
+            .run_capture_stderr("sh", &["-c", "printf 'region blocked\n' >&2; exit 2"], None)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("see stderr above"));
+    }
 
     #[cfg(unix)]
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -427,7 +427,7 @@ fn build_agent_image(
         build_args.extend(["--build-arg", &cache_bust]);
     }
     build_args.extend(["-t", &image, "-f", &dockerfile_path, &context_dir]);
-    runner.run("docker", &build_args, None)?;
+    runner.run_capture_stderr("docker", &build_args, None)?;
 
     // Extract and display the Claude version from the built image
     if let Ok(version) = runner.capture(
@@ -1309,6 +1309,7 @@ use std::collections::VecDeque;
 pub struct FakeRunner {
     pub recorded: Vec<String>,
     pub run_recorded: Vec<String>,
+    pub run_capture_stderr_recorded: Vec<String>,
     pub fail_on: Vec<String>,
     pub fail_with: Vec<(String, String)>,
     pub capture_queue: VecDeque<String>,
@@ -1325,6 +1326,7 @@ impl Default for FakeRunner {
         Self {
             recorded: Vec::new(),
             run_recorded: Vec::new(),
+            run_capture_stderr_recorded: Vec::new(),
             fail_on: Vec::new(),
             fail_with: Vec::new(),
             capture_queue: VecDeque::new(),
@@ -1399,6 +1401,18 @@ impl CommandRunner for FakeRunner {
     ) -> anyhow::Result<()> {
         let command = format!("{} {}", program, args.join(" "));
         self.run_recorded.push(command.clone());
+        self.recorded.push(command.clone());
+        self.check_command(&command)
+    }
+
+    fn run_capture_stderr(
+        &mut self,
+        program: &str,
+        args: &[&str],
+        _cwd: Option<&std::path::Path>,
+    ) -> anyhow::Result<()> {
+        let command = format!("{} {}", program, args.join(" "));
+        self.run_capture_stderr_recorded.push(command.clone());
         self.recorded.push(command.clone());
         self.check_command(&command)
     }
@@ -1891,9 +1905,14 @@ plugins = ["code-review@claude-plugins-official"]
                 |call| call.contains("docker build ") && call.contains("-t jackin-agent-smith")
             )
         );
-        // Docker build always streams output via run (not capture)
         assert!(
             runner
+                .run_capture_stderr_recorded
+                .iter()
+                .any(|call| call.contains("docker build "))
+        );
+        assert!(
+            !runner
                 .run_recorded
                 .iter()
                 .any(|call| call.contains("docker build "))
@@ -2051,9 +2070,14 @@ plugins = []
         assert!(build_call.contains("--build-arg JACKIN_HOST_UID="));
         assert!(build_call.contains("--build-arg JACKIN_HOST_GID="));
 
-        // Docker build always streams output via run (not capture)
         assert!(
             runner
+                .run_capture_stderr_recorded
+                .iter()
+                .any(|call| call.contains("docker build "))
+        );
+        assert!(
+            !runner
                 .run_recorded
                 .iter()
                 .any(|call| call.contains("docker build "))


### PR DESCRIPTION
## Summary
- surface docker build stderr during `jackin load` image builds in normal mode
- avoid repeating the full docker error in the final fatal message by returning a short `see stderr above` hint
- add regression coverage for both the shell runner and the runtime path that now uses stderr capture

## Test Plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy`
- [x] `cargo nextest run`