### PR TITLE
ci(renovate): sign off bot commits so DCO-2 stops blocking its PRs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -22,4 +22,10 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: false
+          # Pin the git author identity so the DCO sign-off trailer in
+          # renovate.json::commitBody always matches the commit-author
+          # email. DCO-2 requires the Signed-off-by email to equal the
+          # commit-author email; without this pin, a change in Renovate's
+          # default author would silently break DCO on every Renovate PR.
+          RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@whitesourcesoftware.com>"
           LOG_LEVEL: debug

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
     "docker:pinDigests"
   ],
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 20
+  "prConcurrentLimit": 20,
+  "commitBody": "Signed-off-by: Renovate Bot <renovate@whitesourcesoftware.com>"
 }


### PR DESCRIPTION
## Summary

Fixes the DCO failure on Renovate PRs (e.g. #130) by teaching Renovate to add a `Signed-off-by:` trailer to every commit it creates. Two coordinated changes:

1. **`renovate.json`** — adds a `commitBody` field with the `Signed-off-by:` trailer. Renovate puts `commitBody` below the subject after a blank line, which is exactly where [DCO-2](https://github.com/cncf/dco2) parses trailers from.
2. **`.github/workflows/renovate.yml`** — pins `RENOVATE_GIT_AUTHOR` explicitly. DCO-2 requires the sign-off email to match the commit-author email; pinning the author identity locks that contract in one place.

## Why now

PR #130 is currently stuck on `DCO` check. The check output is explicit:

> **All commits** are incorrectly signed off. `Sign-off not found`. Remediation commits are not allowed for this repository.

Previous Renovate PRs (#91, #117, #120) were admin-merged past the same check — workable once or twice, not sustainable. This PR fixes the source: Renovate's commit creation.

## Why pin `RENOVATE_GIT_AUTHOR`

Renovate's default commit author has drifted historically (WhiteSource → Mend is one plausible future shift). If the default changed again, the static sign-off email in `renovate.json` would silently stop matching the commit author, and DCO-2 would start failing every Renovate PR with a confusing error. Pinning the env var in the workflow makes the contract explicit:

- author identity set in the workflow env → used for every commit
- sign-off in `renovate.json::commitBody` matches that exact identity
- if either ever needs to change, both change in one easy-to-review PR

The env var value is a static string literal — no untrusted input, no injection surface.

## What this does not do

- **Does not retroactively fix the commit on PR #130.** Renovate's next scan will rebase the stale Renovate branches; their new commits will include the sign-off.
- **Does not change Renovate's update cadence or scope** — only the commit footer.
- **Does not require admin bypass** on any future Renovate PR (assuming DCO-2 stays the only sign-off gate).

## Action required after merge

If you want PR #130 unblocked sooner than Renovate's next scheduled run (`0 6 * * *` UTC), just close #130 — Renovate will reopen it with a sign-off trailer on its next scan. Or trigger a manual run via `workflow_dispatch` on the Renovate workflow.

## Verification

- `renovate.json` is valid JSON (verified).
- `.github/workflows/renovate.yml` is valid YAML (verified).
- No code change, no test change.
- DCO on this PR itself passes (commit signed off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)