### PR TITLE
fix(launch): exit silently when cancelled

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -106,7 +106,9 @@ pub fn run(cli: Cli) -> Result<()> {
             runner.debug = debug;
             tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
-            let (class, workspace) = launch::run_launch(&config, &cwd)?;
+            let Some((class, workspace)) = launch::run_launch(&config, &cwd)? else {
+                return Ok(());
+            };
 
             let sensitive = crate::workspace::find_sensitive_mounts(&workspace.mounts);
             if !sensitive.is_empty() && !crate::workspace::confirm_sensitive_mounts(&sensitive)? {

--- a/src/launch/input.rs
+++ b/src/launch/input.rs
@@ -7,7 +7,7 @@ use crate::workspace::ResolvedWorkspace;
 
 pub(super) enum EventOutcome {
     Continue,
-    Exit(anyhow::Result<(ClassSelector, ResolvedWorkspace)>),
+    Exit(anyhow::Result<Option<(ClassSelector, ResolvedWorkspace)>>),
 }
 
 pub(super) fn handle_event(
@@ -45,7 +45,7 @@ pub(super) fn handle_event(
                         Ok(v) => v,
                         Err(e) => return EventOutcome::Exit(Err(e)),
                     };
-                    return EventOutcome::Exit(Ok((agent, workspace)));
+                    return EventOutcome::Exit(Ok(Some((agent, workspace))));
                 }
                 state.stage = LaunchStage::Agent;
                 state.agent_query.clear();
@@ -58,7 +58,7 @@ pub(super) fn handle_event(
                 .unwrap_or(0);
             }
             KeyCode::Char('q') | KeyCode::Esc => {
-                return EventOutcome::Exit(Err(anyhow::anyhow!("launch cancelled")));
+                return EventOutcome::Exit(Ok(None));
             }
             _ => {}
         },
@@ -101,10 +101,31 @@ pub(super) fn handle_event(
                     Ok(v) => v,
                     Err(e) => return EventOutcome::Exit(Err(e)),
                 };
-                return EventOutcome::Exit(Ok((agent.clone(), workspace)));
+                return EventOutcome::Exit(Ok(Some((agent.clone(), workspace))));
             }
             _ => {}
         },
     }
     EventOutcome::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_q_exits_without_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = AppConfig::default();
+        let mut state = LaunchState::new(&config, temp.path()).unwrap();
+
+        let outcome = handle_event(
+            &mut state,
+            crossterm::event::KeyCode::Char('q'),
+            &config,
+            temp.path(),
+        );
+
+        assert!(matches!(outcome, EventOutcome::Exit(Ok(None))));
+    }
 }

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -14,7 +14,7 @@ use crate::workspace::ResolvedWorkspace;
 pub fn run_launch(
     config: &AppConfig,
     cwd: &std::path::Path,
-) -> anyhow::Result<(ClassSelector, ResolvedWorkspace)> {
+) -> anyhow::Result<Option<(ClassSelector, ResolvedWorkspace)>> {
     use crossterm::ExecutableCommand;
     use crossterm::event::{self, Event, KeyEventKind};
     use crossterm::terminal::{EnterAlternateScreen, enable_raw_mode};


### PR DESCRIPTION
## Summary
- treat quitting the launch picker as a normal exit instead of an error
- return early from `jackin launch` when the picker is cancelled
- add a regression test for the workspace `q` cancel path

## Testing
- cargo fmt -- --check
- cargo clippy
- cargo nextest run