### PR TITLE
fix: default construct locale to UTF-8

### DIFF
--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -84,6 +84,11 @@ RUN groupadd -g "$GID" claude && \
     echo "claude ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/claude && \
     install -d -o claude -g claude /home/claude/.claude /home/claude/.jackin
 
+# Default to a UTF-8 locale so shell prompts and CLI output render correctly,
+# including `docker exec` sessions that bypass jackin's runtime entrypoint.
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
 USER claude
 
 ENV PATH="/home/claude/.local/share/mise/shims:/home/claude/.local/bin:${PATH}"


### PR DESCRIPTION
## Summary
- set `LANG` and `LC_ALL` to `C.UTF-8` in the construct image
- make UTF-8 the default for zsh, starship, tirith, and shellfirm prompt rendering
- ensure `docker exec ... zsh` sessions inherit a sane locale even though they bypass the runtime entrypoint

## Why
The construct image currently defaults to a POSIX / ASCII locale, which causes Unicode prompt glyphs to degrade into `?` characters inside agent containers.

## Verification
- `cargo fmt -- --check && cargo clippy && cargo nextest run`
- `docker build -f docker/construct/Dockerfile docker/construct --build-arg TIRITH_VERSION --build-arg SHELLFIRM_VERSION -t jackin-construct-locale-test`
- `docker run --rm jackin-construct-locale-test sh -lc 'locale charmap && env | rg "^(LANG|LC_ALL)="'`
- `docker run --rm jackin-construct-locale-test sh -lc 'zsh -ic "print -P \$PROMPT"'`
