### PR TITLE
chore: pin rust to latest stable in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 bun = "latest"
 just = "latest"
+rust = "latest"


### PR DESCRIPTION
## Summary

Add `rust = \"latest\"` to `mise.toml` alongside `bun` and `just` so contributors who use [mise](https://mise.jdx.dev/) get the Rust toolchain installed automatically and kept on current stable. Mirrors CI's `dtolnay/rust-toolchain@stable` pattern, so local dev and CI won't drift on toolchain version.

The MSRV declared in `Cargo.toml` (`rust-version = \"1.95\"`) remains the authoritative floor — this just defines the default local toolchain.

## Test plan

- [x] `mise.toml` still parses (single-line diff, only adds `rust = \"latest\"`).
- [ ] Contributor running `mise install` in the repo gets the latest stable Rust toolchain (requires a fresh environment to verify; no impact on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)