### PR TITLE
chore: disable Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,16 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "docker:pinDigests",
-    "default:automergeDigest"
+    "docker:pinDigests"
   ],
-  "platformAutomerge": true,
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 20,
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true
-    }
-  ]
+  "prConcurrentLimit": 20
 }


### PR DESCRIPTION
## Summary
- Flip Renovate from "automerge everything" to "open PRs, wait for human review"
- Motivated by PR #68 surprise-merging `rust = "1.95.0"` despite it being out of scope — Renovate's polling-based automerge bypasses repo `allow_auto_merge`

## Changes
- Remove `default:automergeDigest` from extends (digest PRs still get opened by `docker:pinDigests`, they just won't auto-merge)
- Remove `platformAutomerge: true` (no-op since repo auto-merge is disabled; removing for clarity)
- Remove the `packageRules` block that set `automerge: true` for all update types

## What this does NOT change
- Renovate still runs daily at 06:00 UTC and on push/merge_group
- Renovate still opens PRs for all deps (cargo, docker, github actions, mise tools)
- `docker:pinDigests` still converts tag pins to SHA digest pins
- `prHourlyLimit: 0` and `prConcurrentLimit: 20` stay — no artificial rate limits on opening PRs

## Result
Every Renovate PR requires an explicit `gh pr merge` or UI click. No more accidental merges.

## Test plan
- [ ] Renovate CI run after merge doesn't attempt any automerges
- [ ] Next daily Renovate cycle opens new PRs as before (rust bump will reappear — close it until homebrew catches up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)