### PR TITLE
fix(docs): restore search-popup contrast in dark mode

### DIFF
--- a/docs/src/styles/docs-theme.css
+++ b/docs/src/styles/docs-theme.css
@@ -894,6 +894,26 @@ site-search dialog {
   border: 1px solid var(--jk-ui);
 }
 
+/* Pagefind UI inside the search dialog — restore contrast in dark mode.
+
+   Starlight maps --pagefind-ui-text to var(--sl-color-gray-2) which we
+   define as #1a1c1b in the dark palette — essentially black, drawn on
+   top of an already-dark search popup background (--sl-color-black =
+   #050605). Result-excerpt prose and the search input's typed text
+   become almost invisible.
+
+   Override the relevant Pagefind tokens so the popup draws on our
+   standard panel surface with full-strength text. Scoped to dark mode
+   only — light mode's Starlight defaults render fine against the light
+   palette. */
+:root[data-theme='dark'] #starlight__search {
+  --pagefind-ui-background: var(--jk-panel);
+  --pagefind-ui-text: var(--jk-text);
+  --pagefind-ui-primary: var(--jk-text);
+  --pagefind-ui-border: var(--jk-ui);
+  --pagefind-ui-tag: var(--jk-bg-deep);
+}
+
 /* ==========================================================================
    Theme toggle styling lives in overrides/ThemeSelect.astro (scoped)
    ========================================================================== */


### PR DESCRIPTION
## Summary

The Pagefind search popup is hard to read in dark mode because Starlight maps several Pagefind UI tokens through our `--sl-color-*` palette in ways that collapse contrast:

- `--pagefind-ui-text` → `--sl-color-gray-2` (#1a1c1b in our dark palette) → result-excerpt prose and search-input typed text render almost-black on the dark popup.
- `--pagefind-ui-background` → `--sl-color-black` (#050605) → popup body sits deeper than the surrounding dialog surface (`--jk-panel` = #0f1110).

Override the relevant Pagefind tokens inside `#starlight__search` only when `[data-theme='dark']`. Light mode is untouched — Starlight's defaults render fine against the light palette.

## Test plan

- [x] `bun run build` passes (39 pages)
- [ ] Visual: open https://jackin.tailrocks.com/getting-started/why/, switch to dark mode, open search (cmd+K), type a query — result titles + excerpts now read clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)