### PR TITLE
fix: suppress noisy output in non-debug mode

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -9,6 +9,9 @@ pub struct RunOptions {
     /// and captured so it can be included in error messages.  When `false`
     /// (the default), stderr is inherited directly from the parent process.
     pub capture_stderr: bool,
+    /// When `true`, both stdout and stderr are sent to `/dev/null`.
+    /// Useful for suppressing noisy output (e.g. git fetch) in non-debug mode.
+    pub quiet: bool,
 }
 
 pub trait CommandRunner {
@@ -67,7 +70,19 @@ impl CommandRunner for ShellRunner {
     ) -> anyhow::Result<()> {
         self.log_command(program, args, cwd);
 
-        if opts.capture_stderr {
+        if opts.quiet {
+            let mut child = Self::build_command(program, args, cwd)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()?;
+            let status = child.wait()?;
+            anyhow::ensure!(
+                status.success(),
+                "command failed: {} {}",
+                program,
+                args.join(" ")
+            );
+        } else if opts.capture_stderr {
             let mut child = Self::build_command(program, args, cwd)
                 .stderr(std::process::Stdio::piped())
                 .spawn()?;
@@ -190,6 +205,7 @@ mod tests {
         let mut runner = ShellRunner::default();
         let opts = RunOptions {
             capture_stderr: true,
+            ..RunOptions::default()
         };
 
         let error = runner

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -397,12 +397,14 @@ fn resolve_agent_repo(
     selector: &ClassSelector,
     git_url: &str,
     runner: &mut impl CommandRunner,
+    debug: bool,
 ) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo, std::fs::File)> {
     resolve_agent_repo_with(
         paths,
         selector,
         git_url,
         runner,
+        debug,
         confirm_repo_removal_interactive,
     )
 }
@@ -412,6 +414,7 @@ fn resolve_agent_repo_with(
     selector: &ClassSelector,
     git_url: &str,
     runner: &mut impl CommandRunner,
+    debug: bool,
     confirm_removal: impl FnOnce() -> anyhow::Result<bool>,
 ) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedAgentRepo, std::fs::File)> {
     let cached_repo = CachedRepo::new(paths, selector);
@@ -436,6 +439,11 @@ fn resolve_agent_repo_with(
     lock_file
         .lock_exclusive()
         .map_err(|e| anyhow::anyhow!("failed to acquire repo lock for {}: {e}", selector.key()))?;
+
+    let git_run_opts = RunOptions {
+        quiet: !debug,
+        ..RunOptions::default()
+    };
 
     let repo_path = cached_repo.repo_dir.display().to_string();
     if cached_repo.repo_dir.join(".git").is_dir() {
@@ -463,7 +471,7 @@ fn resolve_agent_repo_with(
                     "git",
                     &["clone", git_url, &repo_path],
                     None,
-                    &RunOptions::default(),
+                    &git_run_opts,
                 )?;
                 let validated_repo = validate_agent_repo(&cached_repo.repo_dir)?;
                 return Ok((cached_repo, validated_repo, lock_file));
@@ -499,20 +507,20 @@ fn resolve_agent_repo_with(
             "git",
             &["-C", &repo_path, "fetch", "origin", &branch],
             None,
-            &RunOptions::default(),
+            &git_run_opts,
         )?;
         runner.run(
             "git",
             &["-C", &repo_path, "merge", "--ff-only", "FETCH_HEAD"],
             None,
-            &RunOptions::default(),
+            &git_run_opts,
         )?;
     } else {
         runner.run(
             "git",
             &["clone", git_url, &repo_path],
             None,
-            &RunOptions::default(),
+            &git_run_opts,
         )?;
     }
 
@@ -600,6 +608,7 @@ fn build_agent_image(
         None,
         &RunOptions {
             capture_stderr: true,
+            ..RunOptions::default()
         },
     )?;
 
@@ -899,7 +908,7 @@ fn load_agent_with(
     steps.next("Resolving agent identity");
 
     let (cached_repo, validated_repo, repo_lock) =
-        resolve_agent_repo(paths, selector, &source.git, runner)?;
+        resolve_agent_repo(paths, selector, &source.git, runner, opts.debug)?;
 
     // Trust gate: prompt the operator before running an untrusted third-party agent
     let newly_trusted = if source.trusted {
@@ -2692,6 +2701,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
         )
         .unwrap_err();
 
@@ -2761,6 +2771,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
             || Ok(true), // user confirms removal
         );
 
@@ -2800,6 +2811,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
             || Ok(false), // user declines
         )
         .unwrap_err();
@@ -2844,6 +2856,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
         )
         .unwrap_err();
 
@@ -2901,6 +2914,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
             || Ok(true),
         );
 
@@ -2943,6 +2957,7 @@ plugins = []
             &selector,
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
+            false,
         );
 
         assert!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -612,7 +612,7 @@ fn build_agent_image(
         },
     )?;
 
-    // Extract and display the Claude version from the built image
+    // Extract and store the Claude version from the built image
     if let Ok(version) = runner.capture(
         "docker",
         &["run", "--rm", "--entrypoint", "claude", &image, "--version"],
@@ -620,10 +620,12 @@ fn build_agent_image(
     ) {
         let version = version.trim();
         if !version.is_empty() {
-            eprintln!("        Claude {version}");
+            if debug {
+                eprintln!("        Claude {version}");
+            }
             if let Some(semver) = version_check::parse_claude_version(version) {
                 version_check::store_image_version(paths, &image, semver);
-            } else {
+            } else if debug {
                 eprintln!("warning: unexpected claude --version output: {version:?}");
             }
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -470,12 +470,7 @@ fn resolve_agent_repo_with(
 
             if confirm_removal()? {
                 std::fs::remove_dir_all(&cached_repo.repo_dir)?;
-                runner.run(
-                    "git",
-                    &["clone", git_url, &repo_path],
-                    None,
-                    &git_run_opts,
-                )?;
+                runner.run("git", &["clone", git_url, &repo_path], None, &git_run_opts)?;
                 let validated_repo = validate_agent_repo(&cached_repo.repo_dir)?;
                 return Ok((cached_repo, validated_repo, lock_file));
             }
@@ -519,12 +514,7 @@ fn resolve_agent_repo_with(
             &git_run_opts,
         )?;
     } else {
-        runner.run(
-            "git",
-            &["clone", git_url, &repo_path],
-            None,
-            &git_run_opts,
-        )?;
+        runner.run("git", &["clone", git_url, &repo_path], None, &git_run_opts)?;
     }
 
     let validated_repo = validate_agent_repo(&cached_repo.repo_dir)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -181,11 +181,14 @@ fn export_host_terminfo(
     std::fs::create_dir_all(&terminfo_dir)?;
 
     // Compile into the cache directory.
+    // Suppress stderr — tic emits harmless warnings for some terminal
+    // entries (e.g. Ghostty's "alias multiply defined" notice).
     let tic = std::process::Command::new("tic")
         .args(["-x", "-o"])
         .arg(&terminfo_dir)
         .arg("-")
         .stdin(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
         .spawn();
     let mut tic = tic?;
     if let Some(ref mut stdin) = tic.stdin {
@@ -673,6 +676,11 @@ fn launch_agent_runtime(
 
     let certs_volume = dind_certs_volume(container_name);
 
+    let docker_run_opts = RunOptions {
+        quiet: !debug,
+        ..RunOptions::default()
+    };
+
     // Create Docker network
     let agent_label = format!("jackin.agent={container_name}");
     runner.run(
@@ -687,7 +695,7 @@ fn launch_agent_runtime(
             network,
         ],
         None,
-        &RunOptions::default(),
+        &docker_run_opts,
     )?;
 
     // Start Docker-in-Docker with TLS
@@ -712,7 +720,7 @@ fn launch_agent_runtime(
         &certs_dind_mount,
         "docker:dind",
     ];
-    runner.run("docker", &dind_args, None, &RunOptions::default())?;
+    runner.run("docker", &dind_args, None, &docker_run_opts)?;
 
     wait_for_dind(dind, &certs_volume, runner, *debug)?;
 


### PR DESCRIPTION
## Summary
- Add `quiet` field to `RunOptions` that sends both stdout and stderr to `/dev/null`
- Suppress git fetch/merge/clone output (`From https://...`, `* branch main -> FETCH_HEAD`, `Already up to date.`) unless `--debug`
- Hide `Claude 2.1.x (Claude Code)` version line after image build unless `--debug`
- Suppress Docker network create and DinD container ID hashes unless `--debug`
- Suppress `tic` terminfo compiler warnings (e.g. Ghostty's `alias multiply defined`) unconditionally — these are harmless

## Test plan
- [x] All 334 existing tests pass
- [ ] Run `jackin load the-architect` — verify clean TUI with no leaked output
- [ ] Run `jackin load --debug the-architect` — verify all debug output is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)