### PR TITLE
feat: add --debug flag to launch command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,7 +132,11 @@ Examples:
     },
     /// Open the interactive TUI launcher to pick a workspace and agent
     #[command(before_help = BANNER, styles = HELP_STYLES)]
-    Launch,
+    Launch {
+        /// Print raw container output for troubleshooting
+        #[arg(long, default_value_t = false)]
+        debug: bool,
+    },
     /// Manage saved workspaces
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Workspace {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -761,7 +761,7 @@ mod tests {
     #[test]
     fn parses_launch_command() {
         let cli = Cli::try_parse_from(["jackin", "launch"]).unwrap();
-        assert!(matches!(cli.command, Command::Launch));
+        assert!(matches!(cli.command, Command::Launch { debug: false }));
     }
 
     /// Strip ANSI escape sequences for clean test assertions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,9 @@ pub fn run(cli: Cli) -> Result<()> {
             );
             result
         }
-        Command::Launch => {
+        Command::Launch { debug } => {
+            runner.debug = debug;
+            tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
             let (class, workspace) = crate::launch::run_launch(&config, &cwd)?;
 
@@ -321,7 +323,7 @@ pub fn run(cli: Cli) -> Result<()> {
 
             let opts = runtime::LoadOptions {
                 no_intro: false,
-                debug: false,
+                debug,
                 rebuild: false,
             };
             let result =


### PR DESCRIPTION
## Summary

- Adds `--debug` flag to `jackin launch`, matching the existing flag on `jackin load`
- Sets `runner.debug` and `tui::set_debug_mode()` before the TUI runs, and passes `debug` into `LoadOptions`
- Enables `jackin launch --debug` for troubleshooting container output

## Test plan

- [ ] Run `jackin launch --help` and verify `--debug` appears in the output
- [ ] Run `jackin launch --debug`, select a workspace/agent, and verify debug output is printed
- [ ] Run `jackin launch` (without `--debug`) and verify no debug output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)