### PR TITLE
docs(agents): generalize commit-attribution rule; add Claude and Amp trailers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,15 +14,35 @@ This repository uses `main` as its primary branch. This file is the canonical ho
 
 If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
 
-## Codex Commit Attribution (agent-only)
+## Commit Attribution (agent-only)
 
-Until Codex supports automatic commit trailers, every commit created by the Codex agent in this repository must include this exact trailer:
+Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — **never stack multiple agent trailers on one commit** (for example, an Amp-generated commit must not also carry `Co-authored-by: Claude` or `Co-authored-by: Codex` just because Amp used one of those vendors' models under the hood).
 
-```text
-Co-authored-by: Codex <codex@openai.com>
-```
+Until the listed agents emit their trailers automatically, the trailer must be added by hand when creating or amending the commit.
 
-Add it manually when creating or amending Codex-generated commits.
+**Trailers by agent:**
+
+- **Claude** (Claude Code CLI, or any Claude-API coding agent used directly):
+
+  ```text
+  Co-authored-by: Claude <noreply@anthropic.com>
+  ```
+
+- **Codex** (OpenAI Codex CLI):
+
+  ```text
+  Co-authored-by: Codex <codex@openai.com>
+  ```
+
+- **Amp** (Sourcegraph Amp, regardless of underlying model):
+
+  ```text
+  Co-authored-by: Amp <amp@ampcode.com>
+  ```
+
+Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
+
+If you are uncertain which agent is creating the commit, ask — the trailer is how the operator tracks which agent produced which change, and wrong attribution is worse than no attribution.
 
 ## Code review & automated scanning (agent-only)
 


### PR DESCRIPTION
## Summary

Replaces the single-agent "Codex Commit Attribution" section in `AGENTS.md` with a broader "Commit Attribution" section that covers every agent committing to this repo today, and spells out two rules the prior version left implicit.

## Rules codified

**1. Exactly one `Co-authored-by` agent trailer per commit.** An Amp-generated commit must not also carry `Co-authored-by: Claude` or `Co-authored-by: Codex` just because Amp used one of those vendors' models under the hood. The trailer identifies the **agent tool**, not the model.

**2. Canonical trailer list for each agent, in one place:**

| Agent | Trailer |
|---|---|
| Claude (Claude Code CLI / Claude-API coding agents) | `Co-authored-by: Claude <noreply@anthropic.com>` |
| Codex (OpenAI Codex CLI) | `Co-authored-by: Codex <codex@openai.com>` |
| Amp (Sourcegraph Amp, regardless of underlying model) | `Co-authored-by: Amp <amp@ampcode.com>` |

Amp's `Amp-Thread-ID:` metadata trailer is explicitly called out as acceptable alongside its `Co-authored-by: Amp` trailer — thread-ID identifies the conversation, not a second agent.

## Why this is needed

Commit [`852d635d`](https://github.com/jackin-project/jackin/commit/852d635d643b179f55ffc6c210cbcb63c7631912) on `main` landed with both `Co-authored-by: Codex` and `Co-authored-by: Amp` trailers, making it impossible to tell which agent actually produced the work. Also, **Claude Code commits in this repo have historically had no attribution trailer at all** (including every Phase 1–11 refactor commit I made before this rule landed). Both gaps are now closed.

## No code change

Doc only. `cargo fmt --check` / `cargo clippy` / `cargo nextest run` untouched.

## Note on retroactive fixes

Past merged commits on `main` cannot be retroactively corrected without a force-push, which is destructive and not authorized. This rule applies going forward.

## Test plan

- [x] Rendered the diff; new section is self-contained and replaces the old Codex-only section cleanly.
- [x] No other rule in `AGENTS.md` touched.
- [x] `docs/AGENTS.md` and other `AGENTS.md` files in sibling directories are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)