### PR TITLE
refactor(cleanup): extract shared TTY guard and workspace lookup helpers

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -436,10 +436,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     mode: String,
                 }
 
-                let workspace = config
-                    .workspaces
-                    .get(&name)
-                    .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?;
+                let workspace = config.require_workspace(&name)?;
 
                 let allowed = if workspace.allowed_agents.is_empty() {
                     "any agent".to_string()
@@ -504,11 +501,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
 
-                let current_ws = config
-                    .workspaces
-                    .get(&name)
-                    .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?
-                    .clone();
+                let current_ws = config.require_workspace(&name)?.clone();
 
                 let plan = workspace::planner::plan_edit(
                     &current_ws,
@@ -546,12 +539,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 // If there are any collapses to apply, prompt (or bail on
                 // non-TTY without --yes).
                 if !all_collapses.is_empty() && !assume_yes {
-                    use std::io::IsTerminal;
-                    if !std::io::stdin().is_terminal() {
-                        anyhow::bail!(
-                            "refusing to collapse mounts without confirmation; pass --yes to proceed non-interactively"
-                        );
-                    }
+                    tui::require_interactive_stdin(
+                        "refusing to collapse mounts without confirmation; pass --yes to proceed non-interactively",
+                    )?;
 
                     if !plan.edit_driven_collapses.is_empty() {
                         eprintln!(
@@ -651,11 +641,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
             WorkspaceCommand::Prune { name, assume_yes } => {
-                let current_ws = config
-                    .workspaces
-                    .get(&name)
-                    .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?
-                    .clone();
+                let current_ws = config.require_workspace(&name)?.clone();
 
                 // All existing mounts; nothing new.
                 let plan = workspace::plan_collapse(&current_ws.mounts, &[])?;
@@ -665,12 +651,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
 
                 if !assume_yes {
-                    use std::io::IsTerminal;
-                    if !std::io::stdin().is_terminal() {
-                        anyhow::bail!(
-                            "refusing to collapse mounts without confirmation; pass --yes to proceed non-interactively"
-                        );
-                    }
+                    tui::require_interactive_stdin(
+                        "refusing to collapse mounts without confirmation; pass --yes to proceed non-interactively",
+                    )?;
                     eprintln!(
                         "Will remove {} redundant mount(s) from workspace {name:?}:",
                         plan.removed.len()

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -2,6 +2,17 @@ use super::AppConfig;
 use crate::workspace::{WorkspaceConfig, WorkspaceEdit, validate_workspace_config};
 
 impl AppConfig {
+    /// Return the workspace named `name`, or an `unknown workspace` error.
+    ///
+    /// Shared by every CLI and runtime site that needs to look up a saved
+    /// workspace by name and error on miss. The error message shape is
+    /// part of the CLI contract — do not change it casually.
+    pub fn require_workspace(&self, name: &str) -> anyhow::Result<&WorkspaceConfig> {
+        self.workspaces
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))
+    }
+
     pub fn create_workspace(
         &mut self,
         name: &str,
@@ -43,11 +54,7 @@ impl AppConfig {
             }
         }
 
-        let current = self
-            .workspaces
-            .get(name)
-            .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?;
-        let mut workspace = current.clone();
+        let mut workspace = self.require_workspace(name)?.clone();
 
         if let Some(workdir) = edit.workdir {
             workspace.workdir = workdir;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,4 +27,4 @@ pub use output::{
     clear_screen, fatal, hint, print_config_table, print_deploying, print_logo, set_terminal_title,
     shorten_home, step_fail, step_quiet, step_shimmer,
 };
-pub use prompt::{prompt_choice, spin_wait};
+pub use prompt::{prompt_choice, require_interactive_stdin, spin_wait};

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -6,15 +6,32 @@ use super::{DEBUG_MODE, PHOSPHOR_DIM, PHOSPHOR_GREEN, rgb};
 
 // ── Interactive prompt ───────────────────────────────────────────────────
 
+/// Bail with `msg` when stdin is not an interactive terminal.
+///
+/// Call at the top of any flow that would otherwise prompt the operator via
+/// `dialoguer` or `prompt_choice`. Shared across CLI call sites (workspace
+/// edit/prune, sensitive-mount confirmation) so the non-TTY guard pattern
+/// exists in one place instead of being copy-pasted with drifting messages.
+///
+/// Returns `Ok(())` when stdin is a terminal so the caller can continue
+/// into its prompt. Does NOT prompt itself.
+pub fn require_interactive_stdin(msg: &str) -> anyhow::Result<()> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!("{msg}");
+    }
+    Ok(())
+}
+
 /// Display a numbered prompt on stderr and read a choice from stdin.
 /// Returns the 0-based index of the chosen option.
 /// Errors if stdin is not a terminal.
 pub fn prompt_choice(message: &str, options: &[&str]) -> anyhow::Result<usize> {
-    use std::io::{BufRead, IsTerminal};
+    use std::io::BufRead;
 
-    if !std::io::stdin().is_terminal() {
-        anyhow::bail!("ambiguous target requires interactive input, but stdin is not a terminal");
-    }
+    require_interactive_stdin(
+        "ambiguous target requires interactive input, but stdin is not a terminal",
+    )?;
 
     eprintln!("{message}");
     for (i, option) in options.iter().enumerate() {

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -108,11 +108,7 @@ pub fn resolve_load_workspace(
             (ws, label)
         }
         LoadWorkspaceInput::Saved(name) => {
-            let workspace = config
-                .workspaces
-                .get(&name)
-                .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))?
-                .clone();
+            let workspace = config.require_workspace(&name)?.clone();
             if !workspace.allowed_agents.is_empty()
                 && !workspace
                     .allowed_agents

--- a/src/workspace/sensitive.rs
+++ b/src/workspace/sensitive.rs
@@ -42,17 +42,14 @@ pub fn find_sensitive_mounts(mounts: &[MountConfig]) -> Vec<SensitiveMount> {
 /// decline, and `Err` on I/O errors.
 pub fn confirm_sensitive_mounts(sensitive: &[SensitiveMount]) -> anyhow::Result<bool> {
     use owo_colors::OwoColorize;
-    use std::io::IsTerminal;
 
     if sensitive.is_empty() {
         return Ok(true);
     }
 
-    if !std::io::stdin().is_terminal() {
-        anyhow::bail!(
-            "sensitive mount paths detected but stdin is not a terminal — cannot prompt for confirmation"
-        );
-    }
+    crate::tui::require_interactive_stdin(
+        "sensitive mount paths detected but stdin is not a terminal — cannot prompt for confirmation",
+    )?;
 
     eprintln!(
         "\n{}",


### PR DESCRIPTION
## Summary

Addresses two items from the [refactor roadmap's acceptance checklist](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md):

> *"The non-TTY / confirmation guard pattern exists as a single shared helper, not in five places."*
> *"The unknown workspace {name} error is produced by one shared helper, not constructed ad hoc."*

Two new helpers in existing modules; no new files, no new modules. **Net zero LOC (−47 / +47)**, same error messages, same behavior.

## `tui::require_interactive_stdin(msg: &str) -> anyhow::Result<()>`

Pre-flight check for interactive prompting. Bails with `msg` when stdin isn't a terminal. Does NOT prompt — callers pair it with `dialoguer::Confirm` or `prompt_choice`.

**Replaces 4 inline copy-pasted blocks:**

| Site | Old | New |
|---|---|---|
| `app/mod.rs` Edit-arm collapse confirm | 4-line `use IsTerminal + is_terminal() + bail!` | `tui::require_interactive_stdin(…)?` |
| `app/mod.rs` Prune-arm confirm | same 4-line pattern | `tui::require_interactive_stdin(…)?` |
| `workspace/sensitive.rs::confirm_sensitive_mounts` | same 4-line pattern | `tui::require_interactive_stdin(…)?` |
| `tui/prompt.rs::prompt_choice` | inline check | delegates to the helper |

**Not migrated:** `runtime/repo_cache.rs::confirm_repo_removal_interactive` returns `Ok(false)` on non-TTY (silent decline) rather than bailing. Different semantics → keeps its inline check.

## `AppConfig::require_workspace(&self, name) -> Result<&WorkspaceConfig>`

Canonical error-on-miss lookup. **Replaces 5 ad-hoc `config.workspaces.get(&name).ok_or_else(|| anyhow!("unknown workspace {name}"))` sites:**

- `app/mod.rs::WorkspaceCommand::Show` (read path)
- `app/mod.rs::WorkspaceCommand::Edit` (`.require_workspace(&name)?.clone()`)
- `app/mod.rs::WorkspaceCommand::Prune` (same)
- `workspace/resolve.rs::resolve_load_workspace` (same)
- `config/workspaces.rs::edit_workspace` internal guard

**Not migrated:** `remove_workspace` uses `.remove(name)` (consuming), not `.get(name)` (borrowing). Different signature → keeps its inline `ok_or_else` with an identical error message. Users see the same message; only the implementation site differs.

## Why this matters

The error message shape `unknown workspace {name}` is part of the CLI contract. Centralizing it means accidental drift (e.g. somebody typing `"not found: {name}"` in a future PR) becomes a one-line mistake instead of a five-line one. Same reasoning for the TTY-guard helper — the pair of bail messages had already mildly drifted between callers.

## Test Preservation Policy

**No tests added, deleted, or weakened.** All 427 baseline tests continue to pass. The helpers exercise the same code paths existing tests already cover (e.g., `workspace_edit_non_tty_without_yes_bails` still asserts the Edit-arm bail message, just routed through the helper now).

## Behavior

**No CLI behavior change.** Same error messages byte-for-byte. Same exit codes. Same help text. The only observable diff in a debug build is the stack-trace `bail!` call site moving from the inline block to `require_interactive_stdin` — message string is identical.

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **427 tests run: 427 passed, 0 skipped**

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 427/427
- [x] No test deleted or weakened
- [x] Error messages are byte-identical to before
- [x] `cargo run -- workspace show nonexistent` still prints `unknown workspace nonexistent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)