### PR TITLE
docs: adopt Conventional Commits + refresh product vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,34 @@ Never commit directly to `main`.
 - Keep branch names short, lowercase, and hyphen-separated
 - Merge back to `main` via pull request after review
 
+## Commit Messages
+
+All commits in this repository MUST follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Subject format: `<type>[optional scope][!]: <description>`
+
+Allowed types:
+
+| Type       | Use for                                                |
+| ---------- | ------------------------------------------------------ |
+| `feat`     | New user-visible feature                               |
+| `fix`      | Bug fix                                                |
+| `docs`     | Documentation-only change                              |
+| `style`    | Formatting, whitespace; no logic change                |
+| `refactor` | Internal restructuring; no behavior change             |
+| `perf`     | Performance improvement                                |
+| `test`     | Adding or updating tests                               |
+| `build`    | Build system, tooling, dependencies                    |
+| `ci`       | CI configuration                                       |
+| `chore`    | Routine maintenance (release, merge, deps)             |
+| `revert`   | Reverts a prior commit                                 |
+
+Scope is optional but encouraged when it clarifies the change area, e.g., `feat(launch): preview resolved mounts per agent in TUI`.
+
+Breaking changes use `!` after the type/scope (`feat!:` or `feat(api)!:`) and include a `BREAKING CHANGE:` footer in the body.
+
+PR squash-merge: the PR title becomes the commit subject, so PR titles must also follow this convention.
+
 ## Codex Commit Attribution
 
 Until Codex supports automatic commit trailers, every commit created by the

--- a/docs/src/components/landing/rainEngine.test.ts
+++ b/docs/src/components/landing/rainEngine.test.ts
@@ -11,7 +11,7 @@ test('ageToColor returns pale green for age 1-2', () => {
   expect(ageToColor(2)).toBe('rgb(180,255,180)');
 });
 
-test('ageToColor returns MATRIX_GREEN for age 3-5', () => {
+test('ageToColor returns PHOSPHOR_GREEN for age 3-5', () => {
   expect(ageToColor(3)).toBe('rgb(0,255,65)');
   expect(ageToColor(5)).toBe('rgb(0,255,65)');
 });

--- a/docs/src/components/landing/rainEngine.ts
+++ b/docs/src/components/landing/rainEngine.ts
@@ -7,10 +7,10 @@ export const RAIN_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq
 export function ageToColor(age: number): string | null {
   if (age === 0)  return 'rgb(255,255,255)';   // WHITE — leader
   if (age <= 2)   return 'rgb(180,255,180)';   // pale green
-  if (age <= 5)   return 'rgb(0,255,65)';      // MATRIX_GREEN
+  if (age <= 5)   return 'rgb(0,255,65)';      // PHOSPHOR_GREEN
   if (age <= 10)  return 'rgb(0,200,50)';      // mid green
-  if (age <= 16)  return 'rgb(0,140,30)';      // MATRIX_DIM
-  if (age <= 24)  return 'rgb(0,80,18)';       // MATRIX_DARK
+  if (age <= 16)  return 'rgb(0,140,30)';      // PHOSPHOR_DIM
+  if (age <= 24)  return 'rgb(0,80,18)';       // PHOSPHOR_DARK
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Add `## Commit Messages` section to `AGENTS.md` documenting Conventional Commits 1.0.0 with allowed-types table.
- Refresh product vocabulary in `rainEngine.ts` and `rainEngine.test.ts` (comment labels + one test name) aligned to the Rust-side `PHOSPHOR_*` constants.

## Test plan

- [x] `bun run build` (in `docs/`) passes
- [x] `bun test` (in `docs/`) passes
- [x] `cargo fmt -- --check && cargo clippy && cargo nextest run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)