### PR TITLE
refactor(runtime): extract naming helpers to runtime::naming (Phase 5a)

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,22 +11,13 @@ use fs2::FileExt;
 use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 
-// ── Docker label keys ─────────────────────────────────────────────────────
-//
-// Used to tag and filter jackin-managed containers and networks.
+mod naming;
 
-/// Applied to agent containers, `DinD` sidecars, and networks.
-const LABEL_MANAGED: &str = "jackin.managed=true";
-/// Agent containers only — distinguishes them from `DinD` sidecars.
-const LABEL_ROLE_AGENT: &str = "jackin.role=agent";
-/// `DinD` sidecars only — distinguishes them from agent containers.
-const LABEL_ROLE_DIND: &str = "jackin.role=dind";
-/// Filter expression for `docker ps --filter` to find managed containers.
-const FILTER_MANAGED: &str = "label=jackin.managed=true";
-/// Filter expression for `docker ps --filter` to find agent containers.
-const FILTER_ROLE_AGENT: &str = "label=jackin.role=agent";
-/// Filter expression for `docker ps --filter` to find `DinD` sidecars.
-const FILTER_ROLE_DIND: &str = "label=jackin.role=dind";
+pub use self::naming::matching_family;
+use self::naming::{
+    FILTER_MANAGED, FILTER_ROLE_AGENT, FILTER_ROLE_DIND, LABEL_MANAGED, LABEL_ROLE_AGENT,
+    LABEL_ROLE_DIND, dind_certs_volume, format_agent_display, image_name,
+};
 
 /// Environment variables owned by the jackin runtime that must not be
 /// overridden by agent manifests.  These are injected as `-e` flags in
@@ -1463,31 +1454,6 @@ pub fn list_running_agent_display_names(
     Ok(names)
 }
 
-/// Format a human-friendly agent name from a container name and its display label.
-///
-/// Examples:
-///   - `("jackin-the-architect", "The Architect")` → `"The Architect"`
-///   - `("jackin-the-architect-clone-2", "The Architect")` → `"The Architect (Clone 2)"`
-///   - `("jackin-the-architect", "")` → `"jackin-the-architect"`
-fn format_agent_display(container_name: &str, display_name: &str) -> String {
-    if display_name.is_empty() {
-        return container_name.to_string();
-    }
-
-    container_name.rsplit_once("-clone-").map_or_else(
-        || display_name.to_string(),
-        |suffix| format!("{display_name} (Clone {})", suffix.1),
-    )
-}
-
-pub fn matching_family(selector: &ClassSelector, names: &[String]) -> Vec<String> {
-    names
-        .iter()
-        .filter(|name| crate::instance::class_family_matches(selector, name))
-        .cloned()
-        .collect()
-}
-
 pub fn purge_class_data(paths: &JackinPaths, selector: &ClassSelector) -> anyhow::Result<()> {
     if !paths.data_dir.exists() {
         return Ok(());
@@ -1695,10 +1661,6 @@ pub fn exile_all(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn image_name(selector: &ClassSelector) -> String {
-    format!("jackin-{}", crate::instance::runtime_slug(selector))
-}
-
 /// Claim a unique container name for this agent class by acquiring an
 /// exclusive lock file.
 ///
@@ -1742,12 +1704,6 @@ fn claim_container_name(
 
         clone_index += 1;
     }
-}
-
-/// Docker volume name for the TLS client certificates shared between the
-/// `DinD` sidecar (writer) and the agent container (reader).
-fn dind_certs_volume(container_name: &str) -> String {
-    format!("{container_name}-dind-certs")
 }
 
 struct LoadCleanup {
@@ -2814,18 +2770,6 @@ plugins = []
     }
 
     #[test]
-    fn dind_certs_volume_derives_from_container_name() {
-        assert_eq!(
-            dind_certs_volume("jackin-agent-smith"),
-            "jackin-agent-smith-dind-certs"
-        );
-        assert_eq!(
-            dind_certs_volume("jackin-chainargos__the-architect-clone-2"),
-            "jackin-chainargos__the-architect-clone-2-dind-certs"
-        );
-    }
-
-    #[test]
     fn is_missing_cleanup_error_tolerates_all_resource_types() {
         let container_err =
             anyhow::anyhow!("Error response from daemon: No such container: jackin-agent-smith");
@@ -2964,14 +2908,6 @@ plugins = []
             parse_repo_name("git@github.com:jackin-project/jackin"),
             Some("jackin-project/jackin".to_string())
         );
-    }
-
-    #[test]
-    fn image_name_distinguishes_namespaced_and_flat_classes() {
-        let namespaced = ClassSelector::new(Some("chainargos"), "the-architect");
-        let flat = ClassSelector::new(None, "chainargos-the-architect");
-
-        assert_ne!(image_name(&namespaced), image_name(&flat));
     }
 
     #[test]
@@ -3406,30 +3342,6 @@ plugins = []
 
         let labels: Vec<&str> = rows.iter().map(|(l, _)| l.as_str()).collect();
         assert!(!labels.contains(&"dind"));
-    }
-
-    #[test]
-    fn format_agent_display_uses_display_name_for_primary() {
-        assert_eq!(
-            format_agent_display("jackin-the-architect", "The Architect"),
-            "The Architect"
-        );
-    }
-
-    #[test]
-    fn format_agent_display_appends_clone_index() {
-        assert_eq!(
-            format_agent_display("jackin-the-architect-clone-2", "The Architect"),
-            "The Architect (Clone 2)"
-        );
-    }
-
-    #[test]
-    fn format_agent_display_falls_back_to_container_name() {
-        assert_eq!(
-            format_agent_display("jackin-the-architect", ""),
-            "jackin-the-architect"
-        );
     }
 
     #[test]

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -1,0 +1,104 @@
+//! Naming conventions, Docker label/filter constants, and lightweight identifier helpers.
+
+use crate::selector::ClassSelector;
+
+// ── Docker label keys ─────────────────────────────────────────────────────
+//
+// Used to tag and filter jackin-managed containers and networks.
+
+/// Applied to agent containers, `DinD` sidecars, and networks.
+pub(super) const LABEL_MANAGED: &str = "jackin.managed=true";
+/// Agent containers only — distinguishes them from `DinD` sidecars.
+pub(super) const LABEL_ROLE_AGENT: &str = "jackin.role=agent";
+/// `DinD` sidecars only — distinguishes them from agent containers.
+pub(super) const LABEL_ROLE_DIND: &str = "jackin.role=dind";
+/// Filter expression for `docker ps --filter` to find managed containers.
+pub(super) const FILTER_MANAGED: &str = "label=jackin.managed=true";
+/// Filter expression for `docker ps --filter` to find agent containers.
+pub(super) const FILTER_ROLE_AGENT: &str = "label=jackin.role=agent";
+/// Filter expression for `docker ps --filter` to find `DinD` sidecars.
+pub(super) const FILTER_ROLE_DIND: &str = "label=jackin.role=dind";
+
+/// Format a human-friendly agent name from a container name and its display label.
+///
+/// Examples:
+///   - `("jackin-the-architect", "The Architect")` → `"The Architect"`
+///   - `("jackin-the-architect-clone-2", "The Architect")` → `"The Architect (Clone 2)"`
+///   - `("jackin-the-architect", "")` → `"jackin-the-architect"`
+pub(super) fn format_agent_display(container_name: &str, display_name: &str) -> String {
+    if display_name.is_empty() {
+        return container_name.to_string();
+    }
+
+    container_name.rsplit_once("-clone-").map_or_else(
+        || display_name.to_string(),
+        |suffix| format!("{display_name} (Clone {})", suffix.1),
+    )
+}
+
+pub fn matching_family(selector: &ClassSelector, names: &[String]) -> Vec<String> {
+    names
+        .iter()
+        .filter(|name| crate::instance::class_family_matches(selector, name))
+        .cloned()
+        .collect()
+}
+
+pub(super) fn image_name(selector: &ClassSelector) -> String {
+    format!("jackin-{}", crate::instance::runtime_slug(selector))
+}
+
+/// Docker volume name for the TLS client certificates shared between the
+/// `DinD` sidecar (writer) and the agent container (reader).
+pub(super) fn dind_certs_volume(container_name: &str) -> String {
+    format!("{container_name}-dind-certs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dind_certs_volume_derives_from_container_name() {
+        assert_eq!(
+            dind_certs_volume("jackin-agent-smith"),
+            "jackin-agent-smith-dind-certs"
+        );
+        assert_eq!(
+            dind_certs_volume("jackin-chainargos__the-architect-clone-2"),
+            "jackin-chainargos__the-architect-clone-2-dind-certs"
+        );
+    }
+
+    #[test]
+    fn image_name_distinguishes_namespaced_and_flat_classes() {
+        let namespaced = ClassSelector::new(Some("chainargos"), "the-architect");
+        let flat = ClassSelector::new(None, "chainargos-the-architect");
+
+        assert_ne!(image_name(&namespaced), image_name(&flat));
+    }
+
+    #[test]
+    fn format_agent_display_uses_display_name_for_primary() {
+        assert_eq!(
+            format_agent_display("jackin-the-architect", "The Architect"),
+            "The Architect"
+        );
+    }
+
+    #[test]
+    fn format_agent_display_appends_clone_index() {
+        assert_eq!(
+            format_agent_display("jackin-the-architect-clone-2", "The Architect"),
+            "The Architect (Clone 2)"
+        );
+    }
+
+    #[test]
+    fn format_agent_display_falls_back_to_container_name() {
+        assert_eq!(
+            format_agent_display("jackin-the-architect", ""),
+            "jackin-the-architect"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First step of [Phase 5](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md) of the Rust structure refactor roadmap. Per the plan's explicit guidance, this PR does the `naming.rs` extraction **only** — before any other runtime concern splits.

> **From the plan:** *"Today, runtime's internal coupling runs through string-typed image names, container names, and family-match substrings. Introducing lightweight newtypes (or at minimum a single module that owns every naming/labeling constant and helper) means later extractions touch a small, stable interface rather than scattered format strings. This step alone does not split behavior; it only centralizes identifiers."*

Runtime is the highest-risk phase of the refactor (3807-LOC monolith, tight coupling via label strings and naming conventions, legacy label-compat concerns for `hardline`). Doing `naming.rs` as a standalone PR bounds risk and unblocks the subsequent repo_cache / image / launch / attach / discovery / cleanup extractions cleanly.

## Changes

- `src/runtime.rs` → `src/runtime/mod.rs` (directory conversion — required to host submodules).
- New `src/runtime/naming.rs` (104 LOC) receives:
  - 6 Docker label/filter constants.
  - 4 naming helpers: `image_name`, `dind_certs_volume`, `format_agent_display`, `matching_family`.
  - 5 co-located unit tests.

## Verbatim moves

No function body edits. No renames. No logic changes. **No newtypes introduced** — the plan left that open as an option but explicitly said "or at minimum a single module that owns every naming/labeling constant and helper." Starting with the minimum is safer; newtypes can follow in a later cleanup PR if they add readability.

## Visibility

| Item | Before | After |
|---|---|---|
| 6 label/filter constants | private (`const`) | `pub(super)` |
| `image_name`, `dind_certs_volume`, `format_agent_display` | private `fn` | `pub(super)` |
| `matching_family` | `pub fn` | `pub fn` + `pub use self::naming::matching_family;` in `mod.rs` |

External callers (`crate::runtime::matching_family` in `src/app/context.rs` and `src/app/mod.rs`) resolve unchanged via the re-export. **Zero call sites outside `src/runtime/` required edits.**

## Test Preservation Policy

5 tests moved verbatim to `naming.rs`'s `#[cfg(test)] mod tests`:

- `dind_certs_volume_derives_from_container_name`
- `image_name_distinguishes_namespaced_and_flat_classes`
- `format_agent_display_uses_display_name_for_primary`
- `format_agent_display_appends_clone_index`
- `format_agent_display_falls_back_to_container_name`

**Test count:** 418 → 418. No test deleted. No test weakened.

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings (matches main baseline)
- `cargo nextest run` — **418 tests run: 418 passed, 0 skipped**

## Out of scope (explicitly — deferred to Phase 5b and beyond)

- `parse_repo_name`, `git_repo_name`, `claim_container_name` — not pure naming.
- `primary_container_name` (lives in `src/instance.rs`) — Phase 7.
- `RUNTIME_OWNED_ENV_VARS` constant — Phase 10 (env policy unification).
- Any extraction of `repo_cache`, `image`, `attach`, `discovery`, `cleanup`, or `identity` concerns — subsequent PRs.
- The 245-LOC `launch_agent_runtime` and 223-LOC `load_agent_with` — need step-by-step extraction AFTER their surrounding module is split.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 418/418
- [x] No test deleted or weakened
- [x] No call sites outside `src/runtime/` required edits (verified via `grep -rn "runtime::" src/ tests/ src/bin/`)
- [x] `src/main.rs` and `src/bin/jackin-validate.rs` still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)