### PR TITLE
refactor(instance): split by concern (Phase 7)

### DIFF
--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -1,83 +1,8 @@
+use super::{AgentState, AuthProvisionOutcome};
 use crate::config::AuthForwardMode;
-use crate::manifest::{AgentManifest, ClaudeMarketplaceConfig};
-use crate::paths::JackinPaths;
-use crate::selector::ClassSelector;
-use serde::Serialize;
-use std::path::{Path, PathBuf};
-
-/// Outcome of the `.claude.json` provisioning step, so callers can surface
-/// a one-time notice when host credentials are forwarded.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AuthProvisionOutcome {
-    /// No host auth was forwarded (ignore mode, or copy mode with existing file).
-    Skipped,
-    /// Host auth was copied into the container state.
-    Copied,
-    /// Host auth was synced (overwritten) into the container state.
-    Synced,
-    /// Mode would have forwarded, but host file was missing — wrote `{}`.
-    HostMissing,
-}
-
-#[derive(Debug, Clone)]
-pub struct AgentState {
-    pub root: PathBuf,
-    pub claude_dir: PathBuf,
-    pub claude_json: PathBuf,
-    pub jackin_dir: PathBuf,
-    pub plugins_json: PathBuf,
-    pub gh_config_dir: PathBuf,
-}
-
-#[derive(Debug, Serialize)]
-struct PluginState<'a> {
-    marketplaces: &'a [ClaudeMarketplaceConfig],
-    plugins: &'a [String],
-}
+use std::path::Path;
 
 impl AgentState {
-    pub fn prepare(
-        paths: &JackinPaths,
-        container_name: &str,
-        manifest: &AgentManifest,
-        auth_forward: AuthForwardMode,
-        host_home: &Path,
-    ) -> anyhow::Result<(Self, AuthProvisionOutcome)> {
-        let root = paths.data_dir.join(container_name);
-        let claude_dir = root.join(".claude");
-        let claude_json = root.join(".claude.json");
-        let jackin_dir = root.join(".jackin");
-        let plugins_json = jackin_dir.join("plugins.json");
-        let gh_config_dir = root.join(".config/gh");
-
-        std::fs::create_dir_all(&claude_dir)?;
-        std::fs::create_dir_all(&jackin_dir)?;
-        std::fs::create_dir_all(&gh_config_dir)?;
-
-        let outcome =
-            Self::provision_claude_auth(&claude_json, &claude_dir, auth_forward, host_home)?;
-
-        std::fs::write(
-            &plugins_json,
-            serde_json::to_string_pretty(&PluginState {
-                marketplaces: &manifest.claude.marketplaces,
-                plugins: &manifest.claude.plugins,
-            })?,
-        )?;
-
-        Ok((
-            Self {
-                root,
-                claude_dir,
-                claude_json,
-                jackin_dir,
-                plugins_json,
-                gh_config_dir,
-            },
-            outcome,
-        ))
-    }
-
     /// Provision both `.claude.json` (preferences/metadata) and
     /// `.claude/.credentials.json` (OAuth tokens) according to the chosen
     /// auth forwarding strategy.
@@ -89,7 +14,7 @@ impl AgentState {
     /// On macOS the host credentials live in the system Keychain
     /// ("Claude Code-credentials"), not in a file.  On Linux they are
     /// stored at `~/.claude/.credentials.json`.
-    fn provision_claude_auth(
+    pub(super) fn provision_claude_auth(
         claude_json: &Path,
         claude_dir: &Path,
         mode: AuthForwardMode,
@@ -283,69 +208,12 @@ fn repair_permissions(path: &Path) {
     }
 }
 
-pub fn runtime_slug(selector: &ClassSelector) -> String {
-    selector.namespace.as_ref().map_or_else(
-        || selector.name.clone(),
-        |namespace| format!("{namespace}__{}", selector.name),
-    )
-}
-
-pub fn primary_container_name(selector: &ClassSelector) -> String {
-    format!("jackin-{}", runtime_slug(selector))
-}
-
-pub fn next_container_name(selector: &ClassSelector, existing: &[String]) -> String {
-    let primary = primary_container_name(selector);
-    if !existing.iter().any(|name| name == &primary) {
-        return primary;
-    }
-
-    let mut clone_index = 1;
-    loop {
-        let candidate = format!("{primary}-clone-{clone_index}");
-        if !existing.iter().any(|name| name == &candidate) {
-            return candidate;
-        }
-        clone_index += 1;
-    }
-}
-
-pub fn class_family_matches(selector: &ClassSelector, container_name: &str) -> bool {
-    let primary = primary_container_name(selector);
-    container_name == primary || container_name.starts_with(&format!("{primary}-clone-"))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::config::AuthForwardMode;
+    use crate::instance::{AgentState, AuthProvisionOutcome};
     use crate::paths::JackinPaths;
-    use crate::selector::ClassSelector;
-    use serde_json::json;
     use tempfile::tempdir;
-
-    #[test]
-    fn picks_next_clone_name() {
-        let selector = ClassSelector::new(None, "agent-smith");
-        let existing = vec![
-            "jackin-agent-smith".to_string(),
-            "jackin-agent-smith-clone-1".to_string(),
-        ];
-
-        let name = next_container_name(&selector, &existing);
-
-        assert_eq!(name, "jackin-agent-smith-clone-2");
-    }
-
-    #[test]
-    fn distinguishes_namespaced_and_flat_class_container_names() {
-        let namespaced = ClassSelector::new(Some("chainargos"), "the-architect");
-        let flat = ClassSelector::new(None, "chainargos-the-architect");
-
-        assert_ne!(
-            primary_container_name(&namespaced),
-            primary_container_name(&flat)
-        );
-    }
 
     const TEST_CREDENTIALS: &str =
         r#"{"claudeAiOauth":{"accessToken":"test","refreshToken":"test"}}"#;
@@ -378,119 +246,6 @@ plugins = []
         )
         .unwrap();
         crate::manifest::AgentManifest::load(temp.path()).unwrap()
-    }
-
-    #[test]
-    fn prepares_persisted_claude_state() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        let manifest = simple_manifest(&temp);
-
-        let (state, _) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Ignore,
-            temp.path(),
-        )
-        .unwrap();
-
-        assert!(state.claude_dir.is_dir());
-        assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
-    }
-
-    #[test]
-    fn prepares_plugins_json_for_runtime_bootstrap() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-
-        std::fs::write(
-            temp.path().join("jackin.agent.toml"),
-            r#"dockerfile = "Dockerfile"
-
-[claude]
-plugins = ["code-review@claude-plugins-official", "feature-dev@claude-plugins-official"]
-"#,
-        )
-        .unwrap();
-        std::fs::write(
-            temp.path().join("Dockerfile"),
-            "FROM projectjackin/construct:trixie\n",
-        )
-        .unwrap();
-
-        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
-        let (state, _) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Ignore,
-            temp.path(),
-        )
-        .unwrap();
-
-        assert!(state.jackin_dir.is_dir());
-        let value: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
-        assert_eq!(value["marketplaces"], json!([]));
-        assert_eq!(
-            value["plugins"],
-            json!([
-                "code-review@claude-plugins-official",
-                "feature-dev@claude-plugins-official"
-            ])
-        );
-    }
-
-    #[test]
-    fn prepares_plugins_json_with_marketplaces_for_runtime_bootstrap() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-
-        std::fs::write(
-            temp.path().join("jackin.agent.toml"),
-            r#"dockerfile = "Dockerfile"
-
-[claude]
-plugins = ["superpowers@superpowers-marketplace"]
-
-[[claude.marketplaces]]
-source = "obra/superpowers-marketplace"
-sparse = ["plugins", ".claude-plugin"]
-"#,
-        )
-        .unwrap();
-        std::fs::write(
-            temp.path().join("Dockerfile"),
-            "FROM projectjackin/construct:trixie\n",
-        )
-        .unwrap();
-
-        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
-        let (state, _) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Ignore,
-            temp.path(),
-        )
-        .unwrap();
-
-        let value: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
-        assert_eq!(
-            value["marketplaces"],
-            json!([
-                {
-                    "source": "obra/superpowers-marketplace",
-                    "sparse": ["plugins", ".claude-plugin"]
-                }
-            ])
-        );
-        assert_eq!(
-            value["plugins"],
-            json!(["superpowers@superpowers-marketplace"])
-        );
     }
 
     // ── Auth forwarding tests ───────────────────────────────────────────

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -1,0 +1,124 @@
+use crate::config::AuthForwardMode;
+use crate::manifest::AgentManifest;
+use crate::paths::JackinPaths;
+use std::path::{Path, PathBuf};
+
+mod auth;
+pub mod naming;
+mod plugins;
+
+pub use naming::{class_family_matches, next_container_name, primary_container_name, runtime_slug};
+
+use plugins::PluginState;
+
+/// Outcome of the `.claude.json` provisioning step, so callers can surface
+/// a one-time notice when host credentials are forwarded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthProvisionOutcome {
+    /// No host auth was forwarded (ignore mode, or copy mode with existing file).
+    Skipped,
+    /// Host auth was copied into the container state.
+    Copied,
+    /// Host auth was synced (overwritten) into the container state.
+    Synced,
+    /// Mode would have forwarded, but host file was missing — wrote `{}`.
+    HostMissing,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentState {
+    pub root: PathBuf,
+    pub claude_dir: PathBuf,
+    pub claude_json: PathBuf,
+    pub jackin_dir: PathBuf,
+    pub plugins_json: PathBuf,
+    pub gh_config_dir: PathBuf,
+}
+
+impl AgentState {
+    pub fn prepare(
+        paths: &JackinPaths,
+        container_name: &str,
+        manifest: &AgentManifest,
+        auth_forward: AuthForwardMode,
+        host_home: &Path,
+    ) -> anyhow::Result<(Self, AuthProvisionOutcome)> {
+        let root = paths.data_dir.join(container_name);
+        let claude_dir = root.join(".claude");
+        let claude_json = root.join(".claude.json");
+        let jackin_dir = root.join(".jackin");
+        let plugins_json = jackin_dir.join("plugins.json");
+        let gh_config_dir = root.join(".config/gh");
+
+        std::fs::create_dir_all(&claude_dir)?;
+        std::fs::create_dir_all(&jackin_dir)?;
+        std::fs::create_dir_all(&gh_config_dir)?;
+
+        let outcome =
+            Self::provision_claude_auth(&claude_json, &claude_dir, auth_forward, host_home)?;
+
+        std::fs::write(
+            &plugins_json,
+            serde_json::to_string_pretty(&PluginState {
+                marketplaces: &manifest.claude.marketplaces,
+                plugins: &manifest.claude.plugins,
+            })?,
+        )?;
+
+        Ok((
+            Self {
+                root,
+                claude_dir,
+                claude_json,
+                jackin_dir,
+                plugins_json,
+                gh_config_dir,
+            },
+            outcome,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::JackinPaths;
+    use tempfile::tempdir;
+
+    fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::AgentManifest {
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        crate::manifest::AgentManifest::load(temp.path()).unwrap()
+    }
+
+    #[test]
+    fn prepares_persisted_claude_state() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let manifest = simple_manifest(&temp);
+
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert!(state.claude_dir.is_dir());
+        assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
+    }
+}

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -1,0 +1,63 @@
+use crate::selector::ClassSelector;
+
+pub fn runtime_slug(selector: &ClassSelector) -> String {
+    selector.namespace.as_ref().map_or_else(
+        || selector.name.clone(),
+        |namespace| format!("{namespace}__{}", selector.name),
+    )
+}
+
+pub fn primary_container_name(selector: &ClassSelector) -> String {
+    format!("jackin-{}", runtime_slug(selector))
+}
+
+pub fn next_container_name(selector: &ClassSelector, existing: &[String]) -> String {
+    let primary = primary_container_name(selector);
+    if !existing.iter().any(|name| name == &primary) {
+        return primary;
+    }
+
+    let mut clone_index = 1;
+    loop {
+        let candidate = format!("{primary}-clone-{clone_index}");
+        if !existing.iter().any(|name| name == &candidate) {
+            return candidate;
+        }
+        clone_index += 1;
+    }
+}
+
+pub fn class_family_matches(selector: &ClassSelector, container_name: &str) -> bool {
+    let primary = primary_container_name(selector);
+    container_name == primary || container_name.starts_with(&format!("{primary}-clone-"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selector::ClassSelector;
+
+    #[test]
+    fn picks_next_clone_name() {
+        let selector = ClassSelector::new(None, "agent-smith");
+        let existing = vec![
+            "jackin-agent-smith".to_string(),
+            "jackin-agent-smith-clone-1".to_string(),
+        ];
+
+        let name = next_container_name(&selector, &existing);
+
+        assert_eq!(name, "jackin-agent-smith-clone-2");
+    }
+
+    #[test]
+    fn distinguishes_namespaced_and_flat_class_container_names() {
+        let namespaced = ClassSelector::new(Some("chainargos"), "the-architect");
+        let flat = ClassSelector::new(None, "chainargos-the-architect");
+
+        assert_ne!(
+            primary_container_name(&namespaced),
+            primary_container_name(&flat)
+        );
+    }
+}

--- a/src/instance/plugins.rs
+++ b/src/instance/plugins.rs
@@ -1,0 +1,111 @@
+use crate::manifest::ClaudeMarketplaceConfig;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(super) struct PluginState<'a> {
+    pub(super) marketplaces: &'a [ClaudeMarketplaceConfig],
+    pub(super) plugins: &'a [String],
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::AuthForwardMode;
+    use crate::instance::AgentState;
+    use crate::paths::JackinPaths;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    #[test]
+    fn prepares_plugins_json_for_runtime_bootstrap() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["code-review@claude-plugins-official", "feature-dev@claude-plugins-official"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+
+        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert!(state.jackin_dir.is_dir());
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
+        assert_eq!(value["marketplaces"], json!([]));
+        assert_eq!(
+            value["plugins"],
+            json!([
+                "code-review@claude-plugins-official",
+                "feature-dev@claude-plugins-official"
+            ])
+        );
+    }
+
+    #[test]
+    fn prepares_plugins_json_with_marketplaces_for_runtime_bootstrap() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        std::fs::write(
+            temp.path().join("jackin.agent.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = ["superpowers@superpowers-marketplace"]
+
+[[claude.marketplaces]]
+source = "obra/superpowers-marketplace"
+sparse = ["plugins", ".claude-plugin"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+
+        let manifest = crate::manifest::AgentManifest::load(temp.path()).unwrap();
+        let (state, _) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Ignore,
+            temp.path(),
+        )
+        .unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&state.plugins_json).unwrap()).unwrap();
+        assert_eq!(
+            value["marketplaces"],
+            json!([
+                {
+                    "source": "obra/superpowers-marketplace",
+                    "sparse": ["plugins", ".claude-plugin"]
+                }
+            ])
+        );
+        assert_eq!(
+            value["plugins"],
+            json!(["superpowers@superpowers-marketplace"])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 7 of the [Rust structure refactor roadmap](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md). Splits `src/instance.rs` (982 LOC) into three concern-focused files + a thin `mod.rs`.

| File | LOC | Owns |
|---|---:|---|
| `mod.rs` | **124** (was 982) | `AuthProvisionOutcome`, `AgentState`, orchestration, re-exports |
| `naming.rs` | 63 | `runtime_slug`, `primary_container_name`, `next_container_name`, `class_family_matches` |
| `auth.rs` | 737 | `AgentState::provision_claude_auth` + 5 private credential helpers |
| `plugins.rs` | 111 | `PluginState<'a>` + plugin-marketplace serialization |

This file contains **security-sensitive behavior** (auth-forwarding, host-credential reading, symlink rejection, private-file permission repair, macOS Keychain fallback). Per the plan's Phase 7 rationale: smaller files reduce accident risk for future auth changes. **Every symlink guard, permission check, and fallback path is preserved verbatim.**

## Verbatim moves

No function body edits. No permission-bit edits. No signature changes. No renames.

Two placement decisions worth calling out:

- **`provision_claude_auth`** stays an `impl AgentState` method (Option B: split `impl` block in `auth.rs`). Preserves the exact `Self::provision_claude_auth(...)` call site in `prepare` — no reshape into a free fn.
- **Plugin-json serialization** left inline in `AgentState::prepare` in `mod.rs` (choice (a), minimal churn). `plugins.rs` holds only the `PluginState<'a>` struct.

## Test Preservation Policy

18 tests preserved, co-located with the behavior they exercise:

- `mod.rs` — 1 orchestration test (`prepares_persisted_claude_state`)
- `naming.rs` — 2 naming tests
- `auth.rs` — 13 auth-mode and symlink tests (every `ignore_mode_*`, `copy_mode_*`, `sync_mode_*`, `rejects_symlink_*`, `switching_*_revokes_forwarded_credentials`, `auth_file_has_restricted_permissions`, `sync_repairs_permissions_*`)
- `plugins.rs` — 2 plugin serialization tests

**Test count:** 418 → 418. No test deleted. No test weakened.

## Visibility

Two `pub(super)` bumps inside the `instance` module:

- `AgentState::provision_claude_auth` — was private, now `pub(super)` so the split `impl` block in `auth.rs` is reachable from `AgentState::prepare` in `mod.rs`.
- `PluginState<'a>` + its two fields — was private, now `pub(super)` so `mod.rs` can construct it for the plugin-json serialization step.

No public API widened. **Zero call sites outside `src/instance/` required edits.** All external references via `crate::instance::{runtime_slug, primary_container_name, class_family_matches, next_container_name, AgentState, AuthProvisionOutcome}` resolve unchanged.

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **418 tests run: 418 passed, 0 skipped**

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 418/418
- [x] No test deleted or weakened
- [x] No permission-bit or symlink-guard change
- [x] No call sites outside `src/instance/` required edits (verified via `grep -rn "instance::" src/ tests/ src/bin/`)
- [x] `src/main.rs` and `src/bin/jackin-validate.rs` still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)