### PR TITLE
fix(entrypoint): skip interactive gh auth login at container start

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -26,12 +26,11 @@ fi
 if [ -x /usr/bin/gh ]; then
     if gh auth status &>/dev/null; then
         echo "[entrypoint] GitHub CLI already authenticated"
+        gh auth setup-git
+        git config --global url."https://github.com/".insteadOf "git@github.com:"
     else
-        echo "[entrypoint] GitHub CLI not authenticated — starting gh auth login"
-        gh auth login
+        echo "[entrypoint] GitHub CLI not authenticated — skipping login (run 'gh auth login' inside the runtime if needed)"
     fi
-    gh auth setup-git
-    git config --global url."https://github.com/".insteadOf "git@github.com:"
 else
     echo "[entrypoint] GitHub CLI not installed — skipping auth"
 fi


### PR DESCRIPTION
## Summary
- Remove the unconditional `gh auth login` call — it prompts interactively and blocks container startup in non-TTY contexts.
- Only run `gh auth setup-git` and the git URL rewrite when gh is already authenticated.
- When unauthenticated, print a one-line hint instead.

## Test plan
- [ ] CI green on this PR
- [ ] Manual: start runtime container without pre-provisioned gh auth, confirm entrypoint completes instead of hanging
- [ ] Manual: start runtime container with gh already authenticated, confirm `setup-git` still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)