### PR TITLE
fix(landing): stop Approach cards from overflowing grid track on narrow viewports

### DIFF
--- a/docs/src/components/landing/styles.css
+++ b/docs/src/components/landing/styles.css
@@ -384,6 +384,10 @@ html {
   line-height: 1.7;
   color: var(--landing-text);
   white-space: pre-wrap;
+  /* Let long unbreakable tokens (e.g. "plugin@marketplace" strings) break
+     when the card is narrower than the token — otherwise they'd force the
+     card wider than the grid track on small viewports. */
+  overflow-wrap: anywhere;
   font-family: inherit;
 }
 .landing-builder-body .b-c { color: var(--landing-text-ghost); }
@@ -412,6 +416,10 @@ html {
   border-radius: 10px;
   background: rgba(0, 255, 65, 0.025);
   position: relative;
+  /* Allow grid item to shrink below its content's intrinsic width so the
+     inner monospace TabbedBuilder code doesn't force the card wider than
+     the grid track on narrow viewports (iPhone portrait). */
+  min-width: 0;
   transition:
     transform 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94),
     border-color 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94),


### PR DESCRIPTION
## Summary

Section 04 (The Approach) cards rendered wider than Section 03 cards on iPhone portrait mode. Grid items default to `min-width: auto`, so the monospace TabbedBuilder content in Route 02 was forcing the track wider than the viewport.

## Fix

- `.landing-approach-card { min-width: 0; }` — lets the grid item shrink below its content's intrinsic width.
- `.landing-builder-body { overflow-wrap: anywhere; }` — lets long monospace tokens like `"plugin@marketplace"` wrap when the card is narrower than the token.

## Test plan

- [x] `bun run build` passes (39 pages)
- [ ] Visual check on iPhone portrait: both sections' cards now span the same width

🤖 Generated with [Claude Code](https://claude.com/claude-code)