### PR TITLE
chore: pin rust toolchain and dev tools to 1.94.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
@@ -34,7 +34,7 @@ jobs:
             cross: true
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - run: cargo test --locked
 
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           targets: ${{ matrix.target }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jackin"
 version = "0.6.0-dev"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.94"
 description = "Matrix-inspired CLI for orchestrating AI coding agents at scale"
 homepage = "https://jackin.tailrocks.com/"
 repository = "https://github.com/jackin-project/jackin"

--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:trixie AS security-tools
+FROM rust:1.94.1-trixie AS security-tools
 
 ARG TIRITH_VERSION
 ARG SHELLFIRM_VERSION

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -75,7 +75,7 @@ Use earlier stages for compilation or asset preparation:
 
 ```dockerfile
 # Build stage — use any base image
-FROM rust:slim AS builder
+FROM rust:1.94.1-slim AS builder
 WORKDIR /build
 COPY tools/ .
 RUN cargo build --release

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-bun = "latest"
-just = "latest"
-rust = "latest"
+bun = "1.3.12"
+just = "1.49.0"
+rust = "1.94.1"

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -64,7 +64,7 @@ mod tests {
         let dockerfile = temp.path().join("Dockerfile");
         std::fs::write(
             &dockerfile,
-            r#"FROM rust:1.87 AS builder
+            r#"FROM rust:1.94.1 AS builder
 RUN cargo build
 
 FROM projectjackin/construct:trixie AS runtime


### PR DESCRIPTION
## Summary
- Revert MSRV from 1.95 to 1.94 and pin the dev + CI Rust toolchains to 1.94.1 (per the [1.94.1 release notes](https://blog.rust-lang.org/2026/03/26/1.94.1-release/))
- Replace every `latest` / `stable` reference with an exact version so local dev, CI, and the construct Docker builder all use the same compiler
- SHA-pin `dtolnay/rust-toolchain` (not just tag) — tag branches on that action are mutable, only the SHA is a real pin

## Changes
| File | Change |
|---|---|
| `Cargo.toml` | MSRV `1.95` → `1.94` |
| `mise.toml` | `bun/just/rust = "latest"` → `1.3.12 / 1.49.0 / 1.94.1` |
| `.github/workflows/ci.yml` (x2) | `@stable` → `@aad518f… # 1.94.1` |
| `.github/workflows/release.yml` (x2) | `@...  # stable` → `@aad518f… # 1.94.1` |
| `docker/construct/Dockerfile` | `rust:trixie` → `rust:1.94.1-trixie` |
| `src/repo_contract.rs` | test fixture `rust:1.87` → `rust:1.94.1` |
| `docs/pages/developing/creating-agents.mdx` | example `rust:slim` → `rust:1.94.1-slim` |

Historical planning docs under `docs/superpowers/{plans,specs}/2026-04-08-*` still reference `rust:trixie` and are intentionally left as-is (dated design records).

## Test plan
- [ ] CI `check` job passes (cargo fmt, clippy, test --locked) on the pinned 1.94.1 toolchain
- [ ] `build-validator` multi-target builds on both `x86_64` and `aarch64` Linux targets
- [ ] Local `mise install` resolves bun 1.3.12, just 1.49.0, rust 1.94.1
- [ ] construct Docker image builds cleanly with `rust:1.94.1-trixie` builder stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
