### PR TITLE
chore: add NOTICE, CONTRIBUTING, DCO, and provenance metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to jackin'
+
+Thanks for your interest in contributing. A few ground rules.
+
+## License
+
+jackin' is licensed under the Apache License, Version 2.0. By submitting
+a contribution, you agree that it will be licensed under the same terms
+in accordance with Section 5 of the Apache License 2.0.
+
+## Developer Certificate of Origin (DCO)
+
+All contributions must be signed off under the Developer Certificate
+of Origin v1.1 (https://developercertificate.org/). Sign off every
+commit with:
+
+    git commit -s
+
+This adds a `Signed-off-by: Your Name <email>` trailer asserting that
+you have the right to submit the contribution under the project's
+license.
+
+The full DCO text:
+
+> Developer Certificate of Origin
+> Version 1.1
+>
+> By making a contribution to this project, I certify that:
+>
+> (a) The contribution was created in whole or in part by me and I
+>     have the right to submit it under the open source license
+>     indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to the best
+>     of my knowledge, is covered under an appropriate open source
+>     license and I have the right under that license to submit that
+>     work with modifications, whether created in whole or in part
+>     by me, under the same open source license (unless I am
+>     permitted to submit under a different license), as indicated
+>     in the file; or
+>
+> (c) The contribution was provided directly to me by some other
+>     person who certified (a), (b) or (c) and I have not modified
+>     it.
+>
+> (d) I understand and agree that this project and the contribution
+>     are public and that a record of the contribution (including all
+>     personal information I submit with it, including my sign-off) is
+>     maintained indefinitely and may be redistributed consistent with
+>     this project or the open source license(s) involved.
+
+## Contributions made on behalf of an employer
+
+If your contribution is made in the course of your employment, or if
+your employer has rights to inventions you make, you are responsible
+for ensuring that you have authorization to contribute the work under
+the Apache License 2.0 and to sign the DCO. If in doubt, please do not
+submit the contribution until you have confirmed this with your
+employer in writing.
+
+Please use a personal email address (not an employer email) in your
+commit author identity and DCO sign-off.
+
+## How to submit
+
+1. Fork the repository.
+2. Create a feature branch.
+3. Make your changes. Commit with `git commit -s` on every commit.
+4. Open a pull request describing what problem it solves.
+5. Ensure CI passes.
+
+## Non-trivial contributions
+
+For contributions beyond small bug fixes or typos, maintainers may ask
+you to confirm in the PR thread that the work was done outside the
+scope of any employer's employment agreement and that you are
+authorized to submit it. This is standard due diligence, not an
+accusation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,12 @@ name = "jackin"
 version = "0.6.0-dev"
 edition = "2024"
 rust-version = "1.94"
+authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]
 description = "CLI for orchestrating autonomous AI coding agents in isolated sandboxed environments — reproducible, scoped, and fully under your control."
 homepage = "https://jackin.tailrocks.com/"
 repository = "https://github.com/jackin-project/jackin"
 license = "Apache-2.0"
+readme = "README.md"
 publish = false
 
 [[bin]]

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+jackin'
+Copyright 2026 Alexey Zhokhov
+
+This product includes software developed by Alexey Zhokhov
+as an independent personal project.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ To develop jackin' itself, use [The Architect](https://github.com/jackin-project
 jackin load the-architect
 ```
 
+## About this project
+
+jackin' is an independent personal project by Alexey Zhokhov. It is
+not affiliated with or endorsed by any employer or client of the
+author.
+
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Hardens the legal/provenance posture of the repo by adding the standard
governance artifacts that were missing. No application code is touched —
this PR is pure metadata/governance.

## Files added / changed

| File | Change | Why |
|---|---|---|
| `NOTICE` | **new** | ASF-style copyright + provenance file. Apache-2.0 §4(d) requires downstream redistributors to preserve a NOTICE if one ships; creating it establishes that attributive hook and names the sole author. |
| `CONTRIBUTING.md` | **new** | Documents (a) that contributions are inbound under Apache-2.0 per §5, (b) the Developer Certificate of Origin v1.1 sign-off requirement (`git commit -s`), (c) employer-contribution guidance (use a personal email; confirm authorization before submitting), and (d) the submission flow. |
| `README.md` | modified | Adds an **About this project** section immediately above the existing `## License` section, asserting that jackin' is an independent personal project, not affiliated with or endorsed by any employer or client. |
| `Cargo.toml` | modified | Adds the two missing `[package]` keys `authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]` and `readme = "README.md"`. Existing `license`, `repository`, `homepage`, `description` were already present — left intact (see discrepancy note below). |

## Discrepancy note — `Cargo.toml` description

The original instructions proposed a `description` that includes a
franchise-brand word. The current `description` was already scrubbed to
a brand-neutral form during the 2026-04-21 franchise-vocabulary sweep,
so per the "leave existing values alone and flag" rule it was not
changed. Current value:

> CLI for orchestrating autonomous AI coding agents in isolated sandboxed environments — reproducible, scoped, and fully under your control.

Flag this for review if you'd like it rephrased.

## DCO enforcement

Per instruction, **no DCO workflow file is added**. The repo owner will
install the [CNCF DCO2 GitHub App](https://github.com/cncf/dco2) on the
`jackin-project` org and enable the `DCO` status check in the `main`
branch protection rules after this PR. DCO2 is the maintained drop-in
replacement for the older `dcoapp/app`.

This PR's own commit is already signed off with DCO v1.1, demonstrating
the expected pattern for future PRs.

## What was NOT changed

- `LICENSE` — untouched, as required.
- Git history — no rewrite.
- No CLA — DCO only, as required.
- No application code.

## Commit author audit

`git log --format='%an <%ae>' | sort -u` on `main` (informational only —
no rewrite requested):

```
Alexey Zhokhov <alexey@zhokhov.com>
Claude <noreply@anthropic.com>
```

Only two distinct commit identities: you, and the `Co-Authored-By` AI
trailer used for agent-assisted commits. No external contributors have
authored commits yet, so there is no inbound IP provenance to chase.

## Reminder for maintainer

After merging, run locally to lock personal identity for this repo
going forward:

```
git config user.email "alexey@zhokhov.com"
git config user.name "Alexey Zhokhov"
```

(Current repo-local config is already set to this identity; the block is
included for completeness per the requested template.)

## Test plan

- [ ] `NOTICE` renders correctly on the GitHub repo landing page's sidebar.
- [ ] `CONTRIBUTING.md` is surfaced by GitHub's new-PR flow.
- [ ] `cargo metadata --no-deps` succeeds (verified locally — OK).
- [ ] Install the DCO2 GitHub App on the `jackin-project` org.
- [ ] Add `DCO` to required status checks on `main` branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)