### PR TITLE
docs(agents): make bun install the explicit first step before dev

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -58,11 +58,27 @@ targeted cleanup first.
 
 ## Common Commands
 
-- Install dependencies: `bun install --frozen-lockfile`
+**First-time setup (and after pulling dependency changes):**
+
+```sh
+bun install --frozen-lockfile
+```
+
+This populates `node_modules/` with the platform-specific optional native binaries (e.g. `@rollup/rollup-darwin-arm64` on Apple Silicon). Skipping it makes `bun run dev` fail with `Cannot find module '@rollup/rollup-...'`.
+
+**Day-to-day:**
+
 - Start dev server: `bun run dev`
 - Build docs: `bun run build`
 - Preview production build: `bun run preview`
 - Run tests: `bun test`
+
+**If `node_modules` was last installed on a different OS** (e.g. an agent built from a Linux container shared the working tree with a macOS host), Bun won't always re-resolve optional native binaries on its own. Reset with:
+
+```sh
+rm -rf node_modules
+bun install --frozen-lockfile
+```
 
 ## Content Notes
 


### PR DESCRIPTION
## Summary

Restructure the Common Commands section in `docs/AGENTS.md` so that `bun install --frozen-lockfile` is presented as the first-time prerequisite rather than as a peer command alongside `bun run dev`. Add a note on resetting `node_modules` when it was previously populated on a different OS (the OrbStack-VM-shares-filesystem-with-macOS case that just bit us).

## Why

A reasonable read of the old flat list was "any of these commands works on its own." Running `bun run dev` without first installing causes a confusing `Cannot find module '@rollup/rollup-darwin-arm64'` error.

## Test plan

- [x] Markdown renders cleanly (no broken fences, no orphan headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)