### PR TITLE
refactor(workspace): centralize create/edit planning in workspace::planner (Phase 2)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -329,51 +329,36 @@ pub fn run(cli: Cli) -> Result<()> {
                 default_agent,
             } => {
                 let expanded_workdir = workspace::resolve_path(&workdir);
-                let mut all_mounts: Vec<_> = mounts
+                let parsed_mounts = mounts
                     .iter()
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
-                if !no_workdir_mount {
-                    let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
-                    if !already_mounted {
-                        all_mounts.insert(
-                            0,
-                            workspace::MountConfig {
-                                src: expanded_workdir.clone(),
-                                dst: expanded_workdir.clone(),
-                                readonly: false,
-                            },
-                        );
-                    }
-                }
-                // Pre-collapse under rule C so the create_workspace
-                // post-condition sees a clean mount list. Any rule-C error
-                // (readonly mismatch, etc.) surfaces here before we try to
-                // write.
-                let all_indexes: Vec<usize> = (0..all_mounts.len()).collect();
-                let plan = workspace::plan_collapse(&all_mounts, &all_indexes)?;
-                if !plan.removed.is_empty() {
+                let plan = workspace::planner::plan_create(
+                    &expanded_workdir,
+                    parsed_mounts,
+                    no_workdir_mount,
+                )?;
+                if !plan.collapsed.is_empty() {
                     let removed_list: Vec<String> = plan
-                        .removed
+                        .collapsed
                         .iter()
                         .map(|r| tui::shorten_home(&r.child.src))
                         .collect();
                     // Parent paths in a single create are all the same set; pick
                     // the first for the summary headline.
-                    let parent = tui::shorten_home(&plan.removed[0].covered_by.src);
+                    let parent = tui::shorten_home(&plan.collapsed[0].covered_by.src);
                     eprintln!(
                         "collapsed {} redundant mount(s) under {parent}: {}",
-                        plan.removed.len(),
+                        plan.collapsed.len(),
                         removed_list.join(", ")
                     );
                 }
-                let final_mounts = plan.kept;
-                let mount_count = final_mounts.len();
+                let mount_count = plan.final_mounts.len();
                 config.create_workspace(
                     &name,
                     WorkspaceConfig {
                         workdir: expanded_workdir,
-                        mounts: final_mounts,
+                        mounts: plan.final_mounts,
                         allowed_agents,
                         default_agent,
                         last_agent: None,
@@ -519,56 +504,23 @@ pub fn run(cli: Cli) -> Result<()> {
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
 
-                // Build the "post-upsert list" the same way edit_workspace will
-                // apply upserts: start from existing mounts (after applying
-                // remove_destinations), then merge each upsert by dst.
                 let current_ws = config
                     .workspaces
                     .get(&name)
                     .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?
                     .clone();
 
-                let mut post_upsert: Vec<workspace::MountConfig> = current_ws
-                    .mounts
-                    .iter()
-                    .filter(|m| !remove_destinations.iter().any(|d| d == &m.dst))
-                    .cloned()
-                    .collect();
-                if no_workdir_mount {
-                    let workdir = &current_ws.workdir;
-                    post_upsert.retain(|m| !(m.src == *workdir && m.dst == *workdir));
-                }
-                let mut new_indexes: Vec<usize> = Vec::new();
-                for upsert in &upsert_mounts {
-                    if let Some(pos) = post_upsert.iter().position(|m| m.dst == upsert.dst) {
-                        post_upsert[pos] = upsert.clone();
-                        new_indexes.push(pos);
-                    } else {
-                        post_upsert.push(upsert.clone());
-                        new_indexes.push(post_upsert.len() - 1);
-                    }
-                }
-
-                // Plan the collapse.
-                let plan = workspace::plan_collapse(&post_upsert, &new_indexes)?;
-
-                // Partition removals by origin.
-                let (edit_driven, pre_existing): (Vec<_>, Vec<_>) =
-                    plan.removed.iter().partition(|r| {
-                        let child_idx = post_upsert
-                            .iter()
-                            .position(|m| m == &r.child)
-                            .expect("child must appear in post_upsert list");
-                        let parent_idx = post_upsert
-                            .iter()
-                            .position(|m| m == &r.covered_by)
-                            .expect("parent must appear in post_upsert list");
-                        new_indexes.contains(&child_idx) || new_indexes.contains(&parent_idx)
-                    });
+                let plan = workspace::planner::plan_edit(
+                    &current_ws,
+                    &upsert_mounts,
+                    &remove_destinations,
+                    no_workdir_mount,
+                )?;
 
                 // Reject pre-existing violations unless --prune.
-                if !pre_existing.is_empty() && !prune {
-                    let details: Vec<String> = pre_existing
+                if !plan.pre_existing_collapses.is_empty() && !prune {
+                    let details: Vec<String> = plan
+                        .pre_existing_collapses
                         .iter()
                         .map(|r| {
                             format!(
@@ -585,9 +537,15 @@ pub fn run(cli: Cli) -> Result<()> {
                     );
                 }
 
+                let all_collapses: Vec<&workspace::Removal> = plan
+                    .edit_driven_collapses
+                    .iter()
+                    .chain(plan.pre_existing_collapses.iter())
+                    .collect();
+
                 // If there are any collapses to apply, prompt (or bail on
                 // non-TTY without --yes).
-                if !plan.removed.is_empty() && !assume_yes {
+                if !all_collapses.is_empty() && !assume_yes {
                     use std::io::IsTerminal;
                     if !std::io::stdin().is_terminal() {
                         anyhow::bail!(
@@ -595,21 +553,21 @@ pub fn run(cli: Cli) -> Result<()> {
                         );
                     }
 
-                    if !edit_driven.is_empty() {
+                    if !plan.edit_driven_collapses.is_empty() {
                         eprintln!(
                             "Adding mount(s) will subsume {} existing mount(s):",
-                            edit_driven.len()
+                            plan.edit_driven_collapses.len()
                         );
-                        for r in &edit_driven {
+                        for r in &plan.edit_driven_collapses {
                             eprintln!("  • {}", tui::shorten_home(&r.child.src));
                         }
                     }
-                    if !pre_existing.is_empty() {
+                    if !plan.pre_existing_collapses.is_empty() {
                         eprintln!(
                             "Cleaning up {} pre-existing redundant mount(s):",
-                            pre_existing.len()
+                            plan.pre_existing_collapses.len()
                         );
-                        for r in &pre_existing {
+                        for r in &plan.pre_existing_collapses {
                             eprintln!("  • {}", tui::shorten_home(&r.child.src));
                         }
                     }
@@ -624,16 +582,6 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                 }
 
-                // Translate collapses into extra remove_destinations so
-                // edit_workspace's existing remove + upsert logic produces the
-                // clean set.
-                let mut effective_removes = remove_destinations.clone();
-                for r in &plan.removed {
-                    if !effective_removes.contains(&r.child.dst) {
-                        effective_removes.push(r.child.dst.clone());
-                    }
-                }
-
                 // Collect what changed for the summary (preserves the existing
                 // summary output, plus collapse lines).
                 let mut changes: Vec<String> = Vec::new();
@@ -641,7 +589,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     changes.push(format!("workdir → {}", tui::shorten_home(w)));
                 }
                 for m in &upsert_mounts {
-                    if plan.removed.iter().any(|r| r.child.dst == m.dst) {
+                    if all_collapses.iter().any(|r| r.child.dst == m.dst) {
                         continue;
                     }
                     if m.src == m.dst {
@@ -657,7 +605,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 for dst in &remove_destinations {
                     changes.push(format!("removed mount {}", tui::shorten_home(dst)));
                 }
-                for r in &plan.removed {
+                for r in &all_collapses {
                     changes.push(format!(
                         "collapsed {} under {}",
                         tui::shorten_home(&r.child.src),
@@ -684,7 +632,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     WorkspaceEdit {
                         workdir: workdir.map(|w| resolve_path(&w)),
                         upsert_mounts,
-                        remove_destinations: effective_removes,
+                        remove_destinations: plan.effective_removals,
                         no_workdir_mount,
                         allowed_agents_to_add: allowed_agents,
                         allowed_agents_to_remove: remove_allowed_agents,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod planner;
+
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};
 

--- a/src/workspace/planner.rs
+++ b/src/workspace/planner.rs
@@ -1,0 +1,290 @@
+//! Pure planning for workspace create and edit operations.
+//!
+//! Takes parsed-and-resolved inputs and returns a plan describing what would
+//! change. Does no I/O, no printing, and does not touch config persistence —
+//! callers are responsible for prompting, reporting, and calling
+//! `AppConfig::create_workspace` / `edit_workspace` with the plan's outputs.
+//!
+//! The split-of-responsibility: the planner decides *what* the mount list
+//! would look like and *which removals were caused by this edit versus were
+//! already redundant*; the CLI decides *whether to ask*, *what to print*, and
+//! *whether to treat pre-existing redundancy as a hard error under `--prune`*.
+
+use crate::workspace::{CollapseError, MountConfig, Removal, WorkspaceConfig, plan_collapse};
+
+/// Plan for `jackin workspace create`.
+pub struct WorkspaceCreatePlan {
+    /// The final, collapsed mount list the caller should persist.
+    pub final_mounts: Vec<MountConfig>,
+    /// Mounts subsumed during the collapse. All are edit-driven for create.
+    pub collapsed: Vec<Removal>,
+}
+
+/// Plan for `jackin workspace edit`.
+pub struct WorkspaceEditPlan {
+    /// Destinations to remove in the persisted edit. Stacks the user-supplied
+    /// `remove_destinations` with every collapsed child, so
+    /// `edit_workspace`'s existing remove-then-upsert logic produces the
+    /// collapsed set.
+    pub effective_removals: Vec<String>,
+    /// Redundancies newly created by this edit (the user added a mount that
+    /// subsumes an existing one).
+    pub edit_driven_collapses: Vec<Removal>,
+    /// Redundancies that were already present before this edit.
+    ///
+    /// Callers typically gate persistence on a `--prune` flag: reject when
+    /// this list is non-empty unless the operator opted in to cleanup.
+    pub pre_existing_collapses: Vec<Removal>,
+}
+
+/// Plan a `workspace create`.
+///
+/// Auto-inserts a workdir-mount at position 0 unless `no_workdir_mount` is
+/// set or the workdir destination is already mounted. Then runs the collapse
+/// with every mount marked as new (since everything is "new" for a create).
+pub fn plan_create(
+    workdir: &str,
+    mounts: Vec<MountConfig>,
+    no_workdir_mount: bool,
+) -> Result<WorkspaceCreatePlan, CollapseError> {
+    let mut all_mounts = mounts;
+    if !no_workdir_mount {
+        let already_mounted = all_mounts.iter().any(|m| m.dst == workdir);
+        if !already_mounted {
+            all_mounts.insert(
+                0,
+                MountConfig {
+                    src: workdir.to_string(),
+                    dst: workdir.to_string(),
+                    readonly: false,
+                },
+            );
+        }
+    }
+    let all_indexes: Vec<usize> = (0..all_mounts.len()).collect();
+    let plan = plan_collapse(&all_mounts, &all_indexes)?;
+    Ok(WorkspaceCreatePlan {
+        final_mounts: plan.kept,
+        collapsed: plan.removed,
+    })
+}
+
+/// Plan a `workspace edit`.
+///
+/// Mirrors `AppConfig::edit_workspace`'s mount-list construction: filter the
+/// current mounts by `remove_destinations`, optionally drop the workdir
+/// auto-mount, then merge each upsert by dst (replacing on match, appending
+/// otherwise). Tracks which indexes were touched by the edit so that
+/// `plan_collapse`'s removals can be classified as `edit_driven_collapses`
+/// (touching a new/updated mount) or `pre_existing_collapses` (entirely
+/// between pre-existing mounts).
+pub fn plan_edit(
+    current: &WorkspaceConfig,
+    upserts: &[MountConfig],
+    remove_destinations: &[String],
+    no_workdir_mount: bool,
+) -> Result<WorkspaceEditPlan, CollapseError> {
+    let mut post_upsert: Vec<MountConfig> = current
+        .mounts
+        .iter()
+        .filter(|m| !remove_destinations.iter().any(|d| d == &m.dst))
+        .cloned()
+        .collect();
+    if no_workdir_mount {
+        let workdir = &current.workdir;
+        post_upsert.retain(|m| !(m.src == *workdir && m.dst == *workdir));
+    }
+    let mut new_indexes: Vec<usize> = Vec::new();
+    for upsert in upserts {
+        if let Some(pos) = post_upsert.iter().position(|m| m.dst == upsert.dst) {
+            post_upsert[pos] = upsert.clone();
+            new_indexes.push(pos);
+        } else {
+            post_upsert.push(upsert.clone());
+            new_indexes.push(post_upsert.len() - 1);
+        }
+    }
+
+    let plan = plan_collapse(&post_upsert, &new_indexes)?;
+
+    let (edit_driven, pre_existing): (Vec<_>, Vec<_>) = plan.removed.iter().partition(|r| {
+        let child_idx = post_upsert
+            .iter()
+            .position(|m| m == &r.child)
+            .expect("child must appear in post_upsert list");
+        let parent_idx = post_upsert
+            .iter()
+            .position(|m| m == &r.covered_by)
+            .expect("parent must appear in post_upsert list");
+        new_indexes.contains(&child_idx) || new_indexes.contains(&parent_idx)
+    });
+    let edit_driven: Vec<Removal> = edit_driven.into_iter().cloned().collect();
+    let pre_existing: Vec<Removal> = pre_existing.into_iter().cloned().collect();
+
+    let mut effective_removals = remove_destinations.to_vec();
+    for r in &plan.removed {
+        if !effective_removals.contains(&r.child.dst) {
+            effective_removals.push(r.child.dst.clone());
+        }
+    }
+
+    Ok(WorkspaceEditPlan {
+        effective_removals,
+        edit_driven_collapses: edit_driven,
+        pre_existing_collapses: pre_existing,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mount(src: &str, dst: &str) -> MountConfig {
+        MountConfig {
+            src: src.to_string(),
+            dst: dst.to_string(),
+            readonly: false,
+        }
+    }
+
+    fn workspace(workdir: &str, mounts: Vec<MountConfig>) -> WorkspaceConfig {
+        WorkspaceConfig {
+            workdir: workdir.to_string(),
+            mounts,
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+        }
+    }
+
+    #[test]
+    fn plan_create_inserts_workdir_auto_mount_at_front() {
+        let plan = plan_create("/work", vec![mount("/data", "/data")], false).unwrap();
+
+        assert_eq!(plan.final_mounts.len(), 2);
+        assert_eq!(plan.final_mounts[0].dst, "/work");
+        assert_eq!(plan.final_mounts[0].src, "/work");
+        assert_eq!(plan.final_mounts[1].dst, "/data");
+        assert!(plan.collapsed.is_empty());
+    }
+
+    #[test]
+    fn plan_create_skips_auto_mount_when_workdir_already_mounted() {
+        let plan = plan_create("/work", vec![mount("/custom-src", "/work")], false).unwrap();
+
+        assert_eq!(plan.final_mounts.len(), 1);
+        assert_eq!(plan.final_mounts[0].src, "/custom-src");
+        assert_eq!(plan.final_mounts[0].dst, "/work");
+        assert!(plan.collapsed.is_empty());
+    }
+
+    #[test]
+    fn plan_create_no_workdir_mount_suppresses_auto_mount() {
+        let plan = plan_create("/work", vec![mount("/data", "/data")], true).unwrap();
+
+        assert_eq!(plan.final_mounts.len(), 1);
+        assert_eq!(plan.final_mounts[0].dst, "/data");
+        assert!(plan.collapsed.is_empty());
+    }
+
+    #[test]
+    fn plan_create_collapses_redundant_children_under_parent() {
+        // /work auto-inserts, then /work/sub is a child of /work — gets collapsed.
+        let plan = plan_create("/work", vec![mount("/work/sub", "/work/sub")], false).unwrap();
+
+        assert_eq!(plan.final_mounts.len(), 1);
+        assert_eq!(plan.final_mounts[0].dst, "/work");
+        assert_eq!(plan.collapsed.len(), 1);
+        assert_eq!(plan.collapsed[0].child.dst, "/work/sub");
+        assert_eq!(plan.collapsed[0].covered_by.dst, "/work");
+    }
+
+    #[test]
+    fn plan_edit_classifies_new_parent_as_edit_driven() {
+        // Existing: /work/sub. Add: /work (new parent). /work/sub gets
+        // subsumed by the new parent — edit-driven.
+        let current = workspace("/work", vec![mount("/work/sub", "/work/sub")]);
+        let plan = plan_edit(&current, &[mount("/work", "/work")], &[], false).unwrap();
+
+        assert_eq!(plan.edit_driven_collapses.len(), 1);
+        assert_eq!(plan.pre_existing_collapses.len(), 0);
+        assert_eq!(plan.edit_driven_collapses[0].child.dst, "/work/sub");
+        assert!(plan.effective_removals.contains(&"/work/sub".to_string()));
+    }
+
+    #[test]
+    fn plan_edit_classifies_untouched_redundancy_as_pre_existing() {
+        // Existing config already has /work and /work/sub (redundant).
+        // Edit does nothing related to those; collapse reports pre-existing.
+        let current = workspace(
+            "/work",
+            vec![mount("/work", "/work"), mount("/work/sub", "/work/sub")],
+        );
+        let plan = plan_edit(&current, &[], &[], false).unwrap();
+
+        assert_eq!(plan.edit_driven_collapses.len(), 0);
+        assert_eq!(plan.pre_existing_collapses.len(), 1);
+        assert_eq!(plan.pre_existing_collapses[0].child.dst, "/work/sub");
+    }
+
+    #[test]
+    fn plan_edit_applies_remove_destinations_before_upsert() {
+        // Remove /work/sub, then add /work. If removes happened *after*
+        // upserts, /work would subsume /work/sub and show up as an
+        // edit-driven collapse. Because removes come first, nothing collapses.
+        let current = workspace("/work", vec![mount("/work/sub", "/work/sub")]);
+        let plan = plan_edit(
+            &current,
+            &[mount("/work", "/work")],
+            &["/work/sub".to_string()],
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            plan.edit_driven_collapses.is_empty(),
+            "no collapse expected: /work/sub was removed before /work was added"
+        );
+        assert!(plan.pre_existing_collapses.is_empty());
+        assert_eq!(plan.effective_removals, vec!["/work/sub".to_string()]);
+    }
+
+    #[test]
+    fn plan_edit_no_workdir_mount_drops_workdir_auto_mount() {
+        // Workdir auto-mount is present; also add /work/sub as an upsert.
+        // If no_workdir_mount correctly drops /work before collapse, /work/sub
+        // has no parent and no collapse fires. If /work survived, /work/sub
+        // would collapse under it as edit-driven.
+        let current = workspace(
+            "/work",
+            vec![mount("/work", "/work"), mount("/data", "/data")],
+        );
+        let plan = plan_edit(&current, &[mount("/work/sub", "/work/sub")], &[], true).unwrap();
+
+        assert!(
+            plan.edit_driven_collapses.is_empty(),
+            "no_workdir_mount must drop /work before collapse considers it"
+        );
+        assert!(plan.pre_existing_collapses.is_empty());
+    }
+
+    #[test]
+    fn plan_edit_effective_removals_stack_on_user_removals() {
+        // User asks to remove /extra. Then an edit adds /work that subsumes
+        // /work/sub. Both removals should appear in effective_removals.
+        let current = workspace(
+            "/work",
+            vec![mount("/work/sub", "/work/sub"), mount("/extra", "/extra")],
+        );
+        let plan = plan_edit(
+            &current,
+            &[mount("/work", "/work")],
+            &["/extra".to_string()],
+            false,
+        )
+        .unwrap();
+
+        assert!(plan.effective_removals.contains(&"/extra".to_string()));
+        assert!(plan.effective_removals.contains(&"/work/sub".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [Rust structure refactor roadmap](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md). The `WorkspaceCommand::Create` and `::Edit` CLI arms previously hand-rolled the mount-list assembly that `edit_workspace` re-performs internally, and each classified collapse removals inline. Both now delegate to a new pure planner module.

- `src/workspace.rs` → `src/workspace/mod.rs` (file move; required to introduce a submodule).
- New `src/workspace/planner.rs` owns `plan_create` and `plan_edit`.
- CLI arms shrink: Create from ~55 LOC of planning to ~4 LOC; Edit's post-upsert rebuild and partition collapses into a single `plan_edit` call.

**Design decision — Option A (lean planner).** The planner returns a raw partition of removals (`edit_driven_collapses` / `pre_existing_collapses`); the CLI keeps the one-line `if !pre_existing.is_empty() && !prune { bail! }` policy. Reusable from the TUI or future programmatic callers that don't have a `--prune` concept.

## Test Preservation Policy

All 409 existing tests continue to pass unchanged. 9 new direct unit tests for the planner cover:

- Auto-workdir-mount insertion at position 0
- `no_workdir_mount` suppressing the auto-insert
- Skipping auto-insert when workdir destination is already mounted
- Collapse of redundant children under an auto-inserted parent
- `plan_edit` classification: new parent ⇒ edit-driven
- `plan_edit` classification: untouched redundancy ⇒ pre-existing
- Remove-before-upsert ordering invariant
- `no_workdir_mount` dropping the workdir auto-mount before collapse
- `effective_removals` stacking user removes with collapsed children

Integration coverage in `tests/workspace_config_crud.rs` (8 tests) and `tests/workspace_mount_collapse.rs` (10 tests) is untouched — this PR adds unit coverage below that integration coverage, not in place of it.

**Test count:** 409 → 418. No tests removed. No tests weakened.

## What's in the planner vs. what stays in the CLI

| Concern | Lives in |
|---|---|
| Auto-workdir-mount insertion | Planner |
| Post-upsert mount-list construction | Planner |
| Collapse invocation | Planner |
| Edit-driven vs pre-existing classification | Planner |
| `effective_removals` stacking | Planner |
| `--prune` gate on pre-existing violations | CLI |
| TTY check + `dialoguer::Confirm` prompt | CLI |
| Summary formatting (`tui::shorten_home`, change list) | CLI |
| `config.edit_workspace` + `config.save` | CLI |

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **418 tests run: 418 passed, 0 skipped**

## No behavior change

- No CLI flag, help text, or error message changed.
- No config schema change.
- Existing `AppConfig::create_workspace` / `edit_workspace` signatures unchanged — the planner feeds them the same inputs the old inline code did.

## Notes for future phases

- Phase 3 (full workspace directory split) will add `paths.rs`, `mounts.rs`, `resolve.rs`, `sensitive.rs`. This PR already converted `workspace.rs` → `workspace/mod.rs`, removing one step.
- Phase 6 (unify CLI/TUI selection) can reuse `plan_edit` directly for a TUI-driven workspace edit flow.

## Test plan

- [x] `cargo fmt -- --check` passes.
- [x] `cargo clippy` produces zero warnings.
- [x] `cargo nextest run` passes with 418/418 tests.
- [x] No existing test deleted or weakened.
- [x] `src/main.rs` and `src/bin/jackin-validate.rs` still compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)