### PR TITLE
[codex] fix workspace auto-detection from host root

### DIFF
--- a/docs/pages/commands/launch.mdx
+++ b/docs/pages/commands/launch.mdx
@@ -33,7 +33,7 @@ The launcher shows two kinds of choices:
 - **Current directory** — a synthetic workspace that mounts your `cwd` at the same path inside the container
 - **Saved workspaces** — named definitions from `~/.config/jackin/config.toml`
 
-If your current directory matches a saved workspace's `workdir`, that workspace is preselected.
+If your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths, that workspace is preselected.
 
 ## Agent selection
 

--- a/docs/pages/commands/load.mdx
+++ b/docs/pages/commands/load.mdx
@@ -88,5 +88,5 @@ If two resolved mounts target the same container destination, `jackin load` fail
 :::
 
 :::tip
-If no selector is given and the current directory matches a saved workspace with a default agent, that agent is used automatically.
+If no selector is given and the current directory falls under a saved workspace's host `workdir` or one of its mounted host paths, that workspace's default or last-used agent is used automatically.
 :::

--- a/docs/pages/guides/workspaces.mdx
+++ b/docs/pages/guides/workspaces.mdx
@@ -168,7 +168,7 @@ jackin workspace edit secure-api --clear-default-agent
 
 ## Workspace auto-detection
 
-When you run `jackin launch`, the TUI launcher checks if your current directory exactly matches a saved workspace's `workdir`. If it does, that workspace is preselected — saving you a selection step and reinforcing the value of naming project boundaries once. This auto-detection works best when the saved workspace keeps the host path and container `workdir` the same. If you remap `workdir` to a container-only path like `/workspace`, choose that saved workspace manually in the launcher. You can always override the preselection by choosing a different workspace or "Current directory."
+When you run `jackin launch`, the TUI launcher checks whether your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths. If it does, that workspace is preselected — saving you a selection step and reinforcing the value of naming project boundaries once. Container-only `workdir` values like `/workspace` can still be auto-detected as long as one of the workspace's mounted host paths contains your current directory. You can always override the preselection by choosing a different workspace or "Current directory."
 
 ## Storage
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -817,6 +817,42 @@ mod tests {
     }
 
     #[test]
+    fn preselects_saved_workspace_from_host_workdir_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("monorepo");
+        let repo_dir = workspace_root.join("jackin");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let workspace_root = workspace_root.canonicalize().unwrap();
+
+        let mut config = crate::config::AppConfig::default();
+        config.agents.insert(
+            "agent-smith".to_string(),
+            crate::config::AgentSource {
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
+                claude: None,
+            },
+        );
+        config.workspaces.insert(
+            "big-monorepo".to_string(),
+            crate::workspace::WorkspaceConfig {
+                workdir: workspace_root.display().to_string(),
+                mounts: vec![crate::workspace::MountConfig {
+                    src: repo_dir.canonicalize().unwrap().display().to_string(),
+                    dst: "/workspace/jackin".to_string(),
+                    readonly: false,
+                }],
+                allowed_agents: vec!["agent-smith".to_string()],
+                default_agent: Some("agent-smith".to_string()),
+                last_agent: None,
+            },
+        );
+
+        let state = LaunchState::new(&config, &workspace_root).unwrap();
+        assert_eq!(state.selected_workspace_name(), Some("big-monorepo"));
+    }
+
+    #[test]
     fn filters_agents_by_query() {
         let state = LaunchState {
             stage: LaunchStage::Agent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,8 @@ fn resolve_target_name(name: &str, config: &AppConfig, cwd: &Path) -> Result<Loa
 
 /// Resolve the agent and workspace from the current directory context.
 ///
-/// Finds a saved workspace whose workdir matches `cwd`, then picks the agent:
+/// Finds the saved workspace whose host workdir or mounted host path best
+/// matches `cwd`, then picks the agent:
 /// 1. `last_agent` (most recently used)
 /// 2. `default_agent` (explicitly configured)
 /// 3. If multiple agents available — prompt
@@ -933,6 +934,44 @@ mod tests {
         );
 
         let resolved = resolve_agent_from_context(&config, &nested_dir).unwrap();
+
+        assert_eq!(resolved.0.key(), "agent-smith");
+        assert_eq!(resolved.1, LoadWorkspaceInput::Saved("my-app".to_string()));
+    }
+
+    #[test]
+    fn resolve_agent_from_context_matches_workspace_from_host_workdir_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("monorepo");
+        let repo_dir = workspace_root.join("jackin");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let workspace_root = workspace_root.canonicalize().unwrap();
+
+        let mut config = config::AppConfig::default();
+        config.agents.insert(
+            "agent-smith".to_string(),
+            config::AgentSource {
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
+                trusted: true,
+                claude: None,
+            },
+        );
+        config.workspaces.insert(
+            "my-app".to_string(),
+            workspace::WorkspaceConfig {
+                workdir: workspace_root.display().to_string(),
+                mounts: vec![workspace::MountConfig {
+                    src: repo_dir.canonicalize().unwrap().display().to_string(),
+                    dst: "/workspace/jackin".to_string(),
+                    readonly: false,
+                }],
+                allowed_agents: vec!["agent-smith".to_string()],
+                default_agent: Some("agent-smith".to_string()),
+                last_agent: None,
+            },
+        );
+
+        let resolved = resolve_agent_from_context(&config, &workspace_root).unwrap();
 
         assert_eq!(resolved.0.key(), "agent-smith");
         assert_eq!(resolved.1, LoadWorkspaceInput::Saved("my-app".to_string()));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -296,20 +296,28 @@ pub struct ResolvedWorkspace {
     pub mounts: Vec<MountConfig>,
 }
 
+fn host_path_match_depth(path: &str, canonical_cwd: &Path) -> Option<usize> {
+    let expanded = expand_tilde(path);
+    let canonical_path = Path::new(&expanded).canonicalize().ok()?;
+
+    if canonical_cwd == canonical_path || canonical_cwd.starts_with(&canonical_path) {
+        Some(canonical_path.components().count())
+    } else {
+        None
+    }
+}
+
 pub fn saved_workspace_match_depth(workspace: &WorkspaceConfig, cwd: &Path) -> Option<usize> {
     let canonical_cwd = cwd.canonicalize().ok()?;
 
-    workspace
-        .mounts
-        .iter()
-        .filter_map(|mount| {
-            let canonical_src = Path::new(&mount.src).canonicalize().ok()?;
-            if canonical_cwd == canonical_src || canonical_cwd.starts_with(&canonical_src) {
-                Some(canonical_src.components().count())
-            } else {
-                None
-            }
-        })
+    std::iter::once(host_path_match_depth(&workspace.workdir, &canonical_cwd))
+        .chain(
+            workspace
+                .mounts
+                .iter()
+                .map(|mount| host_path_match_depth(&mount.src, &canonical_cwd)),
+        )
+        .flatten()
         .max()
 }
 
@@ -572,6 +580,66 @@ mod tests {
         );
         assert_eq!(workspace.mounts.len(), 1);
         assert_eq!(workspace.mounts[0].src, workspace.mounts[0].dst);
+    }
+
+    #[test]
+    fn saved_workspace_match_depth_matches_host_workdir_parent_of_mounts() {
+        let temp = tempdir().unwrap();
+        let workspace_root = temp.path().join("monorepo");
+        let repo_a = workspace_root.join("jackin");
+        let repo_b = workspace_root.join("jackin-dev");
+        std::fs::create_dir_all(&repo_a).unwrap();
+        std::fs::create_dir_all(&repo_b).unwrap();
+
+        let canonical_root = workspace_root.canonicalize().unwrap();
+        let workspace = WorkspaceConfig {
+            workdir: canonical_root.display().to_string(),
+            mounts: vec![
+                MountConfig {
+                    src: repo_a.canonicalize().unwrap().display().to_string(),
+                    dst: "/workspace/jackin".to_string(),
+                    readonly: false,
+                },
+                MountConfig {
+                    src: repo_b.canonicalize().unwrap().display().to_string(),
+                    dst: "/workspace/jackin-dev".to_string(),
+                    readonly: false,
+                },
+            ],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+        };
+
+        assert_eq!(
+            saved_workspace_match_depth(&workspace, &canonical_root),
+            Some(canonical_root.components().count())
+        );
+    }
+
+    #[test]
+    fn saved_workspace_match_depth_still_matches_nested_path_under_mount_root() {
+        let temp = tempdir().unwrap();
+        let project_dir = temp.path().join("project");
+        let nested_dir = project_dir.join("src/bin");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+
+        let workspace = WorkspaceConfig {
+            workdir: "/workspace".to_string(),
+            mounts: vec![MountConfig {
+                src: project_dir.canonicalize().unwrap().display().to_string(),
+                dst: "/workspace".to_string(),
+                readonly: false,
+            }],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+        };
+
+        assert_eq!(
+            saved_workspace_match_depth(&workspace, &nested_dir),
+            Some(project_dir.canonicalize().unwrap().components().count())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- match saved workspaces when the current directory falls under the saved host `workdir`, not just mounted host paths
- keep preferring the deepest matching host path so nested mount matches still win when available
- add regression coverage for `jackin load` context resolution and launcher preselection, and update docs to describe the corrected behavior

## Root cause
`jackin load` without an explicit selector resolves the current directory against saved workspaces via `saved_workspace_match_depth`. That helper only compared `cwd` against mounted host sources. For workspaces whose saved host `workdir` is a parent directory of multiple mounted subrepos, the workspace root itself never matched, so `jackin load` incorrectly reported that no saved workspace matched the current directory.

## Validation
- cargo fmt --all
- cargo clippy
- cargo nextest run