### PR TITLE
chore(ci): switch test runner to cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-nextest
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
-      - run: cargo install cargo-nextest --locked
       - run: cargo nextest run
 
   build-validator:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
-      - run: cargo test --locked
+      - run: cargo install cargo-nextest --locked
+      - run: cargo nextest run
 
   build-validator:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo install cargo-nextest --locked
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-nextest
       - run: cargo nextest run
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo test --locked
+      - run: cargo install cargo-nextest --locked
+      - run: cargo nextest run
 
   build:
     needs: [check-version, test]


### PR DESCRIPTION
## Summary
- Replace `cargo test --locked` with `cargo nextest run` in both `ci.yml` and `release.yml`.
- Install nextest via `taiki-e/install-action@v2.75.18` (pinned SHA) so we download a prebuilt binary in seconds instead of compiling from source on every run.
- Aligns CI with the local pre-commit command documented in AGENTS.md.

## Test plan
- [ ] CI green on this PR (should be ~same duration as before the nextest change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)