### PR TITLE
feat: auth forwarding, terminal forwarding, parallel load support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +767,7 @@ dependencies = [
  "dialoguer",
  "directories",
  "dockerfile-parser-rs",
+ "fs2",
  "owo-colors",
  "predicates",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
 directories = "6.0"
+fs2 = "0.4"
 thiserror = "2.0"
 dockerfile-parser-rs = "3.3.0"
 tempfile = "3.20"

--- a/docker/construct/install-plugins.sh
+++ b/docker/construct/install-plugins.sh
@@ -15,6 +15,17 @@ if [ ! -f "$plugins_file" ]; then
     exit 0
 fi
 
+# Build a set of already-installed plugin IDs so we can skip them.
+installed_ids=""
+if claude plugin list --json > /dev/null 2>&1; then
+    installed_ids=$(claude plugin list --json 2>/dev/null | jq -r '.[].id' 2>/dev/null || true)
+fi
+
+is_installed() {
+    local plugin_id="$1"
+    echo "$installed_ids" | grep -qxF "$plugin_id"
+}
+
 claude plugin marketplace add anthropics/claude-plugins-official > /dev/null 2>&1 || true
 
 jq -c '.marketplaces[]?' "$plugins_file" | while IFS= read -r marketplace; do
@@ -34,5 +45,11 @@ done
 
 jq -r '.plugins[]?' "$plugins_file" | while IFS= read -r plugin; do
     [ -n "$plugin" ] || continue
+    if is_installed "$plugin"; then
+        if [ "${JACKIN_DEBUG:-0}" = "1" ]; then
+            echo "Plugin already installed: $plugin"
+        fi
+        continue
+    fi
     run_maybe_quiet claude plugin install "$plugin"
 done

--- a/docker/construct/zshrc
+++ b/docker/construct/zshrc
@@ -2,5 +2,13 @@ export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"
 eval "$(starship init zsh)"
 
 # Security tools (disable with JACKIN_DISABLE_TIRITH=1 / JACKIN_DISABLE_SHELLFIRM=1)
-[[ "${JACKIN_DISABLE_TIRITH:-0}" != "1" ]] && eval "$(tirith init --shell zsh)"
-[[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]] && eval "$(shellfirm init zsh)"
+if [[ "${JACKIN_DISABLE_TIRITH:-0}" != "1" ]]; then
+    eval "$(tirith init --shell zsh)"
+else
+    echo "[zshrc] tirith shell hook disabled (JACKIN_DISABLE_TIRITH=1)"
+fi
+if [[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]]; then
+    eval "$(shellfirm init zsh)"
+else
+    echo "[zshrc] shellfirm shell hook disabled (JACKIN_DISABLE_SHELLFIRM=1)"
+fi

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -24,11 +24,16 @@ fi
 
 # Authenticate with GitHub if gh is installed in the container
 if [ -x /usr/bin/gh ]; then
-    if ! gh auth status &>/dev/null; then
+    if gh auth status &>/dev/null; then
+        echo "[entrypoint] GitHub CLI already authenticated"
+    else
+        echo "[entrypoint] GitHub CLI not authenticated — starting gh auth login"
         gh auth login
     fi
     gh auth setup-git
     git config --global url."https://github.com/".insteadOf "git@github.com:"
+else
+    echo "[entrypoint] GitHub CLI not installed — skipping auth"
 fi
 
 run_maybe_quiet /home/claude/install-plugins.sh
@@ -36,15 +41,28 @@ run_maybe_quiet /home/claude/install-plugins.sh
 # Register security tool MCP servers (ignore "already exists" on subsequent runs)
 if [[ "${JACKIN_DISABLE_TIRITH:-0}" != "1" ]]; then
     run_maybe_quiet claude mcp add tirith -- tirith mcp-server || true
+else
+    echo "[entrypoint] tirith disabled (JACKIN_DISABLE_TIRITH=1)"
 fi
 if [[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]]; then
     run_maybe_quiet claude mcp add shellfirm -- shellfirm mcp-server || true
+else
+    echo "[entrypoint] shellfirm disabled (JACKIN_DISABLE_SHELLFIRM=1)"
 fi
 
 # Run pre-launch hook if present
 if [ -x /home/claude/.jackin-runtime/pre-launch.sh ]; then
     echo "Running pre-launch hook..."
     /home/claude/.jackin-runtime/pre-launch.sh
+fi
+
+# In debug mode, pause so the operator can review logs before Claude clears the screen
+if [ "${JACKIN_DEBUG:-0}" = "1" ]; then
+    set +x
+    echo ""
+    echo "[entrypoint] Setup complete. Press Enter to launch Claude..."
+    read -r
+    set -x
 fi
 
 printf '\033[2J\033[H'

--- a/docs/pages/commands/config.mdx
+++ b/docs/pages/commands/config.mdx
@@ -10,7 +10,7 @@ description: "View and modify operator configuration"
 jackin config <SUBCOMMAND>
 ```
 
-Manage global operator configuration. Currently supports global mount management.
+Manage global operator configuration — mounts, agent trust, and Claude Code authentication forwarding.
 
 ## `config mount`
 
@@ -73,4 +73,52 @@ Unregister a global mount.
 ```bash
 jackin config mount remove gradle-cache
 jackin config mount remove secrets --scope "chainargos/*"
+```
+
+## `config auth`
+
+Manage Claude Code authentication forwarding from the host machine into agent containers. See the [Authentication Forwarding](/guides/authentication) guide for full details.
+
+### `config auth set`
+
+```bash
+jackin config auth set <MODE> [OPTIONS]
+```
+
+Set the authentication forwarding mode.
+
+| Mode | Description |
+|---|---|
+| `copy` | Copy host auth on first container creation (default) |
+| `sync` | Overwrite from host on each launch when host auth exists; preserve container auth when absent |
+| `ignore` | Never forward; revoke any previously forwarded credentials |
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Apply to a specific agent instead of globally |
+
+```bash
+# Set global default
+jackin config auth set copy
+
+# Override for a specific agent
+jackin config auth set ignore --agent agent-smith
+jackin config auth set sync --agent chainargos/the-architect
+```
+
+### `config auth show`
+
+```bash
+jackin config auth show [OPTIONS]
+```
+
+Show the current authentication forwarding mode.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Show effective mode for a specific agent (includes per-agent override) |
+
+```bash
+jackin config auth show
+jackin config auth show --agent agent-smith
 ```

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -1,0 +1,144 @@
+---
+description: Forward Claude Code authentication from your host machine into agent containers
+---
+
+# Authentication Forwarding
+
+By default, jackin' forwards your host machine's Claude Code authentication into new agent containers. This means agents start pre-authenticated with your account — no manual `/login` inside the container.
+
+## How it works
+
+Claude Code stores its credentials differently depending on the platform:
+
+| Platform | Credential storage |
+|---|---|
+| macOS | System Keychain ("Claude Code-credentials") |
+| Linux | `~/.claude/.credentials.json` |
+
+When jackin' creates or launches an agent container, it reads the host credentials and writes them into the agent's persisted state directory at `~/.jackin/data/<container-name>/.claude/.credentials.json`. The host's `~/.claude.json` (account metadata and preferences) is also copied.
+
+Since the `.claude/` directory and `.claude.json` file are bind-mounted into the container, Claude Code inside the container picks up the credentials immediately.
+
+## Auth forwarding modes
+
+jackin' supports three modes, configurable globally or per-agent:
+
+| Mode | Behavior |
+|---|---|
+| `copy` (default) | Copy host auth on first container creation only. Never overwrite afterwards — the container keeps its own auth state. |
+| `sync` | When host auth exists, overwrite container auth on each launch. When host auth is absent, preserve existing container auth. |
+| `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself via `/login`. |
+
+### copy (default)
+
+The `copy` mode seeds credentials once when the agent state is first created. After that, the container owns its auth — restarting the agent, refreshing host tokens, or even logging out on the host does not affect the container.
+
+This is the safest default: the agent gets a working session without manual login, and there's no risk of the host overwriting container-local auth changes.
+
+### sync
+
+The `sync` mode re-copies host credentials on every launch. Use this when you want agents to always reflect the host's current account — for example, if you rotate credentials frequently or switch between organizations.
+
+When the host's `~/.claude.json` or credentials are missing (e.g. you logged out), `sync` preserves the container's existing auth rather than wiping it. This prevents accidental de-authentication from a missing file.
+
+### ignore
+
+The `ignore` mode is the legacy behavior — the container starts with an empty `{}` config and no credentials. The agent must authenticate itself inside the container (Claude Code's device-flow login via browser).
+
+Switching an agent from `copy` or `sync` to `ignore` actively revokes any previously forwarded credentials by resetting `.claude.json` to `{}` and deleting `.credentials.json`.
+
+## Configuration
+
+### Set the global default
+
+```bash
+jackin config auth set copy     # default — copy on first creation
+jackin config auth set sync     # overwrite from host on each launch
+jackin config auth set ignore   # never forward (legacy behavior)
+```
+
+### Override per agent
+
+```bash
+jackin config auth set ignore --agent agent-smith
+jackin config auth set sync --agent chainargos/the-architect
+```
+
+### Show the current mode
+
+```bash
+# Global default
+jackin config auth show
+
+# Effective mode for a specific agent (includes per-agent override)
+jackin config auth show --agent agent-smith
+```
+
+### config.toml format
+
+```toml
+# Global default
+[claude]
+auth_forward = "copy"
+
+# Per-agent override
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+```
+
+Resolution order: **per-agent override > global default > `copy`**.
+
+:::note
+Auth forwarding is an operator-level setting. Agent manifests (`jackin.agent.toml`) cannot set or override this — it is always the operator's decision.
+:::
+
+## What gets forwarded
+
+Two pieces of data are forwarded from the host:
+
+| File | Contents |
+|---|---|
+| `.claude.json` | Account metadata, preferences (email, org, billing type, startup config) |
+| `.claude/.credentials.json` | OAuth tokens (access token, refresh token, scopes, subscription type) |
+
+Both files are written with `0600` permissions (owner-only read/write). If an older agent state directory has a pre-existing `.claude.json` with permissive permissions (e.g. `0644`), the permissions are tightened on the next write.
+
+## Security considerations
+
+- Forwarded credentials give the agent the same Claude Code access as your host account (same model tier, same organization, same billing).
+- Credentials are stored on disk in the agent's state directory (`~/.jackin/data/<container-name>/`). Use `jackin purge <agent>` to delete all persisted state including credentials.
+- Switching to `ignore` mode actively revokes forwarded credentials — it does not just stop future forwarding.
+- The agent manifest cannot control auth forwarding. An untrusted agent cannot force `sync` or `ignore` against the operator's wishes.
+
+:::warning
+Auth forwarding copies OAuth tokens to the container's filesystem. While the files are permission-locked to `0600`, any process running as the container user can read them. This is equivalent to the existing risk when authenticating manually inside the container — the difference is that forwarding happens automatically.
+:::
+
+## Troubleshooting
+
+### Agent shows "Not logged in" after forwarding
+
+If the agent shows "Not logged in" or falls back to a different model tier (e.g. Sonnet instead of Opus), the credentials may not have been forwarded. Check:
+
+1. **Is auth forwarding enabled?** Run `jackin config auth show` — the default is `copy`.
+2. **Does the host have credentials?** On macOS, check `security find-generic-password -s "Claude Code-credentials" -w`. On Linux, check `~/.claude/.credentials.json`.
+3. **Is this a pre-existing container?** In `copy` mode, credentials are only forwarded on first creation. If the container already exists, either switch to `sync` mode or purge and recreate: `jackin purge <agent> && jackin load <agent>`.
+
+### Revoking forwarded credentials
+
+To stop forwarding and clear existing credentials:
+
+```bash
+jackin config auth set ignore --agent <agent>
+jackin load <agent>  # next launch will reset to {}
+```
+
+Or purge all state:
+
+```bash
+jackin purge <agent>
+```

--- a/docs/pages/guides/security-model.mdx
+++ b/docs/pages/guides/security-model.mdx
@@ -132,12 +132,12 @@ The current implementation creates the user in the construct image and then rema
 
 jackin' persists state at `~/.jackin/data/<container-name>/`. Today that includes:
 
-- `.claude/`
-- `.claude.json`
+- `.claude/` (session history, and `.credentials.json` with OAuth tokens)
+- `.claude.json` (account metadata and preferences)
 - `.config/gh/`
-- `plugins.json`
+- `.jackin/plugins.json`
 
-That means Claude conversation state and `gh` state can survive across sessions.
+That means Claude conversation state, authentication, and `gh` state can survive across sessions.
 
 But several important things do **not** persist:
 
@@ -167,11 +167,17 @@ If an agent can read a mounted secret and the network path is open, jackin' cann
 
 Mounted files are live host files. If the agent edits a mounted path, the host file changes immediately. There is no snapshot or rollback layer between the runtime and the mount.
 
+### Authentication forwarding
+
+By default, jackin' forwards the host's Claude Code OAuth credentials into new agent containers (`auth_forward = "copy"`). This means agents start pre-authenticated but also means OAuth tokens are stored on disk in the agent state directory with `0600` permissions.
+
+You can control this behavior globally or per-agent — see [Authentication Forwarding](/guides/authentication). Setting `auth_forward = "ignore"` revokes any previously forwarded credentials and returns to the legacy behavior of manual in-container login.
+
 ### Credentials obtained inside the runtime remain inside the runtime
 
-jackin' does not mount host credentials by default, which is good.
+Whether credentials were forwarded from the host or obtained via in-container login, they persist in jackin' state until you purge it.
 
-But if you authenticate a tool like `gh` inside the runtime, that credential becomes readable by that runtime and persists in jackin' state until you purge it.
+If you authenticate a tool like `gh` inside the runtime, that credential becomes readable by that runtime as well.
 
 ## Threat model
 

--- a/docs/pages/reference/architecture.mdx
+++ b/docs/pages/reference/architecture.mdx
@@ -126,6 +126,23 @@ Each agent gets an isolated Docker network:
 
 The DinD sidecar auto-generates TLS certificates at startup into a shared Docker volume. The agent container mounts the client certificates read-only and sets `DOCKER_TLS_VERIFY=1` so all Docker CLI commands are authenticated.
 
+## Terminal forwarding
+
+jackin' forwards the host's `$TERM` environment variable into the agent container so that terminal capabilities (colors, keyboard protocols, mouse support) work correctly.
+
+Standard terminal types like `xterm-256color`, `screen-256color`, and `tmux-256color` ship with Debian's `ncurses-base` and are forwarded as-is.
+
+Modern terminals — Ghostty (`xterm-ghostty`), Kitty (`xterm-kitty`), WezTerm, and others — define custom `$TERM` values whose terminfo entries are not included in the container's base image. For these terminals, jackin' automatically:
+
+1. Exports the host's terminfo entry using `infocmp -x`
+2. Compiles it into a cache directory (`~/.jackin/cache/terminfo/`) using `tic -x`
+3. Mounts the compiled terminfo read-only at `/home/claude/.terminfo` inside the container
+4. Forwards the original `$TERM` value
+
+This means terminal-specific features (such as Ghostty's Kitty keyboard protocol or extended color support) work inside the container without any manual setup. The compiled terminfo is cached and reused across agent launches.
+
+If the export fails (e.g. `infocmp` is not installed or the terminfo entry is missing), jackin' falls back to `xterm-256color`.
+
 ## State management
 
 ```
@@ -134,17 +151,21 @@ The DinD sidecar auto-generates TLS certificates at startup into a shared Docker
 │   └── github.com/
 │       └── jackin-project/
 │           └── jackin-agent-smith/
+├── cache/                         # Shared caches (terminfo, version checks)
+│   └── terminfo/
 ├── data/                          # Persisted state per instance
 │   └── jackin-agent-smith/
-│       ├── .claude/
-│       ├── .claude.json
-│       ├── .config/gh/
-│       └── plugins.json
+│       ├── .claude/               # Claude Code session history, context
+│       │   └── .credentials.json  # OAuth tokens (forwarded or container-local)
+│       ├── .claude.json           # Claude Code account metadata and preferences
+│       ├── .config/gh/            # GitHub CLI authentication
+│       └── .jackin/
+│           └── plugins.json       # Installed Claude plugins list
 ```
 
 This is what persists across sessions:
 
-- Claude history and settings
+- Claude history, settings, and authentication
 - jackin' plugin metadata
 - `gh` state acquired inside the runtime
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -16,6 +16,26 @@ description: "The config.toml schema and storage locations"
 
 The configuration file is TOML format at `~/.config/jackin/config.toml`. It's managed through CLI commands — you generally don't need to edit it by hand.
 
+### Claude Code settings
+
+```toml
+[claude]
+auth_forward = "copy"  # "copy" (default), "sync", or "ignore"
+```
+
+| Field | Description | Default |
+|---|---|---|
+| `auth_forward` | How the host's Claude Code credentials are forwarded into agent containers. See [Authentication Forwarding](/guides/authentication). | `copy` |
+
+Per-agent overrides are set under the agent's `[claude]` section:
+
+```toml
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+```
+
+Resolution order: per-agent override > global `[claude]` > `copy`.
+
 ### Workspaces
 
 ```toml
@@ -68,9 +88,10 @@ Each agent instance stores state at `~/.jackin/data/<container-name>/`:
 | File/Directory | Purpose |
 |---|---|
 | `.claude/` | Claude Code session history, conversation context |
-| `.claude.json` | Claude Code settings |
+| `.claude/.credentials.json` | Claude Code OAuth credentials (forwarded from host or obtained via in-container login) |
+| `.claude.json` | Claude Code account metadata and preferences |
 | `.config/gh/` | GitHub CLI authentication and settings |
-| `plugins.json` | Installed Claude plugins list |
+| `.jackin/plugins.json` | Installed Claude plugins list |
 
 This state is mounted back into the container on subsequent loads, so the agent resumes where it left off.
 

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       items: [
         { text: 'Workspaces', link: '/guides/workspaces' },
         { text: 'Mounts', link: '/guides/mounts' },
+        { text: 'Authentication', link: '/guides/authentication' },
         { text: 'Agent Repos', link: '/guides/agent-repos' },
         { text: 'Security Model', link: '/guides/security-model' },
         { text: 'Comparison', link: '/guides/comparison' },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,6 +161,54 @@ pub enum ConfigCommand {
         #[command(subcommand)]
         command: TrustCommand,
     },
+    /// Manage Claude Code authentication forwarding from host
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
+}
+
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum AuthCommand {
+    /// Set the authentication forwarding mode
+    ///
+    /// Controls how the host's ~/.claude.json is forwarded into agent containers.
+    /// Modes: ignore (revoke and never copy), copy (copy on first creation, default),
+    /// sync (overwrite from host on each launch when host auth exists; preserve
+    /// container auth when host auth is absent).
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config auth set copy
+  jackin config auth set sync
+  jackin config auth set ignore
+  jackin config auth set copy --agent agent-smith
+  jackin config auth set sync --agent chainargos/the-architect"
+    )]
+    Set {
+        /// Authentication forwarding mode: ignore, copy, or sync
+        mode: String,
+        /// Apply to a specific agent instead of globally
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    /// Show the current authentication forwarding mode
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config auth show
+  jackin config auth show --agent agent-smith"
+    )]
+    Show {
+        /// Show mode for a specific agent (including inheritance)
+        #[arg(long)]
+        agent: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]
@@ -890,6 +938,77 @@ mod tests {
         assert!(help.contains("jackin config mount remove gradle-cache"));
     }
 
+    // ── Config auth help ─────────────────────────────────────────────────
+
+    #[test]
+    fn config_auth_set_help_shows_examples() {
+        let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
+        assert!(help.contains("Examples:"));
+        assert!(help.contains("jackin config auth set copy"));
+        assert!(help.contains("--agent"));
+    }
+
+    #[test]
+    fn config_auth_show_help_shows_examples() {
+        let help = help_text(&["jackin", "config", "auth", "show", "--help"]);
+        assert!(help.contains("Examples:"));
+        assert!(help.contains("jackin config auth show"));
+    }
+
+    #[test]
+    fn parses_config_auth_set_global() {
+        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "copy"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Auth {
+                    command: AuthCommand::Set {
+                        ref mode,
+                        agent: None,
+                    }
+                }
+            } if mode == "copy"
+        ));
+    }
+
+    #[test]
+    fn parses_config_auth_set_per_agent() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "config",
+            "auth",
+            "set",
+            "sync",
+            "--agent",
+            "agent-smith",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Auth {
+                    command: AuthCommand::Set {
+                        ref mode,
+                        agent: Some(ref agent),
+                    }
+                }
+            } if mode == "sync" && agent == "agent-smith"
+        ));
+    }
+
+    #[test]
+    fn parses_config_auth_show() {
+        let cli = Cli::try_parse_from(["jackin", "config", "auth", "show"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                command: ConfigCommand::Auth {
+                    command: AuthCommand::Show { agent: None }
+                }
+            }
+        ));
+    }
+
     // ── Subcommand banner consistency ───────────────────────────────────
 
     #[test]
@@ -909,6 +1028,8 @@ mod tests {
             vec!["jackin", "config", "mount", "add", "--help"],
             vec!["jackin", "config", "mount", "remove", "--help"],
             vec!["jackin", "config", "mount", "list", "--help"],
+            vec!["jackin", "config", "auth", "set", "--help"],
+            vec!["jackin", "config", "auth", "show", "--help"],
         ];
         for args in &subcommands {
             let help = help_text(args);

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,11 +24,66 @@ const fn is_false(v: &bool) -> bool {
     !*v
 }
 
+/// Controls how the host's `~/.claude.json` is forwarded into agent containers.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthForwardMode {
+    /// Revoke any forwarded auth and never copy — container starts with `{}`.
+    Ignore,
+    /// Copy host auth on first container creation only; never overwrite afterwards.
+    #[default]
+    Copy,
+    /// Overwrite container auth from host on each launch when host auth
+    /// exists; preserve container auth when host auth is absent.
+    Sync,
+}
+
+impl std::fmt::Display for AuthForwardMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ignore => write!(f, "ignore"),
+            Self::Copy => write!(f, "copy"),
+            Self::Sync => write!(f, "sync"),
+        }
+    }
+}
+
+impl std::str::FromStr for AuthForwardMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ignore" => Ok(Self::Ignore),
+            "copy" => Ok(Self::Copy),
+            "sync" => Ok(Self::Sync),
+            other => Err(format!(
+                "invalid auth_forward mode {other:?}; expected one of: ignore, copy, sync"
+            )),
+        }
+    }
+}
+
+/// Global Claude Code configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClaudeConfig {
+    #[serde(default)]
+    pub auth_forward: AuthForwardMode,
+}
+
+/// Per-agent Claude Code configuration override.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClaudeAgentConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_forward: Option<AuthForwardMode>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSource {
     pub git: String,
     #[serde(default, skip_serializing_if = "is_false")]
     pub trusted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<ClaudeAgentConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,6 +134,8 @@ pub struct DockerConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
+    pub claude: ClaudeConfig,
+    #[serde(default)]
     pub agents: BTreeMap<String, AgentSource>,
     #[serde(default)]
     pub docker: DockerConfig,
@@ -128,9 +185,29 @@ impl AppConfig {
                 selector.name
             ),
             trusted: false,
+            claude: None,
         };
         self.agents.insert(selector.key(), source.clone());
         Ok((source, true))
+    }
+
+    /// Resolve the effective `AuthForwardMode` for a given agent.
+    ///
+    /// Resolution order: per-agent override → global default → `Copy`.
+    pub fn resolve_auth_forward_mode(&self, agent_key: &str) -> AuthForwardMode {
+        self.agents
+            .get(agent_key)
+            .and_then(|a| a.claude.as_ref())
+            .and_then(|c| c.auth_forward)
+            .unwrap_or(self.claude.auth_forward)
+    }
+
+    /// Set the per-agent auth forward mode override.
+    pub fn set_agent_auth_forward(&mut self, key: &str, mode: AuthForwardMode) {
+        if let Some(source) = self.agents.get_mut(key) {
+            let claude = source.claude.get_or_insert_with(ClaudeAgentConfig::default);
+            claude.auth_forward = Some(mode);
+        }
     }
 
     pub fn save(&self, paths: &JackinPaths) -> anyhow::Result<()> {
@@ -419,9 +496,11 @@ impl AppConfig {
     fn sync_builtin_agents(&mut self) -> bool {
         let mut changed = false;
         for &(name, git) in BUILTIN_AGENTS {
+            let existing_claude = self.agents.get(name).and_then(|a| a.claude.clone());
             let expected = AgentSource {
                 git: git.to_string(),
                 trusted: true,
+                claude: existing_claude,
             };
             match self.agents.get(name) {
                 Some(existing) if existing.git == expected.git && existing.trusted => {}
@@ -1256,5 +1335,138 @@ smith-data = { src = "/tmp/smith", dst = "/smith" }
         assert_eq!(resolved.len(), 2);
         assert!(resolved.iter().any(|(_, m)| m.dst == "/global"));
         assert!(resolved.iter().any(|(_, m)| m.dst == "/smith"));
+    }
+
+    // ── Auth forwarding config tests ────────────────────────────────────
+
+    #[test]
+    fn auth_forward_defaults_to_copy() {
+        let config = AppConfig::default();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Copy);
+    }
+
+    #[test]
+    fn deserializes_global_claude_auth_forward() {
+        let toml_str = r#"
+[claude]
+auth_forward = "sync"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+    }
+
+    #[test]
+    fn deserializes_per_agent_claude_auth_forward() {
+        let toml_str = r#"
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        let agent = config.agents.get("agent-smith").unwrap();
+        assert_eq!(
+            agent.claude.as_ref().unwrap().auth_forward,
+            Some(AuthForwardMode::Ignore)
+        );
+    }
+
+    #[test]
+    fn resolve_auth_forward_defaults_to_copy() {
+        let config = AppConfig::default();
+        assert_eq!(
+            config.resolve_auth_forward_mode("nonexistent"),
+            AuthForwardMode::Copy
+        );
+    }
+
+    #[test]
+    fn resolve_auth_forward_uses_global_setting() {
+        let toml_str = r#"
+[claude]
+auth_forward = "sync"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Sync
+        );
+    }
+
+    #[test]
+    fn resolve_auth_forward_per_agent_overrides_global() {
+        let toml_str = r#"
+[claude]
+auth_forward = "sync"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Ignore
+        );
+    }
+
+    #[test]
+    fn auth_forward_round_trips_through_toml() {
+        let toml_str = r#"
+[claude]
+auth_forward = "sync"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let reloaded: AppConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reloaded.claude.auth_forward, AuthForwardMode::Sync);
+        assert_eq!(
+            reloaded.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Ignore
+        );
+    }
+
+    #[test]
+    fn set_agent_auth_forward_creates_claude_section() {
+        let toml_str = r#"
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+"#;
+        let mut config: AppConfig = toml::from_str(toml_str).unwrap();
+        config.set_agent_auth_forward("agent-smith", AuthForwardMode::Sync);
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Sync
+        );
+    }
+
+    #[test]
+    fn existing_config_without_claude_section_deserializes_with_defaults() {
+        let toml_str = r#"
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Copy);
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Copy
+        );
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,8 +1,23 @@
+use crate::config::AuthForwardMode;
 use crate::manifest::{AgentManifest, ClaudeMarketplaceConfig};
 use crate::paths::JackinPaths;
 use crate::selector::ClassSelector;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Outcome of the `.claude.json` provisioning step, so callers can surface
+/// a one-time notice when host credentials are forwarded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthProvisionOutcome {
+    /// No host auth was forwarded (ignore mode, or copy mode with existing file).
+    Skipped,
+    /// Host auth was copied into the container state.
+    Copied,
+    /// Host auth was synced (overwritten) into the container state.
+    Synced,
+    /// Mode would have forwarded, but host file was missing — wrote `{}`.
+    HostMissing,
+}
 
 #[derive(Debug, Clone)]
 pub struct AgentState {
@@ -25,7 +40,9 @@ impl AgentState {
         paths: &JackinPaths,
         container_name: &str,
         manifest: &AgentManifest,
-    ) -> anyhow::Result<Self> {
+        auth_forward: AuthForwardMode,
+        host_home: &Path,
+    ) -> anyhow::Result<(Self, AuthProvisionOutcome)> {
         let root = paths.data_dir.join(container_name);
         let claude_dir = root.join(".claude");
         let claude_json = root.join(".claude.json");
@@ -36,9 +53,9 @@ impl AgentState {
         std::fs::create_dir_all(&claude_dir)?;
         std::fs::create_dir_all(&jackin_dir)?;
         std::fs::create_dir_all(&gh_config_dir)?;
-        if !claude_json.exists() {
-            std::fs::write(&claude_json, "{}")?;
-        }
+
+        let outcome =
+            Self::provision_claude_auth(&claude_json, &claude_dir, auth_forward, host_home)?;
 
         std::fs::write(
             &plugins_json,
@@ -48,14 +65,221 @@ impl AgentState {
             })?,
         )?;
 
-        Ok(Self {
-            root,
-            claude_dir,
-            claude_json,
-            jackin_dir,
-            plugins_json,
-            gh_config_dir,
-        })
+        Ok((
+            Self {
+                root,
+                claude_dir,
+                claude_json,
+                jackin_dir,
+                plugins_json,
+                gh_config_dir,
+            },
+            outcome,
+        ))
+    }
+
+    /// Provision both `.claude.json` (preferences/metadata) and
+    /// `.claude/.credentials.json` (OAuth tokens) according to the chosen
+    /// auth forwarding strategy.
+    ///
+    /// `.claude.json` must always exist after this call because Docker
+    /// bind-mounts require the source to be a file, not a missing path
+    /// (otherwise Docker creates a directory, breaking Claude Code).
+    ///
+    /// On macOS the host credentials live in the system Keychain
+    /// ("Claude Code-credentials"), not in a file.  On Linux they are
+    /// stored at `~/.claude/.credentials.json`.
+    fn provision_claude_auth(
+        claude_json: &Path,
+        claude_dir: &Path,
+        mode: AuthForwardMode,
+        host_home: &Path,
+    ) -> anyhow::Result<AuthProvisionOutcome> {
+        let host_claude_json = host_home.join(".claude.json");
+        let credentials_json = claude_dir.join(".credentials.json");
+
+        let outcome = match mode {
+            AuthForwardMode::Ignore => {
+                // Always ensure a clean slate — if switching from copy/sync to
+                // ignore, the previously forwarded credentials must be revoked.
+                if !claude_json.exists() || std::fs::read_to_string(claude_json)? != "{}" {
+                    write_private_file(claude_json, "{}")?;
+                }
+                if credentials_json.exists() {
+                    std::fs::remove_file(&credentials_json)?;
+                }
+                AuthProvisionOutcome::Skipped
+            }
+            AuthForwardMode::Copy => {
+                if claude_json.exists() {
+                    AuthProvisionOutcome::Skipped
+                } else if let Some(creds) = read_host_credentials(host_home) {
+                    copy_host_claude_json(&host_claude_json, claude_json)?;
+                    write_private_file(&credentials_json, &creds)?;
+                    AuthProvisionOutcome::Copied
+                } else {
+                    // Host has no auth — create an empty bootstrap file
+                    // so Docker can bind-mount it. Claude Code will run
+                    // its own first-time auth flow inside the container.
+                    write_private_file(claude_json, "{}")?;
+                    AuthProvisionOutcome::HostMissing
+                }
+            }
+            AuthForwardMode::Sync => {
+                if let Some(creds) = read_host_credentials(host_home) {
+                    copy_host_claude_json(&host_claude_json, claude_json)?;
+                    write_private_file(&credentials_json, &creds)?;
+                    AuthProvisionOutcome::Synced
+                } else {
+                    // Host has no auth — leave the container's existing
+                    // files untouched (it may have credentials from a
+                    // previous manual login). Only bootstrap an empty
+                    // file if nothing exists yet.
+                    if !claude_json.exists() {
+                        write_private_file(claude_json, "{}")?;
+                    }
+                    // Repair permissions on pre-existing auth files that
+                    // may have legacy permissive modes (e.g. 0644).
+                    repair_permissions(claude_json);
+                    repair_permissions(&credentials_json);
+                    AuthProvisionOutcome::HostMissing
+                }
+            }
+        };
+
+        Ok(outcome)
+    }
+}
+
+/// Copy the host's `.claude.json` into the container state, or write `{}`
+/// if the host file doesn't exist.
+fn copy_host_claude_json(host_path: &Path, dest_path: &Path) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(host_path).unwrap_or_else(|_| "{}".to_string());
+    write_private_file(dest_path, &content)
+}
+
+/// Read the host's Claude Code OAuth credentials.
+///
+/// Checks the file-based store at `~/.claude/.credentials.json` first
+/// (used on Linux, and makes the function testable with temp dirs).
+/// Falls back to the macOS Keychain ("Claude Code-credentials") when
+/// the file is absent and `host_home` matches the real home directory.
+fn read_host_credentials(host_home: &Path) -> Option<String> {
+    // File-based credentials (Linux, or macOS with an explicit export).
+    let creds_path = host_home.join(".claude/.credentials.json");
+    if let Ok(content) = std::fs::read_to_string(creds_path) {
+        return Some(content);
+    }
+
+    // macOS Keychain fallback — only attempted when host_home is the
+    // real home directory.  This keeps tests hermetic (they use temp
+    // dirs) while still supporting the Keychain in production.
+    #[cfg(target_os = "macos")]
+    {
+        let real_home = directories::BaseDirs::new().map(|b| b.home_dir().to_path_buf());
+        if real_home.as_deref() == Some(host_home) {
+            let output = std::process::Command::new("security")
+                .args([
+                    "find-generic-password",
+                    "-s",
+                    "Claude Code-credentials",
+                    "-w",
+                ])
+                .output()
+                .ok()?;
+            if output.status.success() {
+                let creds = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !creds.is_empty() {
+                    return Some(creds);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Reject symlinks at `path` to prevent a compromised agent from
+/// redirecting host-side writes to arbitrary files.
+///
+/// The agent's `.claude/` directory is mounted read-write into the
+/// container, so an agent could replace `.credentials.json` with a
+/// symlink.  Without this check, the next `write_private_file` or
+/// `repair_permissions` call would follow the symlink and overwrite
+/// or chmod the target on the host.
+fn reject_symlink(path: &Path) -> anyhow::Result<()> {
+    // Use symlink_metadata (lstat) — regular metadata() follows symlinks.
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        anyhow::ensure!(
+            !meta.file_type().is_symlink(),
+            "refusing to write through symlink at {}; \
+             this may indicate a compromised agent state — \
+             remove the symlink and retry",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Write a file with restricted permissions (`0o600` on Unix) since it
+/// may contain authentication credentials.
+///
+/// Rejects symlinks to prevent a compromised agent from redirecting
+/// writes to arbitrary host paths.  Uses `tempfile::NamedTempFile` to
+/// create an unpredictable temp file (opened with `O_EXCL`, so a
+/// pre-planted symlink at the temp path is impossible), then renames
+/// it to the destination — closing the TOCTOU window entirely.
+fn write_private_file(path: &Path, content: &str) -> anyhow::Result<()> {
+    reject_symlink(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("no parent directory for {}", path.display()))?;
+
+        // NamedTempFile uses O_EXCL internally, so it will never follow
+        // a pre-planted symlink.  The random suffix makes the path
+        // unpredictable.
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        tmp.write_all(content.as_bytes())?;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600))?;
+        tmp.persist(path)?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, content)?;
+    }
+    Ok(())
+}
+
+/// Tighten permissions on an existing file to `0o600` if it exists.
+/// Refuses to operate on symlinks.  No-op on non-Unix or if the file
+/// doesn't exist.
+fn repair_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Use symlink_metadata so we don't follow symlinks.
+        if let Ok(meta) = std::fs::symlink_metadata(path) {
+            if meta.file_type().is_symlink() {
+                eprintln!(
+                    "[jackin] warning: refusing to chmod symlink at {}",
+                    path.display()
+                );
+                return;
+            }
+            if meta.is_file() {
+                let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
     }
 }
 
@@ -123,10 +347,22 @@ mod tests {
         );
     }
 
-    #[test]
-    fn prepares_persisted_claude_state() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
+    const TEST_CREDENTIALS: &str =
+        r#"{"claudeAiOauth":{"accessToken":"test","refreshToken":"test"}}"#;
+
+    /// Set up a fake host auth environment in the temp dir.
+    fn seed_host_auth(temp: &tempfile::TempDir) {
+        std::fs::write(
+            temp.path().join(".claude.json"),
+            r#"{"oauthAccount":{"emailAddress":"test@example.com"}}"#,
+        )
+        .unwrap();
+        let creds_dir = temp.path().join(".claude");
+        std::fs::create_dir_all(&creds_dir).unwrap();
+        std::fs::write(creds_dir.join(".credentials.json"), TEST_CREDENTIALS).unwrap();
+    }
+
+    fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::AgentManifest {
         std::fs::write(
             temp.path().join("jackin.agent.toml"),
             r#"dockerfile = "Dockerfile"
@@ -141,9 +377,23 @@ plugins = []
             "FROM projectjackin/construct:trixie\n",
         )
         .unwrap();
-        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
+        crate::manifest::AgentManifest::load(temp.path()).unwrap()
+    }
 
-        let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
+    #[test]
+    fn prepares_persisted_claude_state() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
 
         assert!(state.claude_dir.is_dir());
         assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
@@ -170,7 +420,14 @@ plugins = ["code-review@claude-plugins-official", "feature-dev@claude-plugins-of
         .unwrap();
 
         let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
-        let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
 
         assert!(state.jackin_dir.is_dir());
         let value: serde_json::Value =
@@ -210,7 +467,14 @@ sparse = ["plugins", ".claude-plugin"]
         .unwrap();
 
         let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
-        let state = AgentState::prepare(&paths, "jackin-agent-smith", &manifest).unwrap();
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
 
         let value: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
@@ -227,5 +491,492 @@ sparse = ["plugins", ".claude-plugin"]
             value["plugins"],
             json!(["superpowers@superpowers-marketplace"])
         );
+    }
+
+    // ── Auth forwarding tests ───────────────────────────────────────────
+
+    // ── Auth forwarding tests ───────────────────────────────────────────
+
+    #[test]
+    fn ignore_mode_writes_empty_json() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        let (state, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
+        assert!(!state.claude_dir.join(".credentials.json").exists());
+        assert_eq!(outcome, AuthProvisionOutcome::Skipped);
+    }
+
+    #[test]
+    fn copy_mode_copies_host_auth_on_first_run() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        let (state, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert!(
+            std::fs::read_to_string(&state.claude_json)
+                .unwrap()
+                .contains("test@example.com")
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.claude_dir.join(".credentials.json")).unwrap(),
+            TEST_CREDENTIALS
+        );
+        assert_eq!(outcome, AuthProvisionOutcome::Copied);
+    }
+
+    #[test]
+    fn copy_mode_falls_back_to_empty_json_when_host_has_none() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        // No host auth seeded
+        let manifest = simple_manifest(&temp);
+
+        let (state, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
+        assert!(!state.claude_dir.join(".credentials.json").exists());
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+    }
+
+    #[test]
+    fn copy_mode_does_not_overwrite_existing() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: creates the file
+        let (state, outcome1) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(outcome1, AuthProvisionOutcome::Copied);
+
+        // Simulate the container modifying its own .claude.json
+        let container_content = r#"{"oauthAccount":{"emailAddress":"container@example.com"}}"#;
+        std::fs::write(&state.claude_json, container_content).unwrap();
+
+        // Second run: should NOT overwrite
+        let (state2, outcome2) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&state2.claude_json).unwrap(),
+            container_content
+        );
+        assert_eq!(outcome2, AuthProvisionOutcome::Skipped);
+    }
+
+    #[test]
+    fn sync_mode_overwrites_existing() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        // First run with host auth
+        seed_host_auth(&temp);
+        let (state, outcome1) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(outcome1, AuthProvisionOutcome::Synced);
+
+        // Simulate container modifying its own .claude.json
+        std::fs::write(&state.claude_json, r#"{"container":"data"}"#).unwrap();
+
+        // Update host credentials
+        let updated_creds = r#"{"claudeAiOauth":{"accessToken":"new","refreshToken":"new"}}"#;
+        std::fs::write(temp.path().join(".claude/.credentials.json"), updated_creds).unwrap();
+
+        // Second run: should overwrite with host content
+        let (state2, outcome2) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(state2.claude_dir.join(".credentials.json")).unwrap(),
+            updated_creds
+        );
+        assert_eq!(outcome2, AuthProvisionOutcome::Synced);
+    }
+
+    // ── Mode transition tests ───────────────────────────────────────────
+
+    #[test]
+    fn switching_from_copy_to_ignore_revokes_forwarded_credentials() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: copy mode seeds credentials
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+        assert!(state.claude_dir.join(".credentials.json").exists());
+
+        // Operator switches to ignore — credentials must be wiped
+        let (state2, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&state2.claude_json).unwrap(), "{}");
+        assert!(!state2.claude_dir.join(".credentials.json").exists());
+    }
+
+    #[test]
+    fn switching_from_sync_to_ignore_revokes_forwarded_credentials() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: sync mode writes credentials
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+        assert!(state.claude_dir.join(".credentials.json").exists());
+
+        // Operator switches to ignore — credentials must be wiped
+        let (state2, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&state2.claude_json).unwrap(), "{}");
+        assert!(!state2.claude_dir.join(".credentials.json").exists());
+    }
+
+    #[test]
+    fn sync_mode_preserves_container_auth_when_host_file_missing() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        // First run: host has auth, sync copies it
+        seed_host_auth(&temp);
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        // Host auth disappears (e.g. user logged out)
+        std::fs::remove_file(temp.path().join(".claude.json")).unwrap();
+        std::fs::remove_file(temp.path().join(".claude/.credentials.json")).unwrap();
+
+        // Container may have its own auth by now (from manual login inside)
+        let container_auth = r#"{"oauthAccount":{"emailAddress":"container@example.com"}}"#;
+        std::fs::write(&state.claude_json, container_auth).unwrap();
+
+        // Second run: host auth missing — container auth must be preserved
+        let (state2, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&state2.claude_json).unwrap(),
+            container_auth
+        );
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auth_file_has_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        let perms = std::fs::metadata(&state.claude_json).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "claude.json should have 0600 permissions"
+        );
+        let creds_perms = std::fs::metadata(state.claude_dir.join(".credentials.json"))
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            creds_perms.mode() & 0o777,
+            0o600,
+            ".credentials.json should have 0600 permissions"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_repairs_permissions_on_legacy_permissive_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        // First run: create the file with ignore mode (gets 0600)
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+
+        // Simulate a legacy state file with permissive mode
+        std::fs::set_permissions(&state.claude_json, std::fs::Permissions::from_mode(0o644))
+            .unwrap();
+        let perms = std::fs::metadata(&state.claude_json).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o644, "precondition: file is 0644");
+
+        // Sync with host auth — must tighten permissions
+        seed_host_auth(&temp);
+        let (state2, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        let perms = std::fs::metadata(&state2.claude_json)
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "sync should repair permissions on existing file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_repairs_permissions_when_host_auth_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        // First run: sync with host auth to seed both files
+        seed_host_auth(&temp);
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        // Simulate legacy permissive modes on both auth files
+        std::fs::set_permissions(&state.claude_json, std::fs::Permissions::from_mode(0o644))
+            .unwrap();
+        let creds_path = state.claude_dir.join(".credentials.json");
+        std::fs::set_permissions(&creds_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        // Remove host auth so sync takes the preserve path
+        std::fs::remove_file(temp.path().join(".claude.json")).unwrap();
+        std::fs::remove_file(temp.path().join(".claude/.credentials.json")).unwrap();
+
+        // Second run: host auth missing — files preserved but permissions repaired
+        let (state2, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+
+        let json_perms = std::fs::metadata(&state2.claude_json)
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            json_perms.mode() & 0o777,
+            0o600,
+            "sync should repair .claude.json permissions even when host auth is missing"
+        );
+        let creds_perms = std::fs::metadata(state2.claude_dir.join(".credentials.json"))
+            .unwrap()
+            .permissions();
+        assert_eq!(
+            creds_perms.mode() & 0o777,
+            0o600,
+            "sync should repair .credentials.json permissions even when host auth is missing"
+        );
+    }
+
+    // ── Symlink traversal protection ────────────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_at_claude_json() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: create the state directory
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        // Replace .claude.json with a symlink to a decoy file
+        let decoy = temp.path().join("decoy.txt");
+        std::fs::write(&decoy, "original").unwrap();
+        std::fs::remove_file(&state.claude_json).unwrap();
+        std::os::unix::fs::symlink(&decoy, &state.claude_json).unwrap();
+
+        // Sync should refuse to write through the symlink
+        let err = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink error, got: {err}"
+        );
+
+        // Decoy file must be untouched
+        assert_eq!(std::fs::read_to_string(&decoy).unwrap(), "original");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_at_credentials_json() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: create the state directory with credentials
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Copy,
+            temp.path(),
+        )
+        .unwrap();
+
+        // Replace .credentials.json with a symlink
+        let decoy = temp.path().join("decoy-creds.txt");
+        std::fs::write(&decoy, "secret").unwrap();
+        let creds_path = state.claude_dir.join(".credentials.json");
+        std::fs::remove_file(&creds_path).unwrap();
+        std::os::unix::fs::symlink(&decoy, &creds_path).unwrap();
+
+        // Sync should refuse to write through the symlink
+        let err = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "expected symlink error, got: {err}"
+        );
+
+        // Decoy file must be untouched
+        assert_eq!(std::fs::read_to_string(&decoy).unwrap(), "secret");
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -758,6 +758,7 @@ mod tests {
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(
@@ -793,6 +794,7 @@ mod tests {
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,6 +496,34 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
             },
+            cli::ConfigCommand::Auth { command: auth_cmd } => match auth_cmd {
+                cli::AuthCommand::Set { mode, agent } => {
+                    let parsed_mode: config::AuthForwardMode =
+                        mode.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
+                    if let Some(agent_selector) = agent {
+                        let class = ClassSelector::parse(&agent_selector)?;
+                        config.resolve_agent_source(&class)?;
+                        config.set_agent_auth_forward(&class.key(), parsed_mode);
+                        config.save(&paths)?;
+                        println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
+                    } else {
+                        config.claude.auth_forward = parsed_mode;
+                        config.save(&paths)?;
+                        println!("Set global auth forwarding to {parsed_mode}.");
+                    }
+                    Ok(())
+                }
+                cli::AuthCommand::Show { agent } => {
+                    if let Some(agent_selector) = agent {
+                        let class = ClassSelector::parse(&agent_selector)?;
+                        let effective = config.resolve_auth_forward_mode(&class.key());
+                        println!("{effective}");
+                    } else {
+                        println!("{}", config.claude.auth_forward);
+                    }
+                    Ok(())
+                }
+            },
         },
         Command::Workspace { command } => match command {
             WorkspaceCommand::Create {
@@ -886,6 +914,7 @@ mod tests {
             config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(
@@ -922,6 +951,7 @@ mod tests {
             config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,12 +1,13 @@
 use crate::config::AppConfig;
 use crate::derived_image::create_derived_build_context;
 use crate::docker::{CommandRunner, RunOptions};
-use crate::instance::{AgentState, next_container_name};
+use crate::instance::{AgentState, primary_container_name};
 use crate::paths::JackinPaths;
 use crate::repo::{CachedRepo, validate_agent_repo};
 use crate::selector::ClassSelector;
 use crate::tui;
 use crate::version_check;
+use fs2::FileExt;
 use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 
@@ -96,6 +97,108 @@ fn try_capture(runner: &mut impl CommandRunner, program: &str, args: &[&str]) ->
         .capture(program, args, None)
         .ok()
         .filter(|s| !s.is_empty())
+}
+
+// ── Terminal / terminfo resolution ────────────────────────────────────────
+//
+// Modern terminals (Ghostty, Kitty, WezTerm) define custom TERM values
+// whose terminfo entries don't ship in Debian's ncurses-base.  Rather
+// than falling back to xterm-256color (which loses terminal-specific
+// capabilities), we export the host's terminfo entry, compile it into a
+// cache directory, and mount it read-only into the container.
+
+/// Terminal types that ship with Debian's `ncurses-base` package and can
+/// be forwarded into the container without an extra terminfo mount.
+const STANDARD_TERMS: &[&str] = &[
+    "ansi",
+    "dumb",
+    "linux",
+    "rxvt",
+    "rxvt-unicode",
+    "rxvt-unicode-256color",
+    "screen",
+    "screen-256color",
+    "tmux",
+    "tmux-256color",
+    "vt100",
+    "vt220",
+    "xterm",
+    "xterm-256color",
+    "xterm-color",
+];
+
+/// Resolve the TERM value and an optional terminfo bind-mount for the
+/// container.
+///
+/// Returns `(term_value, Some(mount_string))` when the host's terminfo
+/// was exported, or `(term_value, None)` when the TERM is standard or
+/// export failed (in which case `term_value` is the safe fallback).
+fn resolve_terminal_setup(cache_dir: &std::path::Path) -> (String, Option<String>) {
+    let host_term = std::env::var("TERM").unwrap_or_default();
+
+    if host_term.is_empty() {
+        return ("xterm-256color".to_string(), None);
+    }
+
+    if STANDARD_TERMS.contains(&host_term.as_str()) {
+        return (host_term, None);
+    }
+
+    // Exotic terminal — try to export and compile the terminfo entry.
+    export_host_terminfo(&host_term, cache_dir).map_or_else(
+        |_| ("xterm-256color".to_string(), None),
+        |terminfo_dir| {
+            let mount = format!("{}:/home/claude/.terminfo:ro", terminfo_dir.display());
+            (host_term, Some(mount))
+        },
+    )
+}
+
+/// Export the host's terminfo entry for `term` into `cache_dir/terminfo/`.
+///
+/// Uses `infocmp -x` to dump the source and `tic -x -o` to compile it.
+/// The compiled output is a small architecture-independent binary that
+/// can be mounted directly into any container.
+fn export_host_terminfo(
+    term: &str,
+    cache_dir: &std::path::Path,
+) -> anyhow::Result<std::path::PathBuf> {
+    let terminfo_dir = cache_dir.join("terminfo");
+
+    // Check if already cached (first letter dir + entry file).
+    let first_char = term.chars().next().unwrap_or('x');
+    let entry_path = terminfo_dir.join(first_char.to_string()).join(term);
+    if entry_path.exists() {
+        return Ok(terminfo_dir);
+    }
+
+    // Export the source from the host.
+    let infocmp = std::process::Command::new("infocmp")
+        .args(["-x", term])
+        .output()?;
+    anyhow::ensure!(infocmp.status.success(), "infocmp failed for {term}");
+
+    std::fs::create_dir_all(&terminfo_dir)?;
+
+    // Compile into the cache directory.
+    let tic = std::process::Command::new("tic")
+        .args(["-x", "-o"])
+        .arg(&terminfo_dir)
+        .arg("-")
+        .stdin(std::process::Stdio::piped())
+        .spawn();
+    let mut tic = tic?;
+    if let Some(ref mut stdin) = tic.stdin {
+        use std::io::Write;
+        stdin.write_all(&infocmp.stdout)?;
+    }
+    let status = tic.wait()?;
+    anyhow::ensure!(
+        status.success(),
+        "tic failed to compile terminfo for {term}"
+    );
+
+    Ok(terminfo_dir)
 }
 
 fn load_git_identity(runner: &mut impl CommandRunner) -> GitIdentity {
@@ -294,7 +397,7 @@ fn resolve_agent_repo(
     selector: &ClassSelector,
     git_url: &str,
     runner: &mut impl CommandRunner,
-) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo)> {
+) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo, std::fs::File)> {
     resolve_agent_repo_with(
         paths,
         selector,
@@ -310,7 +413,7 @@ fn resolve_agent_repo_with(
     git_url: &str,
     runner: &mut impl CommandRunner,
     confirm_removal: impl FnOnce() -> anyhow::Result<bool>,
-) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo)> {
+) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo, std::fs::File)> {
     let cached_repo = CachedRepo::new(paths, selector);
     let repo_parent = cached_repo.repo_dir.parent().ok_or_else(|| {
         anyhow::anyhow!(
@@ -319,6 +422,20 @@ fn resolve_agent_repo_with(
         )
     })?;
     std::fs::create_dir_all(repo_parent)?;
+
+    // Short-lived lock around git operations on the shared repo directory.
+    // Multiple `jackin load` commands may run in parallel for the same
+    // agent class (spawning clones); the lock serializes only the git
+    // clone/fetch/merge so they don't race on the same working tree.
+    // The lock is released as soon as the git section completes.
+    let lock_path = paths
+        .data_dir
+        .join(format!("{}.repo.lock", primary_container_name(selector)));
+    std::fs::create_dir_all(&paths.data_dir)?;
+    let lock_file = std::fs::File::create(&lock_path)?;
+    lock_file
+        .lock_exclusive()
+        .map_err(|e| anyhow::anyhow!("failed to acquire repo lock for {}: {e}", selector.key()))?;
 
     let repo_path = cached_repo.repo_dir.display().to_string();
     if cached_repo.repo_dir.join(".git").is_dir() {
@@ -349,7 +466,7 @@ fn resolve_agent_repo_with(
                     &RunOptions::default(),
                 )?;
                 let validated_repo = validate_agent_repo(&cached_repo.repo_dir)?;
-                return Ok((cached_repo, validated_repo));
+                return Ok((cached_repo, validated_repo, lock_file));
             }
 
             anyhow::bail!("cached agent repo remote mismatch — aborting");
@@ -373,9 +490,20 @@ fn resolve_agent_repo_with(
             cached_repo.repo_dir.display()
         );
 
+        // Fetch + merge instead of pull to avoid "Cannot fast-forward to
+        // multiple branches" errors that occur with `git pull` when the
+        // remote has multiple branches.
+        let branch =
+            git_branch(&cached_repo.repo_dir, runner).unwrap_or_else(|| "main".to_string());
         runner.run(
             "git",
-            &["-C", &repo_path, "pull", "--ff-only"],
+            &["-C", &repo_path, "fetch", "origin", &branch],
+            None,
+            &RunOptions::default(),
+        )?;
+        runner.run(
+            "git",
+            &["-C", &repo_path, "merge", "--ff-only", "FETCH_HEAD"],
             None,
             &RunOptions::default(),
         )?;
@@ -389,7 +517,12 @@ fn resolve_agent_repo_with(
     }
 
     let validated_repo = validate_agent_repo(&cached_repo.repo_dir)?;
-    Ok((cached_repo, validated_repo))
+
+    // Return the repo lock so the caller can hold it until the build
+    // context (a snapshot copy of the repo) is created.  This prevents
+    // a parallel load from fast-forwarding the shared repo between
+    // validation and context creation.
+    Ok((cached_repo, validated_repo, lock_file))
 }
 
 /// Build the Docker image for the agent. Returns the image name.
@@ -403,8 +536,13 @@ fn build_agent_image(
     rebuild: bool,
     debug: bool,
     runner: &mut impl CommandRunner,
+    repo_lock: std::fs::File,
 ) -> anyhow::Result<String> {
+    // create_derived_build_context copies the repo into a temp directory,
+    // creating an immutable snapshot.  After this point the shared cached
+    // repo can be safely modified by a parallel load.
     let build = create_derived_build_context(&cached_repo.repo_dir, validated_repo)?;
+    drop(repo_lock);
 
     if debug {
         eprintln!(
@@ -422,12 +560,27 @@ fn build_agent_image(
 
     let build_arg_uid = format!("JACKIN_HOST_UID={}", host.uid);
     let build_arg_gid = format!("JACKIN_HOST_GID={}", host.gid);
-    let cache_bust = format!(
-        "JACKIN_CACHE_BUST={}",
-        std::time::SystemTime::now()
+    // Always pass the cache-bust arg so Docker matches the correct layer.
+    //
+    // When rebuilding (update available / --rebuild), generate a fresh
+    // timestamp to invalidate the cached Claude Code install layer, and
+    // persist it so subsequent non-rebuild builds reuse the same layer.
+    //
+    // When NOT rebuilding, replay the stored bust value.  Without this,
+    // Docker resolves the Dockerfile default `JACKIN_CACHE_BUST=0` and
+    // hits the original pre-bust layer, causing the installed Claude
+    // version to ping-pong between old and new on alternate launches.
+    let cache_bust_value = if rebuild {
+        let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_secs())
-    );
+            .to_string();
+        version_check::store_cache_bust(paths, &image, &ts);
+        ts
+    } else {
+        version_check::stored_cache_bust(paths, &image).unwrap_or_else(|| "0".to_string())
+    };
+    let cache_bust = format!("JACKIN_CACHE_BUST={cache_bust_value}");
     let dockerfile_path = build.dockerfile_path.display().to_string();
     let context_dir = build.context_dir.display().to_string();
 
@@ -437,10 +590,9 @@ fn build_agent_image(
         &build_arg_uid,
         "--build-arg",
         &build_arg_gid,
+        "--build-arg",
+        &cache_bust,
     ];
-    if rebuild {
-        build_args.extend(["--build-arg", &cache_bust]);
-    }
     build_args.extend(["-t", &image, "-f", &dockerfile_path, &context_dir]);
     runner.run(
         "docker",
@@ -483,6 +635,7 @@ struct LaunchContext<'a> {
     git: &'a GitIdentity,
     debug: bool,
     resolved_env: &'a crate::env_resolver::ResolvedEnv,
+    cache_dir: &'a std::path::Path,
 }
 
 /// Create the Docker network, start `DinD`, and launch the agent container.
@@ -504,14 +657,10 @@ fn launch_agent_runtime(
         git,
         debug,
         resolved_env,
+        cache_dir,
     } = ctx;
-    // Clean up stale resources from a previous run that wasn't cleaned up
-    // (e.g. terminal closed, process killed, Ctrl+C during docker run)
+
     let certs_volume = dind_certs_volume(container_name);
-    let _ = run_cleanup_command(runner, &["rm", "-f", container_name]);
-    let _ = run_cleanup_command(runner, &["rm", "-f", dind]);
-    let _ = run_cleanup_command(runner, &["volume", "rm", &certs_volume]);
-    let _ = run_cleanup_command(runner, &["network", "rm", network]);
 
     // Create Docker network
     let agent_label = format!("jackin.agent={container_name}");
@@ -577,6 +726,17 @@ fn launch_agent_runtime(
     );
     let certs_agent_mount = format!("{certs_volume}:/certs/client:ro");
 
+    // Forward the host TERM so the container's terminal type matches what the
+    // terminal emulator actually supports.  Docker defaults to TERM=xterm which
+    // can cause input handling issues (e.g. paste not working) in applications
+    // that adjust behaviour based on terminal capabilities.
+    //
+    // For exotic terminals (Ghostty, Kitty, WezTerm, etc.) whose terminfo
+    // entries don't ship in Debian's ncurses-base, we export and compile the
+    // host's terminfo into a cache directory and mount it into the container.
+    let (resolved_term, terminfo_mount) = resolve_terminal_setup(cache_dir);
+    let container_term = format!("TERM={resolved_term}");
+
     let mut run_args: Vec<&str> = vec![
         "run",
         "-it",
@@ -609,10 +769,26 @@ fn launch_agent_runtime(
         &git_author_name,
         "-e",
         &git_author_email,
+        "-e",
+        &container_term,
     ];
     if *debug {
         run_args.extend_from_slice(&["-e", "JACKIN_DEBUG=1"]);
     }
+
+    // Forward JACKIN_DISABLE_* env vars from the host so the operator can
+    // disable security tools (tirith, shellfirm) without rebuilding the image.
+    let mut passthrough_strings: Vec<String> = Vec::new();
+    for (key, value) in std::env::vars() {
+        if key.starts_with("JACKIN_DISABLE_") {
+            passthrough_strings.push(format!("{key}={value}"));
+        }
+    }
+    for env_str in &passthrough_strings {
+        run_args.push("-e");
+        run_args.push(env_str);
+    }
+
     let mut env_strings: Vec<String> = Vec::new();
     env_strings.push(format!(
         "{}={}",
@@ -644,6 +820,10 @@ fn launch_agent_runtime(
         "-v",
         &plugins_mount,
     ]);
+
+    if let Some(ref ti_mount) = terminfo_mount {
+        run_args.extend_from_slice(&["-v", ti_mount]);
+    }
 
     let mut mount_strings: Vec<String> = Vec::new();
     for mount in &workspace.mounts {
@@ -718,7 +898,8 @@ fn load_agent_with(
     // Step 1: Resolve agent identity (clone or update repo)
     steps.next("Resolving agent identity");
 
-    let (cached_repo, validated_repo) = resolve_agent_repo(paths, selector, &source.git, runner)?;
+    let (cached_repo, validated_repo, repo_lock) =
+        resolve_agent_repo(paths, selector, &source.git, runner)?;
 
     // Trust gate: prompt the operator before running an untrusted third-party agent
     let newly_trusted = if source.trusted {
@@ -734,27 +915,22 @@ fn load_agent_with(
         config.save(paths)?;
     }
 
-    let existing = list_managed_agent_names(runner)?;
-    let container_name = next_container_name(selector, &existing);
-    let state = AgentState::prepare(paths, &container_name, &validated_repo.manifest)?;
-
-    let network = format!("{container_name}-net");
-    let dind = format!("{container_name}-dind");
-
     let agent_display_name = validated_repo.manifest.display_name(&selector.name);
     steps.agent_name.clone_from(&agent_display_name);
 
     // Logo (if present in agent repo)
     tui::print_logo(&cached_repo.repo_dir.join("logo.txt"));
 
-    // Configuration summary
-    let image = image_name(selector);
+    // Show a preliminary config summary (container name will be
+    // confirmed after the image build, right before launch).
+    let image_tag = image_name(selector);
+    let preliminary_name = primary_container_name(selector);
     let config_rows = build_config_rows(
         &agent_display_name,
-        &container_name,
+        &preliminary_name,
         workspace,
         &git,
-        &image,
+        &image_tag,
         runner,
     );
     eprintln!();
@@ -769,13 +945,6 @@ fn load_agent_with(
         crate::env_resolver::resolve_env(&validated_repo.manifest.env, &prompter)?
     };
 
-    let certs_volume = dind_certs_volume(&container_name);
-    let mut cleanup = LoadCleanup::new(
-        container_name.clone(),
-        dind.clone(),
-        certs_volume,
-        network.clone(),
-    );
     let load_result = (|| -> anyhow::Result<()> {
         // Step 2: Build Docker image
         let rebuild = opts.rebuild || {
@@ -796,7 +965,59 @@ fn load_agent_with(
             rebuild,
             opts.debug,
             runner,
+            repo_lock,
         )?;
+
+        // Claim a unique container name using an exclusive lock file.
+        // Each candidate name gets a lock file at `~/.jackin/data/<name>.lock`.
+        // If `try_lock_exclusive` succeeds, we own the name for this
+        // session.  If it fails (another instance holds it), we skip to
+        // the next clone name.  The lock is held for the entire run and
+        // released on exit (or process crash).
+        let (container_name, _name_lock) = claim_container_name(paths, selector, runner)?;
+
+        let auth_mode = config.resolve_auth_forward_mode(&selector.key());
+        let (state, auth_outcome) = AgentState::prepare(
+            paths,
+            &container_name,
+            &validated_repo.manifest,
+            auth_mode,
+            &paths.home_dir,
+        )?;
+
+        match auth_outcome {
+            crate::instance::AuthProvisionOutcome::Copied => {
+                eprintln!(
+                    "[jackin] Copied host Claude Code authentication into agent state \
+                     (auth_forward=copy). Use `jackin config auth set ignore` to disable."
+                );
+            }
+            crate::instance::AuthProvisionOutcome::Synced => {
+                eprintln!(
+                    "[jackin] Synced host Claude Code authentication into agent state \
+                     (auth_forward=sync)."
+                );
+            }
+            crate::instance::AuthProvisionOutcome::HostMissing => match auth_mode {
+                crate::config::AuthForwardMode::Copy => {
+                    eprintln!(
+                        "[jackin] auth_forward=copy but no host credentials found; \
+                             agent will need to authenticate manually via /login."
+                    );
+                }
+                crate::config::AuthForwardMode::Sync => {
+                    eprintln!(
+                        "[jackin] auth_forward=sync but no host credentials found; \
+                             preserving existing container auth if present."
+                    );
+                }
+                crate::config::AuthForwardMode::Ignore => {}
+            },
+            crate::instance::AuthProvisionOutcome::Skipped => {}
+        }
+
+        let network = format!("{container_name}-net");
+        let dind = format!("{container_name}-dind");
 
         // Step 3: Create network and start Docker-in-Docker
         steps.next("Starting Docker-in-Docker");
@@ -813,27 +1034,36 @@ fn load_agent_with(
             git: &git,
             debug: opts.debug,
             resolved_env: &resolved_env,
+            cache_dir: &paths.cache_dir,
         };
-        launch_agent_runtime(&ctx, &mut steps, runner)?;
+        let certs_volume = dind_certs_volume(&container_name);
+        let mut cleanup = LoadCleanup::new(
+            container_name.clone(),
+            dind.clone(),
+            certs_volume,
+            network.clone(),
+        );
+        let launch_result = launch_agent_runtime(&ctx, &mut steps, runner);
+        if launch_result.is_err() {
+            cleanup.run(runner);
+        }
+        launch_result?;
+
+        if list_running_agent_names(runner)?.contains(&container_name) {
+            cleanup.disarm();
+        } else {
+            cleanup.run(runner);
+        }
 
         Ok(())
     })();
 
     match load_result {
         Ok(()) => {
-            if list_running_agent_names(runner)?
-                .iter()
-                .any(|name| name == &container_name)
-            {
-                cleanup.disarm();
-            } else {
-                cleanup.run(runner);
-                render_exit(&agent_display_name, runner, opts);
-            }
+            render_exit(&agent_display_name, runner, opts);
             Ok(())
         }
         Err(error) => {
-            cleanup.run(runner);
             render_exit(&agent_display_name, runner, opts);
             Err(error)
         }
@@ -1276,6 +1506,51 @@ fn image_name(selector: &ClassSelector) -> String {
     format!("jackin-{}", crate::instance::runtime_slug(selector))
 }
 
+/// Claim a unique container name for this agent class by acquiring an
+/// exclusive lock file.
+///
+/// Tries the primary name first, then clone-1, clone-2, etc.  For each
+/// candidate, a lock file at `~/.jackin/data/<name>.lock` is created and
+/// `try_lock_exclusive` is attempted.  If the lock succeeds, the name is
+/// ours for this session.  If another process already holds it (parallel
+/// load), we skip to the next candidate.
+///
+/// The returned `File` holds the lock — it must be kept alive for the
+/// duration of the agent session.  The lock is automatically released
+/// when the file is dropped (normal exit or crash).
+fn claim_container_name(
+    paths: &JackinPaths,
+    selector: &ClassSelector,
+    runner: &mut impl CommandRunner,
+) -> anyhow::Result<(String, std::fs::File)> {
+    let existing = list_managed_agent_names(runner)?;
+    let primary = primary_container_name(selector);
+
+    std::fs::create_dir_all(&paths.data_dir)?;
+
+    // Try primary name first, then clone-1, clone-2, ... (unbounded).
+    let mut clone_index = 0_u32;
+    loop {
+        let name = if clone_index == 0 {
+            primary.clone()
+        } else {
+            format!("{primary}-clone-{clone_index}")
+        };
+
+        // Skip names that have an existing container (running or stopped)
+        if !existing.contains(&name) {
+            let lock_path = paths.data_dir.join(format!("{name}.lock"));
+            let lock_file = std::fs::File::create(&lock_path)?;
+            if lock_file.try_lock_exclusive().is_ok() {
+                return Ok((name, lock_file));
+            }
+            // Lock held by another process — try next name
+        }
+
+        clone_index += 1;
+    }
+}
+
 /// Docker volume name for the TLS client certificates shared between the
 /// `DinD` sidecar (writer) and the agent container (reader).
 fn dind_certs_volume(container_name: &str) -> String {
@@ -1471,6 +1746,7 @@ mod tests {
         let source = crate::config::AgentSource {
             git: "https://github.com/evil-org/jackin-backdoor.git".to_string(),
             trusted: false,
+            claude: None,
         };
 
         let error = confirm_agent_trust(&selector, &source).unwrap_err();
@@ -2652,7 +2928,8 @@ plugins = []
 
         let mut runner = FakeRunner::with_capture_queue([
             "git@github.com:jackin-project/jackin-agent-smith.git".to_string(),
-            String::new(),
+            String::new(),      // git status --porcelain (clean)
+            "main".to_string(), // git rev-parse --abbrev-ref HEAD
         ]);
 
         let result = resolve_agent_repo(
@@ -2670,7 +2947,17 @@ plugins = []
             runner
                 .run_recorded
                 .iter()
-                .any(|call| call.contains("git -C") && call.contains("pull --ff-only"))
+                .any(|call| call.contains("git -C") && call.contains("fetch origin")),
+            "expected a git fetch: {:?}",
+            runner.run_recorded
+        );
+        assert!(
+            runner
+                .run_recorded
+                .iter()
+                .any(|call| call.contains("git -C") && call.contains("merge --ff-only")),
+            "expected a git merge --ff-only: {:?}",
+            runner.run_recorded
         );
     }
 

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -79,6 +79,27 @@ pub fn needs_claude_update(
     installed != latest
 }
 
+/// File that records the last `JACKIN_CACHE_BUST` value used to build an image.
+fn cache_bust_path(paths: &JackinPaths, image: &str) -> PathBuf {
+    paths.cache_dir.join(format!("image-cache-bust/{image}"))
+}
+
+/// Read the last `JACKIN_CACHE_BUST` value used for an image build.
+pub fn stored_cache_bust(paths: &JackinPaths, image: &str) -> Option<String> {
+    let path = cache_bust_path(paths, image);
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
+/// Persist the `JACKIN_CACHE_BUST` value used for a build so that
+/// subsequent non-rebuild launches replay the same value and hit the
+/// same Docker cache layer.
+pub fn store_cache_bust(paths: &JackinPaths, image: &str, value: &str) {
+    let path = cache_bust_path(paths, image);
+    let _ = write_cached(&path, value);
+}
+
 /// Extract a bare semver string from `claude --version` output.
 ///
 /// The command returns e.g. `"2.1.96 (Claude Code)"` but we only need the

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -582,6 +582,7 @@ mod tests {
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(
@@ -624,6 +625,7 @@ mod tests {
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(
@@ -728,6 +730,7 @@ mod tests {
             crate::config::AgentSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
+                claude: None,
             },
         );
         config.workspaces.insert(

--- a/tests/install_plugins_bootstrap.rs
+++ b/tests/install_plugins_bootstrap.rs
@@ -42,6 +42,11 @@ elif flt == ".source":
 elif flt == ".sparse[]?":
     for item in data.get("sparse", []):
         print(item)
+elif flt == ".[].id":
+    if isinstance(data, list):
+        for item in data:
+            if "id" in item:
+                print(item["id"])
 else:
     raise SystemExit(f"unsupported filter: {flt}")
 "#,
@@ -80,11 +85,17 @@ fn install_plugins_script_adds_marketplaces_before_installing_plugins() {
     let claude_path = bin_dir.join("claude");
     write_executable(
         &claude_path,
-        format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n",
+        &format!(
+            r#"#!/bin/sh
+# Return empty JSON array for "plugin list --json" (no plugins installed)
+if [ "$1" = "plugin" ] && [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+    echo '[]'
+    exit 0
+fi
+printf '%s\n' "$*" >> '{}'
+"#,
             log_file.display()
-        )
-        .as_str(),
+        ),
     );
 
     let jq_path = bin_dir.join("jq");
@@ -139,11 +150,21 @@ fn install_plugins_script_surfaces_custom_marketplace_failures() {
     let claude_path = bin_dir.join("claude");
     write_executable(
         &claude_path,
-        format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"marketplace\" ] && [ \"$3\" = \"add\" ] && [ \"$4\" = \"obra/superpowers-marketplace\" ]; then\n  echo 'failed to add marketplace' >&2\n  exit 1\nfi\n",
+        &format!(
+            r#"#!/bin/sh
+# Return empty JSON array for "plugin list --json"
+if [ "$1" = "plugin" ] && [ "$2" = "list" ] && [ "$3" = "--json" ]; then
+    echo '[]'
+    exit 0
+fi
+printf '%s\n' "$*" >> '{}'
+if [ "$1" = "plugin" ] && [ "$2" = "marketplace" ] && [ "$3" = "add" ] && [ "$4" = "obra/superpowers-marketplace" ]; then
+  echo 'failed to add marketplace' >&2
+  exit 1
+fi
+"#,
             log_file.display()
-        )
-        .as_str(),
+        ),
     );
 
     let jq_path = bin_dir.join("jq");


### PR DESCRIPTION
## Summary

- **Auth forwarding**: Forward host Claude Code OAuth credentials into agent containers. Three configurable modes (`copy`/`sync`/`ignore`) with per-agent overrides. Reads from macOS Keychain or Linux file-based credentials. Symlink-hardened writes, 0600 permissions.
- **Terminal forwarding**: Export host terminfo for exotic terminals (Ghostty, Kitty, WezTerm) and mount into containers. Cached at `~/.jackin/cache/terminfo/`.
- **Parallel load support**: Per-container-name lock files for atomic name claiming. Parallel loads create isolated clone instances with separate network, DinD, and volumes. Repo lock held through build context snapshot to prevent validation/build races.
- **Docker cache bust fix**: Persist `JACKIN_CACHE_BUST` value to prevent version ping-pong between Claude Code versions on alternate launches.
- **Plugin install optimization**: Skip already-installed plugins on container restart.
- **Entrypoint improvements**: Debug logging, pause before launch, verbose disable messages.
- **Documentation**: New Authentication Forwarding guide, updated config/architecture/security docs.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo nextest run` (343 tests pass)
- [ ] Manual: run two `jackin load the-architect` in parallel — both should succeed (primary + clone-1)
- [ ] Manual: verify `jackin config auth show` returns `copy` by default
- [ ] Manual: verify Ghostty terminfo is forwarded (`echo $TERM` shows `xterm-ghostty` inside container)
- [ ] Manual: verify auth forwarding works (container starts pre-authenticated with Opus/Max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)