### PR TITLE
refactor(env): introduce env_model; unify reserved-env list (Phase 10)

### DIFF
--- a/src/env_model.rs
+++ b/src/env_model.rs
@@ -1,0 +1,172 @@
+//! Env policy model: reserved runtime env vars and interpolation parsing.
+//!
+//! This module is the single source of truth for:
+//!
+//! * The names and default values of environment variables reserved by the
+//!   jackin runtime — manifests may not declare these, and the runtime
+//!   silently skips them if a resolved set contains them anyway.
+//! * Parsing `${env.VAR_NAME}` interpolation references out of manifest
+//!   strings.  Both manifest validation and runtime env resolution consume
+//!   this helper so that they agree on what constitutes a reference.
+//!
+//! Previously these definitions lived in two places (`manifest::RESERVED_RUNTIME_ENV_VARS`
+//! and `runtime::RUNTIME_OWNED_ENV_VARS`) with the runtime list being a
+//! subset of the manifest list plus two inline `JACKIN_*` checks.  The list
+//! here is the union — identical in membership to the previous manifest
+//! constant — and the runtime now consults it through
+//! [`is_reserved`] instead of maintaining its own.
+
+/// Env var injected by jackin into every agent container so that child
+/// processes can detect they are running inside a jackin-managed runtime.
+pub const JACKIN_RUNTIME_ENV_NAME: &str = "JACKIN_CLAUDE_ENV";
+
+/// Value set for [`JACKIN_RUNTIME_ENV_NAME`].  Manifests that try to declare
+/// `JACKIN_CLAUDE_ENV` are rejected at validation time because the value is
+/// fixed by jackin.
+pub const JACKIN_RUNTIME_ENV_VALUE: &str = "jackin";
+
+/// Env var that carries the `DinD` hostname into the agent container.
+///
+/// In-container tooling reaches the sibling docker-in-docker daemon through
+/// this hostname.  The value is runtime-generated (derived from the container
+/// name) and manifests may not override it.
+pub const JACKIN_DIND_HOSTNAME_ENV_NAME: &str = "JACKIN_DIND_HOSTNAME";
+
+/// Environment variables reserved by the jackin runtime.
+///
+/// Each entry is `(name, default)`.  `Some(value)` indicates a fixed value
+/// assigned by jackin (currently only [`JACKIN_RUNTIME_ENV_NAME`]); `None`
+/// indicates a runtime-generated value (hostname, Docker TLS paths, ...).
+///
+/// Manifests that declare any of these names fail validation, and the
+/// runtime filter in `runtime::launch` skips them via [`is_reserved`] so
+/// that a resolved env set cannot smuggle a value past validation.
+pub(crate) const RESERVED_RUNTIME_ENV_VARS: &[(&str, Option<&str>)] = &[
+    (JACKIN_RUNTIME_ENV_NAME, Some(JACKIN_RUNTIME_ENV_VALUE)),
+    (JACKIN_DIND_HOSTNAME_ENV_NAME, None),
+    // Docker TLS vars injected by jackin — must not be overridden by manifests.
+    ("DOCKER_HOST", None),
+    ("DOCKER_TLS_VERIFY", None),
+    ("DOCKER_CERT_PATH", None),
+];
+
+/// Returns `true` if `name` appears in [`RESERVED_RUNTIME_ENV_VARS`].
+///
+/// Used by the runtime launch path to filter reserved names out of
+/// resolved env sets before constructing `docker run -e` flags.
+pub fn is_reserved(name: &str) -> bool {
+    RESERVED_RUNTIME_ENV_VARS
+        .iter()
+        .any(|(reserved, _)| *reserved == name)
+}
+
+/// Extract env var names from `${env.VAR_NAME}` interpolation placeholders.
+///
+/// Returns the var name portion (after `env.`) for each match.  Non-`env.`
+/// references like `${other.FOO}` are ignored — only the `env` namespace is
+/// recognised for interpolation.
+///
+/// The scanning logic here mirrors `env_resolver::interpolate` — both parse
+/// `${...}` the same way so that validation and runtime resolution agree on
+/// what constitutes a reference.
+pub(crate) fn extract_interpolation_refs(s: &str) -> Vec<&str> {
+    let mut refs = Vec::new();
+    let mut rest = s;
+    while let Some(start) = rest.find("${") {
+        let after_open = &rest[start + 2..];
+        if let Some(end) = after_open.find('}') {
+            let ref_expr = &after_open[..end];
+            if let Some(var_name) = ref_expr.strip_prefix("env.") {
+                refs.push(var_name);
+            }
+            rest = &after_open[end + 1..];
+        } else {
+            break;
+        }
+    }
+    refs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_runtime_env_vars_covers_every_previously_reserved_name() {
+        // Each name previously in manifest::RESERVED_RUNTIME_ENV_VARS
+        // AND in runtime's old RUNTIME_OWNED_ENV_VARS must be present.
+        let names: Vec<&str> = RESERVED_RUNTIME_ENV_VARS.iter().map(|(n, _)| *n).collect();
+        for sentinel in &[
+            "JACKIN_CLAUDE_ENV",    // was manifest JACKIN_RUNTIME_ENV_NAME value
+            "JACKIN_DIND_HOSTNAME", // was manifest JACKIN_DIND_HOSTNAME_ENV_NAME value
+            "DOCKER_HOST",
+            "DOCKER_TLS_VERIFY",
+            "DOCKER_CERT_PATH",
+        ] {
+            assert!(
+                names.contains(sentinel),
+                "reserved env list must include {sentinel} for previous manifest/runtime coverage"
+            );
+        }
+    }
+
+    #[test]
+    fn is_reserved_accepts_all_sentinel_names() {
+        for sentinel in &[
+            "JACKIN_CLAUDE_ENV",
+            "JACKIN_DIND_HOSTNAME",
+            "DOCKER_HOST",
+            "DOCKER_TLS_VERIFY",
+            "DOCKER_CERT_PATH",
+        ] {
+            assert!(
+                is_reserved(sentinel),
+                "{sentinel} must be recognized as reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn is_reserved_rejects_user_names() {
+        assert!(!is_reserved("MY_USER_VAR"));
+        assert!(!is_reserved("PATH"));
+        assert!(!is_reserved(""));
+    }
+
+    #[test]
+    fn extract_interpolation_refs_finds_single_ref() {
+        assert_eq!(
+            extract_interpolation_refs("Branch for ${env.PROJECT}:"),
+            vec!["PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_finds_multiple_refs() {
+        assert_eq!(
+            extract_interpolation_refs("${env.TEAM}/${env.PROJECT}"),
+            vec!["TEAM", "PROJECT"]
+        );
+    }
+
+    #[test]
+    fn extract_interpolation_refs_returns_empty_for_no_refs() {
+        assert!(extract_interpolation_refs("plain text").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_ignores_non_env_namespace() {
+        assert!(extract_interpolation_refs("${other.FOO}").is_empty());
+        assert!(extract_interpolation_refs("${FOO}").is_empty());
+    }
+
+    #[test]
+    fn extract_interpolation_refs_returns_empty_name_for_empty_env_ref() {
+        assert_eq!(extract_interpolation_refs("${env.}"), vec![""]);
+    }
+
+    #[test]
+    fn extract_interpolation_refs_handles_unclosed_brace() {
+        assert!(extract_interpolation_refs("${env.OPEN").is_empty());
+    }
+}

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -26,33 +26,6 @@ pub trait EnvPrompter {
     ) -> anyhow::Result<PromptResult>;
 }
 
-/// Extract env var names from `${env.VAR_NAME}` interpolation placeholders.
-///
-/// Returns the var name portion (after `env.`) for each match.  Non-`env.`
-/// references like `${other.FOO}` are ignored — only the `env` namespace is
-/// recognised for interpolation.
-///
-/// The scanning logic here mirrors [`interpolate`] — both parse `${...}` the
-/// same way so that validation and runtime resolution agree on what constitutes
-/// a reference.
-pub(crate) fn extract_interpolation_refs(s: &str) -> Vec<&str> {
-    let mut refs = Vec::new();
-    let mut rest = s;
-    while let Some(start) = rest.find("${") {
-        let after_open = &rest[start + 2..];
-        if let Some(end) = after_open.find('}') {
-            let ref_expr = &after_open[..end];
-            if let Some(var_name) = ref_expr.strip_prefix("env.") {
-                refs.push(var_name);
-            }
-            rest = &after_open[end + 1..];
-        } else {
-            break;
-        }
-    }
-    refs
-}
-
 /// Replace `${env.VAR_NAME}` placeholders with values from already-resolved vars.
 ///
 /// Uses a single left-to-right scan so that replacement values containing `${...}`
@@ -212,43 +185,6 @@ fn topological_sort(declarations: &BTreeMap<String, EnvVarDecl>) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn extract_interpolation_refs_finds_single_ref() {
-        assert_eq!(
-            extract_interpolation_refs("Branch for ${env.PROJECT}:"),
-            vec!["PROJECT"]
-        );
-    }
-
-    #[test]
-    fn extract_interpolation_refs_finds_multiple_refs() {
-        assert_eq!(
-            extract_interpolation_refs("${env.TEAM}/${env.PROJECT}"),
-            vec!["TEAM", "PROJECT"]
-        );
-    }
-
-    #[test]
-    fn extract_interpolation_refs_returns_empty_for_no_refs() {
-        assert!(extract_interpolation_refs("plain text").is_empty());
-    }
-
-    #[test]
-    fn extract_interpolation_refs_ignores_non_env_namespace() {
-        assert!(extract_interpolation_refs("${other.FOO}").is_empty());
-        assert!(extract_interpolation_refs("${FOO}").is_empty());
-    }
-
-    #[test]
-    fn extract_interpolation_refs_returns_empty_name_for_empty_env_ref() {
-        assert_eq!(extract_interpolation_refs("${env.}"), vec![""]);
-    }
-
-    #[test]
-    fn extract_interpolation_refs_handles_unclosed_brace() {
-        assert!(extract_interpolation_refs("${env.OPEN").is_empty());
-    }
 
     struct MockPrompter {
         responses: std::cell::RefCell<Vec<PromptResult>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod config;
 pub mod derived_image;
 pub mod docker;
+pub mod env_model;
 pub mod env_resolver;
 pub mod instance;
 pub mod launch;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,20 +1,10 @@
-use crate::env_resolver::extract_interpolation_refs;
+use crate::env_model::extract_interpolation_refs;
+pub use crate::env_model::{
+    JACKIN_DIND_HOSTNAME_ENV_NAME, JACKIN_RUNTIME_ENV_NAME, JACKIN_RUNTIME_ENV_VALUE,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
-
-pub const JACKIN_RUNTIME_ENV_NAME: &str = "JACKIN_CLAUDE_ENV";
-pub const JACKIN_RUNTIME_ENV_VALUE: &str = "jackin";
-pub const JACKIN_DIND_HOSTNAME_ENV_NAME: &str = "JACKIN_DIND_HOSTNAME";
-
-const RESERVED_RUNTIME_ENV_VARS: &[(&str, Option<&str>)] = &[
-    (JACKIN_RUNTIME_ENV_NAME, Some(JACKIN_RUNTIME_ENV_VALUE)),
-    (JACKIN_DIND_HOSTNAME_ENV_NAME, None),
-    // Docker TLS vars injected by jackin — must not be overridden by manifests.
-    ("DOCKER_HOST", None),
-    ("DOCKER_TLS_VERIFY", None),
-    ("DOCKER_CERT_PATH", None),
-];
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -111,7 +101,7 @@ impl AgentManifest {
                 );
             }
 
-            if let Some((_, value)) = RESERVED_RUNTIME_ENV_VARS
+            if let Some((_, value)) = crate::env_model::RESERVED_RUNTIME_ENV_VARS
                 .iter()
                 .find(|(reserved, _)| name == reserved)
             {

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -9,7 +9,6 @@ use fs2::FileExt;
 use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 
-use super::RUNTIME_OWNED_ENV_VARS;
 use super::attach::{ContainerState, inspect_container_state, wait_for_dind};
 use super::cleanup::{gc_orphaned_resources, run_cleanup_command};
 use super::discovery::{list_managed_agent_names, list_running_agent_display_names};
@@ -365,7 +364,7 @@ fn launch_agent_runtime(
     let class_label = format!("jackin.class={}", selector.key());
     let display_label = format!("jackin.display_name={agent_display_name}");
     let docker_host = format!("DOCKER_HOST=tcp://{dind}:2376");
-    let dind_hostname = format!("{}={dind}", crate::manifest::JACKIN_DIND_HOSTNAME_ENV_NAME);
+    let dind_hostname = format!("{}={dind}", crate::env_model::JACKIN_DIND_HOSTNAME_ENV_NAME);
     let git_author_name = format!("GIT_AUTHOR_NAME={}", git.user_name);
     let git_author_email = format!("GIT_AUTHOR_EMAIL={}", git.user_email);
     let claude_dir_mount = format!("{}:/home/claude/.claude", state.claude_dir.display());
@@ -448,14 +447,11 @@ fn launch_agent_runtime(
     let mut env_strings: Vec<String> = Vec::new();
     env_strings.push(format!(
         "{}={}",
-        crate::manifest::JACKIN_RUNTIME_ENV_NAME,
-        crate::manifest::JACKIN_RUNTIME_ENV_VALUE
+        crate::env_model::JACKIN_RUNTIME_ENV_NAME,
+        crate::env_model::JACKIN_RUNTIME_ENV_VALUE
     ));
     for (key, value) in &resolved_env.vars {
-        if key == crate::manifest::JACKIN_RUNTIME_ENV_NAME
-            || key == crate::manifest::JACKIN_DIND_HOSTNAME_ENV_NAME
-            || RUNTIME_OWNED_ENV_VARS.contains(&key.as_str())
-        {
+        if crate::env_model::is_reserved(key) {
             continue;
         }
         env_strings.push(format!("{key}={value}"));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -13,13 +13,6 @@ pub mod test_support;
 #[cfg(test)]
 pub use self::test_support::FakeRunner;
 
-/// Environment variables owned by the jackin runtime that must not be
-/// overridden by agent manifests.  These are injected as `-e` flags in
-/// `launch_agent_runtime` and are silently skipped if a manifest declares them.
-/// The corresponding manifest-time validation lives in
-/// `manifest::RESERVED_RUNTIME_ENV_VARS`.
-const RUNTIME_OWNED_ENV_VARS: &[&str] = &["DOCKER_HOST", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH"];
-
 pub use self::attach::{ContainerState, hardline_agent, inspect_container_state};
 pub use self::cleanup::{eject_agent, exile_all, purge_class_data};
 pub use self::discovery::{


### PR DESCRIPTION
## Summary

Phase 10 of the [Rust structure refactor roadmap](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md), scope-narrowed to the reserved-env unification and the interpolation-parser move. Creates a new `src/env_model.rs` that is the single source of truth for reserved-env membership and interpolation parsing. Deletes the duplicate `runtime::RUNTIME_OWNED_ENV_VARS` constant.

## What changed

**New file: `src/env_model.rs` (172 LOC)**

| Item | From | Visibility | Notes |
|---|---|---|---|
| `JACKIN_RUNTIME_ENV_NAME` / `JACKIN_RUNTIME_ENV_VALUE` / `JACKIN_DIND_HOSTNAME_ENV_NAME` | `manifest.rs` | `pub` | Re-exported from `manifest` to preserve `crate::manifest::JACKIN_*` paths |
| `RESERVED_RUNTIME_ENV_VARS` | Union of manifest + runtime lists | `pub(crate)` | Manifest list was already a superset; union == manifest list unchanged |
| `is_reserved(name: &str) -> bool` | New | `pub` | Single-line predicate the runtime filter now consults |
| `extract_interpolation_refs` | `env_resolver.rs` | `pub(crate)` | Verbatim move |
| 3 sentinel-membership tests | New | — | Per the plan's explicit mitigation requirement |
| 6 `extract_interpolation_refs_*` tests | `env_resolver.rs::tests` | — | Verbatim move |

**Rewire summary:**

- `manifest.rs`: drops 3 `pub const` + 1 private const; adds `pub use env_model::{JACKIN_*};` for path stability; swaps to `use crate::env_model::extract_interpolation_refs;`; `validate` reads `env_model::RESERVED_RUNTIME_ENV_VARS`.
- `env_resolver.rs`: removes the function + its 6 tests; adds `use crate::env_model::extract_interpolation_refs;`.
- `runtime/mod.rs`: deletes `RUNTIME_OWNED_ENV_VARS` (was 3 entries, now subsumed).
- `runtime/launch.rs`: three-line reserved-env filter collapses to `if crate::env_model::is_reserved(key)`; `crate::manifest::JACKIN_*` references move to `crate::env_model::JACKIN_*`.

## Scope narrowed from plan

The plan lists four items: reserved-env list, interpolation parsing, dependency-graph construction, topological/cycle detection. **This PR does items 1 and 2 only.** Items 3 and 4 are tightly coupled to `manifest::EnvVarDecl` and `env_resolver::topological_sort` — extracting them without rewriting logic stretches the "move code before rewriting" rule. Deferred to a follow-up PR where a small shape adapter can land separately from the relocation.

## Behavior

**No user-visible change.**

- Reserved-env membership is identical to the previous manifest list (5 entries).
- Runtime filter was already covering all 5 names — the JACKIN_* pair via inline checks and the Docker triple via the now-deleted `RUNTIME_OWNED_ENV_VARS`. Replacing the three-branch check with `is_reserved()` over the unified list preserves the exact same set of "filtered out" keys.

## Test Preservation Policy

| | Count |
|---|---:|
| Baseline tests | 418 |
| Tests moved verbatim | 6 (`extract_interpolation_refs_*`) |
| Tests added (plan-mandated sentinels) | 3 |
| Tests deleted | **0** |
| Tests weakened | **0** |
| Final | **421 passing** |

The 3 new sentinel tests are required by the plan's Phase 10 mitigation: *"Treat the unified list as the union of both existing constants, and in the same PR add a test that asserts the exact membership of each previously-reserved name."*

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **421 tests run: 421 passed, 0 skipped**

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 421/421
- [x] Sentinel test confirms every previously-reserved name is in the unified list
- [x] `manifest::JACKIN_*` external paths still resolve (via `pub use` re-exports)
- [x] No CLI, flag, error-message, or schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)