### PR TITLE
feat(cli): env-var management verbs for all four scopes

### DIFF
--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -121,3 +121,69 @@ Show the current authentication forwarding mode.
 jackin config auth show
 jackin config auth show --agent agent-smith
 ```
+
+## `config env`
+
+Manage operator env vars at global and per-agent scope.
+
+Values are stored verbatim — whatever you type is what goes into the TOML. No editor-side validation of key names or value shape. jackin' resolves values at launch time through the operator-env layer, so `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work.
+
+Without `--agent`, writes and reads target the global `[env]` table. With `--agent <SELECTOR>`, they target `[agents.<SELECTOR>.env]`. The agent selector is not pre-validated — the table path is written even if the agent is not registered, matching how `config auth set --agent` behaves.
+
+### `config env set`
+
+```bash
+jackin config env set <KEY> <VALUE> [OPTIONS]
+```
+
+Set or overwrite an env var at the chosen scope.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Apply to `[agents.<SELECTOR>.env]` instead of the global `[env]` |
+| `--comment <TEXT>` | Write a TOML line comment directly above the key |
+
+```bash
+# Global scope — 1Password reference
+jackin config env set API_TOKEN "op://Personal/api/token"
+
+# Per-agent override
+jackin config env set LOG_LEVEL debug --agent agent-smith
+
+# Attach a comment (useful for rotation reminders)
+jackin config env set OPENAI_KEY "op://Work/OpenAI/key" --comment "rotate quarterly"
+```
+
+### `config env unset`
+
+```bash
+jackin config env unset <KEY> [OPTIONS]
+```
+
+Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without modifying the config file.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Unset from `[agents.<SELECTOR>.env]` instead of the global `[env]` |
+
+```bash
+jackin config env unset API_TOKEN
+jackin config env unset LOG_LEVEL --agent agent-smith
+```
+
+### `config env list`
+
+```bash
+jackin config env list [OPTIONS]
+```
+
+Show the env vars registered at the chosen scope as a table with `Key` and `Value` columns. Prints `No env vars set.` when the scope is empty. Values are shown as-stored (no resolution, no masking).
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | List vars from `[agents.<SELECTOR>.env]` instead of the global `[env]` |
+
+```bash
+jackin config env list
+jackin config env list --agent agent-smith
+```

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -131,3 +131,69 @@ jackin workspace prune my-app --yes  # non-interactive
 ```
 
 Under rule C, a mount is redundant when another mount in the same workspace strictly covers it at the same container location — same host-to-container offset. See [Redundant-mount invariant](../guides/mounts.mdx#redundant-mount-invariant) in the mounts guide.
+
+## `workspace env`
+
+Manage operator env vars at workspace and workspace-agent scope.
+
+Values are stored verbatim — `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work. jackin' resolves values at launch time through the operator-env layer; there is no editor-side validation of key names or value shape.
+
+Without `--agent`, writes and reads target `[workspaces.<WORKSPACE>.env]`. With `--agent <SELECTOR>`, they target `[workspaces.<WORKSPACE>.agents.<SELECTOR>.env]`. The workspace must already exist — unknown workspaces fail fast with a non-zero exit. The agent selector is not pre-validated.
+
+### `workspace env set`
+
+```bash
+jackin workspace env set <WORKSPACE> <KEY> <VALUE> [OPTIONS]
+```
+
+Set or overwrite an env var at the chosen scope.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Apply to `[workspaces.<WORKSPACE>.agents.<SELECTOR>.env]` instead of the workspace-wide table |
+| `--comment <TEXT>` | Write a TOML line comment directly above the key |
+
+```bash
+# Workspace scope
+jackin workspace env set prod DB_URL "op://Work/Prod/db-url"
+
+# Workspace-agent scope
+jackin workspace env set prod OPENAI_KEY "op://Work/OpenAI/key" --agent agent-smith
+
+# Attach a comment
+jackin workspace env set prod DEBUG "1" --comment "temporary; remove after Q2"
+```
+
+### `workspace env unset`
+
+```bash
+jackin workspace env unset <WORKSPACE> <KEY> [OPTIONS]
+```
+
+Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without modifying the config file. Fails fast if `<WORKSPACE>` does not exist.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | Unset from `[workspaces.<WORKSPACE>.agents.<SELECTOR>.env]` instead of the workspace-wide table |
+
+```bash
+jackin workspace env unset prod DB_URL
+jackin workspace env unset prod OPENAI_KEY --agent agent-smith
+```
+
+### `workspace env list`
+
+```bash
+jackin workspace env list <WORKSPACE> [OPTIONS]
+```
+
+Show the env vars registered at the chosen scope as a table with `Key` and `Value` columns. Prints `No env vars set.` when the scope is empty. Values are shown as-stored (no resolution, no masking). Fails fast if `<WORKSPACE>` does not exist.
+
+| Option | Description |
+|---|---|
+| `--agent <SELECTOR>` | List vars from `[workspaces.<WORKSPACE>.agents.<SELECTOR>.env]` instead of the workspace-wide table |
+
+```bash
+jackin workspace env list prod
+jackin workspace env list prod --agent agent-smith
+```

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -364,6 +364,63 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
             },
+            cli::ConfigCommand::Env(env_cmd) => match env_cmd {
+                cli::EnvCommand::Set {
+                    key,
+                    value,
+                    agent,
+                    comment,
+                } => {
+                    if key.is_empty() {
+                        anyhow::bail!("env var key cannot be empty");
+                    }
+                    let scope = agent.map_or(config::EnvScope::Global, config::EnvScope::Agent);
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    editor.set_env_var(&scope, &key, &value);
+                    if let Some(ref c) = comment {
+                        editor.set_env_comment(&scope, &key, Some(c));
+                    }
+                    editor.save()?;
+                    println!("Set {key}.");
+                    Ok(())
+                }
+                cli::EnvCommand::Unset { key, agent } => {
+                    if key.is_empty() {
+                        anyhow::bail!("env var key cannot be empty");
+                    }
+                    let scope = agent.map_or(config::EnvScope::Global, config::EnvScope::Agent);
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    if editor.remove_env_var(&scope, &key) {
+                        editor.save()?;
+                        println!("Removed {key}.");
+                    } else {
+                        drop(editor);
+                        println!("{key} not set.");
+                    }
+                    Ok(())
+                }
+                cli::EnvCommand::List { agent } => {
+                    let vars: Vec<(String, String)> = agent.as_ref().map_or_else(
+                        || {
+                            config
+                                .env
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect()
+                        },
+                        |a| {
+                            config.agents.get(a).map_or_else(Vec::new, |src| {
+                                src.env
+                                    .iter()
+                                    .map(|(k, v)| (k.clone(), v.clone()))
+                                    .collect()
+                            })
+                        },
+                    );
+                    print_env_table(&vars);
+                    Ok(())
+                }
+            },
         },
         Command::Workspace(command) => match command {
             WorkspaceCommand::Create {
@@ -746,6 +803,62 @@ pub fn run(cli: Cli) -> Result<()> {
                 println!("Removed workspace {name:?}.");
                 Ok(())
             }
+            WorkspaceCommand::Env(env_cmd) => match env_cmd {
+                cli::WorkspaceEnvCommand::Set {
+                    workspace,
+                    key,
+                    value,
+                    agent,
+                    comment,
+                } => {
+                    if key.is_empty() {
+                        anyhow::bail!("env var key cannot be empty");
+                    }
+                    config.require_workspace(&workspace)?;
+                    let scope = workspace_env_scope(workspace, agent);
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    editor.set_env_var(&scope, &key, &value);
+                    if let Some(ref c) = comment {
+                        editor.set_env_comment(&scope, &key, Some(c));
+                    }
+                    editor.save()?;
+                    println!("Set {key}.");
+                    Ok(())
+                }
+                cli::WorkspaceEnvCommand::Unset {
+                    workspace,
+                    key,
+                    agent,
+                } => {
+                    if key.is_empty() {
+                        anyhow::bail!("env var key cannot be empty");
+                    }
+                    config.require_workspace(&workspace)?;
+                    let scope = workspace_env_scope(workspace, agent);
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    if editor.remove_env_var(&scope, &key) {
+                        editor.save()?;
+                        println!("Removed {key}.");
+                    } else {
+                        drop(editor);
+                        println!("{key} not set.");
+                    }
+                    Ok(())
+                }
+                cli::WorkspaceEnvCommand::List { workspace, agent } => {
+                    let ws = config.require_workspace(&workspace)?;
+                    let vars: Vec<(String, String)> = agent.as_ref().map_or_else(
+                        || ws.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                        |a| {
+                            ws.agents.get(a).map_or_else(Vec::new, |ov| {
+                                ov.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                            })
+                        },
+                    );
+                    print_env_table(&vars);
+                    Ok(())
+                }
+            },
         },
         Command::Purge(PurgeArgs { selector, all }) => match Selector::parse(&selector)? {
             Selector::Container(container) => {
@@ -766,6 +879,43 @@ pub fn run(cli: Cli) -> Result<()> {
             }
         },
     }
+}
+
+fn workspace_env_scope(workspace: String, agent: Option<String>) -> config::EnvScope {
+    match agent {
+        Some(a) => config::EnvScope::WorkspaceAgent {
+            workspace,
+            agent: a,
+        },
+        None => config::EnvScope::Workspace(workspace),
+    }
+}
+
+#[derive(tabled::Tabled)]
+struct EnvRow {
+    #[tabled(rename = "Key")]
+    key: String,
+    #[tabled(rename = "Value")]
+    value: String,
+}
+
+fn print_env_table(vars: &[(String, String)]) {
+    use tabled::Table;
+    use tabled::settings::Style;
+    if vars.is_empty() {
+        println!("No env vars set.");
+        return;
+    }
+    let rows: Vec<EnvRow> = vars
+        .iter()
+        .map(|(k, v)| EnvRow {
+            key: k.clone(),
+            value: v.clone(),
+        })
+        .collect();
+    let mut table = Table::new(rows);
+    table.with(Style::modern_rounded());
+    println!("{table}");
 }
 
 fn remove_data_dir_if_exists(path: &Path) -> Result<()> {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -13,6 +13,73 @@ pub enum ConfigCommand {
     /// Manage Claude Code authentication forwarding from host
     #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
     Auth(AuthCommand),
+    /// Manage operator env vars at global and per-agent scope
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    Env(EnvCommand),
+}
+
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum EnvCommand {
+    /// Set an env var at global or per-agent scope
+    ///
+    /// Without `--agent`, writes to the global `[env]` table. With
+    /// `--agent <SELECTOR>`, writes to `[agents.<selector>.env]`. The agent
+    /// selector is not pre-validated — the table path is written regardless
+    /// of whether that agent is registered, matching `config auth set`.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config env set API_TOKEN \"op://Personal/api/token\"
+  jackin config env set LOG_LEVEL debug --agent agent-smith
+  jackin config env set OPENAI_KEY \"op://Work/OpenAI/key\" --comment \"rotate quarterly\""
+    )]
+    Set {
+        /// Env var name (stored verbatim; no POSIX validation)
+        key: String,
+        /// Env var value (use `op://...`, `$VAR`, `${VAR}`, or literal)
+        value: String,
+        /// Apply to a specific agent instead of globally
+        #[arg(long)]
+        agent: Option<String>,
+        /// Write a TOML comment line above the key
+        #[arg(long)]
+        comment: Option<String>,
+    },
+    /// Unset an env var at global or per-agent scope
+    ///
+    /// Idempotent: if the key is not present, prints "KEY not set." and
+    /// exits 0 without saving the config.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config env unset API_TOKEN
+  jackin config env unset LOG_LEVEL --agent agent-smith"
+    )]
+    Unset {
+        /// Env var name to remove
+        key: String,
+        /// Unset from a specific agent instead of globally
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    /// List env vars at global or per-agent scope
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin config env list
+  jackin config env list --agent agent-smith"
+    )]
+    List {
+        /// List vars for a specific agent instead of the global scope
+        #[arg(long)]
+        agent: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,8 +35,8 @@ pub mod config;
 pub mod dispatch;
 pub mod workspace;
 
-pub use config::{AuthCommand, ConfigCommand, MountCommand, TrustCommand};
-pub use workspace::WorkspaceCommand;
+pub use config::{AuthCommand, ConfigCommand, EnvCommand, MountCommand, TrustCommand};
+pub use workspace::{WorkspaceCommand, WorkspaceEnvCommand};
 
 /// Operator's CLI for orchestrating AI coding agents in isolated containers
 ///

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -135,6 +135,78 @@ Examples:
         /// Name of the workspace to delete
         name: String,
     },
+    /// Manage operator env vars at workspace and workspace-agent scope
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    Env(WorkspaceEnvCommand),
+}
+
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum WorkspaceEnvCommand {
+    /// Set an env var at workspace or workspace-agent scope
+    ///
+    /// Without `--agent`, writes to `[workspaces.<workspace>.env]`. With
+    /// `--agent <SELECTOR>`, writes to `[workspaces.<workspace>.agents.<selector>.env]`.
+    /// The agent selector is not pre-validated.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin workspace env set prod DB_URL \"op://Work/Prod/db-url\"
+  jackin workspace env set prod OPENAI_KEY \"op://Work/OpenAI/key\" --agent agent-smith
+  jackin workspace env set prod DEBUG \"1\" --comment \"temporary; remove after Q2\""
+    )]
+    Set {
+        /// Workspace name
+        workspace: String,
+        /// Env var name (stored verbatim; no POSIX validation)
+        key: String,
+        /// Env var value (use `op://...`, `$VAR`, `${VAR}`, or literal)
+        value: String,
+        /// Apply to a specific agent inside this workspace
+        #[arg(long)]
+        agent: Option<String>,
+        /// Write a TOML comment line above the key
+        #[arg(long)]
+        comment: Option<String>,
+    },
+    /// Unset an env var at workspace or workspace-agent scope
+    ///
+    /// Idempotent: if the key is not present, prints "KEY not set." and
+    /// exits 0 without saving the config.
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin workspace env unset prod DB_URL
+  jackin workspace env unset prod OPENAI_KEY --agent agent-smith"
+    )]
+    Unset {
+        /// Workspace name
+        workspace: String,
+        /// Env var name to remove
+        key: String,
+        /// Unset from a specific agent inside this workspace
+        #[arg(long)]
+        agent: Option<String>,
+    },
+    /// List env vars at workspace or workspace-agent scope
+    #[command(
+        before_help = BANNER,
+        styles = HELP_STYLES,
+        after_long_help = "\
+Examples:
+  jackin workspace env list prod
+  jackin workspace env list prod --agent agent-smith"
+    )]
+    List {
+        /// Workspace name
+        workspace: String,
+        /// List vars for a specific agent inside this workspace
+        #[arg(long)]
+        agent: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -621,6 +621,123 @@ OTHER = "y"
     }
 
     #[test]
+    fn remove_env_var_agent_scope() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[agents.agent-smith]
+git = "https://example.com/a.git"
+"#,
+        )
+        .unwrap();
+
+        let scope = EnvScope::Agent("agent-smith".to_string());
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(&scope, "LOG_LEVEL", "debug");
+        assert!(
+            editor.remove_env_var(&scope, "LOG_LEVEL"),
+            "first remove should return true"
+        );
+        assert!(
+            !editor.remove_env_var(&scope, "LOG_LEVEL"),
+            "second remove should return false"
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("LOG_LEVEL"), "key not purged: {out}");
+    }
+
+    #[test]
+    fn remove_env_var_workspace_scope() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[workspaces.prod]
+workdir = "/workspace/prod"
+"#,
+        )
+        .unwrap();
+
+        let scope = EnvScope::Workspace("prod".to_string());
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(&scope, "DB_URL", "op://Work/Prod/db-url");
+        assert!(
+            editor.remove_env_var(&scope, "DB_URL"),
+            "first remove should return true"
+        );
+        assert!(
+            !editor.remove_env_var(&scope, "DB_URL"),
+            "second remove should return false"
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("DB_URL"), "key not purged: {out}");
+    }
+
+    #[test]
+    fn remove_env_var_workspace_agent_scope() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[workspaces.prod]
+workdir = "/workspace/prod"
+"#,
+        )
+        .unwrap();
+
+        let scope = EnvScope::WorkspaceAgent {
+            workspace: "prod".to_string(),
+            agent: "agent-smith".to_string(),
+        };
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(&scope, "OPENAI_API_KEY", "op://Work/OpenAI/default");
+        assert!(
+            editor.remove_env_var(&scope, "OPENAI_API_KEY"),
+            "first remove should return true"
+        );
+        assert!(
+            !editor.remove_env_var(&scope, "OPENAI_API_KEY"),
+            "second remove should return false"
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("OPENAI_API_KEY"), "key not purged: {out}");
+    }
+
+    #[test]
+    fn remove_env_var_leaves_sibling_keys_intact() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_env_var(&EnvScope::Global, "KEY_A", "value-a");
+        editor.set_env_var(&EnvScope::Global, "KEY_B", "value-b");
+        editor.save().unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        assert!(editor.remove_env_var(&EnvScope::Global, "KEY_A"));
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!out.contains("KEY_A"), "KEY_A still present: {out}");
+        assert!(
+            out.contains(r#"KEY_B = "value-b""#),
+            "sibling KEY_B gone: {out}"
+        );
+    }
+
+    #[test]
     fn set_env_comment_adds_line_above_key() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());

--- a/tests/cli_env.rs
+++ b/tests/cli_env.rs
@@ -1,0 +1,268 @@
+#![cfg(unix)]
+
+//! Integration coverage for the `jackin config env` and
+//! `jackin workspace env` CLI verbs.
+//!
+//! These tests exercise the real binary end-to-end under a temp `$HOME`
+//! so the config file lives at `$HOME/.config/jackin/config.toml`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::{TempDir, tempdir};
+
+struct Env {
+    _temp: TempDir,
+    home: PathBuf,
+}
+
+fn setup_env() -> Env {
+    let temp = tempdir().unwrap();
+    let home = temp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    Env { _temp: temp, home }
+}
+
+fn jackin(env: &Env) -> Command {
+    let mut cmd = Command::cargo_bin("jackin").unwrap();
+    cmd.env("HOME", &env.home);
+    cmd
+}
+
+fn config_path(env: &Env) -> PathBuf {
+    env.home.join(".config/jackin/config.toml")
+}
+
+fn read_config(env: &Env) -> String {
+    fs::read_to_string(config_path(env)).unwrap()
+}
+
+/// Seed an agent entry in the config file so `[agents.<name>.env]` writes
+/// sit underneath a fully-formed agent table (the `git` field is required
+/// by `AgentSource` serde parsing).
+fn seed_agent(env: &Env, name: &str) {
+    let path = config_path(env);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let entry = format!("\n[agents.{name}]\ngit = \"https://example.com/{name}.git\"\n");
+    fs::write(&path, format!("{existing}{entry}")).unwrap();
+}
+
+fn seed_workspace(env: &Env, name: &str, workdir: &str) {
+    // Use the create command itself so the config shape is authoritative.
+    fs::create_dir_all(workdir).unwrap();
+    jackin(env)
+        .args(["workspace", "create", name, "--workdir", workdir])
+        .assert()
+        .success();
+}
+
+#[test]
+fn config_env_set_global() {
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "config",
+            "env",
+            "set",
+            "API_TOKEN",
+            "op://Personal/api/token",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Set API_TOKEN."));
+    let contents = read_config(&env);
+    assert!(
+        contents.contains("[env]"),
+        "missing [env] table:\n{contents}"
+    );
+    assert!(
+        contents.contains("API_TOKEN = \"op://Personal/api/token\""),
+        "missing API_TOKEN entry:\n{contents}"
+    );
+}
+
+#[test]
+fn config_env_set_with_agent() {
+    let env = setup_env();
+    seed_agent(&env, "agent-smith");
+    jackin(&env)
+        .args([
+            "config",
+            "env",
+            "set",
+            "LOG_LEVEL",
+            "debug",
+            "--agent",
+            "agent-smith",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Set LOG_LEVEL."));
+    let contents = read_config(&env);
+    assert!(
+        contents.contains("[agents.agent-smith.env]"),
+        "missing [agents.agent-smith.env]:\n{contents}"
+    );
+    assert!(
+        contents.contains("LOG_LEVEL = \"debug\""),
+        "missing LOG_LEVEL entry:\n{contents}"
+    );
+}
+
+#[test]
+fn config_env_set_with_comment() {
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "config",
+            "env",
+            "set",
+            "OPENAI_KEY",
+            "op://Work/OpenAI/key",
+            "--comment",
+            "rotate quarterly",
+        ])
+        .assert()
+        .success();
+    let contents = read_config(&env);
+    // The comment line must appear above the key within the file.
+    let comment_pos = contents
+        .find("# rotate quarterly")
+        .unwrap_or_else(|| panic!("missing comment line:\n{contents}"));
+    let key_pos = contents
+        .find("OPENAI_KEY")
+        .unwrap_or_else(|| panic!("missing key:\n{contents}"));
+    assert!(
+        comment_pos < key_pos,
+        "comment must precede key; got:\n{contents}"
+    );
+}
+
+#[test]
+fn config_env_unset_removes_key() {
+    let env = setup_env();
+    jackin(&env)
+        .args(["config", "env", "set", "FOO", "bar"])
+        .assert()
+        .success();
+    jackin(&env)
+        .args(["config", "env", "unset", "FOO"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed FOO."));
+    let contents = read_config(&env);
+    assert!(
+        !contents.contains("FOO"),
+        "FOO should be absent after unset; got:\n{contents}"
+    );
+}
+
+#[test]
+fn config_env_unset_missing_key_exits_0() {
+    let env = setup_env();
+    jackin(&env)
+        .args(["config", "env", "unset", "NO_SUCH_KEY"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("NO_SUCH_KEY not set."));
+}
+
+#[test]
+fn config_env_list_empty() {
+    let env = setup_env();
+    jackin(&env)
+        .args(["config", "env", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No env vars set."));
+}
+
+#[test]
+fn config_env_list_shows_keys() {
+    let env = setup_env();
+    jackin(&env)
+        .args(["config", "env", "set", "ALPHA", "one"])
+        .assert()
+        .success();
+    jackin(&env)
+        .args(["config", "env", "set", "BETA", "two"])
+        .assert()
+        .success();
+    jackin(&env)
+        .args(["config", "env", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ALPHA"))
+        .stdout(predicate::str::contains("BETA"))
+        .stdout(predicate::str::contains("one"))
+        .stdout(predicate::str::contains("two"));
+}
+
+#[test]
+fn workspace_env_set_workspace_scope() {
+    let env = setup_env();
+    let workdir = env.home.join("Projects/prod");
+    seed_workspace(&env, "prod", workdir.to_str().unwrap());
+    jackin(&env)
+        .args([
+            "workspace",
+            "env",
+            "set",
+            "prod",
+            "DB_URL",
+            "op://Work/Prod/db-url",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Set DB_URL."));
+    let contents = read_config(&env);
+    assert!(
+        contents.contains("[workspaces.prod.env]"),
+        "missing [workspaces.prod.env]:\n{contents}"
+    );
+    assert!(
+        contents.contains("DB_URL = \"op://Work/Prod/db-url\""),
+        "missing DB_URL entry:\n{contents}"
+    );
+}
+
+#[test]
+fn workspace_env_set_workspace_agent_scope() {
+    let env = setup_env();
+    let workdir = env.home.join("Projects/prod");
+    seed_workspace(&env, "prod", workdir.to_str().unwrap());
+    jackin(&env)
+        .args([
+            "workspace",
+            "env",
+            "set",
+            "prod",
+            "OPENAI_KEY",
+            "op://Work/OpenAI/key",
+            "--agent",
+            "agent-smith",
+        ])
+        .assert()
+        .success();
+    let contents = read_config(&env);
+    assert!(
+        contents.contains("[workspaces.prod.agents.agent-smith.env]"),
+        "missing [workspaces.prod.agents.agent-smith.env]:\n{contents}"
+    );
+    assert!(
+        contents.contains("OPENAI_KEY = \"op://Work/OpenAI/key\""),
+        "missing OPENAI_KEY entry:\n{contents}"
+    );
+}
+
+#[test]
+fn workspace_env_list_unknown_workspace_exits_nonzero() {
+    let env = setup_env();
+    jackin(&env)
+        .args(["workspace", "env", "list", "no-such-ws"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no-such-ws"));
+}


### PR DESCRIPTION
## Summary

Adds `jackin config env {set,unset,list}` (Global and per-Agent scopes) and `jackin workspace env {set,unset,list}` (Workspace and per-WorkspaceAgent scopes), exposing the full four-scope `EnvScope` surface that `ConfigEditor::set_env_var` and `ConfigEditor::remove_env_var` already implement.

This is a deliberate **CLI-first prerequisite** for Stage 3 (Secrets tab) of the workspace-manager-TUI series. Per the standing rule that the operator console is simplified and CLI carries the full feature surface, the TUI must not be the first interface for env management — this PR closes that gap.

## What's inside

| Commit | Subject |
|---|---|
| `510990df` | `test(config):` cover all EnvScope variants in `remove_env_var` unit tests |
| `c336469a` | `feat(cli):` add env-var management verbs for all four scopes |
| `fc233e18` | `docs(commands):` document `config env` and `workspace env` verbs |

**Routing:**
- `config env [--agent X]` → Global / Agent scopes
- `workspace env <WS> [--agent X]` → Workspace / WorkspaceAgent scopes

**No new dependencies.** `ConfigEditor::remove_env_var` already returns `bool` with the right semantics — `unset` is wired directly with idempotent "not set" output and exit 0 on missing keys.

**Tests:**
- 5 new editor unit tests covering all four `EnvScope` variants on `remove_env_var`
- 10 new integration tests in `tests/cli_env.rs` (the first end-to-end CLI test file in the repo; uses `assert_cmd`/`predicates` already in dev-deps)
- Full suite: 843 passing, no regressions

## Out of scope

- TUI Secrets tab (Stage 3, follow-on PR)
- Value masking, validation of `op://` references, POSIX env-name rules
- `[docker.mounts]` global mount management
- `CHANGELOG.md` (operator curates manually)

## Test plan

- [x] `cargo nextest run -p jackin` — 843 passed
- [x] `cargo nextest run -p jackin --test cli_env` — 10/10 pass
- [x] `cargo clippy -- -D warnings` — clean (CI gate)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo build --all-targets` — clean
- [x] `bun run build` (docs) — 45 pages built, no warnings
- [ ] Manual smoke: `jackin config env set FOO bar`, `--agent`, `--comment`, `unset`, `list` across both parents