### PR TITLE
refactor(cli): ConfigCommand subcommand wrappers use tuple form

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -177,7 +177,7 @@ pub fn run(cli: Cli) -> Result<()> {
             Ok(())
         }
         Command::Config(config_cmd) => match config_cmd {
-            cli::ConfigCommand::Mount { command: mount_cmd } => match mount_cmd {
+            cli::ConfigCommand::Mount(mount_cmd) => match mount_cmd {
                 cli::MountCommand::Add {
                     name,
                     src,
@@ -248,7 +248,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
             },
-            cli::ConfigCommand::Trust { command: trust_cmd } => match trust_cmd {
+            cli::ConfigCommand::Trust(trust_cmd) => match trust_cmd {
                 cli::TrustCommand::Grant { selector } => {
                     let class = ClassSelector::parse(&selector)?;
                     config.resolve_agent_source(&class)?;
@@ -290,7 +290,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
             },
-            cli::ConfigCommand::Auth { command: auth_cmd } => match auth_cmd {
+            cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
                 cli::AuthCommand::Set { mode, agent } => {
                     let parsed_mode: config::AuthForwardMode =
                         mode.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -5,23 +5,14 @@ use super::{BANNER, HELP_STYLES};
 #[derive(Debug, Subcommand, PartialEq, Eq)]
 pub enum ConfigCommand {
     /// Manage global mount configurations
-    #[command(before_help = BANNER, styles = HELP_STYLES)]
-    Mount {
-        #[command(subcommand)]
-        command: MountCommand,
-    },
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    Mount(MountCommand),
     /// Manage trust for third-party agent sources
-    #[command(before_help = BANNER, styles = HELP_STYLES)]
-    Trust {
-        #[command(subcommand)]
-        command: TrustCommand,
-    },
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    Trust(TrustCommand),
     /// Manage Claude Code authentication forwarding from host
-    #[command(before_help = BANNER, styles = HELP_STYLES)]
-    Auth {
-        #[command(subcommand)]
-        command: AuthCommand,
-    },
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    Auth(AuthCommand),
 }
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]
@@ -200,9 +191,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Mount {
-                command: MountCommand::Add { .. }
-            })
+            Command::Config(ConfigCommand::Mount(MountCommand::Add { .. }))
         ));
     }
 
@@ -212,9 +201,7 @@ mod tests {
             Cli::try_parse_from(["jackin", "config", "mount", "remove", "gradle-cache"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Mount {
-                command: MountCommand::Remove { .. }
-            })
+            Command::Config(ConfigCommand::Mount(MountCommand::Remove { .. }))
         ));
     }
 
@@ -223,9 +210,7 @@ mod tests {
         let cli = Cli::try_parse_from(["jackin", "config", "mount", "list"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Mount {
-                command: MountCommand::List
-            })
+            Command::Config(ConfigCommand::Mount(MountCommand::List))
         ));
     }
 
@@ -241,9 +226,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Trust {
-                command: TrustCommand::Grant { .. }
-            })
+            Command::Config(ConfigCommand::Trust(TrustCommand::Grant { .. }))
         ));
     }
 
@@ -259,9 +242,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Trust {
-                command: TrustCommand::Revoke { .. }
-            })
+            Command::Config(ConfigCommand::Trust(TrustCommand::Revoke { .. }))
         ));
     }
 
@@ -270,9 +251,7 @@ mod tests {
         let cli = Cli::try_parse_from(["jackin", "config", "trust", "list"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Trust {
-                command: TrustCommand::List
-            })
+            Command::Config(ConfigCommand::Trust(TrustCommand::List))
         ));
     }
 
@@ -315,12 +294,10 @@ mod tests {
         let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "copy"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Auth {
-                    command: AuthCommand::Set {
+            Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
                         agent: None,
-                    }
-                }) if mode == "copy"
+                    })) if mode == "copy"
         ));
     }
 
@@ -338,12 +315,10 @@ mod tests {
         .unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Auth {
-                    command: AuthCommand::Set {
+            Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
                         agent: Some(ref agent),
-                    }
-                }) if mode == "sync" && agent == "agent-smith"
+                    })) if mode == "sync" && agent == "agent-smith"
         ));
     }
 
@@ -352,9 +327,7 @@ mod tests {
         let cli = Cli::try_parse_from(["jackin", "config", "auth", "show"]).unwrap();
         assert!(matches!(
             cli.command,
-            Command::Config(ConfigCommand::Auth {
-                command: AuthCommand::Show { agent: None }
-            })
+            Command::Config(ConfigCommand::Auth(AuthCommand::Show { agent: None }))
         ));
     }
 }


### PR DESCRIPTION
## Summary

Extends the dispatch-symmetry work from #150 one level deeper. Inside `ConfigCommand`, the three sub-enum-wrapping variants still used struct form; they now match the outer `Command::Workspace(WorkspaceCommand)` / `Command::Config(ConfigCommand)` pattern.

```diff
- Mount { #[command(subcommand)] command: MountCommand }
- Trust { #[command(subcommand)] command: TrustCommand }
- Auth  { #[command(subcommand)] command: AuthCommand  }
+ #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+ Mount(MountCommand),
+ #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+ Trust(TrustCommand),
+ #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+ Auth(AuthCommand),
```

## What stays struct-form (deliberate)

Leaf variants inside `WorkspaceCommand` (`Create`, `Edit`, `Prune`), `MountCommand` (`Add`, `Remove`), `TrustCommand` (`Grant`, `Revoke`), `AuthCommand` (`Set`, `Show`) keep struct form because they hold multiple direct `#[arg(...)]` fields, not a sub-enum. That's idiomatic Clap; flipping to tuple form would require wrapping each in an `Args` struct — done when the variant crosses a file boundary (like `LoadArgs`), unnecessary when the variant stays in the same file as the enum that owns it.

## Dispatch / test updates

- `src/app/mod.rs` — 3 match arms:
  - `cli::ConfigCommand::Mount { command: mount_cmd }` → `cli::ConfigCommand::Mount(mount_cmd)`
  - same for `Trust` and `Auth`.
- `src/cli/config.rs::tests` — 9 `matches!` assertions switched:
  - `Command::Config(ConfigCommand::Mount { command: MountCommand::X { .. } })` → `Command::Config(ConfigCommand::Mount(MountCommand::X { .. }))`
  - Same shape for Trust / Auth branches.

## Behavior check

Spot-checked with `cargo run --bin jackin -- <cmd> --help`:

- `config mount --help` — banner + "Manage global mount configurations" ✓
- `config trust --help` — banner + "Manage trust for third-party agent sources" ✓
- `config auth --help` — banner + "Manage Claude Code authentication forwarding from host" ✓
- All 9 leaf subcommands (`config mount add`, `config trust grant`, `config auth set`, etc.) render identically to pre-refactor output.

## Test Preservation Policy

No tests added, deleted, or weakened. **Test count:** 427 → 427.

## Verification (COMMITS.md)

- `cargo fmt -- --check` — pass
- `cargo clippy` — zero warnings
- `cargo nextest run` — **427 tests run: 427 passed, 0 skipped**

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` zero warnings
- [x] `cargo nextest run` 427/427
- [x] No flag rename, no help-text drift
- [x] All `config <sub>` help pages show banner and description
- [x] All 9 `config <sub> <leaf>` help pages render full content

🤖 Generated with [Claude Code](https://claude.com/claude-code)