### PR TITLE
chore(rust): finish 1.95.0 bump across CI, tests, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -34,7 +34,7 @@ jobs:
             cross: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --locked
 
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/docs/pages/developing/creating-agents.mdx
+++ b/docs/pages/developing/creating-agents.mdx
@@ -75,7 +75,7 @@ Use earlier stages for compilation or asset preparation:
 
 ```dockerfile
 # Build stage — use any base image
-FROM rust:1.94.1-slim AS builder
+FROM rust:1.95.0-slim AS builder
 WORKDIR /build
 COPY tools/ .
 RUN cargo build --release

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -64,7 +64,7 @@ mod tests {
         let dockerfile = temp.path().join("Dockerfile");
         std::fs::write(
             &dockerfile,
-            r#"FROM rust:1.94.1 AS builder
+            r#"FROM rust:1.95.0 AS builder
 RUN cargo build
 
 FROM projectjackin/construct:trixie AS runtime


### PR DESCRIPTION
## Summary

Renovate PR #88 bumped Rust to 1.95.0 in `docker/construct/Dockerfile` and `mise.toml`. This PR completes the upgrade so every remaining place that names a specific Rust version is aligned:

- `.github/workflows/ci.yml` — `dtolnay/rust-toolchain` pin in both `check` and `build-validator` jobs
- `.github/workflows/release.yml` — same pin in `test` and `build` jobs
- `src/repo_contract.rs` — test fixture Dockerfile string
- `docs/pages/developing/creating-agents.mdx` — multi-stage build example

The `dtolnay/rust-toolchain` SHA is pinned to `e081816240890017053eacbb1bdf337761dc5582`, resolved via the GitHub API as the head of the action's `1.95.0` branch.

`Cargo.toml`'s `rust-version = "1.94"` is intentionally left alone — that's the MSRV promise (the lower bound users can build with), which is a separate policy from the dev/CI toolchain version.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` — 357/357 pass
- [ ] CI on the PR confirms the new `dtolnay/rust-toolchain` SHA resolves and installs 1.95.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)