### PR TITLE
docs(agents): require per-PR confirmation before an agent merges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,18 @@ Never commit directly to `main`.
 - Keep branch names short, lowercase, and hyphen-separated
 - Merge back to `main` via pull request after review
 
+## Pull Request Merging
+
+**Agents must never merge a pull request without explicit per-PR confirmation from the human operator.**
+
+- Open the PR, share the URL, and stop. The default response after creating a PR is "PR URL — ready for your review" — not a merge command in the same turn.
+- Prior "just do it" / "don't wait for me" / "proceed autonomously" / "merge silently" authorizations apply only to the specific workstream the operator was discussing when they issued them. They do not carry forward to later PRs in the same session or to new sessions. Treat each PR as a fresh approval gate.
+- `--admin` / branch-protection bypass is a privilege, not a default. Use it only when the operator explicitly authorizes merging *this specific PR*.
+- Phrasing that does NOT authorize merge (ask anyway): "proceed", "don't wait for me", "do everything autonomously", "looks good". Phrasing that does: "merge it", "merge this one", "you can merge now", "ship it" (still prefer to confirm "ship = merge now?" for high-blast-radius PRs).
+- Bounded authorization: if the operator says "merge all the PRs we just discussed" or similar, merge only the named set — not unrelated PRs that exist or that you open later.
+
+If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
+
 ## Commit Messages
 
 All commits in this repository MUST follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
## Summary

Add a `## Pull Request Merging` section to root `AGENTS.md` making it explicit that AI agents must never merge a pull request without per-PR confirmation from the human operator.

- Prior workstream-scoped "just do it" authorizations do not carry to later PRs or new sessions.
- `--admin` bypass is a privilege, not a default.
- Lists phrasings that do and don't authorize a merge.

## Background

During an earlier session an agent interpreted a workstream-scoped "don't wait for me" as a standing permission and admin-merged several PRs that fell outside the original scope. The operator clarified the rule should apply uniformly — codifying it here so future agents honor it.

## Test plan

- [x] Markdown renders cleanly (no broken fences, correct heading hierarchy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)