### PR TITLE
refactor(hygiene): non_exhaustive on public errors, missing Debug derives, TryFrom for selectors

### DIFF
--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -4,6 +4,7 @@ use tempfile::TempDir;
 
 const ENTRYPOINT_SH: &str = include_str!("../docker/runtime/entrypoint.sh");
 
+#[derive(Debug)]
 pub struct DerivedBuildContext {
     pub temp_dir: TempDir,
     pub context_dir: PathBuf,

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -30,7 +30,7 @@ pub trait CommandRunner {
     ) -> anyhow::Result<String>;
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ShellRunner {
     pub debug: bool,
 }

--- a/src/env_resolver.rs
+++ b/src/env_resolver.rs
@@ -1,10 +1,12 @@
 use crate::manifest::EnvVarDecl;
 use std::collections::BTreeMap;
 
+#[derive(Debug, Clone)]
 pub struct ResolvedEnv {
     pub vars: Vec<(String, String)>,
 }
 
+#[derive(Debug, Clone)]
 pub enum PromptResult {
     Value(String),
     Skipped,

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -24,6 +24,7 @@ impl fmt::Display for ClassSelector {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum SelectorError {
     #[error("selector cannot be empty")]
     Empty,
@@ -66,6 +67,18 @@ impl ClassSelector {
     }
 }
 
+impl TryFrom<&str> for ClassSelector {
+    type Error = SelectorError;
+
+    /// Idiomatic wrapper around [`ClassSelector::parse`]. Exists so callers
+    /// that rely on `TryFrom` conversion traits (including generic code and
+    /// `try_into()` call sites) can convert a `&str` without having to
+    /// reach for the inherent `parse` method.
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        Self::parse(input)
+    }
+}
+
 impl Selector {
     pub fn parse(input: &str) -> Result<Self, SelectorError> {
         if input.is_empty() {
@@ -85,6 +98,16 @@ impl Selector {
         }
 
         Ok(Self::Class(ClassSelector::parse(input)?))
+    }
+}
+
+impl TryFrom<&str> for Selector {
+    type Error = SelectorError;
+
+    /// Idiomatic wrapper around [`Selector::parse`]. See the analogous impl
+    /// on [`ClassSelector`] for rationale.
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        Self::parse(input)
     }
 }
 

--- a/src/workspace/planner.rs
+++ b/src/workspace/planner.rs
@@ -157,6 +157,7 @@ pub struct Removal {
 /// Conditions that prevent a silent collapse. The operator must resolve these
 /// by hand before the edit can proceed.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum CollapseError {
     #[error(
         "mount {parent_src} ({parent_mode}) would subsume {child_src} ({child_mode}), \


### PR DESCRIPTION
## Summary

Applies the [plan's "Ongoing API Hygiene"](https://github.com/jackin-project/jackin/blob/main/docs/superpowers/plans/2026-04-23-rust-structure-readability-refactor.md) items 1, 2, and 4. These are the low-risk always-safe cleanups the plan flagged for fold-into-adjacent-PR treatment.

| # | Item | Status |
|---|---|---|
| 1 | `#[non_exhaustive]` on public error enums | ✅ |
| 2 | `#[derive(Debug)]` on public structs at API boundaries | ✅ |
| 3 | `#[derive(PartialEq, Eq)]` on test-compared config types | ⏸ **Skipped — speculative** (see below) |
| 4 | `impl TryFrom<&str>` alongside `parse` | ✅ |

## Item 1: `#[non_exhaustive]` on public error enums

- `SelectorError` (`src/selector.rs:27`) — adding a variant was a breaking change; now isn't.
- `CollapseError` (`src/workspace/planner.rs:160`) — same.

Attribute added above the existing `#[derive(...)]`. No variants renamed, no error messages changed.

## Item 2: `#[derive(Debug)]` where missing

Four types lacked `Debug`:

- `DerivedBuildContext` (`src/derived_image.rs:7`)
- `ShellRunner` (`src/docker.rs:34`) — had `Default` only
- `ResolvedEnv` (`src/env_resolver.rs:4`) — added `Debug + Clone`
- `PromptResult` (`src/env_resolver.rs:8`) — added `Debug + Clone`

`WorkspaceEdit` (mentioned in the plan) already had `Debug` — no change needed.

## Item 3: skipped deliberately

The plan's guidance was "low-risk, always-safe" — not "preemptive." A grep for `assert_eq!.*AgentSource`, `assert_eq!.*AppConfig` and similar turned up zero hits; no test currently compares these types. Adding `PartialEq` now would be speculative API widening. If a future test wants to compare one of these, it can add the derive then.

## Item 4: `impl TryFrom<&str>` for selectors

- `ClassSelector::parse(input: &str) -> Result<Self, SelectorError>` now has a parallel `impl TryFrom<&str> for ClassSelector`.
- `Selector::parse` similarly gets `impl TryFrom<&str> for Selector`.

Both `try_from` impls delegate directly to `Self::parse(input)` — no logic duplication, no behavior change. Enables idiomatic `"foo".try_into()` call sites + use in generic code that bounds `TryFrom`.

## Why this PR now

The plan's completion status (PR #145) listed hygiene items 1–4 as the last remaining ⏳ Open pieces. This PR closes 1, 2, and 4; item 3 gets re-categorized as "deferred if/when a consumer emerges." After this lands, the refactor program's last remaining documented open items are:

- **Phase 5c** (gated on mount-flag characterization tests; explicitly HIGH-risk)
- Optional further `manifest.rs` shrink (explicitly "not mandated")

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **427 tests run: 427 passed, 0 skipped**

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 427/427
- [x] `#[non_exhaustive]` doesn't break any existing match — verified (no exhaustive match on `SelectorError` or `CollapseError` exists inside the crate; tests use `assert!(matches!(...))` or check the error message).
- [x] `TryFrom` impls are additive — no signature conflict with existing `parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)