### PR TITLE
refactor(cli): split root command enum by family (agent + cleanup)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 use std::io::ErrorKind;
 use std::path::Path;
 
+use crate::cli::agent::{HardlineArgs, LaunchArgs, LoadArgs};
+use crate::cli::cleanup::{EjectArgs, PurgeArgs};
 use crate::cli::{self, Cli, Command, WorkspaceCommand};
 use crate::config::{self, AppConfig};
 use crate::docker::ShellRunner;
@@ -30,14 +32,14 @@ pub fn run(cli: Cli) -> Result<()> {
     let mut runner = ShellRunner::default();
 
     match cli.command {
-        Command::Load {
+        Command::Load(LoadArgs {
             selector,
             target,
             mounts,
             rebuild,
             no_intro,
             debug,
-        } => {
+        }) => {
             runner.debug = debug;
             tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
@@ -100,7 +102,7 @@ pub fn run(cli: Cli) -> Result<()> {
             );
             result
         }
-        Command::Launch { debug } => {
+        Command::Launch(LaunchArgs { debug }) => {
             runner.debug = debug;
             tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
@@ -117,7 +119,7 @@ pub fn run(cli: Cli) -> Result<()> {
             remember_last_agent(&paths, &mut config, Some(&workspace.label), &class, &result);
             result
         }
-        Command::Hardline { selector } => {
+        Command::Hardline(HardlineArgs { selector }) => {
             let container = if let Some(sel) = selector {
                 match Selector::parse(&sel)? {
                     Selector::Container(name) => name,
@@ -129,11 +131,11 @@ pub fn run(cli: Cli) -> Result<()> {
             };
             runtime::hardline_agent(&container, &mut runner)
         }
-        Command::Eject {
+        Command::Eject(EjectArgs {
             selector,
             all,
             purge,
-        } => {
+        }) => {
             let containers = match Selector::parse(&selector)? {
                 Selector::Container(container) => vec![container],
                 Selector::Class(class) => {
@@ -697,7 +699,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
         },
-        Command::Purge { selector, all } => match Selector::parse(&selector)? {
+        Command::Purge(PurgeArgs { selector, all }) => match Selector::parse(&selector)? {
             Selector::Container(container) => {
                 remove_data_dir_if_exists(&paths.data_dir.join(&container))?;
                 println!("Purged state for {container}.");

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -1,0 +1,226 @@
+use clap::Args;
+
+#[derive(Debug, Args, PartialEq, Eq)]
+pub struct LoadArgs {
+    /// Agent class selector (e.g. `agent-smith`, `chainargos/agent-brown`).
+    /// When omitted, uses the last-used or default agent for the workspace.
+    pub selector: Option<String>,
+    /// Path, `path:container-dest`, or saved workspace name
+    #[arg(value_name = "TARGET")]
+    pub target: Option<String>,
+    /// Additional bind-mount spec as `path[:ro]` or `src:dst[:ro]` (repeatable)
+    #[arg(long = "mount")]
+    pub mounts: Vec<String>,
+    /// Force rebuild the Docker image (updates Claude to latest version)
+    #[arg(long, default_value_t = false)]
+    pub rebuild: bool,
+    /// Skip the animated intro sequence
+    #[arg(long, default_value_t = false)]
+    pub no_intro: bool,
+    /// Print raw container output for troubleshooting
+    #[arg(long, default_value_t = false)]
+    pub debug: bool,
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+pub struct HardlineArgs {
+    /// Agent class selector or container name to reconnect to.
+    /// When omitted, uses the running agent in the workspace for the current directory.
+    pub selector: Option<String>,
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+pub struct LaunchArgs {
+    /// Print raw container output for troubleshooting
+    #[arg(long, default_value_t = false)]
+    pub debug: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::{Cli, Command};
+    use clap::Parser;
+
+    /// Strip ANSI escape sequences for clean test assertions.
+    fn strip_ansi(s: &str) -> String {
+        let mut result = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                // Skip until 'm' (SGR) or other terminator
+                for inner in chars.by_ref() {
+                    if inner.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+        result
+    }
+
+    fn help_text(args: &[&str]) -> String {
+        let err = Cli::try_parse_from(args).unwrap_err();
+        strip_ansi(&err.to_string())
+    }
+
+    #[test]
+    fn parses_load_command() {
+        let cli = Cli::try_parse_from(["jackin", "load", "agent-smith"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                selector: Some(ref s),
+                target: None,
+                no_intro: false,
+                debug: false,
+                ..
+            }) if s == "agent-smith"
+        ));
+    }
+
+    #[test]
+    fn parses_load_without_selector() {
+        let cli = Cli::try_parse_from(["jackin", "load"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                selector: None,
+                target: None,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_load_rebuild_without_selector() {
+        let cli = Cli::try_parse_from(["jackin", "load", "--rebuild"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                selector: None,
+                rebuild: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_load_with_target_path() {
+        let cli =
+            Cli::try_parse_from(["jackin", "load", "agent-smith", "~/Projects/my-app"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                target: Some(ref t),
+                ..
+            }) if t == "~/Projects/my-app"
+        ));
+    }
+
+    #[test]
+    fn parses_load_with_target_and_mount() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "load",
+            "agent-smith",
+            "big-monorepo",
+            "--mount",
+            "/tmp/cache:/workspace/cache:ro",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                target: Some(ref t),
+                ref mounts,
+                ..
+            }) if t == "big-monorepo" && mounts.len() == 1
+        ));
+    }
+
+    #[test]
+    fn parses_load_with_mount_only() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "load",
+            "agent-smith",
+            "--mount",
+            "/tmp/project:/workspace/project",
+            "--mount",
+            "/tmp/cache:/workspace/cache:ro",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Command::Load(super::LoadArgs {
+                target: None,
+                ref mounts,
+                ..
+            }) if mounts.len() == 2
+        ));
+    }
+
+    #[test]
+    fn parses_launch_command() {
+        let cli = Cli::try_parse_from(["jackin", "launch"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Launch(super::LaunchArgs { debug: false })
+        ));
+    }
+
+    // ── Load help ───────────────────────────────────────────────────────
+
+    #[test]
+    fn load_help_shows_description_and_examples() {
+        let help = help_text(&["jackin", "load", "--help"]);
+        assert!(help.contains("Jack an agent into an isolated container"));
+        assert!(help.contains("Examples:"));
+        assert!(help.contains("jackin load agent-smith"));
+        assert!(help.contains("jackin load agent-smith big-monorepo"));
+    }
+
+    #[test]
+    fn load_help_shows_mount_format() {
+        let help = help_text(&["jackin", "load", "--help"]);
+        assert!(
+            help.contains("path[:ro]") && help.contains("src:dst[:ro]"),
+            "mount format missing"
+        );
+    }
+
+    // ── Hardline help ───────────────────────────────────────────────────
+
+    #[test]
+    fn hardline_help_shows_examples() {
+        let help = help_text(&["jackin", "hardline", "--help"]);
+        assert!(help.contains("Reattach to a running agent"));
+        assert!(help.contains("jackin hardline agent-smith"));
+        assert!(
+            help.contains("jackin hardline ") && help.contains("auto-detect workspace"),
+            "missing no-arg usage in hardline help: {help}"
+        );
+    }
+
+    #[test]
+    fn parses_hardline_without_selector() {
+        let cli = Cli::try_parse_from(["jackin", "hardline"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Hardline(super::HardlineArgs { selector: None })
+        ));
+    }
+
+    #[test]
+    fn parses_hardline_with_selector() {
+        let cli = Cli::try_parse_from(["jackin", "hardline", "agent-smith"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Hardline(super::HardlineArgs { selector: Some(ref s) }) if s == "agent-smith"
+        ));
+    }
+}

--- a/src/cli/cleanup.rs
+++ b/src/cli/cleanup.rs
@@ -1,0 +1,71 @@
+use clap::Args;
+
+#[derive(Debug, Args, PartialEq, Eq)]
+pub struct EjectArgs {
+    /// Agent class selector or container name to stop
+    pub selector: String,
+    /// Stop every running instance of this agent class
+    #[arg(long)]
+    pub all: bool,
+    /// Also delete persisted state after stopping
+    #[arg(long)]
+    pub purge: bool,
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+pub struct PurgeArgs {
+    /// Agent class selector (e.g. `agent-smith`, `chainargos/agent-brown`)
+    pub selector: String,
+    /// Delete state for every instance, not just the default
+    #[arg(long)]
+    pub all: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli::Cli;
+    use clap::Parser;
+
+    /// Strip ANSI escape sequences for clean test assertions.
+    fn strip_ansi(s: &str) -> String {
+        let mut result = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                // Skip until 'm' (SGR) or other terminator
+                for inner in chars.by_ref() {
+                    if inner.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+        result
+    }
+
+    fn help_text(args: &[&str]) -> String {
+        let err = Cli::try_parse_from(args).unwrap_err();
+        strip_ansi(&err.to_string())
+    }
+
+    // ── Eject help ──────────────────────────────────────────────────────
+
+    #[test]
+    fn eject_help_shows_examples() {
+        let help = help_text(&["jackin", "eject", "--help"]);
+        assert!(help.contains("Stop an agent and clean up its container"));
+        assert!(help.contains("jackin eject agent-smith --all"));
+        assert!(help.contains("jackin eject agent-smith --purge"));
+    }
+
+    // ── Purge help ──────────────────────────────────────────────────────
+
+    #[test]
+    fn purge_help_shows_examples() {
+        let help = help_text(&["jackin", "purge", "--help"]);
+        assert!(help.contains("Delete persisted state"));
+        assert!(help.contains("jackin purge agent-smith --all"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,6 +25,8 @@ pub(super) const BANNER: &str = concat!(
     "\x1b[0m",
 );
 
+pub mod agent;
+pub mod cleanup;
 pub mod config;
 pub mod root;
 pub mod workspace;

--- a/src/cli/root.rs
+++ b/src/cli/root.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+use super::agent::{HardlineArgs, LaunchArgs, LoadArgs};
+use super::cleanup::{EjectArgs, PurgeArgs};
 use super::config::ConfigCommand;
 use super::workspace::WorkspaceCommand;
 use super::{BANNER, HELP_STYLES};
@@ -33,26 +35,7 @@ Examples:
   jackin load agent-smith big-monorepo --mount ~/extra-data
   jackin load agent-smith ~/app --mount ~/cache:/cache:ro"
     )]
-    Load {
-        /// Agent class selector (e.g. `agent-smith`, `chainargos/agent-brown`).
-        /// When omitted, uses the last-used or default agent for the workspace.
-        selector: Option<String>,
-        /// Path, `path:container-dest`, or saved workspace name
-        #[arg(value_name = "TARGET")]
-        target: Option<String>,
-        /// Additional bind-mount spec as `path[:ro]` or `src:dst[:ro]` (repeatable)
-        #[arg(long = "mount")]
-        mounts: Vec<String>,
-        /// Force rebuild the Docker image (updates Claude to latest version)
-        #[arg(long, default_value_t = false)]
-        rebuild: bool,
-        /// Skip the animated intro sequence
-        #[arg(long, default_value_t = false)]
-        no_intro: bool,
-        /// Print raw container output for troubleshooting
-        #[arg(long, default_value_t = false)]
-        debug: bool,
-    },
+    Load(LoadArgs),
     /// Reattach to a running agent's session
     ///
     /// When omitted, finds the saved workspace for the current directory and
@@ -67,11 +50,7 @@ Examples:
   jackin hardline chainargos/the-architect
   jackin hardline jackin-agent-smith-clone-1"
     )]
-    Hardline {
-        /// Agent class selector or container name to reconnect to.
-        /// When omitted, uses the running agent in the workspace for the current directory.
-        selector: Option<String>,
-    },
+    Hardline(HardlineArgs),
     /// Stop an agent and clean up its container
     #[command(
         before_help = BANNER,
@@ -83,16 +62,7 @@ Examples:
   jackin eject agent-smith --purge
   jackin eject jackin-agent-smith-clone-1"
     )]
-    Eject {
-        /// Agent class selector or container name to stop
-        selector: String,
-        /// Stop every running instance of this agent class
-        #[arg(long)]
-        all: bool,
-        /// Also delete persisted state after stopping
-        #[arg(long)]
-        purge: bool,
-    },
+    Eject(EjectArgs),
     /// Pull every running agent out at once
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Exile,
@@ -106,20 +76,10 @@ Examples:
   jackin purge agent-smith --all
   jackin purge chainargos/the-architect"
     )]
-    Purge {
-        /// Agent class selector (e.g. `agent-smith`, `chainargos/agent-brown`)
-        selector: String,
-        /// Delete state for every instance, not just the default
-        #[arg(long)]
-        all: bool,
-    },
+    Purge(PurgeArgs),
     /// Open the interactive TUI launcher to pick a workspace and agent
     #[command(before_help = BANNER, styles = HELP_STYLES)]
-    Launch {
-        /// Print raw container output for troubleshooting
-        #[arg(long, default_value_t = false)]
-        debug: bool,
-    },
+    Launch(LaunchArgs),
     /// Manage saved workspaces
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Workspace {
@@ -137,111 +97,6 @@ Examples:
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_load_command() {
-        let cli = Cli::try_parse_from(["jackin", "load", "agent-smith"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                selector: Some(ref s),
-                target: None,
-                no_intro: false,
-                debug: false,
-                ..
-            } if s == "agent-smith"
-        ));
-    }
-
-    #[test]
-    fn parses_load_without_selector() {
-        let cli = Cli::try_parse_from(["jackin", "load"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                selector: None,
-                target: None,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn parses_load_rebuild_without_selector() {
-        let cli = Cli::try_parse_from(["jackin", "load", "--rebuild"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                selector: None,
-                rebuild: true,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn parses_load_with_target_path() {
-        let cli =
-            Cli::try_parse_from(["jackin", "load", "agent-smith", "~/Projects/my-app"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                target: Some(ref t),
-                ..
-            } if t == "~/Projects/my-app"
-        ));
-    }
-
-    #[test]
-    fn parses_load_with_target_and_mount() {
-        let cli = Cli::try_parse_from([
-            "jackin",
-            "load",
-            "agent-smith",
-            "big-monorepo",
-            "--mount",
-            "/tmp/cache:/workspace/cache:ro",
-        ])
-        .unwrap();
-
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                target: Some(ref t),
-                ref mounts,
-                ..
-            } if t == "big-monorepo" && mounts.len() == 1
-        ));
-    }
-
-    #[test]
-    fn parses_load_with_mount_only() {
-        let cli = Cli::try_parse_from([
-            "jackin",
-            "load",
-            "agent-smith",
-            "--mount",
-            "/tmp/project:/workspace/project",
-            "--mount",
-            "/tmp/cache:/workspace/cache:ro",
-        ])
-        .unwrap();
-
-        assert!(matches!(
-            cli.command,
-            Command::Load {
-                target: None,
-                ref mounts,
-                ..
-            } if mounts.len() == 2
-        ));
-    }
-
-    #[test]
-    fn parses_launch_command() {
-        let cli = Cli::try_parse_from(["jackin", "launch"]).unwrap();
-        assert!(matches!(cli.command, Command::Launch { debug: false }));
-    }
 
     /// Strip ANSI escape sequences for clean test assertions.
     fn strip_ansi(s: &str) -> String {
@@ -305,73 +160,6 @@ mod tests {
         ] {
             assert!(help.contains(cmd), "missing command: {cmd}");
         }
-    }
-
-    // ── Load help ───────────────────────────────────────────────────────
-
-    #[test]
-    fn load_help_shows_description_and_examples() {
-        let help = help_text(&["jackin", "load", "--help"]);
-        assert!(help.contains("Jack an agent into an isolated container"));
-        assert!(help.contains("Examples:"));
-        assert!(help.contains("jackin load agent-smith"));
-        assert!(help.contains("jackin load agent-smith big-monorepo"));
-    }
-
-    #[test]
-    fn load_help_shows_mount_format() {
-        let help = help_text(&["jackin", "load", "--help"]);
-        assert!(
-            help.contains("path[:ro]") && help.contains("src:dst[:ro]"),
-            "mount format missing"
-        );
-    }
-
-    // ── Hardline help ───────────────────────────────────────────────────
-
-    #[test]
-    fn hardline_help_shows_examples() {
-        let help = help_text(&["jackin", "hardline", "--help"]);
-        assert!(help.contains("Reattach to a running agent"));
-        assert!(help.contains("jackin hardline agent-smith"));
-        assert!(
-            help.contains("jackin hardline ") && help.contains("auto-detect workspace"),
-            "missing no-arg usage in hardline help: {help}"
-        );
-    }
-
-    #[test]
-    fn parses_hardline_without_selector() {
-        let cli = Cli::try_parse_from(["jackin", "hardline"]).unwrap();
-        assert!(matches!(cli.command, Command::Hardline { selector: None }));
-    }
-
-    #[test]
-    fn parses_hardline_with_selector() {
-        let cli = Cli::try_parse_from(["jackin", "hardline", "agent-smith"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Hardline { selector: Some(ref s) } if s == "agent-smith"
-        ));
-    }
-
-    // ── Eject help ──────────────────────────────────────────────────────
-
-    #[test]
-    fn eject_help_shows_examples() {
-        let help = help_text(&["jackin", "eject", "--help"]);
-        assert!(help.contains("Stop an agent and clean up its container"));
-        assert!(help.contains("jackin eject agent-smith --all"));
-        assert!(help.contains("jackin eject agent-smith --purge"));
-    }
-
-    // ── Purge help ──────────────────────────────────────────────────────
-
-    #[test]
-    fn purge_help_shows_examples() {
-        let help = help_text(&["jackin", "purge", "--help"]);
-        assert!(help.contains("Delete persisted state"));
-        assert!(help.contains("jackin purge agent-smith --all"));
     }
 
     // ── Subcommand banner consistency ───────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses operator feedback: `src/cli/root.rs` at 413 LOC clustered 8 top-level command variants together, making it hard to locate a specific command. Splitting by family gives each command a clearer home.

## Split

| File | LOC | Owns |
|---|---:|---|
| `root.rs` | **201** (was 413) | `Cli`, thin `Command` enum, 3 root-level help tests |
| `agent.rs` | 226 | `LoadArgs`, `HardlineArgs`, `LaunchArgs` + 12 tests |
| `cleanup.rs` | 71 | `EjectArgs`, `PurgeArgs` + 2 tests |

`Exile` stays as a unit variant in `root.rs` (no args, no struct needed).

## The Clap pattern

Each inline-args variant converts to a struct-wrapped variant:

```rust
// Before
Command::Load { selector: Option<String>, target: Option<String>, /* ... */ }

// After — root.rs keeps the #[command(...)] attribute block
Command::Load(LoadArgs)
// — and agent.rs owns the field definitions
pub struct LoadArgs { pub selector: Option<String>, pub target: Option<String>, /* ... */ }
```

Clap parses `Command::Load(LoadArgs)` identically to the inline form. **No CLI flag rename, no help-text drift, no variant reorder.** Verified with `cargo run -- <cmd> --help` spot-checks on all affected subcommands — output is byte-identical.

## `app/mod.rs` match-arm changes

5 arms switched from `Command::Load { selector, target, ... }` to `Command::Load(LoadArgs { selector, target, ... })`. Field names unchanged; arm bodies byte-identical post-destructure.

Unchanged:
- `Command::Exile` (unit variant)
- `Command::Workspace { command }` / `Command::Config { command }` (already used wrapping for their sub-enums)

## Test Preservation Policy

17 tests migrated, co-located by subject:

- `agent.rs::tests` — 12 (`parses_load_*`, `parses_launch_*`, `parses_hardline_*`, Load/Hardline/Launch help-output tests)
- `cleanup.rs::tests` — 2 (Eject + Purge help tests)
- `root.rs::tests` — 3 cross-cutting help tests

**Test count:** 427 → 427. No test deleted. No test weakened.

## Visibility

Fields on each `*Args` struct are `pub` so `src/app/mod.rs` can destructure. No re-export at `crate::cli::*Args` — callers import directly from `crate::cli::agent::*` and `crate::cli::cleanup::*`. Keeps the re-export surface narrow.

Zero call sites outside `src/cli/` and `src/app/mod.rs` required edits.

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **427 tests run: 427 passed, 0 skipped**
- CLI help output spot-check — identical for `load`, `hardline`, `eject`, `purge`, `launch`, and root `--help`

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 427/427
- [x] No flag rename
- [x] No help-text drift
- [x] Match-arm bodies byte-identical post-destructure
- [x] `cargo run -- load --help` matches previous output

🤖 Generated with [Claude Code](https://claude.com/claude-code)