### PR TITLE
style: apply cargo fmt to cli.rs and tui.rs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -809,7 +809,11 @@ mod tests {
     #[test]
     fn root_help_shows_all_commands() {
         let help = help_text(&["jackin", "--help"]);
-        assert!(help.contains("Operator's CLI for orchestrating AI coding agents in isolated containers"));
+        assert!(
+            help.contains(
+                "Operator's CLI for orchestrating AI coding agents in isolated containers"
+            )
+        );
         for cmd in [
             "load",
             "hardline",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -501,10 +501,7 @@ pub fn simple_outro(agent_name: &str, remaining: &[String]) {
         format!("{agent_name} has left the container.").color(rgb(PHOSPHOR_DIM))
     );
     if remaining.is_empty() {
-        eprintln!(
-            "  {}",
-            "No agents remaining.".color(rgb(PHOSPHOR_DIM))
-        );
+        eprintln!("  {}", "No agents remaining.".color(rgb(PHOSPHOR_DIM)));
     } else {
         eprintln!(
             "  {}",


### PR DESCRIPTION
## Summary

Resolves pre-existing rustfmt drift on `src/cli.rs:809` and `src/tui.rs:501` flagged during PR #102's review. No behavior change — purely whitespace.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` clean
- [x] `cargo nextest run` 358/358 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)