### PR TITLE
chore: set up self-hosted Renovate with automerge

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,7 +3,7 @@ name: Renovate
 on:
   merge_group:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 6 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,25 @@
+name: Renovate
+
+on:
+  merge_group:
+  schedule:
+    - cron: "0 * * * *"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: false
+          LOG_LEVEL: debug

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "default:automergeDigest"
+  ],
+  "platformAutomerge": true,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 20,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Mirrors the self-hosted Renovate setup from `ChainArgos/blockchain-nodes` as the pilot rollout for jackin
- Hourly cron + push-to-main + merge_group + manual dispatch triggers
- `platformAutomerge: true` lets GitHub's native auto-merge handle the CI-gated merge once branch protection is in place
- `docker:pinDigests` will convert our new `rust:1.94.1-trixie` tag pin to a digest pin on first run — expected

## Files
- `renovate.json` — config:recommended + docker digest pinning + automerge-all
- `.github/workflows/renovate.yml` — SHA-pinned `renovatebot/github-action@v46.1.9` and `actions/checkout@v6`

## Token setup
`RENOVATE_TOKEN` has been added as an **org-level secret** in `jackin-project`, scoped to the relevant repos. Permissions on the underlying fine-grained PAT:
- `Contents` — write
- `Pull requests` — write
- `Issues` — write
- `Workflows` — write
- `Metadata` — read (auto)

## Test plan
- [ ] PR CI green
- [ ] After merge, trigger manually: `gh workflow run renovate.yml --ref main`
- [ ] First run opens the Dependency Dashboard issue
- [ ] First run opens at least one PR (expect digest pin for `rust:1.94.1-trixie` in construct Dockerfile)
- [ ] First automerge PR flows end-to-end (open → CI → merge → branch deleted)

## Rollout plan
- Pilot: this PR on `jackin` only
- Fan-out to `jackin-agent-smith`, `jackin-the-architect`, `jackin-github-terraform`, `jackin-marketplace`, `jackin-dev`, `homebrew-tap` once pilot is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)