### PR TITLE
feat(config)!: auth_forward sync-default, deprecate copy

### DIFF
--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -59,7 +59,7 @@ Scripts or invocations that still pass `copy` to `jackin config auth set` contin
 
 ```bash
 jackin config auth set sync     # default — overwrite from host on each launch
-jackin config auth set ignore   # never forward (legacy behavior)
+jackin config auth set ignore   # never forward
 ```
 
 ### Override per agent

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -22,23 +22,16 @@ Since the `.claude/` directory and `.claude.json` file are bind-mounted into the
 
 ## Auth forwarding modes
 
-jackin' supports three modes, configurable globally or per-agent:
+jackin' supports two modes, configurable globally or per-agent:
 
 | Mode | Behavior |
 |---|---|
-| `copy` (default) | Copy host auth on first container creation only. Never overwrite afterwards — the container keeps its own auth state. |
-| `sync` | When host auth exists, overwrite container auth on each launch. When host auth is absent, preserve existing container auth. |
+| `sync` (default) | When host auth exists, overwrite container auth on each launch. When host auth is absent, preserve existing container auth. |
 | `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself via `/login`. |
-
-### copy (default)
-
-The `copy` mode seeds credentials once when the agent state is first created. After that, the container owns its auth — restarting the agent, refreshing host tokens, or even logging out on the host does not affect the container.
-
-This is the safest default: the agent gets a working session without manual login, and there's no risk of the host overwriting container-local auth changes.
 
 ### sync
 
-The `sync` mode re-copies host credentials on every launch. Use this when you want agents to always reflect the host's current account — for example, if you rotate credentials frequently or switch between organizations.
+The `sync` mode is the default. It re-copies host credentials on every launch. Use this when you want agents to always reflect the host's current account — for example, if you rotate credentials frequently or switch between organizations.
 
 When the host's `~/.claude.json` or credentials are missing (e.g. you logged out), `sync` preserves the container's existing auth rather than wiping it. This prevents accidental de-authentication from a missing file.
 
@@ -47,6 +40,18 @@ When the host's `~/.claude.json` or credentials are missing (e.g. you logged out
 The `ignore` mode is the legacy behavior — the container starts with an empty `{}` config and no credentials. The agent must authenticate itself inside the container (Claude Code's device-flow login via browser).
 
 Switching an agent from `copy` or `sync` to `ignore` actively revokes any previously forwarded credentials by resetting `.claude.json` to `{}` and deleting `.credentials.json`.
+
+### `copy` (deprecated)
+
+The `copy` mode — "copy host auth on first container creation only; never overwrite afterwards" — was jackin's previous default. It caused subtle auth drift when OAuth refresh tokens rotated across concurrent Claude Code sessions on the host and in containers, surfacing as intermittent `API Error: 401` inside agents.
+
+It was removed in favor of `sync`. On the first launch after upgrading, jackin automatically rewrites any `auth_forward = "copy"` entries in your config to `"sync"` and prints a one-line deprecation notice:
+
+```
+warning: migrated auth_forward "copy" → "sync" in ~/.config/jackin/config.toml (copy is deprecated)
+```
+
+Scripts or invocations that still pass `copy` to `jackin config auth set` continue to work — the value is accepted as a deprecated alias and saved as `sync`.
 
 ## Configuration
 
@@ -80,7 +85,7 @@ jackin config auth show --agent agent-smith
 ```toml
 # Global default
 [claude]
-auth_forward = "copy"
+auth_forward = "sync"
 
 # Per-agent override
 [agents.agent-smith]
@@ -91,7 +96,7 @@ trusted = true
 auth_forward = "ignore"
 ```
 
-Resolution order: **per-agent override > global default > `copy`**.
+Resolution order: **per-agent override > global default > `sync`**.
 
 <Aside type="note">
 Auth forwarding is an operator-level setting. Agent manifests (`jackin.agent.toml`) cannot set or override this — it is always the operator's decision.
@@ -123,7 +128,7 @@ Auth forwarding copies OAuth tokens to the container's filesystem. While the fil
 
 If the agent shows "Not logged in" or falls back to a different model tier (e.g. Sonnet instead of Opus), the credentials may not have been forwarded. Check:
 
-1. **Is auth forwarding enabled?** Run `jackin config auth show` — the default is `copy`.
+1. **Is auth forwarding enabled?** Run `jackin config auth show` — the default is `sync`.
 2. **Does the host have credentials?** On macOS, check `security find-generic-password -s "Claude Code-credentials" -w`. On Linux, check `~/.claude/.credentials.json`.
 3. **Is this a pre-existing container?** In `copy` mode, credentials are only forwarded on first creation. If the container already exists, either switch to `sync` mode or purge and recreate: `jackin purge <agent> && jackin load <agent>`.
 

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -58,8 +58,7 @@ Scripts or invocations that still pass `copy` to `jackin config auth set` contin
 ### Set the global default
 
 ```bash
-jackin config auth set copy     # default — copy on first creation
-jackin config auth set sync     # overwrite from host on each launch
+jackin config auth set sync     # default — overwrite from host on each launch
 jackin config auth set ignore   # never forward (legacy behavior)
 ```
 
@@ -130,7 +129,7 @@ If the agent shows "Not logged in" or falls back to a different model tier (e.g.
 
 1. **Is auth forwarding enabled?** Run `jackin config auth show` — the default is `sync`.
 2. **Does the host have credentials?** On macOS, check `security find-generic-password -s "Claude Code-credentials" -w`. On Linux, check `~/.claude/.credentials.json`.
-3. **Is this a pre-existing container?** In `copy` mode, credentials are only forwarded on first creation. If the container already exists, either switch to `sync` mode or purge and recreate: `jackin purge <agent> && jackin load <agent>`.
+3. **Is this a pre-existing container?** In `sync` mode, host credentials are forwarded on every launch — but if the host has no credentials, the container's existing auth is preserved. If the container has stale auth and the host has fresh auth, restart the container (`jackin eject <agent> && jackin load <agent>`) or purge state (`jackin purge <agent>`) to force a fresh sync.
 
 ### Revoking forwarded credentials
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -19,12 +19,12 @@ The configuration file is TOML format at `~/.config/jackin/config.toml`. It's ma
 
 ```toml
 [claude]
-auth_forward = "copy"  # "copy" (default), "sync", or "ignore"
+auth_forward = "sync"  # "sync" (default) or "ignore"
 ```
 
 | Field | Description | Default |
 |---|---|---|
-| `auth_forward` | How the host's Claude Code credentials are forwarded into agent containers. See [Authentication Forwarding](/guides/authentication). | `copy` |
+| `auth_forward` | How the host's Claude Code credentials are forwarded into agent containers. See [Authentication Forwarding](/guides/authentication). | `sync` |
 
 Per-agent overrides are set under the agent's `[claude]` section:
 
@@ -33,7 +33,7 @@ Per-agent overrides are set under the agent's `[claude]` section:
 auth_forward = "ignore"
 ```
 
-Resolution order: per-agent override > global `[claude]` > `copy`.
+Resolution order: per-agent override > global `[claude]` > `sync`.
 
 ### Workspaces
 

--- a/docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx
@@ -39,9 +39,10 @@ Please run /login · API Error: 401 {"type":"error","error":{"type":"authenticat
 
 The current operator-facing modes are:
 
-- `copy` — copy host auth on first container creation only
-- `sync` — overwrite container auth from host on each launch when host auth exists
+- `sync` — overwrite container auth from host on each launch when host auth exists (default as of the `sync`-default release)
 - `ignore` — never forward host auth; require in-container login
+
+Historically there was also a `copy` mode (copy on first creation; never overwrite afterwards), which is deprecated. Configs that still declare `auth_forward = "copy"` are migrated to `sync` on load with a deprecation notice.
 
 Those modes are coherent, but they optimize for filesystem ownership of credentials, not for concurrent-session reliability.
 

--- a/docs/superpowers/plans/2026-04-23-auth-sync-default.md
+++ b/docs/superpowers/plans/2026-04-23-auth-sync-default.md
@@ -1,0 +1,1248 @@
+# Auth Forward: `sync` as Default, Deprecate `copy` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `auth_forward = "sync"` the default, migrate existing `copy` configs in place with a one-line deprecation notice on load, drop the `AuthForwardMode::Copy` enum variant.
+
+**Architecture:** One-file schema change (drop variant from `AuthForwardMode`), plus a small migration pass in the config loader that detects the deprecated `"copy"` literal at two known TOML paths (`claude.auth_forward`, `agents.*.claude.auth_forward`) and rewrites the file using the existing `AppConfig::save` path. `FromStr` and `Deserialize` accept `"copy"` as a deprecated alias that resolves to `Sync`, so scripts and CI workflows that still pass `copy` never break. CLI surface emits a one-line deprecation warning on `jackin config auth set copy`.
+
+**Tech Stack:** Rust (edition 2024), `serde` + `toml` 1.x (already in `Cargo.toml`), `owo-colors` for the warning color, `anyhow` for errors, `tempfile` + `cargo-nextest` for tests.
+
+**Branch:** `feature/auth-sync-default` (per `BRANCHING.md` — `feature/<short-description>`).
+**Commit style:** Conventional Commits with DCO `Signed-off-by` and `Co-authored-by: Claude <noreply@anthropic.com>` per `AGENTS.md`.
+**Spec:** `docs/superpowers/specs/2026-04-23-auth-sync-default-design.md`.
+
+---
+
+## File Structure
+
+| File                                                                     | Purpose                                                                 |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `src/config/mod.rs`                                                      | `AuthForwardMode` enum, `Default`, `Display`, `FromStr`, custom `Deserialize`. |
+| `src/config/persist.rs`                                                  | `load_or_init` detects deprecated `copy` in raw TOML; rewrites to disk via `save`. |
+| `src/config/agents.rs`                                                   | One docstring update (`→ Copy` → `→ Sync`). Tests updated.              |
+| `src/instance/auth.rs`                                                   | Drop the `Copy` match arm in `provision_claude_auth`. Tests updated.    |
+| `src/cli/config.rs`                                                      | Help-text update: drop `copy` from the examples and the help body.     |
+| `src/app/mod.rs`                                                         | `AuthCommand::Set`: print a deprecation warning when the CLI receives `copy`. |
+| `src/tui/output.rs`                                                      | Add `pub fn deprecation_warning(msg: &str)` (one-liner yellow notice).  |
+| `src/tui/mod.rs`                                                         | Re-export `deprecation_warning`.                                        |
+| `docs/src/content/docs/guides/authentication.mdx`                        | Mode table drops `copy`; `sync` labelled default; mention migration.    |
+| `docs/src/content/docs/reference/configuration.mdx`                      | `auth_forward` default updated.                                         |
+| `docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx`       | "Current State" note that `copy` is deprecated.                         |
+| `CHANGELOG.md`                                                           | `Changed` + `Deprecated` entries under `## [Unreleased]`.               |
+
+No new files.
+
+---
+
+## Preflight
+
+- [ ] **Step 0.1: Ensure clean tree on `main`**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. If dirty, stop and investigate.
+
+- [ ] **Step 0.2: Create the feature branch**
+
+```bash
+git checkout -b feature/auth-sync-default
+```
+
+- [ ] **Step 0.3: Confirm pre-commit gate is currently clean (baseline)**
+
+```bash
+cargo fmt -- --check && cargo clippy && cargo nextest run
+```
+
+Expected: all three exit 0. If any fail, do NOT start this work — fix baseline first or you will be chasing unrelated failures.
+
+---
+
+## Task 1: Drop `Copy`, set `Sync` as default, accept `"copy"` as deprecated alias
+
+**Files:**
+- Modify: `src/config/mod.rs:20-57` (enum, `Display`, `FromStr`, add custom `Deserialize`)
+- Modify: `src/config/agents.rs:46-49` (docstring referencing `Copy`)
+
+- [ ] **Step 1.1: Write failing tests for the new default + deprecated-alias behavior**
+
+Add to the `#[cfg(test)] mod tests` block at the bottom of `src/config/mod.rs`:
+
+```rust
+#[test]
+fn auth_forward_mode_default_is_sync() {
+    assert_eq!(AuthForwardMode::default(), AuthForwardMode::Sync);
+}
+
+#[test]
+fn auth_forward_mode_from_str_accepts_copy_as_deprecated_alias() {
+    use std::str::FromStr;
+    assert_eq!(
+        AuthForwardMode::from_str("copy").unwrap(),
+        AuthForwardMode::Sync
+    );
+}
+
+#[test]
+fn auth_forward_mode_from_str_accepts_sync_and_ignore() {
+    use std::str::FromStr;
+    assert_eq!(
+        AuthForwardMode::from_str("sync").unwrap(),
+        AuthForwardMode::Sync
+    );
+    assert_eq!(
+        AuthForwardMode::from_str("ignore").unwrap(),
+        AuthForwardMode::Ignore
+    );
+}
+
+#[test]
+fn auth_forward_mode_from_str_rejects_unknown_values() {
+    use std::str::FromStr;
+    assert!(AuthForwardMode::from_str("bogus").is_err());
+}
+
+#[test]
+fn auth_forward_mode_deserializes_copy_to_sync() {
+    let toml_str = r#"
+[claude]
+auth_forward = "copy"
+"#;
+    let config: AppConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+}
+
+#[test]
+fn auth_forward_mode_display_does_not_emit_copy() {
+    assert_eq!(AuthForwardMode::Sync.to_string(), "sync");
+    assert_eq!(AuthForwardMode::Ignore.to_string(), "ignore");
+}
+```
+
+- [ ] **Step 1.2: Run the new tests — confirm they fail**
+
+```bash
+cargo nextest run -p jackin --test-threads=1 \
+  config::tests::auth_forward_mode_default_is_sync \
+  config::tests::auth_forward_mode_from_str_accepts_copy_as_deprecated_alias \
+  config::tests::auth_forward_mode_deserializes_copy_to_sync
+```
+
+Expected: fails — `auth_forward_mode_default_is_sync` fails (default is currently `Copy`), `from_str_accepts_copy_as_deprecated_alias` still returns `Copy`, `deserializes_copy_to_sync` still returns `Copy`.
+
+- [ ] **Step 1.3: Edit `AuthForwardMode` enum — remove `Copy`, make `Sync` default**
+
+In `src/config/mod.rs`, replace the enum definition (lines 20–32 currently):
+
+```rust
+/// Controls how the host's `~/.claude.json` is forwarded into agent containers.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthForwardMode {
+    /// Revoke any forwarded auth and never copy — container starts with `{}`.
+    Ignore,
+    /// Overwrite container auth from host on each launch when host auth
+    /// exists; preserve container auth when host auth is absent.
+    #[default]
+    Sync,
+}
+```
+
+Note: `Deserialize` is no longer derived — we'll hand-roll it in Step 1.5 so `"copy"` maps to `Sync` as a deprecated alias.
+
+- [ ] **Step 1.4: Update `Display` and `FromStr`**
+
+Replace the `Display` and `FromStr` impls (lines 34–57 currently):
+
+```rust
+impl std::fmt::Display for AuthForwardMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ignore => write!(f, "ignore"),
+            Self::Sync => write!(f, "sync"),
+        }
+    }
+}
+
+impl std::str::FromStr for AuthForwardMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ignore" => Ok(Self::Ignore),
+            "sync" => Ok(Self::Sync),
+            // Deprecated alias — accepted to avoid breaking scripts and
+            // configs from before the default flipped to `sync`. Callers
+            // that want to surface the deprecation should check for the
+            // literal `"copy"` themselves before calling `parse()`.
+            "copy" => Ok(Self::Sync),
+            other => Err(format!(
+                "invalid auth_forward mode {other:?}; expected one of: sync, ignore"
+            )),
+        }
+    }
+}
+```
+
+- [ ] **Step 1.5: Add custom `Deserialize` impl that routes through `FromStr`**
+
+Add immediately after the `FromStr` impl:
+
+```rust
+impl<'de> serde::Deserialize<'de> for AuthForwardMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(D::Error::custom)
+    }
+}
+```
+
+- [ ] **Step 1.6: Update the docstring in `src/config/agents.rs:46-49`**
+
+Replace:
+
+```rust
+    /// Resolution order: per-agent override → global default → `Copy`.
+```
+
+with:
+
+```rust
+    /// Resolution order: per-agent override → global default → `Sync`.
+```
+
+- [ ] **Step 1.7: Update stale tests that referenced `AuthForwardMode::Copy`**
+
+Two tests in `src/config/agents.rs` (currently at lines 346–388) reference `Copy`:
+
+Find and replace:
+
+```rust
+    #[test]
+    fn auth_forward_defaults_to_copy() {
+        let config = AppConfig::default();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Copy);
+    }
+```
+
+with:
+
+```rust
+    #[test]
+    fn auth_forward_defaults_to_sync() {
+        let config = AppConfig::default();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+    }
+```
+
+And:
+
+```rust
+    #[test]
+    fn resolve_auth_forward_defaults_to_copy() {
+        let config = AppConfig::default();
+        assert_eq!(
+            config.resolve_auth_forward_mode("nonexistent"),
+            AuthForwardMode::Copy
+        );
+    }
+```
+
+with:
+
+```rust
+    #[test]
+    fn resolve_auth_forward_defaults_to_sync() {
+        let config = AppConfig::default();
+        assert_eq!(
+            config.resolve_auth_forward_mode("nonexistent"),
+            AuthForwardMode::Sync
+        );
+    }
+```
+
+Also update `src/config/mod.rs:310-323` test `existing_config_without_claude_section_deserializes_with_defaults`:
+
+```rust
+    #[test]
+    fn existing_config_without_claude_section_deserializes_with_defaults() {
+        let toml_str = r#"
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            AuthForwardMode::Sync
+        );
+    }
+```
+
+- [ ] **Step 1.8: Run tests — confirm the new ones pass and nothing else regresses**
+
+```bash
+cargo nextest run -p jackin config
+```
+
+Expected: all green. If the `auth.rs` tests under `instance::` fail because of the `Copy` variant removal, that's Task 2's job — those failures are expected at this stage.
+
+- [ ] **Step 1.9: Commit Task 1**
+
+```bash
+git add src/config/mod.rs src/config/agents.rs
+git commit -s -m "$(cat <<'EOF'
+feat(config)!: drop AuthForwardMode::Copy; default to Sync; accept "copy" as deprecated alias
+
+Drop the Copy variant from AuthForwardMode. Default is now Sync. The string
+literal "copy" is still accepted by FromStr and Deserialize and resolves to
+Sync, so existing configs and CLI invocations keep working. Callers that
+want to emit a deprecation warning check for the literal themselves.
+
+BREAKING CHANGE: the Rust-level AuthForwardMode::Copy variant no longer
+exists. External Rust code that pattern-matched on it must update its match
+arms. The TOML/CLI surface remains backward-compatible (accepts "copy" as
+an alias).
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Drop the `Copy` arm in `provision_claude_auth`
+
+**Files:**
+- Modify: `src/instance/auth.rs:38-52` (remove the `Copy` match arm)
+- Modify: `src/instance/auth.rs:276-362, 408-437, 653-693, 696-736` (tests that use `AuthForwardMode::Copy`)
+
+- [ ] **Step 2.1: Run the instance tests to see what fails after Task 1**
+
+```bash
+cargo nextest run -p jackin instance::
+```
+
+Expected: multiple failures in `instance::tests` referencing `AuthForwardMode::Copy` (variant no longer exists).
+
+- [ ] **Step 2.2: Remove the `Copy` match arm from `provision_claude_auth`**
+
+In `src/instance/auth.rs`, delete lines 38–52 (the entire `AuthForwardMode::Copy` arm including the comment block). The match should now contain only two arms: `Ignore` and `Sync`. No behavioral change to those two.
+
+After the edit, the match looks like:
+
+```rust
+let outcome = match mode {
+    AuthForwardMode::Ignore => {
+        // ... existing body unchanged ...
+    }
+    AuthForwardMode::Sync => {
+        // ... existing body unchanged ...
+    }
+};
+```
+
+- [ ] **Step 2.3: Replace `Copy` in tests that verified shared behavior**
+
+Tests that used `Copy` only because it was the default and the test wasn't about `Copy` semantics specifically should be updated to `Sync`. Specifically rewrite these test bodies:
+
+`copy_mode_does_not_overwrite_existing` (lines 326-362) — this test verifies the exact `Copy`-specific semantic we're removing ("never overwrite afterwards"). **Delete the test entirely.** The invariant no longer exists.
+
+`copy_mode_copies_host_auth_on_first_run` (lines 276-302) — rename to reflect what it now proves. Replace the body with a `Sync`-equivalent assertion since `Copy` and `Sync` behave identically on first run:
+
+```rust
+    #[test]
+    fn sync_mode_copies_host_auth_on_first_run() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        let (state, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert!(
+            std::fs::read_to_string(&state.claude_json)
+                .unwrap()
+                .contains("test@example.com")
+        );
+        assert_eq!(
+            std::fs::read_to_string(state.claude_dir.join(".credentials.json")).unwrap(),
+            TEST_CREDENTIALS
+        );
+        assert_eq!(outcome, AuthProvisionOutcome::Synced);
+    }
+```
+
+`copy_mode_falls_back_to_empty_json_when_host_has_none` (lines 304-323) — rename and switch to `Sync`:
+
+```rust
+    #[test]
+    fn sync_mode_falls_back_to_empty_json_when_host_has_none() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        // No host auth seeded
+        let manifest = simple_manifest(&temp);
+
+        let (state, outcome) = AgentState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
+        assert!(!state.claude_dir.join(".credentials.json").exists());
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+    }
+```
+
+`switching_from_copy_to_ignore_revokes_forwarded_credentials` (lines 408-437) — rename to `switching_from_sync_to_ignore_revokes_forwarded_credentials` **if it doesn't already exist** (there's already one at 440-468, so the old `copy`-based test is redundant — delete it).
+
+`auth_file_has_restricted_permissions` (lines 513-544) — change `AuthForwardMode::Copy` to `AuthForwardMode::Sync`. Body is unchanged.
+
+`rejects_symlink_at_claude_json` (lines 654-693) — change `AuthForwardMode::Copy` in the two `prepare` calls to `AuthForwardMode::Sync`. Body unchanged.
+
+`rejects_symlink_at_credentials_json` (lines 696-736) — change `AuthForwardMode::Copy` in the two `prepare` calls to `AuthForwardMode::Sync`. Body unchanged.
+
+- [ ] **Step 2.4: Run tests — confirm instance module is green**
+
+```bash
+cargo nextest run -p jackin instance::
+```
+
+Expected: all green, with fewer tests (two deleted).
+
+- [ ] **Step 2.5: Run full suite to catch anything else referencing `Copy`**
+
+```bash
+cargo build --all-targets
+```
+
+Expected: compiles cleanly with no warnings. If there are remaining references to `AuthForwardMode::Copy`, the compiler will point at them.
+
+```bash
+cargo nextest run
+```
+
+Expected: all green.
+
+- [ ] **Step 2.6: Commit Task 2**
+
+```bash
+git add src/instance/auth.rs
+git commit -s -m "$(cat <<'EOF'
+refactor(instance): drop Copy arm in provision_claude_auth
+
+Remove the AuthForwardMode::Copy match arm now that the variant no longer
+exists. Tests that verified Copy-specific "never overwrite after first
+run" semantics are deleted along with the semantic. Tests that used Copy
+only because it was the default are migrated to Sync, which is now the
+default and has equivalent first-run behavior.
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Detect deprecated `copy` in config on load, rewrite to disk, print notice
+
+**Files:**
+- Modify: `src/config/persist.rs:1-46` (`load_or_init`, add detector helper)
+- Modify: `src/tui/output.rs:130-140` (new `deprecation_warning` helper)
+- Modify: `src/tui/mod.rs:26-30` (re-export)
+
+- [ ] **Step 3.1: Add the `deprecation_warning` helper in `src/tui/output.rs`**
+
+After the existing `fatal` function (around line 140), add:
+
+```rust
+/// One-line yellow deprecation warning to stderr. Used for soft-migration
+/// notices like "config field X is deprecated — migrated to Y".
+pub fn deprecation_warning(msg: &str) {
+    const AMBER: (u8, u8, u8) = (230, 180, 80);
+    eprintln!(
+        "  {} {}",
+        "warning:".color(rgb(AMBER)).bold(),
+        msg.color(rgb(AMBER)),
+    );
+}
+```
+
+- [ ] **Step 3.2: Re-export `deprecation_warning` from `src/tui/mod.rs`**
+
+Find the `pub use output::{ ... }` block around line 26 and add `deprecation_warning` to the list, alphabetically or at the end depending on existing style.
+
+- [ ] **Step 3.3: Write failing test for migration detection + rewrite**
+
+In `src/config/persist.rs`, at the bottom of `mod tests`:
+
+```rust
+#[test]
+fn load_migrates_global_copy_to_sync_and_rewrites_config() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+
+    std::fs::write(
+        &paths.config_file,
+        r#"[claude]
+auth_forward = "copy"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+"#,
+    )
+    .unwrap();
+
+    let config = AppConfig::load_or_init(&paths).unwrap();
+
+    // In memory, Copy normalized to Sync
+    assert_eq!(
+        config.claude.auth_forward,
+        crate::config::AuthForwardMode::Sync
+    );
+
+    // On disk, "copy" no longer present
+    let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(
+        !persisted.contains("auth_forward = \"copy\""),
+        "expected on-disk config to be migrated; got:\n{persisted}"
+    );
+    assert!(
+        persisted.contains("auth_forward = \"sync\""),
+        "expected migrated config to contain sync; got:\n{persisted}"
+    );
+}
+
+#[test]
+fn load_migrates_per_agent_copy_to_sync() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.agent-smith.claude]
+auth_forward = "copy"
+"#,
+    )
+    .unwrap();
+
+    let config = AppConfig::load_or_init(&paths).unwrap();
+
+    assert_eq!(
+        config.resolve_auth_forward_mode("agent-smith"),
+        crate::config::AuthForwardMode::Sync
+    );
+
+    let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!persisted.contains("auth_forward = \"copy\""));
+}
+
+#[test]
+fn load_does_not_rewrite_when_no_copy_present() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+
+    // Bootstrap once so builtins are synced and file stabilizes.
+    AppConfig::load_or_init(&paths).unwrap();
+    let mtime_before = std::fs::metadata(&paths.config_file)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Second load with no "copy" anywhere — must not rewrite.
+    AppConfig::load_or_init(&paths).unwrap();
+    let mtime_after = std::fs::metadata(&paths.config_file)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    assert_eq!(mtime_before, mtime_after);
+}
+```
+
+- [ ] **Step 3.4: Run the new tests — confirm they fail**
+
+```bash
+cargo nextest run -p jackin config::persist::tests::load_migrates_global_copy_to_sync_and_rewrites_config config::persist::tests::load_migrates_per_agent_copy_to_sync
+```
+
+Expected: both tests fail — `load_or_init` currently doesn't rewrite when `copy` is present; even though the in-memory value is normalized to `Sync` (thanks to Task 1), the file still contains `"copy"`.
+
+- [ ] **Step 3.5: Add the detector + migration in `load_or_init`**
+
+Make two edits in `src/config/persist.rs`:
+
+**Edit 1 — replace the `impl AppConfig { ... }` block** (lines 4–46 currently) with this exact block:
+
+```rust
+impl AppConfig {
+    pub fn load_or_init(paths: &JackinPaths) -> anyhow::Result<Self> {
+        paths.ensure_base_dirs()?;
+
+        let contents_opt = match std::fs::read_to_string(&paths.config_file) {
+            Ok(c) => Some(c),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => return Err(e.into()),
+        };
+
+        let deprecated_copy_seen = match &contents_opt {
+            Some(c) => contains_deprecated_copy_auth_forward(c)?,
+            None => false,
+        };
+
+        let mut config: Self = match contents_opt {
+            Some(c) => toml::from_str(&c)?,
+            None => Self::default(),
+        };
+
+        let builtins_changed = config.sync_builtin_agents();
+
+        if deprecated_copy_seen {
+            crate::tui::deprecation_warning(&format!(
+                "migrated auth_forward \"copy\" → \"sync\" in {} (copy is deprecated)",
+                paths.config_file.display()
+            ));
+        }
+
+        if builtins_changed || deprecated_copy_seen {
+            config.save(paths)?;
+        }
+
+        config.validate_workspaces()?;
+        Ok(config)
+    }
+
+    pub fn save(&self, paths: &JackinPaths) -> anyhow::Result<()> {
+        let contents = toml::to_string_pretty(self)?;
+        let tmp = paths.config_file.with_extension("tmp");
+
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+        }
+
+        #[cfg(not(unix))]
+        std::fs::write(&tmp, &contents)?;
+
+        std::fs::rename(&tmp, &paths.config_file)?;
+        Ok(())
+    }
+}
+```
+
+**Edit 2 — insert this new free function immediately after the closing `}` of the `impl` block, BEFORE the `#[cfg(test)] mod tests` block:**
+
+```rust
+/// Detect the literal deprecated `auth_forward = "copy"` at either of the
+/// two known config paths: the global `[claude]` table or any
+/// `[agents.*.claude]` table. Returns `true` if any occurrence is found.
+///
+/// Uses `toml::Value` (cheap — we parse the same string into `AppConfig`
+/// right after) instead of a regex, so quoted keys with odd whitespace
+/// are handled correctly.
+fn contains_deprecated_copy_auth_forward(raw: &str) -> anyhow::Result<bool> {
+    let value: toml::Value = toml::from_str(raw)?;
+
+    // Global [claude] auth_forward
+    if let Some(s) = value
+        .get("claude")
+        .and_then(|c| c.get("auth_forward"))
+        .and_then(|v| v.as_str())
+        && s == "copy"
+    {
+        return Ok(true);
+    }
+
+    // Per-agent [agents.<name>.claude] auth_forward
+    if let Some(agents) = value.get("agents").and_then(|a| a.as_table()) {
+        for agent in agents.values() {
+            if let Some(s) = agent
+                .get("claude")
+                .and_then(|c| c.get("auth_forward"))
+                .and_then(|v| v.as_str())
+                && s == "copy"
+            {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+```
+
+**Do not touch the existing `#[cfg(test)] mod tests` block** — the three failing tests from Step 3.3 are already inside it, and the existing `sync_does_not_rewrite_config_when_already_current` test stays untouched as the "no-op on clean config" regression guard.
+
+- [ ] **Step 3.6: Run tests — confirm the new ones pass**
+
+```bash
+cargo nextest run -p jackin config::persist::tests
+```
+
+Expected: all four tests green.
+
+- [ ] **Step 3.7: Run full suite for regressions**
+
+```bash
+cargo nextest run
+```
+
+Expected: all green.
+
+- [ ] **Step 3.8: Commit Task 3**
+
+```bash
+git add src/config/persist.rs src/tui/output.rs src/tui/mod.rs
+git commit -s -m "$(cat <<'EOF'
+feat(config): migrate deprecated auth_forward "copy" to "sync" on load
+
+On every load, scan the raw TOML for auth_forward = "copy" at the two
+known paths (global [claude] and [agents.*.claude]). If found, normalize
+to sync in memory, rewrite the config to disk via the existing save path,
+and print a one-line deprecation warning naming the config file.
+
+Add tui::deprecation_warning() — yellow one-liner to stderr, used for
+soft migration notices like this one.
+
+Existing behavior (builtin agent sync, mtime-invariant reload) is
+preserved for configs that don't contain the deprecated literal.
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: CLI emits deprecation warning when operator runs `jackin config auth set copy`
+
+**Files:**
+- Modify: `src/app/mod.rs:295-311` (CLI `AuthCommand::Set` handler)
+
+- [ ] **Step 4.1: Write a failing test for the CLI deprecation path**
+
+This handler is currently untested directly. The most focused seam is to extract the mode-parsing-and-warning logic into a small function and unit-test that function. Add to `src/app/mod.rs` inside its existing `#[cfg(test)] mod tests` if present, or create one at the bottom:
+
+```rust
+#[cfg(test)]
+mod auth_set_tests {
+    use super::*;
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_accepts_copy_as_deprecated() {
+        let (mode, was_deprecated) =
+            parse_auth_forward_mode_from_cli("copy").unwrap();
+        assert_eq!(mode, crate::config::AuthForwardMode::Sync);
+        assert!(was_deprecated);
+    }
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_accepts_sync_non_deprecated() {
+        let (mode, was_deprecated) =
+            parse_auth_forward_mode_from_cli("sync").unwrap();
+        assert_eq!(mode, crate::config::AuthForwardMode::Sync);
+        assert!(!was_deprecated);
+    }
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_rejects_bogus() {
+        assert!(parse_auth_forward_mode_from_cli("bogus").is_err());
+    }
+}
+```
+
+- [ ] **Step 4.2: Run the new tests — confirm they fail**
+
+```bash
+cargo nextest run -p jackin auth_set_tests
+```
+
+Expected: fails — `parse_auth_forward_mode_from_cli` does not exist.
+
+- [ ] **Step 4.3: Add the helper and update the handler**
+
+At a logical location in `src/app/mod.rs` (e.g. just above the main `run` function), add:
+
+```rust
+/// Parse an `auth_forward` mode value as it arrived from the CLI.
+///
+/// Returns the resolved mode and a boolean indicating whether the operator
+/// passed the deprecated `copy` alias — the caller is responsible for
+/// emitting a user-facing warning in that case.
+fn parse_auth_forward_mode_from_cli(
+    raw: &str,
+) -> anyhow::Result<(config::AuthForwardMode, bool)> {
+    let mode: config::AuthForwardMode =
+        raw.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
+    let was_deprecated = raw == "copy";
+    Ok((mode, was_deprecated))
+}
+```
+
+Replace the `AuthCommand::Set` arm (currently lines 296–311) with:
+
+```rust
+                cli::AuthCommand::Set { mode, agent } => {
+                    let (parsed_mode, was_deprecated) =
+                        parse_auth_forward_mode_from_cli(&mode)?;
+                    if was_deprecated {
+                        tui::deprecation_warning(
+                            "auth_forward \"copy\" is deprecated; saving as \"sync\"",
+                        );
+                    }
+                    if let Some(agent_selector) = agent {
+                        let class = ClassSelector::parse(&agent_selector)?;
+                        config.resolve_agent_source(&class)?;
+                        config.set_agent_auth_forward(&class.key(), parsed_mode);
+                        config.save(&paths)?;
+                        println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
+                    } else {
+                        config.claude.auth_forward = parsed_mode;
+                        config.save(&paths)?;
+                        println!("Set global auth forwarding to {parsed_mode}.");
+                    }
+                    Ok(())
+                }
+```
+
+- [ ] **Step 4.4: Run tests — confirm all green**
+
+```bash
+cargo nextest run -p jackin auth_set_tests
+cargo nextest run
+```
+
+Expected: all green.
+
+- [ ] **Step 4.5: Commit Task 4**
+
+```bash
+git add src/app/mod.rs
+git commit -s -m "$(cat <<'EOF'
+feat(cli): emit deprecation warning when operator sets auth_forward = "copy"
+
+Extract the CLI mode parse into parse_auth_forward_mode_from_cli, which
+returns (mode, was_deprecated). The config auth set handler uses the
+deprecation flag to emit a one-line warning via tui::deprecation_warning
+before saving. The saved value is always the canonical sync; "copy" is
+never written to disk.
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Update CLI help text — remove `copy` from examples and mode list
+
+**Files:**
+- Modify: `src/cli/config.rs:13-57` (doc comments + `after_long_help` blocks)
+
+- [ ] **Step 5.1: Write failing tests asserting help text no longer mentions `copy` as a mode**
+
+Edit the existing `config_auth_set_help_shows_examples` test (around line 278):
+
+```rust
+    #[test]
+    fn config_auth_set_help_shows_examples() {
+        let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
+        assert!(help.contains("Examples:"));
+        assert!(help.contains("jackin config auth set sync"));
+        assert!(help.contains("--agent"));
+        assert!(
+            !help.contains("jackin config auth set copy"),
+            "help text must not recommend the deprecated copy mode"
+        );
+    }
+```
+
+Also add:
+
+```rust
+    #[test]
+    fn config_auth_set_help_lists_modes_without_copy() {
+        let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
+        assert!(help.contains("sync"));
+        assert!(help.contains("ignore"));
+        // `copy` must not appear as an advertised mode. A word-boundary
+        // check is close enough — the string "copy" should not show up
+        // in help text once deprecated.
+        assert!(
+            !help.to_lowercase().contains("copy"),
+            "help text must not mention copy; got:\n{help}"
+        );
+    }
+```
+
+- [ ] **Step 5.2: Run the tests — confirm they fail**
+
+```bash
+cargo nextest run -p jackin cli::config::tests::config_auth_set_help_shows_examples cli::config::tests::config_auth_set_help_lists_modes_without_copy
+```
+
+Expected: both fail — current help still shows `copy`.
+
+- [ ] **Step 5.3: Update the `AuthCommand::Set` doc comment and `after_long_help`**
+
+In `src/cli/config.rs`, replace lines 19–43 (the `Set` variant) with:
+
+```rust
+    /// Set the authentication forwarding mode
+    ///
+    /// Controls how the host's ~/.claude.json is forwarded into agent containers.
+    /// Modes: sync (overwrite from host on each launch when host auth exists;
+    /// preserve container auth when host auth is absent — default), ignore
+    /// (revoke and never copy).
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config auth set sync
+  jackin config auth set ignore
+  jackin config auth set sync --agent agent-smith
+  jackin config auth set ignore --agent chainargos/the-architect"
+    )]
+    Set {
+        /// Authentication forwarding mode: sync or ignore
+        mode: String,
+        /// Apply to a specific agent instead of globally
+        #[arg(long)]
+        agent: Option<String>,
+    },
+```
+
+Similarly update the `Show` variant's `after_long_help` to drop any `copy` references (there are none in the current snippet, but verify).
+
+- [ ] **Step 5.4: Update the existing `parses_config_auth_set_global` test if it uses `copy`**
+
+It does (line 294). Change the argument from `"copy"` to `"sync"`, and update the assertion:
+
+```rust
+    #[test]
+    fn parses_config_auth_set_global() {
+        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "sync"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Config(ConfigCommand::Auth(AuthCommand::Set {
+                        ref mode,
+                        agent: None,
+                    })) if mode == "sync"
+        ));
+    }
+```
+
+- [ ] **Step 5.5: Run tests — confirm all green**
+
+```bash
+cargo nextest run -p jackin cli::
+cargo nextest run
+```
+
+Expected: all green.
+
+- [ ] **Step 5.6: Commit Task 5**
+
+```bash
+git add src/cli/config.rs
+git commit -s -m "$(cat <<'EOF'
+docs(cli): remove "copy" from config auth set help text and examples
+
+The copy mode is deprecated and no longer listed in `--help` output or
+example blocks. Accepted modes are now sync (default) and ignore. The
+CLI still accepts "copy" as a deprecated alias (handled in src/app/mod.rs)
+but we don't advertise it.
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Documentation updates
+
+**Files:**
+- Modify: `docs/src/content/docs/guides/authentication.mdx`
+- Modify: `docs/src/content/docs/reference/configuration.mdx`
+- Modify: `docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx`
+
+- [ ] **Step 6.1: Update `authentication.mdx` mode table and prose**
+
+Replace the table at `docs/src/content/docs/guides/authentication.mdx:27-31`:
+
+```markdown
+## Auth forwarding modes
+
+jackin' supports two modes, configurable globally or per-agent:
+
+| Mode | Behavior |
+|---|---|
+| `sync` (default) | When host auth exists, overwrite container auth on each launch. When host auth is absent, preserve existing container auth. |
+| `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself via `/login`. |
+```
+
+Delete the `### copy (default)` subsection (lines 33-37). Move the `### sync` subsection up, and update the opening line to "The `sync` mode is the default."
+
+Add a new subsection after the mode descriptions:
+
+```markdown
+### `copy` (deprecated)
+
+The `copy` mode — "copy host auth on first container creation only; never overwrite afterwards" — was jackin's previous default. It caused subtle auth drift when OAuth refresh tokens rotated across concurrent Claude Code sessions on the host and in containers, surfacing as intermittent `API Error: 401` inside agents.
+
+It was removed in favor of `sync`. On the first launch after upgrading, jackin automatically rewrites any `auth_forward = "copy"` entries in your config to `"sync"` and prints a one-line deprecation notice:
+
+\`\`\`
+warning: migrated auth_forward "copy" → "sync" in ~/.config/jackin/config.toml (copy is deprecated)
+\`\`\`
+
+Scripts or invocations that still pass `copy` to `jackin config auth set` continue to work — the value is accepted as a deprecated alias and saved as `sync`.
+```
+
+Update the config example at lines 82–92 to use `sync`:
+
+```toml
+# Global default
+[claude]
+auth_forward = "sync"
+
+# Per-agent override
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[agents.agent-smith.claude]
+auth_forward = "ignore"
+```
+
+- [ ] **Step 6.2: Update `configuration.mdx` — default changed**
+
+Search for `auth_forward` in `docs/src/content/docs/reference/configuration.mdx` and update any mention of "default: copy" to "default: sync", and remove `copy` from accepted-values lists.
+
+- [ ] **Step 6.3: Update the roadmap's "Current State" section**
+
+In `docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx`, replace the "Current State" list (lines 40–45):
+
+```markdown
+## Current State
+
+The current operator-facing modes are:
+
+- `sync` — overwrite container auth from host on each launch when host auth exists (default as of the `sync`-default release)
+- `ignore` — never forward host auth; require in-container login
+
+Historically there was also a `copy` mode (copy on first creation; never overwrite afterwards), which is deprecated. Configs that still declare `auth_forward = "copy"` are migrated to `sync` on load with a deprecation notice.
+```
+
+- [ ] **Step 6.4: Verify docs site still builds**
+
+The docs are Astro/Starlight with Bun. From the `docs/` directory:
+
+```bash
+cd docs
+bun install --frozen-lockfile
+bun run build 2>&1 | tail -20
+cd ..
+```
+
+Expected: build succeeds. If `bun install` is slow, the `node_modules` cache should make subsequent builds fast.
+
+- [ ] **Step 6.5: Commit Task 6**
+
+```bash
+git add docs/src/content/docs/guides/authentication.mdx \
+  docs/src/content/docs/reference/configuration.mdx \
+  docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx
+git commit -s -m "$(cat <<'EOF'
+docs(auth): sync is default, copy is deprecated
+
+Update the authentication guide, configuration reference, and the
+claude-auth-strategy roadmap to reflect that sync is now the default
+auth_forward mode and copy is deprecated (auto-migrated on load).
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 7.1: Read the existing CHANGELOG to match style**
+
+```bash
+head -30 CHANGELOG.md
+```
+
+- [ ] **Step 7.2: Add `Changed` and `Deprecated` entries under `## [Unreleased]`**
+
+If an `## [Unreleased]` section does not exist at the top, add one. Under it, add (following existing keep-a-changelog-style headings):
+
+```markdown
+### Changed
+
+- `auth_forward` default is now `sync` (was `copy`). Existing configs that declare `auth_forward = "copy"` are migrated to `"sync"` on the next `jackin` launch, with a one-line deprecation warning. This resolves the intermittent `API Error: 401` that operators saw when multiple Claude Code sessions ran concurrently — see the Claude auth strategy roadmap for context. [#<pr-number>]
+
+### Deprecated
+
+- `auth_forward = "copy"` is deprecated. The value is still accepted by the CLI (`jackin config auth set copy`) and by the TOML config as a compatibility alias, but it resolves to `"sync"` and a deprecation warning is printed. Update your configs to `"sync"` directly. [#<pr-number>]
+```
+
+Leave `<pr-number>` as a literal placeholder for now; it will be filled in once the PR is opened.
+
+- [ ] **Step 7.3: Commit Task 7**
+
+```bash
+git add CHANGELOG.md
+git commit -s -m "$(cat <<'EOF'
+docs(changelog): record sync-default and copy-deprecation changes
+
+Co-authored-by: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 8.1: Full pre-commit gate**
+
+```bash
+cargo fmt -- --check && cargo clippy && cargo nextest run
+```
+
+Expected: all three exit 0, zero warnings, zero failures. If clippy flags anything, fix it in a separate `style:` commit.
+
+- [ ] **Step 8.2: Manual smoke — config with `copy` auto-migrates**
+
+```bash
+mkdir -p /tmp/jackin-migration-test
+cat > /tmp/jackin-migration-test/config.toml <<'EOF'
+[claude]
+auth_forward = "copy"
+EOF
+JACKIN_CONFIG=/tmp/jackin-migration-test/config.toml cargo run -- config auth show 2>&1 | head -10
+```
+
+Expected output contains both:
+- `warning: migrated auth_forward "copy" → "sync" in ...`
+- `sync` (printed by `config auth show`)
+
+Also verify the file was rewritten:
+
+```bash
+cat /tmp/jackin-migration-test/config.toml
+```
+
+Expected: contains `auth_forward = "sync"`, not `"copy"`.
+
+> Note: `JACKIN_CONFIG` is a hypothetical override — adapt this step to whatever `paths.rs` supports. If there is no env-var override, this manual smoke runs against `~/.config/jackin/config.toml` instead; back it up first.
+
+- [ ] **Step 8.3: Manual smoke — CLI deprecation warning**
+
+```bash
+cargo run -- config auth set copy 2>&1 | head -5
+cargo run -- config auth show
+```
+
+Expected: first command prints `warning: auth_forward "copy" is deprecated; saving as "sync"`. Second command prints `sync`.
+
+- [ ] **Step 8.4: Verify commit log is clean and DCO-signed**
+
+```bash
+git log main..HEAD --oneline
+git log main..HEAD --format="%B" | grep -c "Signed-off-by"
+git log main..HEAD --format="%B" | grep -c "Co-authored-by: Claude"
+```
+
+Expected: 7 commits (one per task from 1–7). `Signed-off-by` count = 7. `Co-authored-by: Claude` count = 7.
+
+- [ ] **Step 8.5: Push and open the PR**
+
+```bash
+git push -u origin feature/auth-sync-default
+gh pr create --title "feat(config)!: auth_forward sync-default, deprecate copy" --body "$(cat <<'BODY'
+## Summary
+
+Flips the `auth_forward` default from `copy` to `sync`, removes the `AuthForwardMode::Copy` enum variant, and migrates existing configs in place with a one-line deprecation notice. Fixes the intermittent `API Error: 401` that operators see when multiple Claude Code sessions run concurrently across host and jackin containers.
+
+- On load: any `auth_forward = "copy"` at `[claude]` or `[agents.*.claude]` is normalized to `sync`, written back to disk, and a warning is printed.
+- CLI: `jackin config auth set copy` is accepted, prints a deprecation warning, and saves as `sync`.
+- Rust surface: `AuthForwardMode::Copy` is removed. External code that matched on it must update.
+- TOML/CLI surface: `"copy"` remains a deprecated alias.
+
+Delivers PR 1 of the three-PR Claude auth strategy series. Spec: `docs/superpowers/specs/2026-04-23-auth-sync-default-design.md`. Plan: `docs/superpowers/plans/2026-04-23-auth-sync-default.md`.
+
+## Test plan
+
+- [x] `cargo fmt -- --check && cargo clippy && cargo nextest run` — all green, zero warnings.
+- [x] Manual: config with `auth_forward = "copy"` triggers migration notice and on-disk rewrite.
+- [x] Manual: `jackin config auth set copy` prints deprecation warning and saves `sync`.
+- [x] Manual: docs site builds (`bun run build`).
+- [ ] Reviewer confirms operator-facing messaging is clear.
+- [ ] Reviewer confirms test coverage in `src/config/{mod,persist,agents}.rs` and `src/instance/auth.rs`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+Return the PR URL; **do not merge** (per `AGENTS.md`, agents must never merge a PR without explicit per-PR operator confirmation).
+
+---
+
+## Self-Review Checklist (for the implementer)
+
+Before marking this plan complete:
+
+- [ ] No remaining references to `AuthForwardMode::Copy` in the code (grep: `rg 'AuthForwardMode::Copy' src/`)
+- [ ] No remaining non-test TOML examples containing `auth_forward = "copy"` in the repo
+- [ ] `CHANGELOG.md` PR-number placeholder has been replaced with the actual PR number after the PR is opened
+- [ ] All seven commits carry both `Signed-off-by:` and `Co-authored-by: Claude <noreply@anthropic.com>`
+- [ ] Pre-commit gate is clean on every commit, not just the final one (run after each task; fix fails before moving on)
+- [ ] Manual smoke from Step 8.2 / 8.3 succeeded on the implementer's machine

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,17 @@ use self::context::{
     resolve_running_container_from_context, resolve_target_name,
 };
 
+/// Parse an `auth_forward` mode value as it arrived from the CLI.
+///
+/// Returns the resolved mode and a boolean indicating whether the operator
+/// passed the deprecated `copy` alias — the caller is responsible for
+/// emitting a user-facing warning in that case.
+fn parse_auth_forward_mode_from_cli(raw: &str) -> anyhow::Result<(config::AuthForwardMode, bool)> {
+    let mode: config::AuthForwardMode = raw.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
+    let was_deprecated = raw == "copy";
+    Ok((mode, was_deprecated))
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run(cli: Cli) -> Result<()> {
     let paths = JackinPaths::detect()?;
@@ -294,8 +305,12 @@ pub fn run(cli: Cli) -> Result<()> {
             },
             cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
                 cli::AuthCommand::Set { mode, agent } => {
-                    let parsed_mode: config::AuthForwardMode =
-                        mode.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
+                    let (parsed_mode, was_deprecated) = parse_auth_forward_mode_from_cli(&mode)?;
+                    if was_deprecated {
+                        tui::deprecation_warning(
+                            "auth_forward \"copy\" is deprecated; saving as \"sync\"",
+                        );
+                    }
                     if let Some(agent_selector) = agent {
                         let class = ClassSelector::parse(&agent_selector)?;
                         config.resolve_agent_source(&class)?;
@@ -725,5 +740,29 @@ fn remove_data_dir_if_exists(path: &Path) -> Result<()> {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod auth_set_tests {
+    use super::*;
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_accepts_copy_as_deprecated() {
+        let (mode, was_deprecated) = parse_auth_forward_mode_from_cli("copy").unwrap();
+        assert_eq!(mode, crate::config::AuthForwardMode::Sync);
+        assert!(was_deprecated);
+    }
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_accepts_sync_non_deprecated() {
+        let (mode, was_deprecated) = parse_auth_forward_mode_from_cli("sync").unwrap();
+        assert_eq!(mode, crate::config::AuthForwardMode::Sync);
+        assert!(!was_deprecated);
+    }
+
+    #[test]
+    fn parse_auth_forward_mode_from_cli_rejects_bogus() {
+        assert!(parse_auth_forward_mode_from_cli("bogus").is_err());
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -20,22 +20,21 @@ pub enum AuthCommand {
     /// Set the authentication forwarding mode
     ///
     /// Controls how the host's ~/.claude.json is forwarded into agent containers.
-    /// Modes: ignore (revoke and never copy), copy (copy on first creation, default),
-    /// sync (overwrite from host on each launch when host auth exists; preserve
-    /// container auth when host auth is absent).
+    /// Modes: sync (overwrite from host on each launch when host auth exists;
+    /// preserve container auth when host auth is absent — default), ignore
+    /// (revoke and never copy).
     #[command(
         before_help = BANNER,
         styles = HELP_STYLES,
         after_long_help = "\
 Examples:
-  jackin config auth set copy
   jackin config auth set sync
   jackin config auth set ignore
-  jackin config auth set copy --agent agent-smith
-  jackin config auth set sync --agent chainargos/the-architect"
+  jackin config auth set sync --agent agent-smith
+  jackin config auth set ignore --agent chainargos/the-architect"
     )]
     Set {
-        /// Authentication forwarding mode: ignore, copy, or sync
+        /// Authentication forwarding mode: sync or ignore
         mode: String,
         /// Apply to a specific agent instead of globally
         #[arg(long)]
@@ -278,8 +277,12 @@ mod tests {
     fn config_auth_set_help_shows_examples() {
         let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
         assert!(help.contains("Examples:"));
-        assert!(help.contains("jackin config auth set copy"));
+        assert!(help.contains("jackin config auth set sync"));
         assert!(help.contains("--agent"));
+        assert!(
+            !help.contains("jackin config auth set copy"),
+            "help text must not recommend the deprecated copy mode"
+        );
     }
 
     #[test]
@@ -291,13 +294,13 @@ mod tests {
 
     #[test]
     fn parses_config_auth_set_global() {
-        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "copy"]).unwrap();
+        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "sync"]).unwrap();
         assert!(matches!(
             cli.command,
             Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
                         agent: None,
-                    })) if mode == "copy"
+                    })) if mode == "sync"
         ));
     }
 

--- a/src/config/agents.rs
+++ b/src/config/agents.rs
@@ -45,7 +45,7 @@ impl AppConfig {
 
     /// Resolve the effective `AuthForwardMode` for a given agent.
     ///
-    /// Resolution order: per-agent override → global default → `Copy`.
+    /// Resolution order: per-agent override → global default → `Sync`.
     pub fn resolve_auth_forward_mode(&self, agent_key: &str) -> AuthForwardMode {
         self.agents
             .get(agent_key)
@@ -343,9 +343,9 @@ git = "https://github.com/jackin-project/jackin-the-architect.git"
     // ── Auth forwarding config tests ────────────────────────────────────
 
     #[test]
-    fn auth_forward_defaults_to_copy() {
+    fn auth_forward_defaults_to_sync() {
         let config = AppConfig::default();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Copy);
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
     }
 
     #[test]
@@ -379,11 +379,11 @@ auth_forward = "ignore"
     }
 
     #[test]
-    fn resolve_auth_forward_defaults_to_copy() {
+    fn resolve_auth_forward_defaults_to_sync() {
         let config = AppConfig::default();
         assert_eq!(
             config.resolve_auth_forward_mode("nonexistent"),
-            AuthForwardMode::Copy
+            AuthForwardMode::Sync
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,16 +18,14 @@ const fn is_false(v: &bool) -> bool {
 }
 
 /// Controls how the host's `~/.claude.json` is forwarded into agent containers.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthForwardMode {
     /// Revoke any forwarded auth and never copy — container starts with `{}`.
     Ignore,
-    /// Copy host auth on first container creation only; never overwrite afterwards.
-    #[default]
-    Copy,
     /// Overwrite container auth from host on each launch when host auth
     /// exists; preserve container auth when host auth is absent.
+    #[default]
     Sync,
 }
 
@@ -35,7 +33,6 @@ impl std::fmt::Display for AuthForwardMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Ignore => write!(f, "ignore"),
-            Self::Copy => write!(f, "copy"),
             Self::Sync => write!(f, "sync"),
         }
     }
@@ -45,14 +42,33 @@ impl std::str::FromStr for AuthForwardMode {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // `"copy"` is kept as a separate arm (rather than merged with `"sync"`)
+        // so callers can pattern-match the literal when emitting a deprecation
+        // warning before calling `parse()`.
+        #[allow(clippy::match_same_arms)]
         match s {
             "ignore" => Ok(Self::Ignore),
-            "copy" => Ok(Self::Copy),
             "sync" => Ok(Self::Sync),
+            // Deprecated alias — accepted to avoid breaking scripts and
+            // configs from before the default flipped to `sync`. Callers
+            // that want to surface the deprecation should check for the
+            // literal `"copy"` themselves before calling `parse()`.
+            "copy" => Ok(Self::Sync),
             other => Err(format!(
-                "invalid auth_forward mode {other:?}; expected one of: ignore, copy, sync"
+                "invalid auth_forward mode {other:?}; expected one of: sync, ignore"
             )),
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AuthForwardMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(D::Error::custom)
     }
 }
 
@@ -315,10 +331,10 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
 trusted = true
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Copy);
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
         assert_eq!(
             config.resolve_auth_forward_mode("agent-smith"),
-            AuthForwardMode::Copy
+            AuthForwardMode::Sync
         );
     }
 
@@ -597,5 +613,54 @@ trusted = true
                 },
             )
             .unwrap();
+    }
+
+    #[test]
+    fn auth_forward_mode_default_is_sync() {
+        assert_eq!(AuthForwardMode::default(), AuthForwardMode::Sync);
+    }
+
+    #[test]
+    fn auth_forward_mode_from_str_accepts_copy_as_deprecated_alias() {
+        use std::str::FromStr;
+        assert_eq!(
+            AuthForwardMode::from_str("copy").unwrap(),
+            AuthForwardMode::Sync
+        );
+    }
+
+    #[test]
+    fn auth_forward_mode_from_str_accepts_sync_and_ignore() {
+        use std::str::FromStr;
+        assert_eq!(
+            AuthForwardMode::from_str("sync").unwrap(),
+            AuthForwardMode::Sync
+        );
+        assert_eq!(
+            AuthForwardMode::from_str("ignore").unwrap(),
+            AuthForwardMode::Ignore
+        );
+    }
+
+    #[test]
+    fn auth_forward_mode_from_str_rejects_unknown_values() {
+        use std::str::FromStr;
+        assert!(AuthForwardMode::from_str("bogus").is_err());
+    }
+
+    #[test]
+    fn auth_forward_mode_deserializes_copy_to_sync() {
+        let toml_str = r#"
+[claude]
+auth_forward = "copy"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+    }
+
+    #[test]
+    fn auth_forward_mode_display_does_not_emit_copy() {
+        assert_eq!(AuthForwardMode::Sync.to_string(), "sync");
+        assert_eq!(AuthForwardMode::Ignore.to_string(), "ignore");
     }
 }

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -5,13 +5,32 @@ impl AppConfig {
     pub fn load_or_init(paths: &JackinPaths) -> anyhow::Result<Self> {
         paths.ensure_base_dirs()?;
 
-        let mut config = match std::fs::read_to_string(&paths.config_file) {
-            Ok(contents) => toml::from_str(&contents)?,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::default(),
+        let contents_opt = match std::fs::read_to_string(&paths.config_file) {
+            Ok(c) => Some(c),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => return Err(e.into()),
         };
 
-        if config.sync_builtin_agents() {
+        let deprecated_copy_seen = match &contents_opt {
+            Some(c) => contains_deprecated_copy_auth_forward(c)?,
+            None => false,
+        };
+
+        let mut config: Self = match contents_opt {
+            Some(c) => toml::from_str(&c)?,
+            None => Self::default(),
+        };
+
+        let builtins_changed = config.sync_builtin_agents();
+
+        if deprecated_copy_seen {
+            crate::tui::deprecation_warning(&format!(
+                "migrated auth_forward \"copy\" → \"sync\" in {} (copy is deprecated)",
+                paths.config_file.display()
+            ));
+        }
+
+        if builtins_changed || deprecated_copy_seen {
             config.save(paths)?;
         }
 
@@ -45,6 +64,43 @@ impl AppConfig {
     }
 }
 
+/// Detect the literal deprecated `auth_forward = "copy"` at either of the
+/// two known config paths: the global `[claude]` table or any
+/// `[agents.*.claude]` table. Returns `true` if any occurrence is found.
+///
+/// Uses `toml::Value` (cheap — we parse the same string into `AppConfig`
+/// right after) instead of a regex, so quoted keys with odd whitespace
+/// are handled correctly.
+fn contains_deprecated_copy_auth_forward(raw: &str) -> anyhow::Result<bool> {
+    let value: toml::Value = toml::from_str(raw)?;
+
+    // Global [claude] auth_forward
+    if let Some(s) = value
+        .get("claude")
+        .and_then(|c| c.get("auth_forward"))
+        .and_then(|v| v.as_str())
+        && s == "copy"
+    {
+        return Ok(true);
+    }
+
+    // Per-agent [agents.<name>.claude] auth_forward
+    if let Some(agents) = value.get("agents").and_then(|a| a.as_table()) {
+        for agent in agents.values() {
+            if let Some(s) = agent
+                .get("claude")
+                .and_then(|c| c.get("auth_forward"))
+                .and_then(|v| v.as_str())
+                && s == "copy"
+            {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,6 +123,95 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         // Second load should not rewrite
+        AppConfig::load_or_init(&paths).unwrap();
+        let mtime_after = std::fs::metadata(&paths.config_file)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        assert_eq!(mtime_before, mtime_after);
+    }
+
+    #[test]
+    fn load_migrates_global_copy_to_sync_and_rewrites_config() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        std::fs::write(
+            &paths.config_file,
+            r#"[claude]
+auth_forward = "copy"
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_init(&paths).unwrap();
+
+        // In memory, Copy normalized to Sync
+        assert_eq!(
+            config.claude.auth_forward,
+            crate::config::AuthForwardMode::Sync
+        );
+
+        // On disk, "copy" no longer present
+        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            !persisted.contains("auth_forward = \"copy\""),
+            "expected on-disk config to be migrated; got:\n{persisted}"
+        );
+        assert!(
+            persisted.contains("auth_forward = \"sync\""),
+            "expected migrated config to contain sync; got:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn load_migrates_per_agent_copy_to_sync() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[agents.agent-smith.claude]
+auth_forward = "copy"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_init(&paths).unwrap();
+
+        assert_eq!(
+            config.resolve_auth_forward_mode("agent-smith"),
+            crate::config::AuthForwardMode::Sync
+        );
+
+        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!persisted.contains("auth_forward = \"copy\""));
+    }
+
+    #[test]
+    fn load_does_not_rewrite_when_no_copy_present() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        // Bootstrap once so builtins are synced and file stabilizes.
+        AppConfig::load_or_init(&paths).unwrap();
+        let mtime_before = std::fs::metadata(&paths.config_file)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Second load with no "copy" anywhere — must not rewrite.
         AppConfig::load_or_init(&paths).unwrap();
         let mtime_after = std::fs::metadata(&paths.config_file)
             .unwrap()

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -25,7 +25,7 @@ impl AgentState {
 
         let outcome = match mode {
             AuthForwardMode::Ignore => {
-                // Always ensure a clean slate — if switching from copy/sync to
+                // Always ensure a clean slate — if switching from sync to
                 // ignore, the previously forwarded credentials must be revoked.
                 if !claude_json.exists() || std::fs::read_to_string(claude_json)? != "{}" {
                     write_private_file(claude_json, "{}")?;
@@ -34,21 +34,6 @@ impl AgentState {
                     std::fs::remove_file(&credentials_json)?;
                 }
                 AuthProvisionOutcome::Skipped
-            }
-            AuthForwardMode::Copy => {
-                if claude_json.exists() {
-                    AuthProvisionOutcome::Skipped
-                } else if let Some(creds) = read_host_credentials(host_home) {
-                    copy_host_claude_json(&host_claude_json, claude_json)?;
-                    write_private_file(&credentials_json, &creds)?;
-                    AuthProvisionOutcome::Copied
-                } else {
-                    // Host has no auth — create an empty bootstrap file
-                    // so Docker can bind-mount it. Claude Code will run
-                    // its own first-time auth flow inside the container.
-                    write_private_file(claude_json, "{}")?;
-                    AuthProvisionOutcome::HostMissing
-                }
             }
             AuthForwardMode::Sync => {
                 if let Some(creds) = read_host_credentials(host_home) {
@@ -274,7 +259,7 @@ plugins = []
     }
 
     #[test]
-    fn copy_mode_copies_host_auth_on_first_run() {
+    fn sync_mode_copies_host_auth_on_first_run() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         seed_host_auth(&temp);
@@ -284,7 +269,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Copy,
+            AuthForwardMode::Sync,
             temp.path(),
         )
         .unwrap();
@@ -298,11 +283,11 @@ plugins = []
             std::fs::read_to_string(state.claude_dir.join(".credentials.json")).unwrap(),
             TEST_CREDENTIALS
         );
-        assert_eq!(outcome, AuthProvisionOutcome::Copied);
+        assert_eq!(outcome, AuthProvisionOutcome::Synced);
     }
 
     #[test]
-    fn copy_mode_falls_back_to_empty_json_when_host_has_none() {
+    fn sync_mode_falls_back_to_empty_json_when_host_has_none() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         // No host auth seeded
@@ -312,7 +297,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Copy,
+            AuthForwardMode::Sync,
             temp.path(),
         )
         .unwrap();
@@ -320,45 +305,6 @@ plugins = []
         assert_eq!(std::fs::read_to_string(&state.claude_json).unwrap(), "{}");
         assert!(!state.claude_dir.join(".credentials.json").exists());
         assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
-    }
-
-    #[test]
-    fn copy_mode_does_not_overwrite_existing() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        seed_host_auth(&temp);
-        let manifest = simple_manifest(&temp);
-
-        // First run: creates the file
-        let (state, outcome1) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Copy,
-            temp.path(),
-        )
-        .unwrap();
-        assert_eq!(outcome1, AuthProvisionOutcome::Copied);
-
-        // Simulate the container modifying its own .claude.json
-        let container_content = r#"{"oauthAccount":{"emailAddress":"container@example.com"}}"#;
-        std::fs::write(&state.claude_json, container_content).unwrap();
-
-        // Second run: should NOT overwrite
-        let (state2, outcome2) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Copy,
-            temp.path(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(&state2.claude_json).unwrap(),
-            container_content
-        );
-        assert_eq!(outcome2, AuthProvisionOutcome::Skipped);
     }
 
     #[test]
@@ -404,37 +350,6 @@ plugins = []
     }
 
     // ── Mode transition tests ───────────────────────────────────────────
-
-    #[test]
-    fn switching_from_copy_to_ignore_revokes_forwarded_credentials() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        seed_host_auth(&temp);
-        let manifest = simple_manifest(&temp);
-
-        // First run: copy mode seeds credentials
-        let (state, _) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Copy,
-            temp.path(),
-        )
-        .unwrap();
-        assert!(state.claude_dir.join(".credentials.json").exists());
-
-        // Operator switches to ignore — credentials must be wiped
-        let (state2, _) = AgentState::prepare(
-            &paths,
-            "jackin-agent-smith",
-            &manifest,
-            AuthForwardMode::Ignore,
-            temp.path(),
-        )
-        .unwrap();
-        assert_eq!(std::fs::read_to_string(&state2.claude_json).unwrap(), "{}");
-        assert!(!state2.claude_dir.join(".credentials.json").exists());
-    }
 
     #[test]
     fn switching_from_sync_to_ignore_revokes_forwarded_credentials() {
@@ -522,7 +437,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Copy,
+            AuthForwardMode::Sync,
             temp.path(),
         )
         .unwrap();
@@ -663,7 +578,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Copy,
+            AuthForwardMode::Sync,
             temp.path(),
         )
         .unwrap();
@@ -705,7 +620,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Copy,
+            AuthForwardMode::Sync,
             temp.path(),
         )
         .unwrap();

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -15,10 +15,8 @@ use plugins::PluginState;
 /// a one-time notice when host credentials are forwarded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthProvisionOutcome {
-    /// No host auth was forwarded (ignore mode, or copy mode with existing file).
+    /// No host auth was forwarded (ignore mode).
     Skipped,
-    /// Host auth was copied into the container state.
-    Copied,
     /// Host auth was synced (overwritten) into the container state.
     Synced,
     /// Mode would have forwarded, but host file was missing — wrote `{}`.

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -654,12 +654,6 @@ fn load_agent_with(
         )?;
 
         match auth_outcome {
-            crate::instance::AuthProvisionOutcome::Copied => {
-                eprintln!(
-                    "[jackin] Copied host Claude Code authentication into agent state \
-                     (auth_forward=copy). Use `jackin config auth set ignore` to disable."
-                );
-            }
             crate::instance::AuthProvisionOutcome::Synced => {
                 eprintln!(
                     "[jackin] Synced host Claude Code authentication into agent state \
@@ -667,12 +661,6 @@ fn load_agent_with(
                 );
             }
             crate::instance::AuthProvisionOutcome::HostMissing => match auth_mode {
-                crate::config::AuthForwardMode::Copy => {
-                    eprintln!(
-                        "[jackin] auth_forward=copy but no host credentials found; \
-                             agent will need to authenticate manually via /login."
-                    );
-                }
                 crate::config::AuthForwardMode::Sync => {
                     eprintln!(
                         "[jackin] auth_forward=sync but no host credentials found; \

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,7 @@ pub mod prompt;
 
 pub use animation::{intro_animation, outro_animation, simple_outro};
 pub use output::{
-    clear_screen, fatal, hint, print_config_table, print_deploying, print_logo, set_terminal_title,
-    shorten_home, step_fail, step_quiet, step_shimmer,
+    clear_screen, deprecation_warning, fatal, hint, print_config_table, print_deploying,
+    print_logo, set_terminal_title, shorten_home, step_fail, step_quiet, step_shimmer,
 };
 pub use prompt::{prompt_choice, require_interactive_stdin, spin_wait};

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -139,6 +139,17 @@ pub fn fatal(msg: &str) {
     );
 }
 
+/// One-line yellow deprecation warning to stderr. Used for soft-migration
+/// notices like "config field X is deprecated — migrated to Y".
+pub fn deprecation_warning(msg: &str) {
+    const AMBER: (u8, u8, u8) = (230, 180, 80);
+    eprintln!(
+        "  {} {}",
+        "warning:".color(rgb(AMBER)).bold(),
+        msg.color(rgb(AMBER)),
+    );
+}
+
 pub fn set_terminal_title(title: &str) {
     eprint!("\x1b]0;jackin' \u{00b7} {title}\x07");
     let _ = io::stderr().flush();


### PR DESCRIPTION
## Summary

**PR 1 of the three-PR Claude auth strategy series** (series recap: #155 specs). This PR flips the `auth_forward` default from `copy` to `sync`, removes the `AuthForwardMode::Copy` enum variant, and migrates existing `copy` configs in place with a one-line deprecation notice on first launch. Fixes the intermittent `API Error: 401 Invalid authentication credentials` that operators hit when OAuth refresh tokens rotate across concurrent Claude Code sessions.

### Current contents

This PR currently contains the **implementation plan only** — task-by-task TDD breakdown for review before code commits land:

- `docs/superpowers/plans/2026-04-23-auth-sync-default.md` (1248 lines, 8 TDD tasks)

Implementation commits will be pushed to this same branch (`feature/auth-sync-default`) once the plan is approved.

### Landing behavior

- On load: any `auth_forward = "copy"` at `[claude]` or `[agents.*.claude]` is normalized to `sync`, written back to disk, and a warning is printed.
- CLI: `jackin config auth set copy` is accepted, prints a deprecation warning, and saves as `sync`.
- Rust surface: `AuthForwardMode::Copy` is removed (external code pattern-matching on it must update).
- TOML/CLI surface: `"copy"` remains a deprecated alias — scripts don't break.

### Spec

`docs/superpowers/specs/2026-04-23-auth-sync-default-design.md` (landed via #155).

## Test plan

**Plan review (current state):**

- [ ] Plan structure reads cleanly — header, file structure, preflight, tasks, self-review.
- [ ] Migration approach (pre-scan `toml::Value` for `"copy"`, rewrite via existing `save` path) is acceptable.
- [ ] Deprecation surface: CLI warning text, one-line migration notice, and the new `tui::deprecation_warning` helper are all aligned.
- [ ] `AuthForwardMode::Copy` removal with a breaking-change commit is acceptable (public Rust surface; TOML/CLI compatibility preserved).
- [ ] Branch name `feature/auth-sync-default` (per `BRANCHING.md`) is the intended shape.

**Implementation (follow-up commits on this branch):**

- [ ] Pre-commit gate green on every commit: `cargo fmt -- --check && cargo clippy && cargo nextest run`
- [ ] Manual: config with `auth_forward = "copy"` triggers migration notice + on-disk rewrite.
- [ ] Manual: `jackin config auth set copy` prints deprecation warning, saves `sync`.
- [ ] Manual: docs site builds (`bun run build` in `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)