### PR TITLE
feat(config): toml_edit migration (PR 1 of 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1825,11 +1826,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -1841,13 +1848,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -2154,6 +2179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "4.5", features = ["derive", "color"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
+toml_edit = "0.22"
 directories = "6.0"
 fs2 = "0.4"
 thiserror = "2.0"

--- a/docs/superpowers/plans/2026-04-23-toml-edit-migration.md
+++ b/docs/superpowers/plans/2026-04-23-toml-edit-migration.md
@@ -1,0 +1,2356 @@
+# toml_edit Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace jackin's full-reserialize config write path with a targeted `toml_edit` patch path so hand-written comments, blank lines, and key ordering survive every programmatic save.
+
+**Architecture:** A new `src/config/editor.rs` module owns a `toml_edit::DocumentMut` and exposes typed setters for each mutation the app performs. Reads stay in `AppConfig::load_or_init` (serde + `toml`); writes go through `ConfigEditor::open → mutate → save`. `AppConfig::save()` is removed; the in-memory mutator methods on `AppConfig` are deleted or made `pub(super)` so nothing outside `src/config/` can change persisted state except through the editor.
+
+**Tech Stack:** Rust, `toml_edit` (new dep, latest 0.22.x), `toml` (kept for the read path), `serde`, `anyhow`, `tempfile` (test-only, already in the tree).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-23-toml-edit-migration-design.md` (PR #160, merging separately).
+
+---
+
+## Branching & commits
+
+All work happens on `feature/toml-edit-migration` (already created off `main`). Every commit:
+- Uses Conventional Commits (`feat(config): …`, `refactor(config): …`, `test(config): …`).
+- Includes `Signed-off-by:` via `git commit -s` (DCO required by repo).
+- Includes `Co-authored-by: Claude <noreply@anthropic.com>` as the single agent trailer.
+- Does **not** touch `CHANGELOG.md` (operator curates manually).
+
+Verify trailers with `git log -1 --format="%B"` after each commit.
+
+---
+
+## File Structure
+
+New files:
+- `src/config/editor.rs` — `ConfigEditor` struct, `EnvScope` enum, all typed setters, co-located `#[cfg(test)] mod tests`.
+- `src/config/fixtures/config.round_trip.toml` — fixture with mixed comments, blank lines, quoted keys, and nested tables for the byte-for-byte round-trip test.
+
+Modified files (roughly in order of task sequencing):
+- `Cargo.toml` — add `toml_edit = "0.22"`.
+- `src/config/mod.rs` — add `pub mod editor;`, re-export `ConfigEditor` and `EnvScope`.
+- `src/config/persist.rs` — delete `AppConfig::save`; migrate the `load_or_init` save branch to use `ConfigEditor`.
+- `src/config/agents.rs` — delete `AppConfig::trust_agent`, `untrust_agent`, `set_agent_auth_forward`; keep `sync_builtin_agents` (called from load path but the save uses the editor now).
+- `src/config/mounts.rs` — delete `AppConfig::add_mount`, `remove_mount`.
+- `src/config/workspaces.rs` — delete `AppConfig::create_workspace`, `edit_workspace`, `remove_workspace`.
+- `src/app/mod.rs` — migrate 10 call sites (lines 210, 216, 269, 282, 318, 322, 386, 655, 705, 714).
+- `src/app/context.rs` — migrate 1 call site (line 327 area, `remember_last_agent`).
+- `src/runtime/launch.rs` — migrate 1 call site (line 600 area).
+
+Unchanged (verified):
+- `src/config/mod.rs` — all structs (`AppConfig`, `AgentSource`, `AuthForwardMode`, etc.) keep the same serde shape.
+- `src/workspace/mod.rs` — `WorkspaceConfig`, `WorkspaceAgentOverride`, `WorkspaceEdit` unchanged.
+- `src/paths.rs` — `JackinPaths` unchanged.
+
+---
+
+## Design notes for implementers
+
+### `toml_edit` 0.22 API cheat-sheet
+
+```rust
+use toml_edit::{DocumentMut, Item, Table, Value, value};
+
+// Parse
+let mut doc: DocumentMut = raw.parse()?;
+
+// Navigate / upsert a table:
+let table = doc["workspaces"]
+    .or_insert(Item::Table(Table::new()))
+    .as_table_mut()
+    .expect("`workspaces` must be a table");
+
+// Insert/update a scalar value:
+table.insert("KEY", value("some string"));
+
+// Remove a key:
+table.remove("KEY");
+
+// Set a "# comment\n" line above a key (leaf decor of the Key, not the Value):
+if let Some(mut key) = table.key_mut("KEY") {
+    key.leaf_decor_mut().set_prefix("# comment\n");
+}
+
+// Serialize back:
+let out = doc.to_string();
+```
+
+### Nested-path helper
+
+Most setters need to upsert a table path like `workspaces.<name>.agents.<agent>.env`. Implement a private helper:
+
+```rust
+fn table_path_mut<'a>(doc: &'a mut DocumentMut, path: &[&str]) -> &'a mut Table {
+    let mut current: &mut Item = doc.as_item_mut();
+    for segment in path {
+        current = current
+            .as_table_mut()
+            .expect("expected table segment")
+            .entry(segment)
+            .or_insert(Item::Table(Table::new()));
+    }
+    current.as_table_mut().expect("final path segment is a table")
+}
+```
+
+Use it as `table_path_mut(&mut self.doc, &["workspaces", name, "agents", agent, "env"])`.
+
+### Atomic write
+
+Lift the body of today's `AppConfig::save()` (see `src/config/persist.rs:46–69`) into `ConfigEditor::save()` verbatim — same `.tmp` + fsync + rename, same `0o600` on unix. Do **not** switch to the `NamedTempFile` pattern from `src/instance/auth.rs`; the spec pins atomic-write parity with today's behavior, and behavioral differences between the two patterns (symlink handling) are out of scope.
+
+### `EnvScope` → TOML path
+
+| Scope | TOML table path |
+|---|---|
+| `EnvScope::Global` | `["env"]` |
+| `EnvScope::Agent("agent-smith")` | `["agents", "agent-smith", "env"]` |
+| `EnvScope::Workspace("ws")` | `["workspaces", "ws", "env"]` |
+| `EnvScope::WorkspaceAgent { workspace: "ws", agent: "a" }` | `["workspaces", "ws", "agents", "a", "env"]` |
+
+Private helper:
+
+```rust
+fn env_scope_path<'a>(scope: &'a EnvScope) -> Vec<&'a str> {
+    match scope {
+        EnvScope::Global => vec!["env"],
+        EnvScope::Agent(a) => vec!["agents", a.as_str(), "env"],
+        EnvScope::Workspace(w) => vec!["workspaces", w.as_str(), "env"],
+        EnvScope::WorkspaceAgent { workspace, agent } => {
+            vec!["workspaces", workspace.as_str(), "agents", agent.as_str(), "env"]
+        }
+    }
+}
+```
+
+---
+
+## Task 1: Foundation — dependency, module skeleton, tripwire test
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `src/config/editor.rs`
+- Modify: `src/config/mod.rs` (add module declaration + re-exports)
+
+- [ ] **Step 1: Add `toml_edit` to Cargo.toml**
+
+Edit `Cargo.toml`. Find the block around line 22–27 with `toml = "1.1"`. Insert `toml_edit` (latest 0.22 minor/patch — verify on crates.io at implementation time):
+
+```toml
+toml = "1.1"
+toml_edit = "0.22"
+```
+
+Run `cargo check` to confirm the dep resolves. Expected: success, new `toml_edit` entry in `Cargo.lock`.
+
+- [ ] **Step 2: Create the module skeleton**
+
+Create `src/config/editor.rs`:
+
+```rust
+//! Comment-preserving config writer.
+//!
+//! Reads still go through `AppConfig::load_or_init` (serde + `toml`).
+//! Writes go through `ConfigEditor::open → mutate → save`, which keeps
+//! user-written comments, blank lines, and key ordering intact in
+//! sections untouched by the mutation.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use toml_edit::{DocumentMut, Item, Table};
+
+use crate::config::AppConfig;
+use crate::paths::JackinPaths;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvScope {
+    Global,
+    Agent(String),
+    Workspace(String),
+    WorkspaceAgent { workspace: String, agent: String },
+}
+
+pub struct ConfigEditor {
+    doc: DocumentMut,
+    path: PathBuf,
+}
+
+impl ConfigEditor {
+    /// Loads the existing config file as a `DocumentMut`. If the file
+    /// does not exist, delegates to `AppConfig::load_or_init` to
+    /// materialize defaults, then reopens the resulting file.
+    pub fn open(paths: &JackinPaths) -> anyhow::Result<Self> {
+        if !paths.config_file.exists() {
+            // Trigger the existing default-materialization path.
+            AppConfig::load_or_init(paths)?;
+        }
+        let raw = std::fs::read_to_string(&paths.config_file)
+            .with_context(|| format!("reading {}", paths.config_file.display()))?;
+        let doc: DocumentMut = raw
+            .parse()
+            .with_context(|| format!("parsing {}", paths.config_file.display()))?;
+        Ok(Self {
+            doc,
+            path: paths.config_file.clone(),
+        })
+    }
+
+    /// Writes the mutated document atomically. Returns a freshly-loaded
+    /// `AppConfig` so callers that still need the in-memory shape get
+    /// it without a second manual `load_or_init`.
+    pub fn save(self) -> anyhow::Result<AppConfig> {
+        let contents = self.doc.to_string();
+        let tmp = self.path.with_extension("tmp");
+
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+        }
+
+        #[cfg(not(unix))]
+        std::fs::write(&tmp, &contents)?;
+
+        std::fs::rename(&tmp, &self.path)?;
+
+        // Reload from disk so callers that need the in-memory struct
+        // get a fresh, fully-validated view (validate_workspaces,
+        // validate_reserved_names all re-run).
+        let paths = synthesize_paths(&self.path);
+        AppConfig::load_or_init(&paths)
+    }
+}
+
+/// Rebuild the `JackinPaths` bundle from just the config file path.
+/// Used by `ConfigEditor::save` so we can call `load_or_init` without
+/// threading a `JackinPaths` through the editor.
+fn synthesize_paths(config_file: &std::path::Path) -> JackinPaths {
+    // The only field `load_or_init` reads from JackinPaths is
+    // config_file and ensure_base_dirs (which reads config_dir).
+    // config_dir is the parent of config_file.
+    let config_dir = config_file
+        .parent()
+        .expect("config file has no parent")
+        .to_path_buf();
+    let home_dir = config_dir
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| config_dir.clone());
+    JackinPaths {
+        home_dir: home_dir.clone(),
+        config_dir: config_dir.clone(),
+        config_file: config_file.to_path_buf(),
+        agents_dir: home_dir.join("agents"),
+        data_dir: home_dir.join("data"),
+        cache_dir: home_dir.join("cache"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn idempotent_save_is_byte_identical() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        let original = r#"# Top-of-file note about this config
+[claude]
+auth_forward = "sync"
+
+# Agents we trust
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+# My production workspace
+[workspaces.prod]
+workdir = "/workspace/prod"
+
+[workspaces.prod.env]
+# Rotate quarterly (last: 2026-Q1)
+API_TOKEN = "op://Personal/api/token"
+"#;
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let editor = ConfigEditor::open(&paths).unwrap();
+        editor.save().unwrap();
+
+        let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert_eq!(round_tripped, original, "open → save must be byte-identical");
+    }
+}
+```
+
+- [ ] **Step 3: Wire the module into `src/config/mod.rs`**
+
+Near the other `pub mod` declarations in `src/config/mod.rs`, add:
+
+```rust
+pub mod editor;
+```
+
+And near the other re-exports:
+
+```rust
+pub use editor::{ConfigEditor, EnvScope};
+```
+
+- [ ] **Step 4: Run the tripwire test**
+
+Run: `cargo test -p jackin --lib config::editor::tests::idempotent_save_is_byte_identical`
+Expected: PASS.
+
+If the test fails, `toml_edit` is round-tripping lossily on some construct in the fixture. Narrow the fixture until it passes, then note what was lost in a follow-up investigation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/config/editor.rs src/config/mod.rs
+git commit -s -m "feat(config): scaffold ConfigEditor with toml_edit round-trip
+
+Introduces src/config/editor.rs with a ConfigEditor struct that owns a
+toml_edit::DocumentMut. ConfigEditor::open loads and parses, save writes
+atomically (.tmp + fsync + rename, 0o600 on unix) and returns a
+freshly-loaded AppConfig.
+
+No mutators yet — subsequent commits add typed setters and migrate call
+sites off AppConfig::save.
+
+Tripwire test (idempotent_save_is_byte_identical) pins that an open →
+save with no mutations produces byte-identical output, including
+hand-written comments. If this ever fails, toml_edit is round-tripping
+lossily.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `set_env_var` (all four scopes)
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module in `src/config/editor.rs`:
+
+```rust
+#[test]
+fn set_env_var_creates_global_env_table() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_var(EnvScope::Global, "API_TOKEN", "op://Personal/api/token");
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[env]"), "missing [env] table: {out}");
+    assert!(
+        out.contains(r#"API_TOKEN = "op://Personal/api/token""#),
+        "missing entry: {out}"
+    );
+}
+
+#[test]
+fn set_env_var_upserts_workspace_agent_scope() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[workspaces.prod]
+workdir = "/workspace/prod"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_var(
+        EnvScope::WorkspaceAgent {
+            workspace: "prod".to_string(),
+            agent: "agent-smith".to_string(),
+        },
+        "OPENAI_API_KEY",
+        "op://Work/OpenAI/default",
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(
+        out.contains("[workspaces.prod.agents.agent-smith.env]"),
+        "missing nested table: {out}"
+    );
+    assert!(
+        out.contains(r#"OPENAI_API_KEY = "op://Work/OpenAI/default""#),
+        "missing entry: {out}"
+    );
+}
+
+#[test]
+fn set_env_var_overwrites_existing_value() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[env]
+API_TOKEN = "old-value"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_var(EnvScope::Global, "API_TOKEN", "new-value");
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains(r#"API_TOKEN = "new-value""#), "{out}");
+    assert!(!out.contains("old-value"), "{out}");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::set_env_var`
+Expected: FAIL (compile error, `set_env_var` not found).
+
+- [ ] **Step 3: Implement the nested-path helper and `set_env_var`**
+
+In `src/config/editor.rs`, inside `impl ConfigEditor`:
+
+```rust
+pub fn set_env_var(&mut self, scope: EnvScope, key: &str, value_str: &str) {
+    let path = env_scope_path(&scope);
+    let table = table_path_mut(&mut self.doc, &path);
+    table.insert(key, toml_edit::value(value_str));
+}
+```
+
+And at module scope, add the two private helpers:
+
+```rust
+fn env_scope_path(scope: &EnvScope) -> Vec<&str> {
+    match scope {
+        EnvScope::Global => vec!["env"],
+        EnvScope::Agent(a) => vec!["agents", a.as_str(), "env"],
+        EnvScope::Workspace(w) => vec!["workspaces", w.as_str(), "env"],
+        EnvScope::WorkspaceAgent { workspace, agent } => {
+            vec!["workspaces", workspace.as_str(), "agents", agent.as_str(), "env"]
+        }
+    }
+}
+
+fn table_path_mut<'a>(doc: &'a mut DocumentMut, path: &[&str]) -> &'a mut Table {
+    fn walk<'a>(item: &'a mut Item, path: &[&str]) -> &'a mut Table {
+        let table = item.as_table_mut().expect("path segment is not a table");
+        if path.is_empty() {
+            return table;
+        }
+        let entry = table
+            .entry(path[0])
+            .or_insert(Item::Table(Table::new()));
+        walk(entry, &path[1..])
+    }
+    walk(doc.as_item_mut(), path)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS (all four tests: the original tripwire + three new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor::set_env_var with scope-table upsert
+
+Adds set_env_var for all four EnvScope variants (Global, Agent,
+Workspace, WorkspaceAgent). Intermediate tables are created as needed
+via the private table_path_mut helper, so writing to
+WorkspaceAgent { workspace: \"new\", agent: \"new\" } works even when
+neither table exists.
+
+Existing values are overwritten. Tests cover the upsert, cross-scope
+path construction, and overwrite semantics.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `remove_env_var`
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module:
+
+```rust
+#[test]
+fn remove_env_var_returns_true_when_present() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[env]
+API_TOKEN = "x"
+OTHER = "y"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+    editor.save().unwrap();
+
+    assert!(removed);
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains("API_TOKEN"), "{out}");
+    assert!(out.contains(r#"OTHER = "y""#), "sibling gone: {out}");
+}
+
+#[test]
+fn remove_env_var_returns_false_when_absent() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+    editor.save().unwrap();
+
+    assert!(!removed);
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::remove_env_var`
+Expected: FAIL (`remove_env_var` not defined).
+
+- [ ] **Step 3: Implement**
+
+In `impl ConfigEditor`:
+
+```rust
+pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
+    let path = env_scope_path(&scope);
+    // Walk without creating: return false if any segment is missing.
+    let mut current: &mut Item = self.doc.as_item_mut();
+    for segment in &path {
+        match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
+            Some(next) => current = next,
+            None => return false,
+        }
+    }
+    match current.as_table_mut() {
+        Some(table) => table.remove(key).is_some(),
+        None => false,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests::remove_env_var`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor::remove_env_var
+
+Removes an env var from any scope, returning true if the key existed
+and false if it did not (including when the scope's table is missing).
+Does not create intermediate tables — removes-from-nothing is a no-op.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `set_env_comment` — the feature this whole migration exists for
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module:
+
+```rust
+#[test]
+fn set_env_comment_adds_line_above_key() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[env]
+API_TOKEN = "op://vault-id/item-id/field"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_comment(
+        EnvScope::Global,
+        "API_TOKEN",
+        Some("op://Personal/Google/password"),
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(
+        out.contains("# op://Personal/Google/password\nAPI_TOKEN"),
+        "expected comment directly above key: {out}"
+    );
+}
+
+#[test]
+fn set_env_comment_replaces_existing_comment() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        "[env]\n# old annotation\nAPI_TOKEN = \"x\"\n",
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_comment(EnvScope::Global, "API_TOKEN", Some("new annotation"));
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("# new annotation"), "{out}");
+    assert!(!out.contains("# old annotation"), "{out}");
+}
+
+#[test]
+fn set_env_comment_none_removes_annotation() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        "[env]\n# some note\nAPI_TOKEN = \"x\"\n",
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_comment(EnvScope::Global, "API_TOKEN", None);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains("# some note"), "{out}");
+    assert!(out.contains(r#"API_TOKEN = "x""#), "key still present: {out}");
+}
+
+#[test]
+fn mutating_sibling_preserves_comment_above_other_key() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    let original = "[env]\n# rotate quarterly\nAPI_TOKEN = \"x\"\nOTHER = \"y\"\n";
+    std::fs::write(&paths.config_file, original).unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_var(EnvScope::Global, "OTHER", "z");
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(
+        out.contains("# rotate quarterly\nAPI_TOKEN = \"x\""),
+        "sibling mutation wiped adjacent comment: {out}"
+    );
+    assert!(out.contains(r#"OTHER = "z""#), "{out}");
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::set_env_comment`
+Expected: FAIL (not defined).
+Also run the sibling test: `cargo test -p jackin --lib config::editor::tests::mutating_sibling_preserves_comment_above_other_key`
+Expected: the sibling test should PASS even before `set_env_comment` exists, since `set_env_var`'s upsert uses `table.insert` which should preserve adjacent decor. If it fails, that's a `toml_edit` usage bug in Task 2 that must be fixed before proceeding.
+
+- [ ] **Step 3: Implement `set_env_comment`**
+
+In `impl ConfigEditor`:
+
+```rust
+pub fn set_env_comment(&mut self, scope: EnvScope, key: &str, comment: Option<&str>) {
+    let path = env_scope_path(&scope);
+    // Walk without creating — setting a comment on a nonexistent key
+    // is a silent no-op (same contract as remove_env_var).
+    let mut current: &mut Item = self.doc.as_item_mut();
+    for segment in &path {
+        match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
+            Some(next) => current = next,
+            None => return,
+        }
+    }
+    let Some(table) = current.as_table_mut() else {
+        return;
+    };
+    let Some(mut key_mut) = table.key_mut(key) else {
+        return;
+    };
+    let decor = key_mut.leaf_decor_mut();
+    let prefix = match comment {
+        Some(text) => format!("# {text}\n"),
+        None => String::new(),
+    };
+    decor.set_prefix(prefix);
+}
+```
+
+Note on `toml_edit` version: on 0.22+, the `Table::key_mut(key) -> Option<KeyMut<'_>>` and `KeyMut::leaf_decor_mut() -> &mut Decor` methods are stable. If the installed `toml_edit` predates this, check crates.io for the equivalent; the test suite tells you immediately if the method names changed.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests::set_env_comment`
+Expected: PASS (all three `set_env_comment_*` tests).
+
+Also re-run: `cargo test -p jackin --lib config::editor::tests`
+Expected: all seven tests PASS (1 tripwire + 3 set_env_var + 2 remove_env_var + 3 set_env_comment + 1 sibling-preserve = 10 tests actually).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor::set_env_comment
+
+Sets or removes a \"# comment\\n\" line immediately above an env var
+entry via toml_edit's leaf_decor_mut on the key. The secrets screen
+(PR 3 of this series) will use this to annotate ID-form op://
+references with their human-readable name.
+
+Tests cover: adding a new comment, replacing an existing one, removing
+via None, and — critically — that mutating a sibling key does NOT
+disturb the comment above an unrelated key in the same table.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Cross-table and fixture round-trip tests
+
+**Files:**
+- Create: `src/config/fixtures/config.round_trip.toml`
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Create the fixture**
+
+Create `src/config/fixtures/config.round_trip.toml`:
+
+```toml
+# Jackin config — top-of-file note
+# keep this across saves
+
+[claude]
+auth_forward = "sync"
+
+# Our two builtin agents
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[agents.the-architect]
+git = "https://github.com/jackin-project/jackin-the-architect.git"
+trusted = true
+
+# An external agent we vetted in 2025-Q4
+[agents."chainargos/agent-brown"]
+git = "git@github.com:chainargos/jackin-agent-brown.git"
+trusted = true
+
+# Production workspace — the big one
+[workspaces.prod]
+workdir = "/workspace/prod"
+
+[workspaces.prod.env]
+# Rotate quarterly (last: 2026-Q1)
+API_TOKEN = "op://Personal/api/token"
+
+# Passes through from host
+GITHUB_TOKEN = "$GITHUB_TOKEN"
+
+[workspaces.prod.agents.agent-smith.env]
+OPENAI_API_KEY = "op://Work/OpenAI/default"
+
+# Playground workspace — disposable
+[workspaces.playground]
+workdir = "/tmp/playground"
+```
+
+- [ ] **Step 2: Write the cross-table and fixture tests**
+
+Append to `src/config/editor.rs` `tests` module:
+
+```rust
+#[test]
+fn mutating_one_workspace_preserves_comments_in_another() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    let original = r#"# workspace a — keep this comment
+[workspaces.a]
+workdir = "/a"
+
+# workspace b — also keep
+[workspaces.b]
+workdir = "/b"
+"#;
+    std::fs::write(&paths.config_file, original).unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_env_var(EnvScope::Workspace("a".to_string()), "K", "v");
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("# workspace b — also keep"), "{out}");
+    assert!(out.contains("# workspace a — keep this comment"), "{out}");
+}
+
+#[test]
+fn fixture_round_trip_is_byte_identical() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+
+    let original = include_str!("fixtures/config.round_trip.toml");
+    std::fs::write(&paths.config_file, original).unwrap();
+
+    let editor = ConfigEditor::open(&paths).unwrap();
+    editor.save().unwrap();
+
+    let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert_eq!(
+        round_tripped, original,
+        "fixture round-trip is lossy — toml_edit is dropping something"
+    );
+}
+```
+
+- [ ] **Step 3: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS on all tests including the two new ones. If the fixture test fails, the saved output will be visible in the assertion diff — examine which construct in the fixture is not round-tripping and either (a) simplify the fixture if it's something we don't actually use, or (b) investigate the `toml_edit` usage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config/fixtures/config.round_trip.toml src/config/editor.rs
+git commit -s -m "test(config): fixture round-trip + cross-table comment preservation
+
+Adds a realistic fixture (mixed comments, quoted keys with slashes,
+nested env tables) and asserts open → save is byte-identical. This is
+the main smoke test that toml_edit's round-trip actually preserves
+everything we care about in a real config.
+
+Also adds a cross-table test: mutating workspaces.a's env does not
+disturb comments attached to workspaces.b.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Atomic write parity tests
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module:
+
+```rust
+#[test]
+#[cfg(unix)]
+fn saved_file_is_0600_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "[env]\nK = \"v\"\n").unwrap();
+
+    let editor = ConfigEditor::open(&paths).unwrap();
+    editor.save().unwrap();
+
+    let perms = std::fs::metadata(&paths.config_file).unwrap().permissions();
+    assert_eq!(perms.mode() & 0o777, 0o600, "config file must be 0600");
+}
+
+#[test]
+fn save_leaves_no_tmp_file_on_success() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "[env]\nK = \"v\"\n").unwrap();
+
+    let editor = ConfigEditor::open(&paths).unwrap();
+    editor.save().unwrap();
+
+    let tmp = paths.config_file.with_extension("tmp");
+    assert!(!tmp.exists(), "expected .tmp to be renamed away");
+}
+```
+
+- [ ] **Step 2: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS — the atomic-write logic was copied from `persist.rs::save` in Task 1 and should already satisfy both properties. If either fails, inspect `ConfigEditor::save()` against `src/config/persist.rs:46–69`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "test(config): pin ConfigEditor atomic-write parity
+
+Asserts the saved config is 0600 on unix and that the .tmp sidecar does
+not outlive a successful save. Matches the invariants of the existing
+AppConfig::save body that ConfigEditor::save lifted.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Mount editor methods (`add_mount`, `remove_mount`)
+
+**Context:** The existing `AppConfig::add_mount`/`remove_mount` signatures are `(&mut self, name: &str, mount: MountConfig, scope: Option<&str>)` and `(&mut self, name: &str, scope: Option<&str>) -> bool`. These live in `src/config/mounts.rs`. The TOML representation is in `[docker.mounts]`, and `MountEntry` is an untagged enum of either a single `MountConfig` or a scoped `BTreeMap<String, MountConfig>`.
+
+Preserve exactly the same call shape on `ConfigEditor` so the call-site migrations are mechanical.
+
+**Files:**
+- Modify: `src/config/editor.rs`
+- Read (reference): `src/config/mounts.rs` (to replicate scope routing semantics)
+
+- [ ] **Step 1: Read the current implementation**
+
+Read `src/config/mounts.rs` end-to-end. Note:
+- How `add_mount` routes a mount into `MountEntry::Mount` vs `MountEntry::Scoped(BTreeMap)` based on `scope`.
+- How `remove_mount` handles the same branching.
+- What happens when scope is `None` and the existing entry is `Scoped` (or vice versa).
+
+Replicate this branching in the editor. The goal is behavioral equivalence: a test that exercised `AppConfig::add_mount` should produce the same on-disk result via `ConfigEditor::add_mount`.
+
+- [ ] **Step 2: Write tests mirroring the existing behavior**
+
+Append to `src/config/editor.rs` `tests`. Cover the four combinations:
+
+```rust
+#[test]
+fn add_mount_unscoped_creates_single_mount_entry() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.add_mount(
+        "shared-home",
+        crate::workspace::MountConfig {
+            src: "/home/user".to_string(),
+            dst: "/workspace/home".to_string(),
+            readonly: false,
+        },
+        None,
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[docker.mounts.shared-home]"), "{out}");
+    assert!(out.contains(r#"src = "/home/user""#), "{out}");
+}
+
+#[test]
+fn add_mount_scoped_creates_nested_entry() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.add_mount(
+        "creds",
+        crate::workspace::MountConfig {
+            src: "/run/secrets/x".to_string(),
+            dst: "/secrets/x".to_string(),
+            readonly: true,
+        },
+        Some("agent-smith"),
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[docker.mounts.creds.agent-smith]"), "{out}");
+    assert!(out.contains(r#"src = "/run/secrets/x""#), "{out}");
+    assert!(out.contains("readonly = true"), "{out}");
+}
+
+#[test]
+fn remove_mount_unscoped_deletes_entry() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[docker.mounts.shared-home]
+src = "/home/user"
+dst = "/workspace/home"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let removed = editor.remove_mount("shared-home", None);
+    editor.save().unwrap();
+
+    assert!(removed);
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains("shared-home"), "{out}");
+}
+
+#[test]
+fn remove_mount_returns_false_for_missing() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let removed = editor.remove_mount("nope", None);
+    editor.save().unwrap();
+    assert!(!removed);
+}
+```
+
+- [ ] **Step 3: Run to verify fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::add_mount`
+Expected: FAIL (`add_mount` not defined on `ConfigEditor`).
+
+- [ ] **Step 4: Implement**
+
+Add to `impl ConfigEditor`. Use `toml_edit::ser::to_document` or hand-construct the mount table. Hand-construction is clearer:
+
+```rust
+pub fn add_mount(
+    &mut self,
+    name: &str,
+    mount: crate::workspace::MountConfig,
+    scope: Option<&str>,
+) {
+    // Walk to or create [docker.mounts.<name>]
+    let mount_table = table_path_mut(&mut self.doc, &["docker", "mounts", name]);
+
+    match scope {
+        None => {
+            // Single-mount entry: replace the table's contents with src/dst/readonly.
+            mount_table.clear();
+            mount_table.insert("src", toml_edit::value(mount.src));
+            mount_table.insert("dst", toml_edit::value(mount.dst));
+            if mount.readonly {
+                mount_table.insert("readonly", toml_edit::value(true));
+            }
+        }
+        Some(scope_key) => {
+            // Scoped entry: [docker.mounts.<name>.<scope_key>]
+            let scoped = table_path_mut(&mut self.doc, &["docker", "mounts", name, scope_key]);
+            scoped.clear();
+            scoped.insert("src", toml_edit::value(mount.src));
+            scoped.insert("dst", toml_edit::value(mount.dst));
+            if mount.readonly {
+                scoped.insert("readonly", toml_edit::value(true));
+            }
+        }
+    }
+}
+
+pub fn remove_mount(&mut self, name: &str, scope: Option<&str>) -> bool {
+    // Walk to docker.mounts without creating.
+    let Some(docker) = self.doc.get_mut("docker").and_then(|i| i.as_table_mut()) else {
+        return false;
+    };
+    let Some(mounts) = docker.get_mut("mounts").and_then(|i| i.as_table_mut()) else {
+        return false;
+    };
+    match scope {
+        None => mounts.remove(name).is_some(),
+        Some(scope_key) => {
+            let Some(entry) = mounts.get_mut(name).and_then(|i| i.as_table_mut()) else {
+                return false;
+            };
+            entry.remove(scope_key).is_some()
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS — all mount tests plus everything from prior tasks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor::add_mount, remove_mount
+
+Preserves the existing (name, mount, scope: Option<&str>) call shape so
+call-site migrations stay mechanical. Unscoped writes [docker.mounts.N];
+scoped writes [docker.mounts.N.scope]. remove_mount returns whether the
+entry existed.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Agent editor methods (trust, auth_forward, upsert builtin)
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests`:
+
+```rust
+#[test]
+fn set_agent_trust_toggles_trusted_field() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.my-agent]
+git = "https://example.com/a.git"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_agent_trust("my-agent", true);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("trusted = true"), "{out}");
+}
+
+#[test]
+fn set_agent_trust_false_removes_field() {
+    // The AppConfig schema uses #[serde(default, skip_serializing_if = "is_false")]
+    // on `trusted`, so the canonical representation of false is absent.
+    // Match that: setting trust=false removes the key if present.
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.my-agent]
+git = "x"
+trusted = true
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_agent_trust("my-agent", false);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains("trusted"), "{out}");
+}
+
+#[test]
+fn set_agent_auth_forward_writes_claude_subtable() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.my-agent]
+git = "x"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_agent_auth_forward("my-agent", crate::config::AuthForwardMode::Token);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[agents.my-agent.claude]"), "{out}");
+    assert!(out.contains(r#"auth_forward = "token""#), "{out}");
+}
+
+#[test]
+fn set_global_auth_forward_writes_root_claude_table() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_global_auth_forward(crate::config::AuthForwardMode::Sync);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[claude]"), "{out}");
+    assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+}
+
+#[test]
+fn upsert_builtin_agent_creates_entry_when_missing() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.upsert_builtin_agent(
+        "agent-smith",
+        "https://github.com/jackin-project/jackin-agent-smith.git",
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[agents.agent-smith]"), "{out}");
+    assert!(out.contains("trusted = true"), "{out}");
+}
+
+#[test]
+fn upsert_builtin_agent_preserves_existing_claude_override() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.agent-smith]
+git = "OLD-URL"
+trusted = false
+
+[agents.agent-smith.claude]
+auth_forward = "token"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.upsert_builtin_agent(
+        "agent-smith",
+        "https://github.com/jackin-project/jackin-agent-smith.git",
+    );
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#), "{out}");
+    assert!(out.contains("trusted = true"), "{out}");
+    assert!(out.contains(r#"auth_forward = "token""#), "claude override wiped: {out}");
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::set_agent_trust`
+Expected: FAIL (method not defined).
+
+- [ ] **Step 3: Implement**
+
+In `impl ConfigEditor`:
+
+```rust
+pub fn set_agent_trust(&mut self, agent_key: &str, trusted: bool) {
+    let table = table_path_mut(&mut self.doc, &["agents", agent_key]);
+    if trusted {
+        table.insert("trusted", toml_edit::value(true));
+    } else {
+        // Canonical representation of false is absent (matches serde
+        // skip_serializing_if on AgentSource::trusted).
+        table.remove("trusted");
+    }
+}
+
+pub fn set_agent_auth_forward(
+    &mut self,
+    agent_key: &str,
+    mode: crate::config::AuthForwardMode,
+) {
+    let claude_table = table_path_mut(&mut self.doc, &["agents", agent_key, "claude"]);
+    claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+}
+
+pub fn set_global_auth_forward(&mut self, mode: crate::config::AuthForwardMode) {
+    let claude_table = table_path_mut(&mut self.doc, &["claude"]);
+    claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+}
+
+pub fn upsert_builtin_agent(&mut self, agent_key: &str, git_url: &str) {
+    // Touch only git + trusted. Leave [agents.X.claude] and
+    // [agents.X.env] alone — those are operator-owned.
+    let table = table_path_mut(&mut self.doc, &["agents", agent_key]);
+    table.insert("git", toml_edit::value(git_url));
+    table.insert("trusted", toml_edit::value(true));
+}
+```
+
+And at module scope, helper for the serde-matching string form:
+
+```rust
+fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str {
+    match mode {
+        crate::config::AuthForwardMode::Ignore => "ignore",
+        crate::config::AuthForwardMode::Sync => "sync",
+        crate::config::AuthForwardMode::Token => "token",
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor agent mutators
+
+Adds set_agent_trust, set_agent_auth_forward, set_global_auth_forward,
+upsert_builtin_agent. The builtin upsert touches only git + trusted so
+operator-owned [agents.X.claude] and [agents.X.env] overrides survive
+the sync that runs on every load_or_init.
+
+set_agent_trust(false) removes the trusted key entirely to match the
+canonical serde shape (skip_serializing_if = is_false).
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Workspace editor methods
+
+**Context:** `AppConfig` currently has `create_workspace`, `edit_workspace(name, WorkspaceEdit)`, `remove_workspace` in `src/config/workspaces.rs`. `edit_workspace` does non-trivial validation (workdir must exist / must be equal-to-or-parent-of a mount destination) and produces a `WorkspacePlan` for user-visible output.
+
+**Trade-off:** duplicating that validation inside `ConfigEditor` is a waste. Instead, `ConfigEditor::edit_workspace` should:
+1. Load the current `AppConfig` from the editor's document (parse a serde copy in-memory).
+2. Run the existing `AppConfig::edit_workspace` logic on that in-memory copy to get the validated result + the resulting `WorkspaceConfig`.
+3. Apply the validated result as targeted patches to `self.doc`.
+
+But that means `AppConfig::edit_workspace` (and the validation helpers it calls) must stay live. They do — they live on `AppConfig` today; the mutators stay `pub(super)` after migration so the editor can call them. Reader code outside `src/config/` no longer has access (that's the whole point of the migration).
+
+For `create_workspace` and `remove_workspace` the operations are simpler — just insert/remove a `[workspaces.N]` table. We replicate the validation by running serde on the resulting doc and surfacing any `validate_workspaces` error.
+
+**Files:**
+- Modify: `src/config/editor.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests`:
+
+```rust
+#[test]
+fn create_workspace_adds_table() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    let mount_src = temp.path().join("src");
+    std::fs::create_dir_all(&mount_src).unwrap();
+    std::fs::write(&paths.config_file, "").unwrap();
+
+    let ws = crate::workspace::WorkspaceConfig {
+        workdir: "/workspace/new".to_string(),
+        mounts: vec![crate::workspace::MountConfig {
+            src: mount_src.display().to_string(),
+            dst: "/workspace/new".to_string(),
+            readonly: false,
+        }],
+        allowed_agents: vec![],
+        default_agent: None,
+        last_agent: None,
+        env: std::collections::BTreeMap::new(),
+        agents: std::collections::BTreeMap::new(),
+    };
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.create_workspace("new-ws", ws).unwrap();
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains("[workspaces.new-ws]"), "{out}");
+    assert!(out.contains(r#"workdir = "/workspace/new""#), "{out}");
+}
+
+#[test]
+fn set_last_agent_preserves_other_fields() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    let original = r#"[workspaces.prod]
+workdir = "/workspace/prod"
+default_agent = "agent-smith"
+"#;
+    std::fs::write(&paths.config_file, original).unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.set_last_agent("prod", "agent-smith");
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains(r#"last_agent = "agent-smith""#), "{out}");
+    assert!(out.contains(r#"default_agent = "agent-smith""#), "{out}");
+}
+
+#[test]
+fn remove_workspace_deletes_table() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[workspaces.a]
+workdir = "/a"
+
+[workspaces.b]
+workdir = "/b"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.remove_workspace("a").unwrap();
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains("[workspaces.a]"), "{out}");
+    assert!(out.contains("[workspaces.b]"), "{out}");
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p jackin --lib config::editor::tests::create_workspace`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the simpler methods directly**
+
+In `impl ConfigEditor`:
+
+```rust
+pub fn set_last_agent(&mut self, workspace: &str, agent_key: &str) {
+    let table = table_path_mut(&mut self.doc, &["workspaces", workspace]);
+    table.insert("last_agent", toml_edit::value(agent_key));
+}
+
+pub fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
+    let Some(workspaces) = self.doc.get_mut("workspaces").and_then(|i| i.as_table_mut()) else {
+        anyhow::bail!("workspace {name:?} not found");
+    };
+    if workspaces.remove(name).is_none() {
+        anyhow::bail!("workspace {name:?} not found");
+    }
+    Ok(())
+}
+
+pub fn create_workspace(
+    &mut self,
+    name: &str,
+    ws: crate::workspace::WorkspaceConfig,
+) -> anyhow::Result<()> {
+    // Collision check first — match today's create_workspace behavior.
+    if self
+        .doc
+        .get("workspaces")
+        .and_then(|i| i.as_table())
+        .and_then(|t| t.get(name))
+        .is_some()
+    {
+        anyhow::bail!("workspace {name:?} already exists");
+    }
+
+    // Serialize the WorkspaceConfig to a toml_edit Item via the string
+    // round-trip. toml::to_string on the struct, parse as DocumentMut,
+    // lift the resulting [workspaces.<name>] body.
+    let rendered = toml::to_string(&ws)
+        .with_context(|| format!("serializing workspace {name:?}"))?;
+    let parsed: DocumentMut = rendered
+        .parse()
+        .with_context(|| format!("re-parsing serialized workspace {name:?}"))?;
+
+    // `rendered` is the body of a [workspaces.<name>] table — i.e. its
+    // top-level items become the table's items. Lift them in.
+    let workspaces_table = table_path_mut(&mut self.doc, &["workspaces", name]);
+    for (key, item) in parsed.as_table().iter() {
+        workspaces_table.insert(key, item.clone());
+    }
+
+    Ok(())
+}
+```
+
+Note: `edit_workspace` is NOT added yet — it's coming in the same task as Step 4 below because it's more involved.
+
+- [ ] **Step 4: Implement `edit_workspace` by delegating to AppConfig**
+
+`WorkspaceEdit` application is non-trivial (validation, mount upserts, allowed-agent list diffs). Rather than duplicate, delegate:
+
+```rust
+pub fn edit_workspace(
+    &mut self,
+    name: &str,
+    edit: crate::workspace::WorkspaceEdit,
+) -> anyhow::Result<()> {
+    // Snapshot current on-disk state into an AppConfig.
+    let mut in_memory: AppConfig = toml::from_str(&self.doc.to_string())
+        .context("re-parsing current doc into AppConfig for workspace edit")?;
+
+    // Apply the edit using the existing validated logic. This mutates
+    // in_memory and returns Ok on success / Err with the validation
+    // message on failure.
+    in_memory.edit_workspace(name, edit)?;
+
+    // Pull the resulting WorkspaceConfig back out and splat into the doc.
+    let updated = in_memory
+        .workspaces
+        .get(name)
+        .ok_or_else(|| anyhow::anyhow!("workspace {name:?} disappeared after edit"))?;
+
+    // Replace the entire [workspaces.<name>] table. This preserves
+    // comments in OTHER workspaces and in unrelated top-level sections,
+    // which is what the migration cares about. Comments inside the
+    // edited workspace itself are consumed — that's acceptable because
+    // the edit IS the change the user is making to that workspace.
+    let rendered = toml::to_string(updated)?;
+    let parsed: DocumentMut = rendered.parse()?;
+    let target = table_path_mut(&mut self.doc, &["workspaces", name]);
+    target.clear();
+    for (key, item) in parsed.as_table().iter() {
+        target.insert(key, item.clone());
+    }
+
+    Ok(())
+}
+```
+
+This preserves the validation contract of `AppConfig::edit_workspace` exactly and limits the "clears comments" behavior to the one workspace being edited.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cargo test -p jackin --lib config::editor::tests`
+Expected: PASS on the three new tests + every prior test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/editor.rs
+git commit -s -m "feat(config): ConfigEditor workspace mutators
+
+Adds create_workspace, edit_workspace, remove_workspace, set_last_agent.
+
+create_workspace collision-checks then splats a serialized
+WorkspaceConfig into [workspaces.<name>]. edit_workspace delegates to
+AppConfig::edit_workspace's validated logic (mount upserts,
+allowed_agents diffs, workdir validation) and then replaces the
+[workspaces.<name>] table — comments inside the edited workspace are
+consumed (that IS the change), but all other sections survive intact.
+
+set_last_agent is a targeted insert that preserves every other field
+on the workspace, including default_agent.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Migrate call sites in `src/app/mod.rs`
+
+**Context:** Ten call sites in this file each follow the pattern `config.MUTATOR(...); config.save(&paths)?;`. Convert each to the `ConfigEditor::open → mutate → save` shape.
+
+**Files:**
+- Modify: `src/app/mod.rs`
+
+- [ ] **Step 1: Run the full test suite to establish a green baseline**
+
+Run: `cargo test -p jackin`
+Expected: all tests PASS. If anything is red before the migration, fix it first — we need a known-green baseline to catch any regressions from the migration.
+
+- [ ] **Step 2: Migrate the mount sites (lines 210, 216)**
+
+At `src/app/mod.rs:204–217` area, the current code:
+
+```rust
+let mount = config::MountConfig {
+    src: resolved_src,
+    dst: dst.clone(),
+    readonly,
+};
+config.add_mount(&name, mount, scope.as_deref());
+config.save(&paths)?;
+println!("Added mount {name:?} ({scope_label}): {src} -> {dst}{ro}");
+```
+
+Replace with:
+
+```rust
+let mount = config::MountConfig {
+    src: resolved_src,
+    dst: dst.clone(),
+    readonly,
+};
+let mut editor = crate::config::ConfigEditor::open(&paths)?;
+editor.add_mount(&name, mount, scope.as_deref());
+config = editor.save()?;
+println!("Added mount {name:?} ({scope_label}): {src} -> {dst}{ro}");
+```
+
+Apply the analogous transformation to the `MountCommand::Remove` branch (line 216 area):
+
+```rust
+let mut editor = crate::config::ConfigEditor::open(&paths)?;
+if editor.remove_mount(&name, scope.as_deref()) {
+    config = editor.save()?;
+    println!("Removed mount {name:?}.");
+} else {
+    // Nothing to save, drop the editor
+    drop(editor);
+    println!("No mount named {name:?} to remove.");
+}
+```
+
+Note: the `drop(editor)` is cosmetic — `ConfigEditor` is `Drop`-safe because it only holds in-memory data. Include it for clarity that no save happens on the no-op path.
+
+- [ ] **Step 3: Migrate the trust sites (lines 269, 282)**
+
+Current (Grant):
+
+```rust
+let class = ClassSelector::parse(&selector)?;
+config.resolve_agent_source(&class)?;
+if config.trust_agent(&class.key()) {
+    config.save(&paths)?;
+    println!("Trusted {}.", class.key());
+} else {
+    println!("{} is already trusted.", class.key());
+}
+```
+
+Replace with:
+
+```rust
+let class = ClassSelector::parse(&selector)?;
+config.resolve_agent_source(&class)?;
+// resolve_agent_source may have mutated config in-memory (inserting
+// a new agent entry); persist that and the trust change together.
+let was_trusted = config
+    .agents
+    .get(&class.key())
+    .map(|a| a.trusted)
+    .unwrap_or(false);
+if !was_trusted {
+    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+    // resolve_agent_source may have just inserted this agent; make
+    // sure the editor sees its git URL.
+    if let Some(source) = config.agents.get(&class.key()) {
+        editor.upsert_agent_source(&class.key(), source);
+    }
+    editor.set_agent_trust(&class.key(), true);
+    config = editor.save()?;
+    println!("Trusted {}.", class.key());
+} else {
+    println!("{} is already trusted.", class.key());
+}
+```
+
+This introduces a new need: `ConfigEditor::upsert_agent_source(key, &AgentSource)`. Add it alongside `upsert_builtin_agent`:
+
+```rust
+pub fn upsert_agent_source(&mut self, agent_key: &str, source: &crate::config::AgentSource) {
+    // Hand-splat git + trusted. Leave claude & env overrides alone if
+    // they already exist; otherwise serialize and insert.
+    let table = table_path_mut(&mut self.doc, &["agents", agent_key]);
+    table.insert("git", toml_edit::value(source.git.clone()));
+    if source.trusted {
+        table.insert("trusted", toml_edit::value(true));
+    } else {
+        table.remove("trusted");
+    }
+    // Serialize claude override if present and the table doesn't have one.
+    if let Some(claude) = &source.claude {
+        if !table.contains_key("claude") {
+            let rendered = toml::to_string(claude).unwrap_or_default();
+            if let Ok(parsed) = rendered.parse::<DocumentMut>() {
+                let claude_table = table_path_mut(&mut self.doc, &["agents", agent_key, "claude"]);
+                for (k, v) in parsed.as_table().iter() {
+                    claude_table.insert(k, v.clone());
+                }
+            }
+        }
+    }
+    // Env is operator-owned — do not overwrite.
+}
+```
+
+Add a test for it (append to `tests`):
+
+```rust
+#[test]
+fn upsert_agent_source_preserves_existing_env() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[agents.foo]
+git = "OLD"
+
+[agents.foo.env]
+MY_VAR = "preserved"
+"#,
+    )
+    .unwrap();
+
+    let source = crate::config::AgentSource {
+        git: "NEW".to_string(),
+        trusted: true,
+        claude: None,
+        env: std::collections::BTreeMap::new(),
+    };
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.upsert_agent_source("foo", &source);
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(out.contains(r#"git = "NEW""#), "{out}");
+    assert!(out.contains(r#"MY_VAR = "preserved""#), "{out}");
+}
+```
+
+Revoke branch (line 282 area):
+
+```rust
+cli::TrustCommand::Revoke { selector } => {
+    let class = ClassSelector::parse(&selector)?;
+    if AppConfig::is_builtin_agent(&class.key()) {
+        anyhow::bail!("{} is a built-in agent and is always trusted.", class.key());
+    }
+    let was_trusted = config
+        .agents
+        .get(&class.key())
+        .map(|a| a.trusted)
+        .unwrap_or(false);
+    if was_trusted {
+        let mut editor = crate::config::ConfigEditor::open(&paths)?;
+        editor.set_agent_trust(&class.key(), false);
+        config = editor.save()?;
+        println!("Revoked trust for {}.", class.key());
+    } else {
+        println!("{} is not trusted.", class.key());
+    }
+}
+```
+
+- [ ] **Step 4: Migrate the auth_forward sites (lines 318, 322)**
+
+Current:
+
+```rust
+if let Some(agent_selector) = agent {
+    let class = ClassSelector::parse(&agent_selector)?;
+    config.resolve_agent_source(&class)?;
+    config.set_agent_auth_forward(&class.key(), parsed_mode);
+    config.save(&paths)?;
+    println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
+} else {
+    config.claude.auth_forward = parsed_mode;
+    config.save(&paths)?;
+    println!("Set global auth forwarding to {parsed_mode}.");
+}
+```
+
+Replace:
+
+```rust
+if let Some(agent_selector) = agent {
+    let class = ClassSelector::parse(&agent_selector)?;
+    config.resolve_agent_source(&class)?;
+    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+    if let Some(source) = config.agents.get(&class.key()) {
+        editor.upsert_agent_source(&class.key(), source);
+    }
+    editor.set_agent_auth_forward(&class.key(), parsed_mode);
+    config = editor.save()?;
+    println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
+} else {
+    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+    editor.set_global_auth_forward(parsed_mode);
+    config = editor.save()?;
+    println!("Set global auth forwarding to {parsed_mode}.");
+}
+```
+
+- [ ] **Step 5: Migrate the workspace sites (lines 386, 655, 705, 714)**
+
+Line 386 — `create_workspace`:
+
+```rust
+// Before:
+config.create_workspace(&name, WorkspaceConfig { ... })?;
+config.save(&paths)?;
+// After:
+let ws = WorkspaceConfig { ... };
+let mut editor = crate::config::ConfigEditor::open(&paths)?;
+editor.create_workspace(&name, ws)?;
+config = editor.save()?;
+```
+
+Lines 655 and 705 — `edit_workspace`:
+
+```rust
+// Before:
+config.edit_workspace(&name, WorkspaceEdit { ... })?;
+config.save(&paths)?;
+// After:
+let mut editor = crate::config::ConfigEditor::open(&paths)?;
+editor.edit_workspace(&name, WorkspaceEdit { ... })?;
+config = editor.save()?;
+```
+
+Line 714 — `remove_workspace`:
+
+```rust
+// Before:
+config.remove_workspace(&name)?;
+config.save(&paths)?;
+// After:
+let mut editor = crate::config::ConfigEditor::open(&paths)?;
+editor.remove_workspace(&name)?;
+config = editor.save()?;
+```
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `cargo test -p jackin`
+Expected: all tests PASS. If any existing integration test fails, the migration shape is wrong — read the failure, identify whether it's a missing editor method or a caller change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/mod.rs src/config/editor.rs
+git commit -s -m "refactor(app): route config writes through ConfigEditor
+
+Migrates the ten config.mutate(); config.save() pairs in src/app/mod.rs
+(mounts, trust, auth_forward, workspace create/edit/remove) to the new
+ConfigEditor::open → mutate → save shape. AppConfig::save still exists
+at this point; it gets removed in a later commit once all callers are
+migrated.
+
+Adds ConfigEditor::upsert_agent_source because the trust/auth_forward
+CLI paths call resolve_agent_source first (which may insert a new
+agent into the in-memory config); the editor must see the same insert
+so it persists alongside the trust change.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Migrate `src/app/context.rs` (last-used-agent)
+
+**Files:**
+- Modify: `src/app/context.rs`
+
+- [ ] **Step 1: Replace the save site at line 327 area**
+
+Current `remember_last_agent` body:
+
+```rust
+if let Some(workspace_name) = workspace_name
+    && let Some(workspace) = config.workspaces.get_mut(workspace_name)
+{
+    workspace.last_agent = Some(class.key());
+    if let Err(error) = config.save(paths) {
+        eprintln!("warning: failed to save last-used agent: {error}");
+    }
+}
+```
+
+Replace with:
+
+```rust
+let Some(workspace_name) = workspace_name else { return; };
+if !config.workspaces.contains_key(workspace_name) {
+    return;
+}
+let Ok(mut editor) = crate::config::ConfigEditor::open(paths) else {
+    eprintln!("warning: failed to open config for last-used-agent save");
+    return;
+};
+editor.set_last_agent(workspace_name, &class.key());
+match editor.save() {
+    Ok(reloaded) => *config = reloaded,
+    Err(error) => eprintln!("warning: failed to save last-used agent: {error}"),
+}
+```
+
+- [ ] **Step 2: Run the test suite**
+
+Run: `cargo test -p jackin`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/context.rs
+git commit -s -m "refactor(app): route last-used-agent save through ConfigEditor
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Migrate `src/runtime/launch.rs` (newly-trusted / newly-registered)
+
+**Files:**
+- Modify: `src/runtime/launch.rs`
+
+- [ ] **Step 1: Replace the save site at line 600 area**
+
+Current:
+
+```rust
+let newly_trusted = if source.trusted {
+    false
+} else {
+    confirm_trust(selector, &source)?;
+    config.trust_agent(&selector.key());
+    true
+};
+
+// Persist config when the agent was newly registered or newly trusted
+if is_new || newly_trusted {
+    config.save(paths)?;
+}
+```
+
+Replace with:
+
+```rust
+let newly_trusted = if source.trusted {
+    false
+} else {
+    confirm_trust(selector, &source)?;
+    // Mutate the in-memory copy so callers downstream see the trust
+    // without a reload; persist via editor below.
+    if let Some(entry) = config.agents.get_mut(&selector.key()) {
+        entry.trusted = true;
+    }
+    true
+};
+
+if is_new || newly_trusted {
+    let mut editor = crate::config::ConfigEditor::open(paths)?;
+    if let Some(agent_source) = config.agents.get(&selector.key()) {
+        editor.upsert_agent_source(&selector.key(), agent_source);
+    }
+    editor.set_agent_trust(&selector.key(), true);
+    *config = editor.save()?;
+}
+```
+
+- [ ] **Step 2: Run the test suite**
+
+Run: `cargo test -p jackin`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/runtime/launch.rs
+git commit -s -m "refactor(launch): route newly-trusted agent save through ConfigEditor
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Migrate `src/config/persist.rs` (load-time migrations)
+
+**Files:**
+- Modify: `src/config/persist.rs`
+
+- [ ] **Step 1: Replace the save branch in `load_or_init`**
+
+The current body at `src/config/persist.rs:5–44` ends with:
+
+```rust
+let builtins_changed = config.sync_builtin_agents();
+
+if deprecated_copy_seen {
+    crate::tui::deprecation_warning(&format!(
+        "migrated auth_forward \"copy\" → \"sync\" in {} (copy is deprecated)",
+        paths.config_file.display()
+    ));
+}
+
+if builtins_changed || deprecated_copy_seen {
+    config.save(paths)?;
+}
+```
+
+Replace the whole post-load migration block with:
+
+```rust
+let builtins_changed = config.sync_builtin_agents();
+
+if deprecated_copy_seen {
+    crate::tui::deprecation_warning(&format!(
+        "migrated auth_forward \"copy\" → \"sync\" in {} (copy is deprecated)",
+        paths.config_file.display()
+    ));
+}
+
+if builtins_changed || deprecated_copy_seen {
+    let mut editor = crate::config::ConfigEditor::open(paths)?;
+    if builtins_changed {
+        for &(name, git) in crate::config::agents::BUILTIN_AGENTS {
+            editor.upsert_builtin_agent(name, git);
+        }
+    }
+    if deprecated_copy_seen {
+        // Rewrite every "copy" string we find to "sync" at the exact
+        // paths contains_deprecated_copy_auth_forward checks:
+        //   [claude].auth_forward
+        //   [agents.*.claude].auth_forward
+        editor.normalize_deprecated_copy();
+    }
+    // Discard the reloaded AppConfig — we already have `config` in the
+    // correct post-migration shape.
+    editor.save()?;
+}
+```
+
+- [ ] **Step 2: Expose `BUILTIN_AGENTS` from the `agents` module**
+
+In `src/config/agents.rs`, find the `BUILTIN_AGENTS` constant (currently `pub(super)`). If `load_or_init` in `persist.rs` is in the same `super` module the existing visibility may already work — verify with `cargo check`. If not, change to `pub(crate)`:
+
+```rust
+pub(crate) const BUILTIN_AGENTS: &[(&str, &str)] = &[
+    ("agent-smith", "https://github.com/jackin-project/jackin-agent-smith.git"),
+    ("the-architect", "https://github.com/jackin-project/jackin-the-architect.git"),
+];
+```
+
+- [ ] **Step 3: Implement `ConfigEditor::normalize_deprecated_copy`**
+
+In `impl ConfigEditor` in `src/config/editor.rs`:
+
+```rust
+/// Rewrite any `auth_forward = "copy"` to `"sync"` at the two paths
+/// `contains_deprecated_copy_auth_forward` checks:
+///   [claude].auth_forward
+///   [agents.*.claude].auth_forward
+///
+/// Does not touch any other structure. Used by load_or_init when the
+/// on-disk config still contains the deprecated literal.
+pub fn normalize_deprecated_copy(&mut self) {
+    // Global [claude]
+    if let Some(claude) = self.doc.get_mut("claude").and_then(|i| i.as_table_mut()) {
+        if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
+            claude.insert("auth_forward", toml_edit::value("sync"));
+        }
+    }
+    // Per-agent [agents.X.claude]
+    if let Some(agents) = self.doc.get_mut("agents").and_then(|i| i.as_table_mut()) {
+        for (_, agent_item) in agents.iter_mut() {
+            let Some(agent_table) = agent_item.as_table_mut() else { continue };
+            let Some(claude) = agent_table.get_mut("claude").and_then(|i| i.as_table_mut())
+            else {
+                continue;
+            };
+            if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
+                claude.insert("auth_forward", toml_edit::value("sync"));
+            }
+        }
+    }
+}
+```
+
+And add a test for it:
+
+```rust
+#[test]
+fn normalize_deprecated_copy_rewrites_global_and_agent_paths() {
+    let temp = tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    std::fs::write(
+        &paths.config_file,
+        r#"[claude]
+auth_forward = "copy"
+
+[agents.foo]
+git = "x"
+
+[agents.foo.claude]
+auth_forward = "copy"
+
+[agents.bar]
+git = "y"
+"#,
+    )
+    .unwrap();
+
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor.normalize_deprecated_copy();
+    editor.save().unwrap();
+
+    let out = std::fs::read_to_string(&paths.config_file).unwrap();
+    assert!(!out.contains(r#""copy""#), "{out}");
+    assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+}
+```
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `cargo test -p jackin`
+Expected: all tests PASS, including the existing `sync_does_not_rewrite_config_when_already_current` (line 115) and `load_or_init_rejects_invalid_persisted_workspace`. If any fail, the replacement of the migration branch introduced a regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/persist.rs src/config/agents.rs src/config/editor.rs
+git commit -s -m "refactor(config): route load_or_init migrations through ConfigEditor
+
+The builtin-sync and deprecated-copy migrations run in-memory on
+AppConfig as before, but the resulting save goes through
+ConfigEditor::upsert_builtin_agent and normalize_deprecated_copy
+instead of AppConfig::save. User comments and blank lines in config
+sections untouched by the migration now survive the first load after
+upgrade.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Remove `AppConfig::save` and the dead mutators
+
+**Context:** At this point, `cargo build` succeeds with `AppConfig::save` unused. The dead-code path can be deleted, along with the in-memory mutator methods that have editor equivalents.
+
+**Files:**
+- Modify: `src/config/persist.rs`
+- Modify: `src/config/agents.rs`
+- Modify: `src/config/mounts.rs`
+- Modify: `src/config/workspaces.rs`
+
+- [ ] **Step 1: Delete `AppConfig::save`**
+
+In `src/config/persist.rs`, delete the `pub fn save(&self, paths: &JackinPaths) -> anyhow::Result<()> { ... }` method (lines 46–69 in the original). Keep `load_or_init`, `contains_deprecated_copy_auth_forward`, and everything else.
+
+Run `cargo check`. Expected: success. No callers of `save` should remain after tasks 10–13.
+
+If `cargo check` reports unused imports in `persist.rs` (e.g., `OpenOptions`, `PermissionsExt`), remove them.
+
+- [ ] **Step 2: Audit and delete dead mutators on `AppConfig`**
+
+For each of these methods in the listed files, check whether it has callers **outside the `src/config/` module tree**:
+
+- `src/config/agents.rs`: `trust_agent`, `untrust_agent`, `set_agent_auth_forward`
+- `src/config/mounts.rs`: `add_mount`, `remove_mount`
+- `src/config/workspaces.rs`: `create_workspace`, `remove_workspace`
+
+Run (from the jackin root):
+```
+grep -rn "config\.trust_agent\|config\.untrust_agent\|config\.set_agent_auth_forward\|config\.add_mount\|config\.remove_mount\|config\.create_workspace\|config\.remove_workspace" src/ --include="*.rs" | grep -v "^src/config/"
+```
+
+After tasks 10–13, this should return no matches. If it does, migrate those call sites before proceeding.
+
+If clean, delete these methods from their respective files. `AppConfig::edit_workspace` is retained because `ConfigEditor::edit_workspace` calls it internally; mark it `pub(crate)` so external code can no longer invoke it directly:
+
+```rust
+pub(crate) fn edit_workspace(&mut self, name: &str, edit: WorkspaceEdit) -> anyhow::Result<()> {
+    // unchanged body
+}
+```
+
+Similarly `AppConfig::resolve_agent_source` is still called from `src/app/mod.rs` and `src/runtime/launch.rs` — leave that public.
+
+- [ ] **Step 3: Run the test suite + clippy**
+
+Run: `cargo test -p jackin && cargo clippy -p jackin -- -D warnings`
+Expected: all tests PASS, clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -s -m "refactor(config): remove AppConfig::save and dead mutator methods
+
+AppConfig::save is removed; ConfigEditor is the sole write path. The
+in-memory mutator methods (trust_agent, untrust_agent,
+set_agent_auth_forward, add_mount, remove_mount, create_workspace,
+remove_workspace) are deleted — their editor equivalents are now the
+only way to change persisted state.
+
+AppConfig::edit_workspace stays (called internally by
+ConfigEditor::edit_workspace) but is demoted to pub(crate) so the rest
+of the crate cannot bypass the editor.
+
+Co-authored-by: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Final verification
+
+**Files:** None modified — this is a gate, not a change.
+
+- [ ] **Step 1: Full test suite, release build, clippy**
+
+Run (from jackin root):
+
+```bash
+cargo test -p jackin --all-targets && \
+cargo build -p jackin --release && \
+cargo clippy -p jackin --all-targets -- -D warnings
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Confirm no stray `AppConfig::save` or `config.save` references**
+
+Run:
+
+```bash
+grep -rn "config\.save\|AppConfig::save" src/ --include="*.rs"
+```
+
+Expected: zero matches outside comments or doc strings. If any remain, migrate them before opening a PR.
+
+- [ ] **Step 3: Confirm no `toml::to_string_pretty(` on the write side**
+
+Run:
+
+```bash
+grep -n "toml::to_string_pretty" src/ -r --include="*.rs"
+```
+
+Expected: matches only in tests or in `ConfigEditor` internals (the `WorkspaceConfig` serialize helper inside `create_workspace` / `edit_workspace` uses `toml::to_string` — that's fine because those results are re-parsed by `toml_edit`, not written to disk).
+
+- [ ] **Step 4: Manual smoke test — hand-written comment survives a save**
+
+```bash
+# Make a test config with a hand-written comment
+mkdir -p /tmp/jackin-smoke
+cat > /tmp/jackin-smoke/config.toml <<'EOF'
+# I wrote this comment by hand and expect it to survive.
+
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+# this too
+[workspaces.demo]
+workdir = "/tmp"
+EOF
+
+# Run a command that triggers a save (trust revoke/grant, mount add, etc.)
+JACKIN_HOME=/tmp/jackin-smoke/home \
+  cargo run -p jackin -- config mount add shared-home /tmp:/workspace/home
+
+# Expected: the hand-written comments are still present in the config
+grep "I wrote this comment" /tmp/jackin-smoke/config.toml && echo "✓ comment preserved"
+grep "this too" /tmp/jackin-smoke/config.toml && echo "✓ second comment preserved"
+```
+
+*(Adjust env var to jackin's actual override for the config path — see `JackinPaths::detect`. The point is: hand-written comments must survive the programmatic save.)*
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin feature/toml-edit-migration
+gh pr create --title "feat(config): toml_edit migration (PR 1 of 3)" --body "$(cat <<'EOF'
+## Summary
+
+Implements the spec at `docs/superpowers/specs/2026-04-23-toml-edit-migration-design.md` (PR #160).
+
+- New `ConfigEditor` in `src/config/editor.rs` owns a `toml_edit::DocumentMut` and exposes typed setters for every mutation the app performs. Reads still use `AppConfig::load_or_init` (serde + `toml`); writes go through `ConfigEditor::open → mutate → save`.
+- `AppConfig::save` and the in-memory mutators (`trust_agent`, `add_mount`, `create_workspace`, etc.) are removed. The rest of the app cannot change persisted state except through the editor.
+- 13 call sites migrated across `src/app/mod.rs`, `src/app/context.rs`, `src/runtime/launch.rs`, and `src/config/persist.rs`.
+- User-written comments, blank lines, and key ordering now survive every programmatic save.
+
+## Test plan
+
+- [ ] `cargo test -p jackin --all-targets` — green
+- [ ] `cargo clippy -p jackin --all-targets -- -D warnings` — clean
+- [ ] Manual smoke test: a hand-written `# comment` in `~/.config/jackin/config.toml` survives a `jackin config mount add` (or any other save-triggering command)
+- [ ] Fixture round-trip test (`fixture_round_trip_is_byte_identical`) passes — the main smoke test that `toml_edit` round-trips everything we use
+- [ ] `set_env_comment` + `mutating_sibling_preserves_comment_above_other_key` tests pass — the two tests that validate the specific feature PR 3 depends on
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL to the operator and stop — do not merge without explicit per-PR confirmation.
+
+---
+
+## Self-review notes
+
+Ran spec-coverage check against `docs/superpowers/specs/2026-04-23-toml-edit-migration-design.md`:
+
+- **Goal 1** (preserve comments/blanks/order): Tasks 4, 5 (comment tests), Task 5 (fixture round-trip), Task 15 Step 4 (manual smoke). ✓
+- **Goal 2** (read path + schema unchanged): No task modifies `AppConfig` field shapes; Task 14 explicitly demotes `edit_workspace` to `pub(crate)` only. ✓
+- **Goal 3** (all writes through one module): Tasks 10–14 migrate every call site; Task 14 deletes the old `save()`. ✓
+- **Goal 4** (atomic-write parity): Task 1 lifts the existing body verbatim; Task 6 pins the invariants. ✓
+- **Goal 5** (idempotent-save tripwire): Task 1 Step 4. ✓
+
+Spec testing section (8 tests): tripwire (Task 1), preserves comment above mutated sibling (Task 4), preserves comments in untouched tables (Task 5), preserves blank lines/key order — covered by the fixture round-trip which checks whole-file equality (Task 5), `set_env_comment` contract (Task 4), upsert creates intermediate tables (Task 2), atomic-write parity (Task 6), load-then-save on real fixture (Task 5). All eight have tasks. ✓
+
+Spec non-goals: no TUI/CLI changes (none introduced), no schema change (confirmed in Task 14), no multi-process locking (not added), no CHANGELOG touch (absent from every commit message). ✓
+
+Placeholder scan: no "TBD" / "appropriate error handling" / "similar to Task N" / "write tests for the above". Every test has explicit code; every impl step has explicit code. ✓
+
+Type consistency: `EnvScope` used identically across Tasks 2, 3, 4, 5; `AuthForwardMode::{Sync, Token, Ignore}` matches the enum in `src/config/mod.rs:22–46`; `WorkspaceConfig` / `MountConfig` struct literals match the verified field lists from the exploration report. ✓
+
+One forward-looking method emerged mid-plan (`upsert_agent_source` in Task 10 Step 3) that was not in the original spec API surface. It arose because `config.resolve_agent_source` may have mutated memory before the editor opens — a real interaction not surfaced during brainstorming. The plan introduces it with a dedicated test and notes the reason in the commit message. This is a real spec gap that could be addressed by either (a) updating the spec to include `upsert_agent_source`, or (b) noting it as an implementation detail discovered during execution. Option (b) is cheaper; leaving it as-is.

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -320,13 +320,31 @@ pub(crate) fn remember_last_agent(
         return;
     }
 
-    if let Some(workspace_name) = workspace_name
-        && let Some(workspace) = config.workspaces.get_mut(workspace_name)
-    {
-        workspace.last_agent = Some(class.key());
-        if let Err(error) = config.save(paths) {
-            eprintln!("warning: failed to save last-used agent: {error}");
+    let Some(workspace_name) = workspace_name else {
+        return;
+    };
+    if !config.workspaces.contains_key(workspace_name) {
+        return;
+    }
+    // Flush the current in-memory state to disk so the editor opens a
+    // document that contains all workspace fields. Without this, a workspace
+    // that exists only in memory (e.g. in tests, or on first load) would
+    // produce a partial TOML entry that fails deserialization after save.
+    if let Err(error) = paths.ensure_base_dirs().and_then(|()| config.save(paths)) {
+        eprintln!("warning: failed to save last-used agent: {error}");
+        return;
+    }
+    let mut editor = match crate::config::ConfigEditor::open(paths) {
+        Ok(editor) => editor,
+        Err(error) => {
+            eprintln!("warning: failed to open config for last-used-agent save: {error}");
+            return;
         }
+    };
+    editor.set_last_agent(workspace_name, &class.key());
+    match editor.save() {
+        Ok(reloaded) => *config = reloaded,
+        Err(error) => eprintln!("warning: failed to save last-used agent: {error}"),
     }
 }
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -326,14 +326,11 @@ pub(crate) fn remember_last_agent(
     if !config.workspaces.contains_key(workspace_name) {
         return;
     }
-    // Flush the current in-memory state to disk so the editor opens a
-    // document that contains all workspace fields. Without this, a workspace
-    // that exists only in memory (e.g. in tests, or on first load) would
-    // produce a partial TOML entry that fails deserialization after save.
-    if let Err(error) = paths.ensure_base_dirs().and_then(|()| config.save(paths)) {
-        eprintln!("warning: failed to save last-used agent: {error}");
-        return;
-    }
+    // Production callers always reach this point with the config already
+    // persisted on disk (it was loaded from disk at startup, and every
+    // mutation flows through ConfigEditor). Tests that construct an
+    // AppConfig purely in memory must persist it before calling this
+    // function — see `remember_last_agent_persists_successful_loads`.
     let mut editor = match crate::config::ConfigEditor::open(paths) {
         Ok(editor) => editor,
         Err(error) => {
@@ -724,17 +721,22 @@ mod tests {
         assert!(err.contains("no saved workspace matches"), "got: {err}");
     }
 
-    #[test]
-    fn remember_last_agent_persists_successful_loads() {
-        let temp = tempfile::tempdir().unwrap();
-        let paths = paths::JackinPaths::for_tests(temp.path());
+    /// Test helper: construct a minimal workspace-containing AppConfig,
+    /// persist it to disk at the expected config path, and return the
+    /// live in-memory copy. Matches the production invariant that
+    /// `remember_last_agent` observes: the config is already on disk.
+    fn persisted_config_with_workspace(
+        paths: &paths::JackinPaths,
+        temp_path: &std::path::Path,
+    ) -> config::AppConfig {
+        paths.ensure_base_dirs().unwrap();
         let mut config = config::AppConfig::default();
         config.workspaces.insert(
             "my-app".to_string(),
             workspace::WorkspaceConfig {
                 workdir: "/workspace".to_string(),
                 mounts: vec![workspace::MountConfig {
-                    src: temp.path().display().to_string(),
+                    src: temp_path.display().to_string(),
                     dst: "/workspace".to_string(),
                     readonly: false,
                 }],
@@ -745,6 +747,16 @@ mod tests {
                 agents: std::collections::BTreeMap::new(),
             },
         );
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&paths.config_file, serialized).unwrap();
+        config
+    }
+
+    #[test]
+    fn remember_last_agent_persists_successful_loads() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths::JackinPaths::for_tests(temp.path());
+        let mut config = persisted_config_with_workspace(&paths, temp.path());
 
         remember_last_agent(
             &paths,
@@ -767,23 +779,7 @@ mod tests {
     fn remember_last_agent_skips_failed_loads() {
         let temp = tempfile::tempdir().unwrap();
         let paths = paths::JackinPaths::for_tests(temp.path());
-        let mut config = config::AppConfig::default();
-        config.workspaces.insert(
-            "my-app".to_string(),
-            workspace::WorkspaceConfig {
-                workdir: "/workspace".to_string(),
-                mounts: vec![workspace::MountConfig {
-                    src: temp.path().display().to_string(),
-                    dst: "/workspace".to_string(),
-                    readonly: false,
-                }],
-                allowed_agents: vec![],
-                default_agent: None,
-                last_agent: None,
-                env: std::collections::BTreeMap::new(),
-                agents: std::collections::BTreeMap::new(),
-            },
-        );
+        let mut config = persisted_config_with_workspace(&paths, temp.path());
 
         remember_last_agent(
             &paths,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,12 +268,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 cli::TrustCommand::Grant { selector } => {
                     let class = ClassSelector::parse(&selector)?;
                     config.resolve_agent_source(&class)?;
-                    let was_trusted = config
-                        .agents
-                        .get(&class.key())
-                        .map(|a| a.trusted)
-                        .unwrap_or(false);
-                    if !was_trusted {
+                    let was_trusted = config.agents.get(&class.key()).is_some_and(|a| a.trusted);
+                    if was_trusted {
+                        println!("{} is already trusted.", class.key());
+                    } else {
                         let mut editor = crate::config::ConfigEditor::open(&paths)?;
                         if let Some(source) = config.agents.get(&class.key()) {
                             editor.upsert_agent_source(&class.key(), source);
@@ -281,8 +279,6 @@ pub fn run(cli: Cli) -> Result<()> {
                         editor.set_agent_trust(&class.key(), true);
                         editor.save()?;
                         println!("Trusted {}.", class.key());
-                    } else {
-                        println!("{} is already trusted.", class.key());
                     }
                     Ok(())
                 }
@@ -291,11 +287,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     if AppConfig::is_builtin_agent(&class.key()) {
                         anyhow::bail!("{} is a built-in agent and is always trusted.", class.key());
                     }
-                    let was_trusted = config
-                        .agents
-                        .get(&class.key())
-                        .map(|a| a.trusted)
-                        .unwrap_or(false);
+                    let was_trusted = config.agents.get(&class.key()).is_some_and(|a| a.trusted);
                     if was_trusted {
                         let mut editor = crate::config::ConfigEditor::open(&paths)?;
                         editor.set_agent_trust(&class.key(), false);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -208,14 +208,14 @@ pub fn run(cli: Cli) -> Result<()> {
                     };
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     editor.add_mount(&name, mount, scope.as_deref());
-                    config = editor.save()?;
+                    editor.save()?;
                     println!("Added mount {name:?} ({scope_label}): {src} -> {dst}{ro}");
                     Ok(())
                 }
                 cli::MountCommand::Remove { name, scope } => {
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     if editor.remove_mount(&name, scope.as_deref()) {
-                        config = editor.save()?;
+                        editor.save()?;
                         println!("Removed mount {name:?}.");
                     } else {
                         drop(editor);
@@ -279,7 +279,7 @@ pub fn run(cli: Cli) -> Result<()> {
                             editor.upsert_agent_source(&class.key(), source);
                         }
                         editor.set_agent_trust(&class.key(), true);
-                        config = editor.save()?;
+                        editor.save()?;
                         println!("Trusted {}.", class.key());
                     } else {
                         println!("{} is already trusted.", class.key());
@@ -299,7 +299,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     if was_trusted {
                         let mut editor = crate::config::ConfigEditor::open(&paths)?;
                         editor.set_agent_trust(&class.key(), false);
-                        config = editor.save()?;
+                        editor.save()?;
                         println!("Revoked trust for {}.", class.key());
                     } else {
                         println!("{} is not currently trusted.", class.key());
@@ -339,12 +339,12 @@ pub fn run(cli: Cli) -> Result<()> {
                             editor.upsert_agent_source(&class.key(), source);
                         }
                         editor.set_agent_auth_forward(&class.key(), parsed_mode);
-                        config = editor.save()?;
+                        editor.save()?;
                         println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
                     } else {
                         let mut editor = crate::config::ConfigEditor::open(&paths)?;
                         editor.set_global_auth_forward(parsed_mode);
-                        config = editor.save()?;
+                        editor.save()?;
                         println!("Set global auth forwarding to {parsed_mode}.");
                     }
                     Ok(())
@@ -407,7 +407,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 };
                 let mut editor = crate::config::ConfigEditor::open(&paths)?;
                 editor.create_workspace(&name, ws)?;
-                config = editor.save()?;
+                editor.save()?;
                 println!(
                     "Created workspace {name:?} (workdir: {}, {mount_count} mount(s)).",
                     tui::shorten_home(&workdir)
@@ -677,7 +677,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         },
                     },
                 )?;
-                config = editor.save()?;
+                editor.save()?;
                 println!("Updated workspace {name:?}:");
                 for change in &changes {
                     println!("  - {change}");
@@ -728,7 +728,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         ..WorkspaceEdit::default()
                     },
                 )?;
-                config = editor.save()?;
+                editor.save()?;
                 println!(
                     "Pruned {} redundant mount(s) from workspace {name:?}.",
                     plan.removed.len()
@@ -738,7 +738,7 @@ pub fn run(cli: Cli) -> Result<()> {
             WorkspaceCommand::Remove { name } => {
                 let mut editor = crate::config::ConfigEditor::open(&paths)?;
                 editor.remove_workspace(&name)?;
-                config = editor.save()?;
+                editor.save()?;
                 println!("Removed workspace {name:?}.");
                 Ok(())
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -206,16 +206,19 @@ pub fn run(cli: Cli) -> Result<()> {
                         dst: dst.clone(),
                         readonly,
                     };
-                    config.add_mount(&name, mount, scope.as_deref());
-                    config.save(&paths)?;
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    editor.add_mount(&name, mount, scope.as_deref());
+                    config = editor.save()?;
                     println!("Added mount {name:?} ({scope_label}): {src} -> {dst}{ro}");
                     Ok(())
                 }
                 cli::MountCommand::Remove { name, scope } => {
-                    if config.remove_mount(&name, scope.as_deref()) {
-                        config.save(&paths)?;
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    if editor.remove_mount(&name, scope.as_deref()) {
+                        config = editor.save()?;
                         println!("Removed mount {name:?}.");
                     } else {
+                        drop(editor);
                         println!("Mount {name:?} not found.");
                     }
                     Ok(())
@@ -265,8 +268,18 @@ pub fn run(cli: Cli) -> Result<()> {
                 cli::TrustCommand::Grant { selector } => {
                     let class = ClassSelector::parse(&selector)?;
                     config.resolve_agent_source(&class)?;
-                    if config.trust_agent(&class.key()) {
-                        config.save(&paths)?;
+                    let was_trusted = config
+                        .agents
+                        .get(&class.key())
+                        .map(|a| a.trusted)
+                        .unwrap_or(false);
+                    if !was_trusted {
+                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                        if let Some(source) = config.agents.get(&class.key()) {
+                            editor.upsert_agent_source(&class.key(), source);
+                        }
+                        editor.set_agent_trust(&class.key(), true);
+                        config = editor.save()?;
                         println!("Trusted {}.", class.key());
                     } else {
                         println!("{} is already trusted.", class.key());
@@ -278,8 +291,15 @@ pub fn run(cli: Cli) -> Result<()> {
                     if AppConfig::is_builtin_agent(&class.key()) {
                         anyhow::bail!("{} is a built-in agent and is always trusted.", class.key());
                     }
-                    if config.untrust_agent(&class.key()) {
-                        config.save(&paths)?;
+                    let was_trusted = config
+                        .agents
+                        .get(&class.key())
+                        .map(|a| a.trusted)
+                        .unwrap_or(false);
+                    if was_trusted {
+                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                        editor.set_agent_trust(&class.key(), false);
+                        config = editor.save()?;
                         println!("Revoked trust for {}.", class.key());
                     } else {
                         println!("{} is not currently trusted.", class.key());
@@ -314,12 +334,17 @@ pub fn run(cli: Cli) -> Result<()> {
                     if let Some(agent_selector) = agent {
                         let class = ClassSelector::parse(&agent_selector)?;
                         config.resolve_agent_source(&class)?;
-                        config.set_agent_auth_forward(&class.key(), parsed_mode);
-                        config.save(&paths)?;
+                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                        if let Some(source) = config.agents.get(&class.key()) {
+                            editor.upsert_agent_source(&class.key(), source);
+                        }
+                        editor.set_agent_auth_forward(&class.key(), parsed_mode);
+                        config = editor.save()?;
                         println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
                     } else {
-                        config.claude.auth_forward = parsed_mode;
-                        config.save(&paths)?;
+                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                        editor.set_global_auth_forward(parsed_mode);
+                        config = editor.save()?;
                         println!("Set global auth forwarding to {parsed_mode}.");
                     }
                     Ok(())
@@ -371,19 +396,18 @@ pub fn run(cli: Cli) -> Result<()> {
                     );
                 }
                 let mount_count = plan.final_mounts.len();
-                config.create_workspace(
-                    &name,
-                    WorkspaceConfig {
-                        workdir: expanded_workdir,
-                        mounts: plan.final_mounts,
-                        allowed_agents,
-                        default_agent,
-                        last_agent: None,
-                        env: std::collections::BTreeMap::new(),
-                        agents: std::collections::BTreeMap::new(),
-                    },
-                )?;
-                config.save(&paths)?;
+                let ws = WorkspaceConfig {
+                    workdir: expanded_workdir,
+                    mounts: plan.final_mounts,
+                    allowed_agents,
+                    default_agent,
+                    last_agent: None,
+                    env: std::collections::BTreeMap::new(),
+                    agents: std::collections::BTreeMap::new(),
+                };
+                let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                editor.create_workspace(&name, ws)?;
+                config = editor.save()?;
                 println!(
                     "Created workspace {name:?} (workdir: {}, {mount_count} mount(s)).",
                     tui::shorten_home(&workdir)
@@ -636,7 +660,8 @@ pub fn run(cli: Cli) -> Result<()> {
                     changes.push(format!("default agent → {agent}"));
                 }
 
-                config.edit_workspace(
+                let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                editor.edit_workspace(
                     &name,
                     WorkspaceEdit {
                         workdir: workdir.map(|w| resolve_path(&w)),
@@ -652,7 +677,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         },
                     },
                 )?;
-                config.save(&paths)?;
+                config = editor.save()?;
                 println!("Updated workspace {name:?}:");
                 for change in &changes {
                     println!("  - {change}");
@@ -695,14 +720,15 @@ pub fn run(cli: Cli) -> Result<()> {
 
                 let remove_dsts: Vec<String> =
                     plan.removed.iter().map(|r| r.child.dst.clone()).collect();
-                config.edit_workspace(
+                let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                editor.edit_workspace(
                     &name,
                     WorkspaceEdit {
                         remove_destinations: remove_dsts,
                         ..WorkspaceEdit::default()
                     },
                 )?;
-                config.save(&paths)?;
+                config = editor.save()?;
                 println!(
                     "Pruned {} redundant mount(s) from workspace {name:?}.",
                     plan.removed.len()
@@ -710,8 +736,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
             WorkspaceCommand::Remove { name } => {
-                config.remove_workspace(&name)?;
-                config.save(&paths)?;
+                let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                editor.remove_workspace(&name)?;
+                config = editor.save()?;
                 println!("Removed workspace {name:?}.");
                 Ok(())
             }

--- a/src/config/agents.rs
+++ b/src/config/agents.rs
@@ -1,7 +1,7 @@
 use super::{AgentSource, AppConfig, AuthForwardMode, ClaudeAgentConfig};
 use crate::selector::ClassSelector;
 
-pub(super) const BUILTIN_AGENTS: &[(&str, &str)] = &[
+pub(crate) const BUILTIN_AGENTS: &[(&str, &str)] = &[
     (
         "agent-smith",
         "https://github.com/jackin-project/jackin-agent-smith.git",

--- a/src/config/agents.rs
+++ b/src/config/agents.rs
@@ -56,7 +56,9 @@ impl AppConfig {
     }
 
     /// Set the per-agent auth forward mode override.
-    pub fn set_agent_auth_forward(&mut self, key: &str, mode: AuthForwardMode) {
+    // pub(crate): test-only affordance; production callers use ConfigEditor.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn set_agent_auth_forward(&mut self, key: &str, mode: AuthForwardMode) {
         if let Some(source) = self.agents.get_mut(key) {
             let claude = source.claude.get_or_insert_with(ClaudeAgentConfig::default);
             claude.auth_forward = Some(mode);
@@ -64,7 +66,9 @@ impl AppConfig {
     }
 
     /// Mark an agent source as trusted.  Returns `true` when the flag changed.
-    pub fn trust_agent(&mut self, key: &str) -> bool {
+    // pub(crate): test-only affordance; production callers use ConfigEditor.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn trust_agent(&mut self, key: &str) -> bool {
         if let Some(source) = self.agents.get_mut(key)
             && !source.trusted
         {
@@ -77,7 +81,9 @@ impl AppConfig {
     /// Revoke trust for an agent source.  Returns `true` when the flag changed.
     /// Note: does not prevent revoking builtins — the caller should check
     /// [`is_builtin_agent`] first.
-    pub fn untrust_agent(&mut self, key: &str) -> bool {
+    // pub(crate): test-only affordance; production callers use ConfigEditor.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn untrust_agent(&mut self, key: &str) -> bool {
         if let Some(source) = self.agents.get_mut(key)
             && source.trusted
         {
@@ -199,8 +205,10 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
         );
         assert!(is_new);
 
-        // Not yet persisted — caller must save explicitly
-        config.save(&paths).unwrap();
+        // Not yet persisted — write via toml::to_string_pretty (AppConfig::save
+        // was removed in Task 14; tests bootstrap the file directly).
+        let contents = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&paths.config_file, &contents).unwrap();
         assert!(
             std::fs::read_to_string(&paths.config_file)
                 .unwrap()
@@ -305,7 +313,9 @@ git = "git@github.com:chainargos/jackin-agent-brown.git"
 
         config.resolve_agent_source(&selector).unwrap();
         config.trust_agent("chainargos/the-architect");
-        config.save(&paths).unwrap();
+        // AppConfig::save removed in Task 14 — write the bootstrap file directly.
+        let contents = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&paths.config_file, &contents).unwrap();
 
         let reloaded = AppConfig::load_or_init(&paths).unwrap();
         assert!(

--- a/src/config/agents.rs
+++ b/src/config/agents.rs
@@ -1,7 +1,7 @@
 use super::{AgentSource, AppConfig, AuthForwardMode, ClaudeAgentConfig};
 use crate::selector::ClassSelector;
 
-pub(crate) const BUILTIN_AGENTS: &[(&str, &str)] = &[
+pub const BUILTIN_AGENTS: &[(&str, &str)] = &[
     (
         "agent-smith",
         "https://github.com/jackin-project/jackin-agent-smith.git",

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -450,4 +450,35 @@ API_TOKEN = "op://Personal/api/token"
         let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
         assert_eq!(round_tripped, original, "open → save must be byte-identical");
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn saved_file_is_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "[env]\nK = \"v\"\n").unwrap();
+
+        let editor = ConfigEditor::open(&paths).unwrap();
+        editor.save().unwrap();
+
+        let perms = std::fs::metadata(&paths.config_file).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600, "config file must be 0600");
+    }
+
+    #[test]
+    fn save_leaves_no_tmp_file_on_success() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "[env]\nK = \"v\"\n").unwrap();
+
+        let editor = ConfigEditor::open(&paths).unwrap();
+        editor.save().unwrap();
+
+        let tmp = paths.config_file.with_extension("tmp");
+        assert!(!tmp.exists(), "expected .tmp to be renamed away");
+    }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -140,11 +140,7 @@ impl ConfigEditor {
                 // Unscoped: [docker.mounts.<name>]
                 let mount_table = table_path_mut(
                     &mut self.doc,
-                    &[
-                        "docker".to_string(),
-                        "mounts".to_string(),
-                        name.to_string(),
-                    ],
+                    &["docker".to_string(), "mounts".to_string(), name.to_string()],
                 );
                 mount_table.clear();
                 mount_table.insert("src", toml_edit::value(mount.src));
@@ -187,11 +183,7 @@ impl ConfigEditor {
     /// `AppConfig::remove_mount`'s cleanup so empty scope tables do not
     /// accumulate in the on-disk config.
     pub fn remove_mount(&mut self, name: &str, scope: Option<&str>) -> bool {
-        let Some(docker) = self
-            .doc
-            .get_mut("docker")
-            .and_then(|i| i.as_table_mut())
-        else {
+        let Some(docker) = self.doc.get_mut("docker").and_then(|i| i.as_table_mut()) else {
             return false;
         };
         let Some(mounts) = docker.get_mut("mounts").and_then(|i| i.as_table_mut()) else {
@@ -200,10 +192,7 @@ impl ConfigEditor {
         match scope {
             None => mounts.remove(name).is_some(),
             Some(scope_key) => {
-                let Some(entry) = mounts
-                    .get_mut(scope_key)
-                    .and_then(|i| i.as_table_mut())
-                else {
+                let Some(entry) = mounts.get_mut(scope_key).and_then(|i| i.as_table_mut()) else {
                     return false;
                 };
                 let removed = entry.remove(name).is_some();
@@ -236,7 +225,11 @@ impl ConfigEditor {
     ) {
         let claude_table = table_path_mut(
             &mut self.doc,
-            &["agents".to_string(), agent_key.to_string(), "claude".to_string()],
+            &[
+                "agents".to_string(),
+                agent_key.to_string(),
+                "claude".to_string(),
+            ],
         );
         claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
     }
@@ -293,7 +286,11 @@ impl ConfigEditor {
                     if let Ok(parsed) = rendered.parse::<DocumentMut>() {
                         let claude_table = table_path_mut(
                             &mut self.doc,
-                            &["agents".to_string(), agent_key.to_string(), "claude".to_string()],
+                            &[
+                                "agents".to_string(),
+                                agent_key.to_string(),
+                                "claude".to_string(),
+                            ],
                         );
                         for (k, v) in parsed.as_table().iter() {
                             claude_table.insert(k, v.clone());
@@ -321,7 +318,9 @@ impl ConfigEditor {
         // Per-agent [agents.X.claude]
         if let Some(agents) = self.doc.get_mut("agents").and_then(|i| i.as_table_mut()) {
             for (_, agent_item) in agents.iter_mut() {
-                let Some(agent_table) = agent_item.as_table_mut() else { continue };
+                let Some(agent_table) = agent_item.as_table_mut() else {
+                    continue;
+                };
                 let Some(claude) = agent_table.get_mut("claude").and_then(|i| i.as_table_mut())
                 else {
                     continue;
@@ -358,7 +357,11 @@ impl ConfigEditor {
     }
 
     pub fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
-        let Some(workspaces) = self.doc.get_mut("workspaces").and_then(|i| i.as_table_mut()) else {
+        let Some(workspaces) = self
+            .doc
+            .get_mut("workspaces")
+            .and_then(|i| i.as_table_mut())
+        else {
             anyhow::bail!("workspace {name:?} not found");
         };
         if workspaces.remove(name).is_none() {
@@ -384,16 +387,14 @@ impl ConfigEditor {
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("workspace {name:?} disappeared after create"))?;
 
-        let rendered = toml::to_string(inserted)
-            .with_context(|| format!("serializing workspace {name:?}"))?;
+        let rendered =
+            toml::to_string(inserted).with_context(|| format!("serializing workspace {name:?}"))?;
         let parsed: DocumentMut = rendered
             .parse()
             .with_context(|| format!("re-parsing serialized workspace {name:?}"))?;
 
-        let workspaces_table = table_path_mut(
-            &mut self.doc,
-            &["workspaces".to_string(), name.to_string()],
-        );
+        let workspaces_table =
+            table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
         for (key, item) in parsed.as_table().iter() {
             workspaces_table.insert(key, item.clone());
         }
@@ -427,10 +428,7 @@ impl ConfigEditor {
         // the edit IS the change the user is making to that workspace.
         let rendered = toml::to_string(updated)?;
         let parsed: DocumentMut = rendered.parse()?;
-        let target = table_path_mut(
-            &mut self.doc,
-            &["workspaces".to_string(), name.to_string()],
-        );
+        let target = table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
         target.clear();
         for (key, item) in parsed.as_table().iter() {
             target.insert(key, item.clone());
@@ -469,9 +467,7 @@ fn table_path_mut<'a>(doc: &'a mut DocumentMut, path: &[String]) -> &'a mut Tabl
         if path.is_empty() {
             return table;
         }
-        let entry = table
-            .entry(&path[0])
-            .or_insert(Item::Table(Table::new()));
+        let entry = table.entry(&path[0]).or_insert(Item::Table(Table::new()));
         walk(entry, &path[1..])
     }
     walk(doc.as_item_mut(), path)
@@ -661,7 +657,10 @@ API_TOKEN = "op://vault-id/item-id/field"
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(!out.contains("# some note"), "{out}");
-        assert!(out.contains(r#"API_TOKEN = "x""#), "key still present: {out}");
+        assert!(
+            out.contains(r#"API_TOKEN = "x""#),
+            "key still present: {out}"
+        );
     }
 
     #[test]
@@ -760,7 +759,10 @@ API_TOKEN = "op://Personal/api/token"
         editor.save().unwrap();
 
         let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert_eq!(round_tripped, original, "open → save must be byte-identical");
+        assert_eq!(
+            round_tripped, original,
+            "open → save must be byte-identical"
+        );
     }
 
     #[test]
@@ -906,7 +908,10 @@ creds = { src = "/run/secrets/x", dst = "/secrets/x" }
 
         assert!(removed);
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(!out.contains("agent-smith"), "empty scope table should be gone: {out}");
+        assert!(
+            !out.contains("agent-smith"),
+            "empty scope table should be gone: {out}"
+        );
     }
 
     #[test]
@@ -929,7 +934,10 @@ logs = { src = "/b", dst = "/b" }
 
         assert!(removed);
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[docker.mounts.agent-smith]"), "scope table should still exist: {out}");
+        assert!(
+            out.contains("[docker.mounts.agent-smith]"),
+            "scope table should still exist: {out}"
+        );
         assert!(!out.contains("creds"), "{out}");
         assert!(out.contains("logs"), "{out}");
     }
@@ -1061,9 +1069,15 @@ auth_forward = "token"
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#), "{out}");
+        assert!(
+            out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#),
+            "{out}"
+        );
         assert!(out.contains("trusted = true"), "{out}");
-        assert!(out.contains(r#"auth_forward = "token""#), "claude override wiped: {out}");
+        assert!(
+            out.contains(r#"auth_forward = "token""#),
+            "claude override wiped: {out}"
+        );
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -215,6 +215,48 @@ impl ConfigEditor {
         }
     }
 
+    pub fn set_agent_trust(&mut self, agent_key: &str, trusted: bool) {
+        let table = table_path_mut(
+            &mut self.doc,
+            &["agents".to_string(), agent_key.to_string()],
+        );
+        if trusted {
+            table.insert("trusted", toml_edit::value(true));
+        } else {
+            // Canonical representation of false is absent (matches serde
+            // skip_serializing_if on AgentSource::trusted).
+            table.remove("trusted");
+        }
+    }
+
+    pub fn set_agent_auth_forward(
+        &mut self,
+        agent_key: &str,
+        mode: crate::config::AuthForwardMode,
+    ) {
+        let claude_table = table_path_mut(
+            &mut self.doc,
+            &["agents".to_string(), agent_key.to_string(), "claude".to_string()],
+        );
+        claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+    }
+
+    pub fn set_global_auth_forward(&mut self, mode: crate::config::AuthForwardMode) {
+        let claude_table = table_path_mut(&mut self.doc, &["claude".to_string()]);
+        claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+    }
+
+    pub fn upsert_builtin_agent(&mut self, agent_key: &str, git_url: &str) {
+        // Touch only git + trusted. Leave [agents.X.claude] and
+        // [agents.X.env] alone — those are operator-owned.
+        let table = table_path_mut(
+            &mut self.doc,
+            &["agents".to_string(), agent_key.to_string()],
+        );
+        table.insert("git", toml_edit::value(git_url));
+        table.insert("trusted", toml_edit::value(true));
+    }
+
     pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
         let path = env_scope_path(&scope);
         // Walk without creating: return false if any segment is missing.
@@ -229,6 +271,14 @@ impl ConfigEditor {
             Some(table) => table.remove(key).is_some(),
             None => false,
         }
+    }
+}
+
+fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str {
+    match mode {
+        crate::config::AuthForwardMode::Ignore => "ignore",
+        crate::config::AuthForwardMode::Sync => "sync",
+        crate::config::AuthForwardMode::Token => "token",
     }
 }
 
@@ -716,5 +766,137 @@ logs = { src = "/b", dst = "/b" }
         assert!(out.contains("[docker.mounts.agent-smith]"), "scope table should still exist: {out}");
         assert!(!out.contains("creds"), "{out}");
         assert!(out.contains("logs"), "{out}");
+    }
+
+    #[test]
+    fn set_agent_trust_toggles_trusted_field() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.my-agent]
+git = "https://example.com/a.git"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_agent_trust("my-agent", true);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("trusted = true"), "{out}");
+    }
+
+    #[test]
+    fn set_agent_trust_false_removes_field() {
+        // Canonical TOML representation of trusted=false is absent (serde
+        // skip_serializing_if on AgentSource::trusted).
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.my-agent]
+git = "x"
+trusted = true
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_agent_trust("my-agent", false);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("trusted"), "{out}");
+    }
+
+    #[test]
+    fn set_agent_auth_forward_writes_claude_subtable() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.my-agent]
+git = "x"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_agent_auth_forward("my-agent", crate::config::AuthForwardMode::Token);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[agents.my-agent.claude]"), "{out}");
+        assert!(out.contains(r#"auth_forward = "token""#), "{out}");
+    }
+
+    #[test]
+    fn set_global_auth_forward_writes_root_claude_table() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_global_auth_forward(crate::config::AuthForwardMode::Sync);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[claude]"), "{out}");
+        assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+    }
+
+    #[test]
+    fn upsert_builtin_agent_creates_entry_when_missing() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.upsert_builtin_agent(
+            "agent-smith",
+            "https://github.com/jackin-project/jackin-agent-smith.git",
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[agents.agent-smith]"), "{out}");
+        assert!(out.contains("trusted = true"), "{out}");
+    }
+
+    #[test]
+    fn upsert_builtin_agent_preserves_existing_claude_override() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.agent-smith]
+git = "OLD-URL"
+trusted = false
+
+[agents.agent-smith.claude]
+auth_forward = "token"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.upsert_builtin_agent(
+            "agent-smith",
+            "https://github.com/jackin-project/jackin-agent-smith.git",
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#), "{out}");
+        assert!(out.contains("trusted = true"), "{out}");
+        assert!(out.contains(r#"auth_forward = "token""#), "claude override wiped: {out}");
     }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -88,14 +88,14 @@ impl ConfigEditor {
         Ok(config)
     }
 
-    pub fn set_env_var(&mut self, scope: EnvScope, key: &str, value_str: &str) {
-        let path = env_scope_path(&scope);
+    pub fn set_env_var(&mut self, scope: &EnvScope, key: &str, value_str: &str) {
+        let path = env_scope_path(scope);
         let table = table_path_mut(&mut self.doc, &path);
         table.insert(key, toml_edit::value(value_str));
     }
 
-    pub fn set_env_comment(&mut self, scope: EnvScope, key: &str, comment: Option<&str>) {
-        let path = env_scope_path(&scope);
+    pub fn set_env_comment(&mut self, scope: &EnvScope, key: &str, comment: Option<&str>) {
+        let path = env_scope_path(scope);
         // Walk without creating — setting a comment on a nonexistent key
         // is a silent no-op (same contract as remove_env_var).
         let mut current: &mut Item = self.doc.as_item_mut();
@@ -112,10 +112,7 @@ impl ConfigEditor {
             return;
         };
         let decor = key_mut.leaf_decor_mut();
-        let prefix = match comment {
-            Some(text) => format!("# {text}\n"),
-            None => String::new(),
-        };
+        let prefix = comment.map_or_else(String::new, |text| format!("# {text}\n"));
         decor.set_prefix(prefix);
     }
 
@@ -257,7 +254,7 @@ impl ConfigEditor {
     ///
     /// Used by call sites that first invoke `resolve_agent_source` (which may
     /// insert a new agent into the in-memory `AppConfig`) and need the editor
-    /// to persist that insert alongside whatever trust / auth_forward change
+    /// to persist that insert alongside whatever trust / `auth_forward` change
     /// they're about to make.
     pub fn upsert_agent_source(&mut self, agent_key: &str, source: &crate::config::AgentSource) {
         let table = table_path_mut(
@@ -281,21 +278,20 @@ impl ConfigEditor {
                 .and_then(|t| t.get(agent_key))
                 .and_then(|i| i.as_table())
                 .and_then(|t| t.get("claude"));
-            if existing_claude.is_none() {
-                if let Ok(rendered) = toml::to_string(claude) {
-                    if let Ok(parsed) = rendered.parse::<DocumentMut>() {
-                        let claude_table = table_path_mut(
-                            &mut self.doc,
-                            &[
-                                "agents".to_string(),
-                                agent_key.to_string(),
-                                "claude".to_string(),
-                            ],
-                        );
-                        for (k, v) in parsed.as_table().iter() {
-                            claude_table.insert(k, v.clone());
-                        }
-                    }
+            if existing_claude.is_none()
+                && let Ok(rendered) = toml::to_string(claude)
+                && let Ok(parsed) = rendered.parse::<DocumentMut>()
+            {
+                let claude_table = table_path_mut(
+                    &mut self.doc,
+                    &[
+                        "agents".to_string(),
+                        agent_key.to_string(),
+                        "claude".to_string(),
+                    ],
+                );
+                for (k, v) in parsed.as_table() {
+                    claude_table.insert(k, v.clone());
                 }
             }
         }
@@ -303,17 +299,17 @@ impl ConfigEditor {
 
     /// Rewrite any `auth_forward = "copy"` to `"sync"` at the two paths
     /// `contains_deprecated_copy_auth_forward` checks:
-    ///   [claude].auth_forward
-    ///   [agents.*.claude].auth_forward
+    ///   [claude].`auth_forward`
+    ///   [agents.*.claude].`auth_forward`
     ///
-    /// Does not touch any other structure. Used by load_or_init when the
+    /// Does not touch any other structure. Used by `load_or_init` when the
     /// on-disk config still contains the deprecated literal.
     pub fn normalize_deprecated_copy(&mut self) {
         // Global [claude]
-        if let Some(claude) = self.doc.get_mut("claude").and_then(|i| i.as_table_mut()) {
-            if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
-                claude.insert("auth_forward", toml_edit::value("sync"));
-            }
+        if let Some(claude) = self.doc.get_mut("claude").and_then(|i| i.as_table_mut())
+            && claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy")
+        {
+            claude.insert("auth_forward", toml_edit::value("sync"));
         }
         // Per-agent [agents.X.claude]
         if let Some(agents) = self.doc.get_mut("agents").and_then(|i| i.as_table_mut()) {
@@ -332,8 +328,8 @@ impl ConfigEditor {
         }
     }
 
-    pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
-        let path = env_scope_path(&scope);
+    pub fn remove_env_var(&mut self, scope: &EnvScope, key: &str) -> bool {
+        let path = env_scope_path(scope);
         // Walk without creating: return false if any segment is missing.
         let mut current: &mut Item = self.doc.as_item_mut();
         for segment in &path {
@@ -342,10 +338,9 @@ impl ConfigEditor {
                 None => return false,
             }
         }
-        match current.as_table_mut() {
-            Some(table) => table.remove(key).is_some(),
-            None => false,
-        }
+        current
+            .as_table_mut()
+            .is_some_and(|table| table.remove(key).is_some())
     }
 
     pub fn set_last_agent(&mut self, workspace: &str, agent_key: &str) {
@@ -395,7 +390,7 @@ impl ConfigEditor {
 
         let workspaces_table =
             table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
-        for (key, item) in parsed.as_table().iter() {
+        for (key, item) in parsed.as_table() {
             workspaces_table.insert(key, item.clone());
         }
 
@@ -430,7 +425,7 @@ impl ConfigEditor {
         let parsed: DocumentMut = rendered.parse()?;
         let target = table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
         target.clear();
-        for (key, item) in parsed.as_table().iter() {
+        for (key, item) in parsed.as_table() {
             target.insert(key, item.clone());
         }
 
@@ -438,7 +433,7 @@ impl ConfigEditor {
     }
 }
 
-fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str {
+const fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str {
     match mode {
         crate::config::AuthForwardMode::Ignore => "ignore",
         crate::config::AuthForwardMode::Sync => "sync",
@@ -486,7 +481,7 @@ mod tests {
         std::fs::write(&paths.config_file, "").unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(EnvScope::Global, "API_TOKEN", "op://Personal/api/token");
+        editor.set_env_var(&EnvScope::Global, "API_TOKEN", "op://Personal/api/token");
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -512,7 +507,7 @@ workdir = "/workspace/prod"
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
         editor.set_env_var(
-            EnvScope::WorkspaceAgent {
+            &EnvScope::WorkspaceAgent {
                 workspace: "prod".to_string(),
                 agent: "agent-smith".to_string(),
             },
@@ -546,7 +541,7 @@ API_TOKEN = "old-value"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(EnvScope::Global, "API_TOKEN", "new-value");
+        editor.set_env_var(&EnvScope::Global, "API_TOKEN", "new-value");
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -569,7 +564,7 @@ OTHER = "y"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+        let removed = editor.remove_env_var(&EnvScope::Global, "API_TOKEN");
         editor.save().unwrap();
 
         assert!(removed);
@@ -586,7 +581,7 @@ OTHER = "y"
         std::fs::write(&paths.config_file, "").unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+        let removed = editor.remove_env_var(&EnvScope::Global, "API_TOKEN");
         editor.save().unwrap();
 
         assert!(!removed);
@@ -607,7 +602,7 @@ API_TOKEN = "op://vault-id/item-id/field"
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
         editor.set_env_comment(
-            EnvScope::Global,
+            &EnvScope::Global,
             "API_TOKEN",
             Some("op://Personal/Google/password"),
         );
@@ -632,7 +627,7 @@ API_TOKEN = "op://vault-id/item-id/field"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_comment(EnvScope::Global, "API_TOKEN", Some("new annotation"));
+        editor.set_env_comment(&EnvScope::Global, "API_TOKEN", Some("new annotation"));
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -652,7 +647,7 @@ API_TOKEN = "op://vault-id/item-id/field"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_comment(EnvScope::Global, "API_TOKEN", None);
+        editor.set_env_comment(&EnvScope::Global, "API_TOKEN", None);
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -672,7 +667,7 @@ API_TOKEN = "op://vault-id/item-id/field"
         std::fs::write(&paths.config_file, original).unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(EnvScope::Global, "OTHER", "z");
+        editor.set_env_var(&EnvScope::Global, "OTHER", "z");
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -699,7 +694,7 @@ workdir = "/b"
         std::fs::write(&paths.config_file, original).unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(EnvScope::Workspace("a".to_string()), "K", "v");
+        editor.set_env_var(&EnvScope::Workspace("a".to_string()), "K", "v");
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -373,6 +373,49 @@ API_TOKEN = "op://vault-id/item-id/field"
     }
 
     #[test]
+    fn mutating_one_workspace_preserves_comments_in_another() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let original = r#"# workspace a — keep this comment
+[workspaces.a]
+workdir = "/a"
+
+# workspace b — also keep
+[workspaces.b]
+workdir = "/b"
+"#;
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(EnvScope::Workspace("a".to_string()), "K", "v");
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("# workspace b — also keep"), "{out}");
+        assert!(out.contains("# workspace a — keep this comment"), "{out}");
+    }
+
+    #[test]
+    fn fixture_round_trip_is_byte_identical() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        let original = include_str!("fixtures/config.round_trip.toml");
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let editor = ConfigEditor::open(&paths).unwrap();
+        editor.save().unwrap();
+
+        let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert_eq!(
+            round_tripped, original,
+            "fixture round-trip is lossy — toml_edit is dropping something"
+        );
+    }
+
+    #[test]
     fn idempotent_save_is_byte_identical() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -8,7 +8,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item, Table};
 
 use crate::config::AppConfig;
 use crate::paths::JackinPaths;
@@ -87,12 +87,123 @@ impl ConfigEditor {
             .with_context(|| format!("deserializing {}", self.path.display()))?;
         Ok(config)
     }
+
+    pub fn set_env_var(&mut self, scope: EnvScope, key: &str, value_str: &str) {
+        let path = env_scope_path(&scope);
+        let table = table_path_mut(&mut self.doc, &path);
+        table.insert(key, toml_edit::value(value_str));
+    }
+}
+
+fn env_scope_path(scope: &EnvScope) -> Vec<String> {
+    match scope {
+        EnvScope::Global => vec!["env".to_string()],
+        EnvScope::Agent(a) => vec!["agents".to_string(), a.clone(), "env".to_string()],
+        EnvScope::Workspace(w) => vec!["workspaces".to_string(), w.clone(), "env".to_string()],
+        EnvScope::WorkspaceAgent { workspace, agent } => vec![
+            "workspaces".to_string(),
+            workspace.clone(),
+            "agents".to_string(),
+            agent.clone(),
+            "env".to_string(),
+        ],
+    }
+}
+
+fn table_path_mut<'a>(doc: &'a mut DocumentMut, path: &[String]) -> &'a mut Table {
+    fn walk<'a>(item: &'a mut Item, path: &[String]) -> &'a mut Table {
+        let table = item.as_table_mut().expect("path segment is not a table");
+        if path.is_empty() {
+            return table;
+        }
+        let entry = table
+            .entry(&path[0])
+            .or_insert(Item::Table(Table::new()));
+        walk(entry, &path[1..])
+    }
+    walk(doc.as_item_mut(), path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn set_env_var_creates_global_env_table() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(EnvScope::Global, "API_TOKEN", "op://Personal/api/token");
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[env]"), "missing [env] table: {out}");
+        assert!(
+            out.contains(r#"API_TOKEN = "op://Personal/api/token""#),
+            "missing entry: {out}"
+        );
+    }
+
+    #[test]
+    fn set_env_var_upserts_workspace_agent_scope() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[workspaces.prod]
+workdir = "/workspace/prod"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(
+            EnvScope::WorkspaceAgent {
+                workspace: "prod".to_string(),
+                agent: "agent-smith".to_string(),
+            },
+            "OPENAI_API_KEY",
+            "op://Work/OpenAI/default",
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            out.contains("[workspaces.prod.agents.agent-smith.env]"),
+            "missing nested table: {out}"
+        );
+        assert!(
+            out.contains(r#"OPENAI_API_KEY = "op://Work/OpenAI/default""#),
+            "missing entry: {out}"
+        );
+    }
+
+    #[test]
+    fn set_env_var_overwrites_existing_value() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[env]
+API_TOKEN = "old-value"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(EnvScope::Global, "API_TOKEN", "new-value");
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains(r#"API_TOKEN = "new-value""#), "{out}");
+        assert!(!out.contains("old-value"), "{out}");
+    }
 
     #[test]
     fn idempotent_save_is_byte_identical() {

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -296,21 +296,19 @@ impl ConfigEditor {
         name: &str,
         ws: crate::workspace::WorkspaceConfig,
     ) -> anyhow::Result<()> {
-        // Collision check first — match today's create_workspace behavior.
-        if self
-            .doc
-            .get("workspaces")
-            .and_then(|i| i.as_table())
-            .and_then(|t| t.get(name))
-            .is_some()
-        {
-            anyhow::bail!("workspace {name:?} already exists");
-        }
+        // Delegate to AppConfig::create_workspace's validated logic
+        // (collision check, workdir / mount-destination relationship,
+        // plan-collapse sanity) so the editor path behaves identically
+        // to the direct-mutation path. Mirrors edit_workspace's pattern.
+        let mut in_memory: AppConfig = toml::from_str(&self.doc.to_string())
+            .context("re-parsing current doc into AppConfig for workspace creation")?;
+        in_memory.create_workspace(name, ws)?;
+        let inserted = in_memory
+            .workspaces
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("workspace {name:?} disappeared after create"))?;
 
-        // Serialize the WorkspaceConfig to toml_edit items via string round-trip:
-        // toml::to_string on the struct, parse as DocumentMut, splat the body
-        // into the new [workspaces.<name>] table.
-        let rendered = toml::to_string(&ws)
+        let rendered = toml::to_string(inserted)
             .with_context(|| format!("serializing workspace {name:?}"))?;
         let parsed: DocumentMut = rendered
             .parse()
@@ -1022,6 +1020,41 @@ auth_forward = "token"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains("[workspaces.new-ws]"), "{out}");
         assert!(out.contains(r#"workdir = "/workspace/new""#), "{out}");
+    }
+
+    #[test]
+    fn create_workspace_rejects_invalid_workdir_mount_combo() {
+        // Editor delegates to AppConfig::create_workspace, which validates
+        // that the workdir is equal-to / inside / parent-of some mount dst.
+        // A workdir that doesn't line up with any mount dst must be rejected.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mount_src = temp.path().join("src");
+        std::fs::create_dir_all(&mount_src).unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let ws = crate::workspace::WorkspaceConfig {
+            workdir: "/elsewhere".to_string(),
+            mounts: vec![crate::workspace::MountConfig {
+                src: mount_src.display().to_string(),
+                dst: "/workspace/unrelated".to_string(),
+                readonly: false,
+            }],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+            env: std::collections::BTreeMap::new(),
+            agents: std::collections::BTreeMap::new(),
+        };
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let err = editor.create_workspace("bad-ws", ws).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("workspace") || msg.contains("mount") || msg.contains("workdir"),
+            "expected validation error mentioning workspace/mount/workdir: {msg}"
+        );
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -119,6 +119,96 @@ impl ConfigEditor {
         decor.set_prefix(prefix);
     }
 
+    /// Adds or replaces a named mount, mirroring `AppConfig::add_mount`.
+    ///
+    /// Unscoped (`scope = None`): writes `[docker.mounts.<name>]` — a single
+    /// `MountConfig` entry keyed by `name`.
+    ///
+    /// Scoped (`scope = Some(scope_key)`): writes `[docker.mounts.<scope_key>]`
+    /// with `name` as an inner key — i.e. the shape is
+    /// `docker.mounts[scope_key][name]`, matching how `AppConfig` stores
+    /// `MountEntry::Scoped`. Note this means `scope_key` is the OUTER key, not
+    /// `name` — the same ordering used by `AppConfig::add_mount`.
+    pub fn add_mount(
+        &mut self,
+        name: &str,
+        mount: crate::workspace::MountConfig,
+        scope: Option<&str>,
+    ) {
+        match scope {
+            None => {
+                // Unscoped: [docker.mounts.<name>]
+                let mount_table = table_path_mut(
+                    &mut self.doc,
+                    &[
+                        "docker".to_string(),
+                        "mounts".to_string(),
+                        name.to_string(),
+                    ],
+                );
+                mount_table.clear();
+                mount_table.insert("src", toml_edit::value(mount.src));
+                mount_table.insert("dst", toml_edit::value(mount.dst));
+                if mount.readonly {
+                    mount_table.insert("readonly", toml_edit::value(true));
+                }
+            }
+            Some(scope_key) => {
+                // Scoped: [docker.mounts.<scope_key>] with name as inner key.
+                // Matches AppConfig::add_mount which stores MountEntry::Scoped
+                // keyed by scope_key at the outer level.
+                let scoped_table = table_path_mut(
+                    &mut self.doc,
+                    &[
+                        "docker".to_string(),
+                        "mounts".to_string(),
+                        scope_key.to_string(),
+                    ],
+                );
+                // Build a sub-table for this named mount.
+                let mut entry_table = Table::new();
+                entry_table.insert("src", toml_edit::value(mount.src));
+                entry_table.insert("dst", toml_edit::value(mount.dst));
+                if mount.readonly {
+                    entry_table.insert("readonly", toml_edit::value(true));
+                }
+                scoped_table.insert(name, Item::Table(entry_table));
+            }
+        }
+    }
+
+    /// Removes a named mount, mirroring `AppConfig::remove_mount`. Returns
+    /// `true` if an entry was present and removed.
+    ///
+    /// Unscoped (`scope = None`): removes `docker.mounts[name]`.
+    /// Scoped (`scope = Some(scope_key)`): removes `docker.mounts[scope_key][name]`.
+    /// If the scope's sub-table becomes empty after removal the empty table is
+    /// left in place (toml_edit keeps it; callers that care can compact later).
+    pub fn remove_mount(&mut self, name: &str, scope: Option<&str>) -> bool {
+        let Some(docker) = self
+            .doc
+            .get_mut("docker")
+            .and_then(|i| i.as_table_mut())
+        else {
+            return false;
+        };
+        let Some(mounts) = docker.get_mut("mounts").and_then(|i| i.as_table_mut()) else {
+            return false;
+        };
+        match scope {
+            None => mounts.remove(name).is_some(),
+            Some(scope_key) => {
+                let Some(entry) = mounts
+                    .get_mut(scope_key)
+                    .and_then(|i| i.as_table_mut())
+                else {
+                    return false;
+                };
+                entry.remove(name).is_some()
+            }
+        }
+    }
+
     pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
         let path = env_scope_path(&scope);
         // Walk without creating: return false if any segment is missing.
@@ -480,5 +570,96 @@ API_TOKEN = "op://Personal/api/token"
 
         let tmp = paths.config_file.with_extension("tmp");
         assert!(!tmp.exists(), "expected .tmp to be renamed away");
+    }
+
+    // ---- mount tests ----
+
+    #[test]
+    fn add_mount_unscoped_creates_single_mount_entry() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.add_mount(
+            "shared-home",
+            crate::workspace::MountConfig {
+                src: "/home/user".to_string(),
+                dst: "/workspace/home".to_string(),
+                readonly: false,
+            },
+            None,
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[docker.mounts.shared-home]"), "{out}");
+        assert!(out.contains(r#"src = "/home/user""#), "{out}");
+    }
+
+    #[test]
+    fn add_mount_scoped_creates_nested_entry() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        // Behavioral equivalence with AppConfig::add_mount:
+        // scope is the OUTER key; name is the INNER key.
+        // So scope=agent-smith produces [docker.mounts.agent-smith] with creds = {...}
+        editor.add_mount(
+            "creds",
+            crate::workspace::MountConfig {
+                src: "/run/secrets/x".to_string(),
+                dst: "/secrets/x".to_string(),
+                readonly: true,
+            },
+            Some("agent-smith"),
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        // The scoped shape: [docker.mounts.agent-smith] with creds sub-table
+        assert!(out.contains("[docker.mounts.agent-smith]"), "{out}");
+        assert!(out.contains(r#"src = "/run/secrets/x""#), "{out}");
+        assert!(out.contains("readonly = true"), "{out}");
+    }
+
+    #[test]
+    fn remove_mount_unscoped_deletes_entry() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[docker.mounts.shared-home]
+src = "/home/user"
+dst = "/workspace/home"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_mount("shared-home", None);
+        editor.save().unwrap();
+
+        assert!(removed);
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("shared-home"), "{out}");
+    }
+
+    #[test]
+    fn remove_mount_returns_false_for_missing() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_mount("nope", None);
+        editor.save().unwrap();
+        assert!(!removed);
     }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -93,6 +93,22 @@ impl ConfigEditor {
         let table = table_path_mut(&mut self.doc, &path);
         table.insert(key, toml_edit::value(value_str));
     }
+
+    pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
+        let path = env_scope_path(&scope);
+        // Walk without creating: return false if any segment is missing.
+        let mut current: &mut Item = self.doc.as_item_mut();
+        for segment in &path {
+            match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
+                Some(next) => current = next,
+                None => return false,
+            }
+        }
+        match current.as_table_mut() {
+            Some(table) => table.remove(key).is_some(),
+            None => false,
+        }
+    }
 }
 
 fn env_scope_path(scope: &EnvScope) -> Vec<String> {
@@ -203,6 +219,44 @@ API_TOKEN = "old-value"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains(r#"API_TOKEN = "new-value""#), "{out}");
         assert!(!out.contains("old-value"), "{out}");
+    }
+
+    #[test]
+    fn remove_env_var_returns_true_when_present() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[env]
+API_TOKEN = "x"
+OTHER = "y"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+        editor.save().unwrap();
+
+        assert!(removed);
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("API_TOKEN"), "{out}");
+        assert!(out.contains(r#"OTHER = "y""#), "sibling gone: {out}");
+    }
+
+    #[test]
+    fn remove_env_var_returns_false_when_absent() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_env_var(EnvScope::Global, "API_TOKEN");
+        editor.save().unwrap();
+
+        assert!(!removed);
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -1,0 +1,125 @@
+//! Comment-preserving config writer.
+//!
+//! Reads still go through `AppConfig::load_or_init` (serde + `toml`).
+//! Writes go through `ConfigEditor::open → mutate → save`, which keeps
+//! user-written comments, blank lines, and key ordering intact in
+//! sections untouched by the mutation.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use toml_edit::DocumentMut;
+
+use crate::config::AppConfig;
+use crate::paths::JackinPaths;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvScope {
+    Global,
+    Agent(String),
+    Workspace(String),
+    WorkspaceAgent { workspace: String, agent: String },
+}
+
+pub struct ConfigEditor {
+    doc: DocumentMut,
+    path: PathBuf,
+}
+
+impl ConfigEditor {
+    /// Loads the existing config file as a `DocumentMut`. If the file
+    /// does not exist, delegates to `AppConfig::load_or_init` to
+    /// materialize defaults, then reopens the resulting file.
+    pub fn open(paths: &JackinPaths) -> anyhow::Result<Self> {
+        if !paths.config_file.exists() {
+            AppConfig::load_or_init(paths)?;
+        }
+        let raw = std::fs::read_to_string(&paths.config_file)
+            .with_context(|| format!("reading {}", paths.config_file.display()))?;
+        let doc: DocumentMut = raw
+            .parse()
+            .with_context(|| format!("parsing {}", paths.config_file.display()))?;
+        Ok(Self {
+            doc,
+            path: paths.config_file.clone(),
+        })
+    }
+
+    /// Writes the mutated document atomically. Returns a freshly-deserialized
+    /// `AppConfig` parsed directly from the written content so callers that
+    /// still need the in-memory shape get it without a second manual
+    /// `load_or_init`.
+    ///
+    /// Note: this deliberately bypasses `AppConfig::load_or_init`'s
+    /// builtin-agent sync to avoid clobbering the just-written document with
+    /// a serde round-trip.
+    pub fn save(self) -> anyhow::Result<AppConfig> {
+        let contents = self.doc.to_string();
+        let tmp = self.path.with_extension("tmp");
+
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+        }
+
+        #[cfg(not(unix))]
+        std::fs::write(&tmp, &contents)?;
+
+        std::fs::rename(&tmp, &self.path)?;
+
+        let config: AppConfig = toml::from_str(&contents)
+            .with_context(|| format!("deserializing {}", self.path.display()))?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn idempotent_save_is_byte_identical() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        let original = r#"# Top-of-file note about this config
+[claude]
+auth_forward = "sync"
+
+# Agents we trust
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+# My production workspace
+[workspaces.prod]
+workdir = "/workspace/prod"
+
+[[workspaces.prod.mounts]]
+src = "/workspace/prod"
+dst = "/workspace/prod"
+
+[workspaces.prod.env]
+# Rotate quarterly (last: 2026-Q1)
+API_TOKEN = "op://Personal/api/token"
+"#;
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let editor = ConfigEditor::open(&paths).unwrap();
+        editor.save().unwrap();
+
+        let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert_eq!(round_tripped, original, "open → save must be byte-identical");
+    }
+}

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -304,6 +304,35 @@ impl ConfigEditor {
         }
     }
 
+    /// Rewrite any `auth_forward = "copy"` to `"sync"` at the two paths
+    /// `contains_deprecated_copy_auth_forward` checks:
+    ///   [claude].auth_forward
+    ///   [agents.*.claude].auth_forward
+    ///
+    /// Does not touch any other structure. Used by load_or_init when the
+    /// on-disk config still contains the deprecated literal.
+    pub fn normalize_deprecated_copy(&mut self) {
+        // Global [claude]
+        if let Some(claude) = self.doc.get_mut("claude").and_then(|i| i.as_table_mut()) {
+            if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
+                claude.insert("auth_forward", toml_edit::value("sync"));
+            }
+        }
+        // Per-agent [agents.X.claude]
+        if let Some(agents) = self.doc.get_mut("agents").and_then(|i| i.as_table_mut()) {
+            for (_, agent_item) in agents.iter_mut() {
+                let Some(agent_table) = agent_item.as_table_mut() else { continue };
+                let Some(claude) = agent_table.get_mut("claude").and_then(|i| i.as_table_mut())
+                else {
+                    continue;
+                };
+                if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
+                    claude.insert("auth_forward", toml_edit::value("sync"));
+                }
+            }
+        }
+    }
+
     pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
         let path = env_scope_path(&scope);
         // Walk without creating: return false if any segment is missing.
@@ -1153,6 +1182,37 @@ MY_VAR = "preserved"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains(r#"git = "NEW""#), "{out}");
         assert!(out.contains(r#"MY_VAR = "preserved""#), "{out}");
+    }
+
+    #[test]
+    fn normalize_deprecated_copy_rewrites_global_and_agent_paths() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[claude]
+auth_forward = "copy"
+
+[agents.foo]
+git = "x"
+
+[agents.foo.claude]
+auth_forward = "copy"
+
+[agents.bar]
+git = "y"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.normalize_deprecated_copy();
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains(r#""copy""#), "{out}");
+        assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -94,6 +94,31 @@ impl ConfigEditor {
         table.insert(key, toml_edit::value(value_str));
     }
 
+    pub fn set_env_comment(&mut self, scope: EnvScope, key: &str, comment: Option<&str>) {
+        let path = env_scope_path(&scope);
+        // Walk without creating — setting a comment on a nonexistent key
+        // is a silent no-op (same contract as remove_env_var).
+        let mut current: &mut Item = self.doc.as_item_mut();
+        for segment in &path {
+            match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
+                Some(next) => current = next,
+                None => return,
+            }
+        }
+        let Some(table) = current.as_table_mut() else {
+            return;
+        };
+        let Some(mut key_mut) = table.key_mut(key) else {
+            return;
+        };
+        let decor = key_mut.leaf_decor_mut();
+        let prefix = match comment {
+            Some(text) => format!("# {text}\n"),
+            None => String::new(),
+        };
+        decor.set_prefix(prefix);
+    }
+
     pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
         let path = env_scope_path(&scope);
         // Walk without creating: return false if any segment is missing.
@@ -257,6 +282,94 @@ OTHER = "y"
         editor.save().unwrap();
 
         assert!(!removed);
+    }
+
+    #[test]
+    fn set_env_comment_adds_line_above_key() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[env]
+API_TOKEN = "op://vault-id/item-id/field"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_comment(
+            EnvScope::Global,
+            "API_TOKEN",
+            Some("op://Personal/Google/password"),
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            out.contains("# op://Personal/Google/password\nAPI_TOKEN"),
+            "expected comment directly above key: {out}"
+        );
+    }
+
+    #[test]
+    fn set_env_comment_replaces_existing_comment() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            "[env]\n# old annotation\nAPI_TOKEN = \"x\"\n",
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_comment(EnvScope::Global, "API_TOKEN", Some("new annotation"));
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("# new annotation"), "{out}");
+        assert!(!out.contains("# old annotation"), "{out}");
+    }
+
+    #[test]
+    fn set_env_comment_none_removes_annotation() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            "[env]\n# some note\nAPI_TOKEN = \"x\"\n",
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_comment(EnvScope::Global, "API_TOKEN", None);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("# some note"), "{out}");
+        assert!(out.contains(r#"API_TOKEN = "x""#), "key still present: {out}");
+    }
+
+    #[test]
+    fn mutating_sibling_preserves_comment_above_other_key() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let original = "[env]\n# rotate quarterly\nAPI_TOKEN = \"x\"\nOTHER = \"y\"\n";
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(EnvScope::Global, "OTHER", "z");
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            out.contains("# rotate quarterly\nAPI_TOKEN = \"x\""),
+            "sibling mutation wiped adjacent comment: {out}"
+        );
+        assert!(out.contains(r#"OTHER = "z""#), "{out}");
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -181,9 +181,11 @@ impl ConfigEditor {
     /// `true` if an entry was present and removed.
     ///
     /// Unscoped (`scope = None`): removes `docker.mounts[name]`.
-    /// Scoped (`scope = Some(scope_key)`): removes `docker.mounts[scope_key][name]`.
-    /// If the scope's sub-table becomes empty after removal the empty table is
-    /// left in place (toml_edit keeps it; callers that care can compact later).
+    /// Scoped (`scope = Some(scope_key)`): removes the `name` entry from
+    /// `docker.mounts[scope_key]`. If that scope table becomes empty after
+    /// the removal, the scope table itself is removed too — matching
+    /// `AppConfig::remove_mount`'s cleanup so empty scope tables do not
+    /// accumulate in the on-disk config.
     pub fn remove_mount(&mut self, name: &str, scope: Option<&str>) -> bool {
         let Some(docker) = self
             .doc
@@ -204,7 +206,11 @@ impl ConfigEditor {
                 else {
                     return false;
                 };
-                entry.remove(name).is_some()
+                let removed = entry.remove(name).is_some();
+                if removed && entry.is_empty() {
+                    mounts.remove(scope_key);
+                }
+                removed
             }
         }
     }
@@ -661,5 +667,54 @@ dst = "/workspace/home"
         let removed = editor.remove_mount("nope", None);
         editor.save().unwrap();
         assert!(!removed);
+    }
+
+    #[test]
+    fn remove_mount_scoped_last_entry_deletes_scope_table() {
+        // Matches AppConfig::remove_mount cleanup: when the last named mount
+        // in a scope is removed, the scope table itself is removed.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[docker.mounts.agent-smith]
+creds = { src = "/run/secrets/x", dst = "/secrets/x" }
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_mount("creds", Some("agent-smith"));
+        editor.save().unwrap();
+
+        assert!(removed);
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("agent-smith"), "empty scope table should be gone: {out}");
+    }
+
+    #[test]
+    fn remove_mount_scoped_preserves_scope_when_siblings_remain() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[docker.mounts.agent-smith]
+creds = { src = "/a", dst = "/a" }
+logs = { src = "/b", dst = "/b" }
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        let removed = editor.remove_mount("creds", Some("agent-smith"));
+        editor.save().unwrap();
+
+        assert!(removed);
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[docker.mounts.agent-smith]"), "scope table should still exist: {out}");
+        assert!(!out.contains("creds"), "{out}");
+        assert!(out.contains("logs"), "{out}");
     }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -272,6 +272,98 @@ impl ConfigEditor {
             None => false,
         }
     }
+
+    pub fn set_last_agent(&mut self, workspace: &str, agent_key: &str) {
+        let table = table_path_mut(
+            &mut self.doc,
+            &["workspaces".to_string(), workspace.to_string()],
+        );
+        table.insert("last_agent", toml_edit::value(agent_key));
+    }
+
+    pub fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
+        let Some(workspaces) = self.doc.get_mut("workspaces").and_then(|i| i.as_table_mut()) else {
+            anyhow::bail!("workspace {name:?} not found");
+        };
+        if workspaces.remove(name).is_none() {
+            anyhow::bail!("workspace {name:?} not found");
+        }
+        Ok(())
+    }
+
+    pub fn create_workspace(
+        &mut self,
+        name: &str,
+        ws: crate::workspace::WorkspaceConfig,
+    ) -> anyhow::Result<()> {
+        // Collision check first — match today's create_workspace behavior.
+        if self
+            .doc
+            .get("workspaces")
+            .and_then(|i| i.as_table())
+            .and_then(|t| t.get(name))
+            .is_some()
+        {
+            anyhow::bail!("workspace {name:?} already exists");
+        }
+
+        // Serialize the WorkspaceConfig to toml_edit items via string round-trip:
+        // toml::to_string on the struct, parse as DocumentMut, splat the body
+        // into the new [workspaces.<name>] table.
+        let rendered = toml::to_string(&ws)
+            .with_context(|| format!("serializing workspace {name:?}"))?;
+        let parsed: DocumentMut = rendered
+            .parse()
+            .with_context(|| format!("re-parsing serialized workspace {name:?}"))?;
+
+        let workspaces_table = table_path_mut(
+            &mut self.doc,
+            &["workspaces".to_string(), name.to_string()],
+        );
+        for (key, item) in parsed.as_table().iter() {
+            workspaces_table.insert(key, item.clone());
+        }
+
+        Ok(())
+    }
+
+    pub fn edit_workspace(
+        &mut self,
+        name: &str,
+        edit: crate::workspace::WorkspaceEdit,
+    ) -> anyhow::Result<()> {
+        // Snapshot current on-disk state into an AppConfig.
+        let mut in_memory: AppConfig = toml::from_str(&self.doc.to_string())
+            .context("re-parsing current doc into AppConfig for workspace edit")?;
+
+        // Apply the edit using the existing validated logic. Mutates
+        // in_memory or returns Err with the validation message on failure.
+        in_memory.edit_workspace(name, edit)?;
+
+        // Pull the resulting WorkspaceConfig back out and splat into the doc.
+        let updated = in_memory
+            .workspaces
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("workspace {name:?} disappeared after edit"))?;
+
+        // Replace the entire [workspaces.<name>] table. This preserves
+        // comments in OTHER workspaces and in unrelated top-level sections,
+        // which is what the migration cares about. Comments inside the
+        // edited workspace itself are consumed — that's acceptable because
+        // the edit IS the change the user is making to that workspace.
+        let rendered = toml::to_string(updated)?;
+        let parsed: DocumentMut = rendered.parse()?;
+        let target = table_path_mut(
+            &mut self.doc,
+            &["workspaces".to_string(), name.to_string()],
+        );
+        target.clear();
+        for (key, item) in parsed.as_table().iter() {
+            target.insert(key, item.clone());
+        }
+
+        Ok(())
+    }
 }
 
 fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str {
@@ -898,5 +990,82 @@ auth_forward = "token"
         assert!(out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#), "{out}");
         assert!(out.contains("trusted = true"), "{out}");
         assert!(out.contains(r#"auth_forward = "token""#), "claude override wiped: {out}");
+    }
+
+    #[test]
+    fn create_workspace_adds_table() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mount_src = temp.path().join("src");
+        std::fs::create_dir_all(&mount_src).unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let ws = crate::workspace::WorkspaceConfig {
+            workdir: "/workspace/new".to_string(),
+            mounts: vec![crate::workspace::MountConfig {
+                src: mount_src.display().to_string(),
+                dst: "/workspace/new".to_string(),
+                readonly: false,
+            }],
+            allowed_agents: vec![],
+            default_agent: None,
+            last_agent: None,
+            env: std::collections::BTreeMap::new(),
+            agents: std::collections::BTreeMap::new(),
+        };
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.create_workspace("new-ws", ws).unwrap();
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[workspaces.new-ws]"), "{out}");
+        assert!(out.contains(r#"workdir = "/workspace/new""#), "{out}");
+    }
+
+    #[test]
+    fn set_last_agent_preserves_other_fields() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let original = r#"[workspaces.prod]
+workdir = "/workspace/prod"
+default_agent = "agent-smith"
+"#;
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_last_agent("prod", "agent-smith");
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains(r#"last_agent = "agent-smith""#), "{out}");
+        assert!(out.contains(r#"default_agent = "agent-smith""#), "{out}");
+    }
+
+    #[test]
+    fn remove_workspace_deletes_table() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[workspaces.a]
+workdir = "/a"
+
+[workspaces.b]
+workdir = "/b"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.remove_workspace("a").unwrap();
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("[workspaces.a]"), "{out}");
+        assert!(out.contains("[workspaces.b]"), "{out}");
     }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -52,7 +52,14 @@ impl ConfigEditor {
     ///
     /// Note: this deliberately bypasses `AppConfig::load_or_init`'s
     /// builtin-agent sync to avoid clobbering the just-written document with
-    /// a serde round-trip.
+    /// a serde round-trip. Because it uses `toml::from_str` directly, it
+    /// also skips `load_or_init`'s `validate_workspaces` and
+    /// `validate_reserved_names` checks. The invariant this relies on is
+    /// that validation runs once at load time (via `ConfigEditor::open` →
+    /// `AppConfig::load_or_init` for first-run / `AppConfig::edit_workspace`
+    /// for structural workspace edits) and that the editor's typed setters
+    /// preserve validity — they write keys/values into known scopes and
+    /// cannot construct a workspace or reserved-name violation on their own.
     pub fn save(self) -> anyhow::Result<AppConfig> {
         let contents = self.doc.to_string();
         let tmp = self.path.with_extension("tmp");

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -257,6 +257,53 @@ impl ConfigEditor {
         table.insert("trusted", toml_edit::value(true));
     }
 
+    /// Writes `git` and `trusted` from the given `AgentSource` into
+    /// `[agents.<agent_key>]`, and if the doc has no `[agents.<agent_key>.claude]`
+    /// table yet but the source carries a `claude` override, writes that too.
+    /// Does NOT touch `[agents.<agent_key>.env]` — operator-owned.
+    ///
+    /// Used by call sites that first invoke `resolve_agent_source` (which may
+    /// insert a new agent into the in-memory `AppConfig`) and need the editor
+    /// to persist that insert alongside whatever trust / auth_forward change
+    /// they're about to make.
+    pub fn upsert_agent_source(&mut self, agent_key: &str, source: &crate::config::AgentSource) {
+        let table = table_path_mut(
+            &mut self.doc,
+            &["agents".to_string(), agent_key.to_string()],
+        );
+        table.insert("git", toml_edit::value(source.git.clone()));
+        if source.trusted {
+            table.insert("trusted", toml_edit::value(true));
+        } else {
+            table.remove("trusted");
+        }
+        // If the source carries a claude override and the doc doesn't have
+        // one, serialize it in. If the doc already has one, leave it alone —
+        // operator-owned.
+        if let Some(claude) = &source.claude {
+            let existing_claude = self
+                .doc
+                .get("agents")
+                .and_then(|i| i.as_table())
+                .and_then(|t| t.get(agent_key))
+                .and_then(|i| i.as_table())
+                .and_then(|t| t.get("claude"));
+            if existing_claude.is_none() {
+                if let Ok(rendered) = toml::to_string(claude) {
+                    if let Ok(parsed) = rendered.parse::<DocumentMut>() {
+                        let claude_table = table_path_mut(
+                            &mut self.doc,
+                            &["agents".to_string(), agent_key.to_string(), "claude".to_string()],
+                        );
+                        for (k, v) in parsed.as_table().iter() {
+                            claude_table.insert(k, v.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn remove_env_var(&mut self, scope: EnvScope, key: &str) -> bool {
         let path = env_scope_path(&scope);
         // Walk without creating: return false if any segment is missing.
@@ -1075,6 +1122,37 @@ default_agent = "agent-smith"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains(r#"last_agent = "agent-smith""#), "{out}");
         assert!(out.contains(r#"default_agent = "agent-smith""#), "{out}");
+    }
+
+    #[test]
+    fn upsert_agent_source_preserves_existing_env() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.foo]
+git = "OLD"
+
+[agents.foo.env]
+MY_VAR = "preserved"
+"#,
+        )
+        .unwrap();
+
+        let source = crate::config::AgentSource {
+            git: "NEW".to_string(),
+            trusted: true,
+            claude: None,
+            env: std::collections::BTreeMap::new(),
+        };
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.upsert_agent_source("foo", &source);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains(r#"git = "NEW""#), "{out}");
+        assert!(out.contains(r#"MY_VAR = "preserved""#), "{out}");
     }
 
     #[test]

--- a/src/config/fixtures/config.round_trip.toml
+++ b/src/config/fixtures/config.round_trip.toml
@@ -1,0 +1,37 @@
+# Jackin config — top-of-file note
+# keep this across saves
+
+[claude]
+auth_forward = "sync"
+
+# Our two builtin agents
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[agents.the-architect]
+git = "https://github.com/jackin-project/jackin-the-architect.git"
+trusted = true
+
+# An external agent we vetted in 2025-Q4
+[agents."chainargos/agent-brown"]
+git = "git@github.com:chainargos/jackin-agent-brown.git"
+trusted = true
+
+# Production workspace — the big one
+[workspaces.prod]
+workdir = "/workspace/prod"
+
+[workspaces.prod.env]
+# Rotate quarterly (last: 2026-Q1)
+API_TOKEN = "op://Personal/api/token"
+
+# Passes through from host
+GITHUB_TOKEN = "$GITHUB_TOKEN"
+
+[workspaces.prod.agents.agent-smith.env]
+OPENAI_API_KEY = "op://Work/OpenAI/default"
+
+# Playground workspace — disposable
+[workspaces.playground]
+workdir = "/tmp/playground"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 pub use crate::workspace::MountConfig;
 pub use crate::workspace::WorkspaceAgentOverride;
 
-pub mod editor;
 mod agents;
+pub mod editor;
 mod mounts;
 mod persist;
 mod workspaces;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,11 +5,13 @@ use std::collections::BTreeMap;
 pub use crate::workspace::MountConfig;
 pub use crate::workspace::WorkspaceAgentOverride;
 
+pub mod editor;
 mod agents;
 mod mounts;
 mod persist;
 mod workspaces;
 
+pub use editor::{ConfigEditor, EnvScope};
 pub use mounts::{DockerMounts, MountEntry};
 
 /// Serde helper: `skip_serializing_if` requires `fn(&T) -> bool`.

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -120,7 +120,6 @@ impl AppConfig {
         }
     }
 
-
     pub fn list_mounts(&self) -> Vec<(String, String, &MountConfig)> {
         let mut result = Vec::new();
         for (key, entry) in self.docker.mounts.iter() {

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -95,7 +95,10 @@ impl AppConfig {
         Ok(expanded)
     }
 
-    pub fn add_mount(&mut self, name: &str, mount: MountConfig, scope: Option<&str>) {
+    // pub(crate): test-only affordance for in-memory AppConfig setup in tests
+    // (launch/preview.rs, workspace/resolve.rs). Production callers use ConfigEditor.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn add_mount(&mut self, name: &str, mount: MountConfig, scope: Option<&str>) {
         let scope_key = scope.unwrap_or("");
         if scope_key.is_empty() {
             self.docker
@@ -117,23 +120,6 @@ impl AppConfig {
         }
     }
 
-    pub fn remove_mount(&mut self, name: &str, scope: Option<&str>) -> bool {
-        let scope_key = scope.unwrap_or("");
-        if scope_key.is_empty() {
-            self.docker.mounts.remove(name).is_some()
-        } else {
-            match self.docker.mounts.get_mut(scope_key) {
-                Some(MountEntry::Scoped(map)) => {
-                    let removed = map.remove(name).is_some();
-                    if map.is_empty() {
-                        self.docker.mounts.remove(scope_key);
-                    }
-                    removed
-                }
-                _ => false,
-            }
-        }
-    }
 
     pub fn list_mounts(&self) -> Vec<(String, String, &MountConfig)> {
         let mut result = Vec::new();

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -39,7 +39,29 @@ impl AppConfig {
             // would destroy every user comment before the editor could
             // preserve them, defeating the whole point of this migration.
             if !paths.config_file.exists() {
-                config.save(paths)?;
+                // Inline of the removed AppConfig::save. Atomic write:
+                // serialize → .tmp (0o600 on unix, fsync) → rename.
+                let contents = toml::to_string_pretty(&config)?;
+                let tmp = paths.config_file.with_extension("tmp");
+
+                #[cfg(unix)]
+                {
+                    use std::io::Write;
+                    use std::os::unix::fs::OpenOptionsExt;
+                    let mut file = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .mode(0o600)
+                        .open(&tmp)?;
+                    file.write_all(contents.as_bytes())?;
+                    file.sync_all()?;
+                }
+
+                #[cfg(not(unix))]
+                std::fs::write(&tmp, &contents)?;
+
+                std::fs::rename(&tmp, &paths.config_file)?;
             }
             let mut editor = crate::config::ConfigEditor::open(paths)?;
             if builtins_changed {
@@ -66,30 +88,6 @@ impl AppConfig {
         Ok(config)
     }
 
-    pub fn save(&self, paths: &JackinPaths) -> anyhow::Result<()> {
-        let contents = toml::to_string_pretty(self)?;
-        let tmp = paths.config_file.with_extension("tmp");
-
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&tmp)?;
-            file.write_all(contents.as_bytes())?;
-            file.sync_all()?;
-        }
-
-        #[cfg(not(unix))]
-        std::fs::write(&tmp, &contents)?;
-
-        std::fs::rename(&tmp, &paths.config_file)?;
-        Ok(())
-    }
 }
 
 /// Detect the literal deprecated `auth_forward = "copy"` at either of the

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -31,7 +31,26 @@ impl AppConfig {
         }
 
         if builtins_changed || deprecated_copy_seen {
+            // Ensure the config file exists on disk before opening the editor.
+            // ConfigEditor::open calls AppConfig::load_or_init when the file is
+            // absent, which would recurse. Writing via AppConfig::save first
+            // breaks that cycle; the editor then reopens the written file and
+            // applies comment-preserving mutations on top.
             config.save(paths)?;
+            let mut editor = crate::config::ConfigEditor::open(paths)?;
+            if builtins_changed {
+                for &(name, git) in crate::config::agents::BUILTIN_AGENTS {
+                    editor.upsert_builtin_agent(name, git);
+                }
+            }
+            if deprecated_copy_seen {
+                editor.normalize_deprecated_copy();
+            }
+            // editor.save() returns an AppConfig parsed from the on-disk file,
+            // which has [agents.X.env] preserved (upsert_builtin_agent doesn't
+            // touch env). The in-memory `config` from sync_builtin_agents has
+            // env cleared. Replace the in-memory config with the preserved one.
+            config = editor.save()?;
         }
 
         // Reject operator env maps that declare reserved runtime names.

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -31,12 +31,16 @@ impl AppConfig {
         }
 
         if builtins_changed || deprecated_copy_seen {
-            // Ensure the config file exists on disk before opening the editor.
-            // ConfigEditor::open calls AppConfig::load_or_init when the file is
-            // absent, which would recurse. Writing via AppConfig::save first
-            // breaks that cycle; the editor then reopens the written file and
-            // applies comment-preserving mutations on top.
-            config.save(paths)?;
+            // Bootstrap only when the file doesn't exist yet. Without this
+            // gate, ConfigEditor::open would call load_or_init for the
+            // missing file and recurse. When the file DOES exist (the
+            // builtins-drifted or deprecated-copy upgrade path), we must
+            // NOT rewrite it through the lossy serde path first — that
+            // would destroy every user comment before the editor could
+            // preserve them, defeating the whole point of this migration.
+            if !paths.config_file.exists() {
+                config.save(paths)?;
+            }
             let mut editor = crate::config::ConfigEditor::open(paths)?;
             if builtins_changed {
                 for &(name, git) in crate::config::agents::BUILTIN_AGENTS {
@@ -219,6 +223,49 @@ auth_forward = "copy"
 
         let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(!persisted.contains("auth_forward = \"copy\""));
+    }
+
+    #[test]
+    fn load_migration_preserves_user_comments() {
+        // Regression test for the persist.rs migration path: the copy→sync
+        // and builtin-sync branches must NOT pre-flush through the lossy
+        // serde writer, or every user comment gets destroyed before the
+        // editor can preserve them.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        let original = r#"# Top-of-file note — keep this
+[claude]
+auth_forward = "copy"
+
+# Builtin agent, operator-configured
+[agents.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+# Keep this comment too — it explains why we trust
+[agents.agent-smith.claude]
+auth_forward = "copy"
+"#;
+        std::fs::write(&paths.config_file, original).unwrap();
+
+        let _config = AppConfig::load_or_init(&paths).unwrap();
+
+        let after = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            after.contains("# Top-of-file note — keep this"),
+            "top-of-file comment lost: {after}"
+        );
+        assert!(
+            after.contains("# Builtin agent, operator-configured"),
+            "agent-section comment lost: {after}"
+        );
+        assert!(
+            after.contains("# Keep this comment too — it explains why we trust"),
+            "claude-section comment lost: {after}"
+        );
+        assert!(!after.contains("\"copy\""), "copy not migrated: {after}");
+        assert!(after.contains("auth_forward = \"sync\""), "{after}");
     }
 
     #[test]

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -87,7 +87,6 @@ impl AppConfig {
         config.validate_workspaces()?;
         Ok(config)
     }
-
 }
 
 /// Detect the literal deprecated `auth_forward = "copy"` at either of the

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -13,7 +13,9 @@ impl AppConfig {
             .ok_or_else(|| anyhow::anyhow!("unknown workspace {name}"))
     }
 
-    pub fn create_workspace(
+    // pub(crate): ConfigEditor::create_workspace delegates here for validation;
+    // external callers must go through ConfigEditor to ensure TOML preservation.
+    pub(crate) fn create_workspace(
         &mut self,
         name: &str,
         workspace: WorkspaceConfig,
@@ -46,7 +48,9 @@ impl AppConfig {
         Ok(())
     }
 
-    pub fn edit_workspace(&mut self, name: &str, edit: WorkspaceEdit) -> anyhow::Result<()> {
+    // pub(crate): ConfigEditor::edit_workspace delegates here for validation;
+    // external callers must go through ConfigEditor to ensure TOML preservation.
+    pub(crate) fn edit_workspace(&mut self, name: &str, edit: WorkspaceEdit) -> anyhow::Result<()> {
         let mut seen_upsert_destinations = std::collections::HashSet::new();
         for mount in &edit.upsert_mounts {
             if !seen_upsert_destinations.insert(mount.dst.as_str()) {
@@ -140,7 +144,11 @@ impl AppConfig {
         Ok(())
     }
 
-    pub fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
+    // pub(crate): production callers use ConfigEditor::remove_workspace (which
+    // deletes the TOML table directly); this stays for the test in workspaces.rs
+    // that validates the error message shape.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
         self.workspaces
             .remove(name)
             .map(|_| ())

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -591,13 +591,21 @@ fn load_agent_with(
         false
     } else {
         confirm_trust(selector, &source)?;
-        config.trust_agent(&selector.key());
+        // Mutate the in-memory copy so callers downstream see the trust
+        // without a reload; persist via editor below.
+        if let Some(entry) = config.agents.get_mut(&selector.key()) {
+            entry.trusted = true;
+        }
         true
     };
 
-    // Persist config when the agent was newly registered or newly trusted
     if is_new || newly_trusted {
-        config.save(paths)?;
+        let mut editor = crate::config::ConfigEditor::open(paths)?;
+        if let Some(agent_source) = config.agents.get(&selector.key()) {
+            editor.upsert_agent_source(&selector.key(), agent_source);
+        }
+        editor.set_agent_trust(&selector.key(), true);
+        *config = editor.save()?;
     }
 
     let agent_display_name = validated_repo.manifest.display_name(&selector.name);

--- a/tests/workspace_config_crud.rs
+++ b/tests/workspace_config_crud.rs
@@ -382,7 +382,10 @@ fn workspace_edit_no_workdir_mount_removes_auto_mount() {
         )
         .unwrap();
     let config_before = editor.save().unwrap();
-    assert_eq!(config_before.workspaces.get("my-app").unwrap().mounts.len(), 2);
+    assert_eq!(
+        config_before.workspaces.get("my-app").unwrap().mounts.len(),
+        2
+    );
 
     // Now remove the workdir auto-mount
     let mut editor2 = ConfigEditor::open(&paths).unwrap();
@@ -451,4 +454,3 @@ fn workspace_edit_no_workdir_mount_fails_when_no_auto_mount() {
         "expected clear error, got: {err}"
     );
 }
-

--- a/tests/workspace_config_crud.rs
+++ b/tests/workspace_config_crud.rs
@@ -1,11 +1,27 @@
-use jackin::config;
+use jackin::config::ConfigEditor;
+use jackin::paths::JackinPaths;
 use jackin::workspace::{self, WorkspaceConfig, WorkspaceEdit, parse_mount_spec_resolved};
+
+/// Bootstrap a fresh, empty config file for a ConfigEditor-based test.
+///
+/// Returns a temp dir (kept alive for the test's duration) and the
+/// corresponding JackinPaths.
+fn bootstrap_paths() -> (tempfile::TempDir, JackinPaths) {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    paths.ensure_base_dirs().unwrap();
+    // Write a minimal valid config so ConfigEditor::open succeeds.
+    std::fs::write(&paths.config_file, "").unwrap();
+    (temp, paths)
+}
 
 /// Simulates `jackin workspace create jackin --workdir jackin --mount sibling-project`
 /// from a parent directory. Both relative workdir and mount must be resolved to
 /// absolute paths so that `create_workspace` validation passes.
 #[test]
 fn workspace_create_resolves_relative_workdir_and_mounts() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("jackin");
     let mount_dir = temp.path().join("sibling-project");
@@ -18,8 +34,8 @@ fn workspace_create_resolves_relative_workdir_and_mounts() {
     let expanded_workdir = workspace::resolve_path("jackin");
     let mount = parse_mount_spec_resolved("sibling-project").unwrap();
 
-    let mut config = config::AppConfig::default();
-    let result = config.create_workspace(
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let result = editor.create_workspace(
         "jackin",
         WorkspaceConfig {
             workdir: expanded_workdir.clone(),
@@ -42,6 +58,7 @@ fn workspace_create_resolves_relative_workdir_and_mounts() {
     std::env::set_current_dir(original_cwd).unwrap();
 
     result.unwrap();
+    let config = editor.save().unwrap();
     let ws = config.workspaces.get("jackin").unwrap();
     assert!(ws.workdir.starts_with('/'));
     assert!(!ws.workdir.contains(".."));
@@ -53,6 +70,8 @@ fn workspace_create_resolves_relative_workdir_and_mounts() {
 /// resolve to clean absolute paths.
 #[test]
 fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("jackin");
     let sibling_dir = temp.path().join("jackin-agent-smith");
@@ -65,8 +84,8 @@ fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
     let expanded_workdir = workspace::resolve_path(".");
     let mount = parse_mount_spec_resolved("../jackin-agent-smith").unwrap();
 
-    let mut config = config::AppConfig::default();
-    let result = config.create_workspace(
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    let result = editor.create_workspace(
         "jackin",
         WorkspaceConfig {
             workdir: expanded_workdir.clone(),
@@ -89,6 +108,7 @@ fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
     std::env::set_current_dir(original_cwd).unwrap();
 
     result.unwrap();
+    let config = editor.save().unwrap();
     let ws = config.workspaces.get("jackin").unwrap();
     assert!(ws.workdir.starts_with('/'));
     assert!(!ws.workdir.contains(".."));
@@ -100,6 +120,8 @@ fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
 /// The workdir must be auto-mounted as the first mount.
 #[test]
 fn workspace_create_auto_mounts_workdir_by_default() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("my-app");
     std::fs::create_dir_all(&workdir_dir).unwrap();
@@ -123,8 +145,8 @@ fn workspace_create_auto_mounts_workdir_by_default() {
         }
     }
 
-    let mut config = config::AppConfig::default();
-    config
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "my-app",
             WorkspaceConfig {
@@ -139,6 +161,7 @@ fn workspace_create_auto_mounts_workdir_by_default() {
         )
         .unwrap();
 
+    let config = editor.save().unwrap();
     let ws = config.workspaces.get("my-app").unwrap();
     assert_eq!(ws.mounts.len(), 1);
     assert_eq!(ws.mounts[0].src, expanded_workdir);
@@ -150,6 +173,8 @@ fn workspace_create_auto_mounts_workdir_by_default() {
 /// --mount /tmp/src:/workspace`. The workdir must NOT be auto-mounted.
 #[test]
 fn workspace_create_no_workdir_mount_skips_auto_mount() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let src_dir = temp.path().join("src");
     std::fs::create_dir_all(&src_dir).unwrap();
@@ -175,8 +200,8 @@ fn workspace_create_no_workdir_mount_skips_auto_mount() {
         );
     }
 
-    let mut config = config::AppConfig::default();
-    config
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "monorepo",
             WorkspaceConfig {
@@ -191,6 +216,7 @@ fn workspace_create_no_workdir_mount_skips_auto_mount() {
         )
         .unwrap();
 
+    let config = editor.save().unwrap();
     let ws = config.workspaces.get("monorepo").unwrap();
     assert_eq!(ws.mounts.len(), 1, "should only have the explicit mount");
     assert_eq!(ws.mounts[0].src, src_path);
@@ -201,6 +227,8 @@ fn workspace_create_no_workdir_mount_skips_auto_mount() {
 /// should be skipped even without --no-workdir-mount.
 #[test]
 fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("project");
     std::fs::create_dir_all(&workdir_dir).unwrap();
@@ -228,8 +256,8 @@ fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
         }
     }
 
-    let mut config = config::AppConfig::default();
-    config
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "project",
             WorkspaceConfig {
@@ -244,6 +272,7 @@ fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
         )
         .unwrap();
 
+    let config = editor.save().unwrap();
     let ws = config.workspaces.get("project").unwrap();
     assert_eq!(ws.mounts.len(), 1, "no duplicate mount should be added");
     assert!(ws.mounts[0].readonly, "original mount properties preserved");
@@ -253,6 +282,8 @@ fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
 /// is a relative directory name. The resolved mount must pass validation.
 #[test]
 fn workspace_edit_resolves_relative_mount() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("jackin");
     let dev_dir = temp.path().join("jackin-dev");
@@ -261,8 +292,9 @@ fn workspace_edit_resolves_relative_mount() {
 
     let workdir_abs = workdir_dir.display().to_string();
 
-    let mut config = config::AppConfig::default();
-    config
+    // Create workspace first
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "jackin",
             WorkspaceConfig {
@@ -280,13 +312,16 @@ fn workspace_edit_resolves_relative_mount() {
             },
         )
         .unwrap();
+    editor.save().unwrap();
 
+    // Now edit it
     let original_cwd = std::env::current_dir().unwrap();
     std::env::set_current_dir(temp.path()).unwrap();
 
     let mount = parse_mount_spec_resolved("jackin-dev").unwrap();
 
-    let result = config.edit_workspace(
+    let mut editor2 = ConfigEditor::open(&paths).unwrap();
+    let result = editor2.edit_workspace(
         "jackin",
         WorkspaceEdit {
             upsert_mounts: vec![mount.clone()],
@@ -297,6 +332,7 @@ fn workspace_edit_resolves_relative_mount() {
     std::env::set_current_dir(original_cwd).unwrap();
 
     result.unwrap();
+    let config = editor2.save().unwrap();
     let ws = config.workspaces.get("jackin").unwrap();
     assert_eq!(ws.mounts.len(), 2);
     assert!(ws.mounts[1].src.starts_with('/'));
@@ -307,6 +343,8 @@ fn workspace_edit_resolves_relative_mount() {
 /// auto-mounted workdir after workspace creation.
 #[test]
 fn workspace_edit_no_workdir_mount_removes_auto_mount() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let workdir_dir = temp.path().join("my-app");
     let extra_dir = temp.path().join("extra");
@@ -316,9 +354,9 @@ fn workspace_edit_no_workdir_mount_removes_auto_mount() {
     let workdir_abs = workdir_dir.display().to_string();
     let extra_abs = extra_dir.display().to_string();
 
-    let mut config = config::AppConfig::default();
     // Create workspace with auto-mounted workdir + an extra mount
-    config
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "my-app",
             WorkspaceConfig {
@@ -343,11 +381,12 @@ fn workspace_edit_no_workdir_mount_removes_auto_mount() {
             },
         )
         .unwrap();
-
-    assert_eq!(config.workspaces.get("my-app").unwrap().mounts.len(), 2);
+    let config_before = editor.save().unwrap();
+    assert_eq!(config_before.workspaces.get("my-app").unwrap().mounts.len(), 2);
 
     // Now remove the workdir auto-mount
-    config
+    let mut editor2 = ConfigEditor::open(&paths).unwrap();
+    editor2
         .edit_workspace(
             "my-app",
             WorkspaceEdit {
@@ -357,6 +396,7 @@ fn workspace_edit_no_workdir_mount_removes_auto_mount() {
         )
         .unwrap();
 
+    let config = editor2.save().unwrap();
     let ws = config.workspaces.get("my-app").unwrap();
     assert_eq!(ws.mounts.len(), 1, "auto-mount should be removed");
     assert_eq!(ws.mounts[0].dst, workdir_abs.clone() + "/extra");
@@ -365,15 +405,17 @@ fn workspace_edit_no_workdir_mount_removes_auto_mount() {
 /// `--no-workdir-mount` on edit should fail if there is no auto-mounted workdir.
 #[test]
 fn workspace_edit_no_workdir_mount_fails_when_no_auto_mount() {
+    let (_temp_home, paths) = bootstrap_paths();
+
     let temp = tempfile::tempdir().unwrap();
     let src_dir = temp.path().join("src");
     std::fs::create_dir_all(&src_dir).unwrap();
 
     let src_abs = src_dir.display().to_string();
 
-    let mut config = config::AppConfig::default();
     // Create workspace that was originally made with --no-workdir-mount
-    config
+    let mut editor = ConfigEditor::open(&paths).unwrap();
+    editor
         .create_workspace(
             "monorepo",
             WorkspaceConfig {
@@ -391,8 +433,10 @@ fn workspace_edit_no_workdir_mount_fails_when_no_auto_mount() {
             },
         )
         .unwrap();
+    editor.save().unwrap();
 
-    let err = config
+    let mut editor2 = ConfigEditor::open(&paths).unwrap();
+    let err = editor2
         .edit_workspace(
             "monorepo",
             WorkspaceEdit {
@@ -407,3 +451,4 @@ fn workspace_edit_no_workdir_mount_fails_when_no_auto_mount() {
         "expected clear error, got: {err}"
     );
 }
+


### PR DESCRIPTION
Implements the spec at `docs/superpowers/specs/2026-04-23-toml-edit-migration-design.md` (merged in #160).

**Series:** **PR 1 of 3 — this PR** · PR 2 of 3 — workspace manager TUI (#166) · PR 3 of 3 — Environments tab + 1Password picker (#171)

- New `ConfigEditor` in `src/config/editor.rs` owns a `toml_edit::DocumentMut` and exposes typed setters for every mutation the app performs. Reads still use `AppConfig::load_or_init` (serde + `toml`); writes go through `ConfigEditor::open → mutate → save`.
- `AppConfig::save` is removed; the in-memory mutators (`trust_agent`, `add_mount`, `create_workspace`, etc.) are deleted or demoted to `pub(crate)`. Nothing outside `src/config/` can change persisted state except through the editor.
- 13 call sites migrated across `src/app/mod.rs` (10), `src/app/context.rs`, `src/runtime/launch.rs`, and `src/config/persist.rs` (load-time migrations).
- User-written comments, blank lines, and key ordering now survive every programmatic save.

## What the plan specced vs. what shipped

Five deviations from the written plan emerged during execution and are worth flagging:

1. **`ConfigEditor::save` doesn't call `load_or_init`.** The plan's original code would have created a `save → load_or_init → sync_builtin_agents → AppConfig::save` cycle. `save()` uses `toml::from_str` directly and documents the validation-bypass invariant (validation runs at load, the editor's typed setters preserve validity).
2. **Mount nesting order** — the plan had `[docker.mounts.<name>.<scope>]`; the real `AppConfig::add_mount` uses `[docker.mounts.<scope>.<name>]`. Fixed during Task 7; tests pin the correct shape.
3. **`remove_mount` cleans up empty scope tables** to match `AppConfig::remove_mount`'s behavior — the plan omitted this branch.
4. **`create_workspace` delegates to `AppConfig::create_workspace`** for the workdir/mount validation, matching `edit_workspace`'s pattern. Without this, the CLI migration would have silently lost validation.
5. **`load_or_init` bootstrap save is gated on `!file.exists()`** — the implementer's first pass ran an unconditional lossy save before opening the editor, destroying user comments on upgrade. Regression test `load_migration_preserves_user_comments` pins the fix.

There's also one forward-looking method (`upsert_agent_source`) that wasn't in the original spec but emerged as necessary because `resolve_agent_source` mutates in-memory `AppConfig` before the editor opens.

## Behavioral improvement noted

`AppConfig::sync_builtin_agents` (serde path) clears `[agents.X.env]` whenever it updates a builtin entry (constructs a fresh `AgentSource` with empty env). `ConfigEditor::upsert_builtin_agent` preserves env. The final `config = editor.save()?;` in `load_or_init` means operators now keep their `[agents.X.env]` across builtin syncs — previously, updating a builtin's git URL (or first-run registration) silently wiped operator-owned env overrides.

## Test plan

- [ ] `cargo test -p jackin --all-targets` — all 533 tests green
- [ ] `cargo clippy -p jackin --all-targets -- -D warnings` — clean
- [ ] Comment-preservation smoke tests pass in `src/config/editor.rs`
- [ ] `load_migration_preserves_user_comments` in `src/config/persist.rs` (regression for the bootstrap-gate fix)
- [ ] Manual smoke: hand-written `# comment` in `~/.config/jackin/config.toml` survives a `jackin config mount add` or any other save-triggering command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)