### PR TITLE
fix: launch --debug now disables intro (matching load --debug)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,11 +288,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 anyhow::bail!("aborted — sensitive mount paths were not confirmed");
             }
 
-            let opts = runtime::LoadOptions {
-                no_intro: no_intro || debug,
-                debug,
-                rebuild,
-            };
+            let opts = runtime::LoadOptions::for_load(no_intro, debug, rebuild);
             let result = runtime::load_agent(
                 &paths,
                 &mut config,
@@ -321,11 +317,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 anyhow::bail!("aborted — sensitive mount paths were not confirmed");
             }
 
-            let opts = runtime::LoadOptions {
-                no_intro: false,
-                debug,
-                rebuild: false,
-            };
+            let opts = runtime::LoadOptions::for_launch(debug);
             let result =
                 runtime::load_agent(&paths, &mut config, &class, &workspace, &mut runner, &opts);
             remember_last_agent(&paths, &mut config, Some(&workspace.label), &class, &result);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,6 +41,26 @@ pub struct LoadOptions {
     pub rebuild: bool,
 }
 
+impl LoadOptions {
+    /// Build options for `jackin load`. Debug mode implies `no_intro`.
+    pub fn for_load(no_intro: bool, debug: bool, rebuild: bool) -> Self {
+        Self {
+            no_intro: no_intro || debug,
+            debug,
+            rebuild,
+        }
+    }
+
+    /// Build options for `jackin launch`. Debug mode implies `no_intro`.
+    pub fn for_launch(debug: bool) -> Self {
+        Self {
+            no_intro: debug,
+            debug,
+            rebuild: false,
+        }
+    }
+}
+
 impl Default for LoadOptions {
     fn default() -> Self {
         Self {
@@ -3467,5 +3487,39 @@ plugins = []
                 .iter()
                 .any(|c| c.contains("docker rm -f jackin-agent-smith"))
         );
+    }
+
+    #[test]
+    fn load_options_debug_disables_intro_for_load() {
+        let opts = LoadOptions::for_load(false, true, false);
+        assert!(opts.no_intro, "debug mode must disable intro for load");
+        assert!(opts.debug);
+    }
+
+    #[test]
+    fn load_options_no_intro_flag_for_load() {
+        let opts = LoadOptions::for_load(true, false, false);
+        assert!(opts.no_intro, "explicit no_intro must be respected");
+        assert!(!opts.debug);
+    }
+
+    #[test]
+    fn load_options_intro_plays_when_no_flags_for_load() {
+        let opts = LoadOptions::for_load(false, false, false);
+        assert!(!opts.no_intro, "intro should play when no flags set");
+    }
+
+    #[test]
+    fn load_options_debug_disables_intro_for_launch() {
+        let opts = LoadOptions::for_launch(true);
+        assert!(opts.no_intro, "debug mode must disable intro for launch");
+        assert!(opts.debug);
+    }
+
+    #[test]
+    fn load_options_intro_plays_when_no_debug_for_launch() {
+        let opts = LoadOptions::for_launch(false);
+        assert!(!opts.no_intro, "intro should play when debug is off");
+        assert!(!opts.debug);
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -43,7 +43,7 @@ pub struct LoadOptions {
 
 impl LoadOptions {
     /// Build options for `jackin load`. Debug mode implies `no_intro`.
-    pub fn for_load(no_intro: bool, debug: bool, rebuild: bool) -> Self {
+    pub const fn for_load(no_intro: bool, debug: bool, rebuild: bool) -> Self {
         Self {
             no_intro: no_intro || debug,
             debug,
@@ -52,7 +52,7 @@ impl LoadOptions {
     }
 
     /// Build options for `jackin launch`. Debug mode implies `no_intro`.
-    pub fn for_launch(debug: bool) -> Self {
+    pub const fn for_launch(debug: bool) -> Self {
         Self {
             no_intro: debug,
             debug,


### PR DESCRIPTION
## Summary
- **Bug fix**: `jackin launch --debug` was hardcoding `no_intro: false`, so the intro animation always played even in debug mode — unlike `jackin load --debug` which correctly skipped it.
- **Refactor**: Extract `LoadOptions::for_load()` and `LoadOptions::for_launch()` constructors that encode the invariant (debug implies no_intro) in one place.
- **Tests**: Add 5 unit tests covering all flag combinations for both constructors.

## Test plan
- [x] `cargo test load_options_` — all 5 new tests pass
- [ ] Manual: `jackin launch --debug` no longer shows the intro
- [ ] Manual: `jackin launch` (without --debug) still shows the intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)
