### PR TITLE
docs: refresh PROJECT_STRUCTURE.md; add stale-docs check to TODO.md

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -6,7 +6,7 @@ Quick navigation reference for AI agents working in this repository.
 
 | File | Purpose |
 |---|---|
-| `Cargo.toml` | Crate manifest — dependencies, lints, edition 2024, MSRV 1.94 |
+| `Cargo.toml` | Crate manifest — dependencies and lints |
 | `Cargo.lock` | Locked dependency versions |
 | `AGENTS.md` | Shared instructions for all AI agents (testing, pre-commit, security) |
 | `CLAUDE.md` | Claude-specific pointer to `AGENTS.md` |

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -6,7 +6,7 @@ Quick navigation reference for AI agents working in this repository.
 
 | File | Purpose |
 |---|---|
-| `Cargo.toml` | Crate manifest — dependencies, lints, edition 2024, MSRV 1.87 |
+| `Cargo.toml` | Crate manifest — dependencies, lints, edition 2024, MSRV 1.94 |
 | `Cargo.lock` | Locked dependency versions |
 | `AGENTS.md` | Shared instructions for all AI agents (testing, pre-commit, security) |
 | `CLAUDE.md` | Claude-specific pointer to `AGENTS.md` |
@@ -28,26 +28,46 @@ the deployed site at <https://jackin.tailrocks.com/reference/roadmap/>.
 
 ## Source Code — `src/`
 
-Rust CLI binary. All modules are flat (no subdirectories).
+Rust CLI binary. Every significant concern has its own directory;
+crate-root files are reserved for items that don't cluster into
+a domain group.
 
-| Module | Responsibility |
+### Crate root
+
+| File | Responsibility |
 |---|---|
-| `main.rs` | Entry point — parses CLI and calls `run()` |
-| `lib.rs` | Library root — module declarations, `run()` orchestration, target classification |
-| `cli.rs` | Clap command definitions (load, launch, eject, exile, purge, workspace, config) |
-| `runtime.rs` | Core engine — agent lifecycle (build, run, attach, eject, purge), Docker image management |
-| `docker.rs` | Docker command builder — shell execution abstraction |
-| `workspace.rs` | Workspace resolution — mount specs, workdir, saved workspace lookup |
-| `config.rs` | TOML config persistence — agent registry, workspaces, mount scopes |
-| `manifest.rs` | Agent manifest parser (`jackin.agent.toml` inside agent repos) |
-| `derived_image.rs` | Dockerfile generation for agent images from base construct |
+| `main.rs` | Entry point — constructs `Cli` and calls `jackin::run()` |
+| `lib.rs` | Thin crate root (~20 LOC) — module declarations + `pub use app::run` |
+| `bin/validate.rs` | Separate binary for validating agent manifests (`jackin-validate`) |
+
+### Module tree
+
+| Module | Owns |
+|---|---|
+| `app/` | `run()` command dispatch (`mod.rs`) and context helpers (`context.rs`): target classification, workspace-for-cwd, agent-from-context, last-agent persistence |
+| `cli/` | Clap schema split by topic: `root.rs` (`Cli` + `Command` enum), `agent.rs` (Load/Hardline/Launch args), `cleanup.rs` (Eject/Purge args), `workspace.rs` (`WorkspaceCommand`), `config.rs` (`ConfigCommand` + sub-enums) |
+| `workspace/` | Workspace model and planning. `mod.rs` (types, re-exports), `paths.rs` (expand_tilde, resolve_path), `mounts.rs` (parse/validate), `planner.rs` (`plan_create`, `plan_edit`, `plan_collapse`), `resolve.rs` (runtime resolution), `sensitive.rs` (sensitive-mount detection) |
+| `config/` | TOML config model and persistence. `mod.rs` (types, `require_workspace` helper), `persist.rs` (load/save), `agents.rs` (builtin sync, trust, auth-forward), `mounts.rs` (global mount registry), `workspaces.rs` (workspace CRUD) |
+| `manifest/` | Agent-manifest (`jackin.agent.toml`) schema + validator. `mod.rs` (schema structs, `load`, `display_name`), `validate.rs` (`validate`, `is_valid_env_var_name`) |
+| `runtime/` | Container lifecycle. `mod.rs` (thin re-exports), `naming.rs` (labels, container/image naming, family matching), `identity.rs` (git/host identity), `repo_cache.rs` (repo lock + fetch), `image.rs` (docker build), `launch.rs` (`launch_agent_runtime`, `load_agent`, `load_agent_with`), `attach.rs` (attach + hardline + DinD readiness), `discovery.rs` (list managed agents), `cleanup.rs` (eject, purge, orphan GC), `test_support.rs` (shared `FakeRunner`) |
+| `launch/` | Interactive TUI launcher. `mod.rs` (`run_launch` entrypoint), `state.rs` (`LaunchState`, `WorkspaceChoice`), `input.rs` (event handling), `preview.rs` (workspace preview + detail lines), `render.rs` (all drawing functions) |
+| `instance/` | Per-container state preparation. `mod.rs` (`AgentState`, orchestration), `naming.rs` (container slug + clone naming + class-family matching), `auth.rs` (auth-forward modes + credential handling + symlink safety), `plugins.rs` (plugin-marketplace serialization) |
+| `tui/` | General terminal UI helpers (separate from the launcher). `mod.rs` (shared palette, `DEBUG_MODE`), `animation.rs` (intro/outro, digital rain), `output.rs` (tables, hints, fatal, logo, title), `prompt.rs` (`prompt_choice`, `spin_wait`, `require_interactive_stdin`) |
+
+### Flat helper files at crate root
+
+| File | Responsibility |
+|---|---|
+| `env_model.rs` | Single source of truth for env policy — reserved-runtime-env list, `is_reserved`, `extract_interpolation_refs`, `topological_env_order` (cycle detection) |
+| `env_resolver.rs` | Runtime env resolution — `resolve_env`, interpolation, interactive prompts |
+| `selector.rs` | Agent selector parsing — `ClassSelector`, `Selector`, `TryFrom<&str>` impls |
 | `repo.rs` | Agent repo validation — required files, path traversal checks |
-| `repo_contract.rs` | Enforces agent Dockerfiles use the construct base image |
-| `instance.rs` | Container naming, clone indices, plugin state preparation |
-| `selector.rs` | Agent selector parsing — `owner/repo`, builtins, container names |
-| `launch.rs` | Interactive TUI launcher logic — agent/workspace selection |
-| `tui.rs` | Ratatui terminal UI components — prompts, hints, display helpers |
-| `paths.rs` | XDG-compliant data and config directory resolution |
+| `repo_contract.rs` | Enforces agent `Dockerfile`s extend the `construct` base image |
+| `derived_image.rs` | Dockerfile generation for agent images from the base construct |
+| `docker.rs` | Docker command builder — `CommandRunner` trait and `ShellRunner` |
+| `terminal_prompter.rs` | Interactive env-var prompting for manifest resolution |
+| `version_check.rs` | Claude CLI version detection for image cache-bust |
+| `paths.rs` | XDG-compliant data and config directory resolution (`JackinPaths`) |
 
 ## Documentation — `docs/`
 
@@ -130,11 +150,21 @@ When changing behavior, update both sides:
 
 | Code change in | Update docs in |
 |---|---|
-| `src/cli.rs` (command flags) | `docs/src/content/docs/commands/<cmd>.mdx` |
-| `src/workspace.rs` (mount logic) | `docs/.../guides/workspaces.mdx`, `docs/.../guides/mounts.mdx` |
-| `src/config.rs` (config format) | `docs/.../reference/configuration.mdx` |
-| `src/runtime.rs` (container lifecycle) | `docs/.../reference/architecture.mdx` |
-| `src/manifest.rs` (jackin.agent.toml) | `docs/.../developing/agent-manifest.mdx` |
+| `src/cli/**` (command flags or help text) | `docs/src/content/docs/commands/<cmd>.mdx` |
+| `src/workspace/**` (mount logic) | `docs/.../guides/workspaces.mdx`, `docs/.../guides/mounts.mdx` |
+| `src/config/**` (config format) | `docs/.../reference/configuration.mdx` |
+| `src/runtime/**` (container lifecycle) | `docs/.../reference/architecture.mdx` |
+| `src/manifest/**` (`jackin.agent.toml` schema or validation) | `docs/.../developing/agent-manifest.mdx` |
+| `src/instance/auth.rs` (auth-forward, credential handling) | `docs/.../guides/authentication.mdx`, `docs/.../guides/security-model.mdx` |
+| `src/env_model.rs`, `src/env_resolver.rs` (env policy) | `docs/.../developing/agent-manifest.mdx` (env section) |
 | `src/derived_image.rs` (Dockerfile gen) | `docs/.../developing/construct-image.mdx` |
 | `src/repo.rs` / `src/repo_contract.rs` | `docs/.../guides/agent-repos.mdx` |
 | `docker/construct/Dockerfile` | `docs/.../developing/construct-image.mdx` |
+
+## Keeping this file fresh
+
+If a PR changes module boundaries — adds a new module directory,
+splits a file into a subdirectory, introduces a new cross-cutting
+helper — **update the module tree above in the same PR**. See
+[`TODO.md`](TODO.md) for the stale-docs check every structural PR
+should run.

--- a/TODO.md
+++ b/TODO.md
@@ -17,3 +17,40 @@ Each design doc should include (see any existing page as a template):
 - `## Problem`
 - `## Why It Matters`
 - `## Related Files`
+
+## Stale-docs check (every PR)
+
+Docs rot silently. Every PR must include a one-pass verification that
+structure-sensitive docs still match reality. Treat these as a
+checklist in the PR description — each item takes seconds to check.
+
+### When your PR touches `src/**`
+
+- [ ] Did you add, rename, move, or delete a module / directory under `src/`? If yes, update [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md)'s "Module tree" and any affected row in "Code ↔ Docs Cross-Reference" in the same PR.
+- [ ] Did you change the MSRV (`rust-version` in `Cargo.toml`)? If yes, update the `Cargo.toml` row in `PROJECT_STRUCTURE.md`.
+- [ ] Did you add a new `src/bin/` binary? If yes, add it to the "Crate root" table in `PROJECT_STRUCTURE.md`.
+
+### When your PR touches CLI behavior
+
+- [ ] Did you add, rename, or remove a CLI flag, subcommand, or change default behavior? If yes, the matching `docs/src/content/docs/commands/<cmd>.mdx` needs updating in the same PR.
+- [ ] Did you change `jackin.agent.toml` schema or validation rules? If yes, update `docs/src/content/docs/developing/agent-manifest.mdx`.
+- [ ] Did you change `config.toml` shape? If yes, update `docs/src/content/docs/reference/configuration.mdx`.
+- [ ] Did you change auth-forward, Keychain, symlink, or file-permission behavior in `src/instance/auth.rs`? If yes, update `docs/src/content/docs/guides/authentication.mdx` and `docs/src/content/docs/guides/security-model.mdx`.
+
+### When your PR touches a roadmap item
+
+- [ ] If the PR resolves or advances an item under `docs/src/content/docs/reference/roadmap/`, update that item's `Status` field (`Open | Deferred | Resolved`) and `Related Files` section in the same PR.
+- [ ] If the PR references `src/` paths that have since moved (e.g., a roadmap doc mentions `src/runtime.rs` which is now `src/runtime/`), fix those path references.
+
+### How to verify
+
+One command to surface the obvious drift targets:
+
+```sh
+git diff --name-only origin/main... | grep -E '^src/|^Cargo\.toml' | head
+```
+
+If that list is non-empty, walk through the checkboxes above before
+requesting review. The goal is that a new operator opening
+`PROJECT_STRUCTURE.md` or a roadmap doc always sees paths that
+resolve, commands that exist, and behaviors that match current code.

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,6 @@ checklist in the PR description — each item takes seconds to check.
 ### When your PR touches `src/**`
 
 - [ ] Did you add, rename, move, or delete a module / directory under `src/`? If yes, update [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md)'s "Module tree" and any affected row in "Code ↔ Docs Cross-Reference" in the same PR.
-- [ ] Did you change the MSRV (`rust-version` in `Cargo.toml`)? If yes, update the `Cargo.toml` row in `PROJECT_STRUCTURE.md`.
 - [ ] Did you add a new `src/bin/` binary? If yes, add it to the "Crate root" table in `PROJECT_STRUCTURE.md`.
 
 ### When your PR touches CLI behavior


### PR DESCRIPTION
## Summary

Two related doc-hygiene updates triggered by operator feedback:

1. `PROJECT_STRUCTURE.md`'s "Source Code" section was still claiming *"All modules are flat (no subdirectories)"* and listing every module as a flat file. The structural refactor merged multiple module splits onto main; this PR refreshes the doc to match the current tree.
2. Extending `TODO.md` with a concrete **Stale-docs check (every PR)** section so future PRs cite, rather than re-discover, which docs to refresh when code structure changes.

## PROJECT_STRUCTURE.md — what changed

- **MSRV corrected:** `1.87` → `1.94` (matches current `Cargo.toml`).
- **"Source Code" section rewritten:** replaces the flat-module table with a two-part layout — a "Crate root" table for `main.rs` / `lib.rs` / `bin/validate.rs`, and a "Module tree" table describing every directory under `src/` (`app/`, `cli/`, `workspace/`, `config/`, `manifest/`, `runtime/`, `launch/`, `instance/`, `tui/`) plus a "Flat helper files at crate root" table for modules that don't cluster (`env_model.rs`, `env_resolver.rs`, `selector.rs`, `repo.rs`, `repo_contract.rs`, `derived_image.rs`, `docker.rs`, `terminal_prompter.rs`, `version_check.rs`, `paths.rs`).
- **"Code ↔ Docs Cross-Reference" table:** paths updated from flat-file form (`src/cli.rs`) to directory form (`src/cli/**`). Added new entries for `src/instance/auth.rs → authentication/security-model docs` and `src/env_model.rs + src/env_resolver.rs → agent-manifest env section`.
- **New "Keeping this file fresh" closing paragraph** pointing at TODO.md's stale-docs check so the contract is bidirectional.

## TODO.md — the stale-docs checklist

Appended a structured section that reads as a checklist a PR author walks before requesting review:

- **When your PR touches `src/**`** — update `PROJECT_STRUCTURE.md`'s module tree, adjust `Cargo.toml` row on MSRV change, register new `src/bin/` entries.
- **When your PR touches CLI behavior** — update matching `docs/.../commands/<cmd>.mdx`, `docs/.../developing/agent-manifest.mdx` for manifest schema, `docs/.../reference/configuration.mdx` for `config.toml` shape.
- **When your PR touches `src/instance/auth.rs`** — update the authentication/security-model guides.
- **When your PR touches a roadmap item** — bump the `Status` field and the `Related Files` section on `docs/src/content/docs/reference/roadmap/<item>.mdx`. Fix stale `src/` path references.

Closes with a one-line `git diff` helper to surface typical drift targets:

```sh
git diff --name-only origin/main... | grep -E '^src/|^Cargo\.toml' | head
```

## Why this matters

Docs rot silently. A reader opening `PROJECT_STRUCTURE.md` right before this PR would have seen "flat modules" and broken file path references. Making the stale-docs check a first-class PR expectation means the next round of drift surfaces at review time, not months later.

## No code changed

- `cargo fmt --check`, `cargo clippy`, `cargo nextest run` — all unaffected (docs-only PR).
- `PROJECT_STRUCTURE.md` and `TODO.md` only.

## Test plan

- [x] Spot-check every row in the rewritten "Module tree" matches `find src -type d`.
- [x] Every file path in "Code ↔ Docs Cross-Reference" resolves to an actual file under `src/` or a doc under `docs/`.
- [x] TODO.md checklist items are concrete (each is "did you update `<specific file>`?").

🤖 Generated with [Claude Code](https://claude.com/claude-code)