### PR TITLE
fix(docs): restore contrast on mobile close-menu icon when menu is open

### DIFF
--- a/docs/src/styles/docs-theme.css
+++ b/docs/src/styles/docs-theme.css
@@ -816,6 +816,29 @@ header.header {
 }
 
 /* ==========================================================================
+   Mobile menu toggle — keep the close-X icon high-contrast when expanded.
+
+   Starlight's MobileMenuToggle swaps the button bg to --sl-color-gray-2
+   (mid-grey) when the menu is open while keeping the icon at
+   --sl-color-black. On the dark theme that produces a dark X on a
+   mid-grey pill — visually it reads as disabled/invisible.
+
+   Override: keep the resting bg (--sl-color-white, which is the inverted
+   foreground token on dark theme and a dark surface on light theme) so
+   the high-contrast icon color stays readable in both states. The
+   "expanded" visual feedback is carried by Starlight's box-shadow: none
+   transition, which we keep untouched.
+   ========================================================================== */
+
+starlight-menu-button[aria-expanded='true'] button {
+  background-color: var(--sl-color-white);
+}
+
+[data-theme='light'] starlight-menu-button[aria-expanded='true'] button {
+  background-color: var(--sl-color-black);
+}
+
+/* ==========================================================================
    Top-nav social icons (GitHub) — plain fg color, green on hover.
    Starlight defaults to accent-green for the resting state, but the user
    wanted the icon to read as a neutral glyph (white on dark, near-black


### PR DESCRIPTION
## Summary

When the mobile menu is open, Starlight switches the toggle button's background to mid-grey while keeping the icon dark. On the dark theme this makes the close-X effectively invisible.

Override the expanded bg to stay at the resting color so the icon contrast is preserved. Box-shadow feedback for the pressed state is untouched.

## Test plan

- [x] `bun run build` passes (39 pages)
- [ ] Visual check on iPhone portrait: open menu, confirm X icon is clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)