### PR TITLE
ci(docs): bump lychee-action and lychee for sitemap URL extraction

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,11 +15,17 @@ env:
   DOCS_SITE_URL: https://jackin.tailrocks.com
   JACKIN_REPO_BLOB_URL: https://github.com/jackin-project/jackin/blob/main
   JACKIN_REPO_EDIT_URL: https://github.com/jackin-project/jackin/edit/main
-  # Pinned past lychee-action's v0.23.0 default because v0.24.0 is the first
+  # Pinned past lychee-action's v0.23.0 default because v0.24.x is the first
   # release that extracts <loc> URLs from XML sitemaps (lycheeverse/lychee#2071,
   # released 2026-04-24). The deploy and check-deployed jobs need that to feed
-  # `--files-from lychee/deployed-pages.txt`. Bump in lockstep across the file.
-  LYCHEE_VERSION: 'v0.24.0'
+  # `--files-from lychee/deployed-pages.txt`.
+  #
+  # Using v0.24.1 specifically: lychee v0.24.0 ships its release tarball with a
+  # newly-added top-level subfolder, which lychee-action v2.8.0 cannot extract.
+  # v0.24.1 keeps the flat tarball layout AND keeps the sitemap fix. The action
+  # SHA above is post-v2.8.0 master (faea714) which adds subfolder-aware install
+  # — required for any future v0.24.0+ rollback. Bump in lockstep across the file.
+  LYCHEE_VERSION: 'v0.24.1'
 
 concurrency:
   group: pages-${{ github.event_name }}-${{ github.ref }}
@@ -60,7 +66,7 @@ jobs:
             lychee-${{ runner.os }}-${{ github.workflow }}-
 
       - name: Check built site links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@faea714062690f6c2e6f7f388469ec4fa6d9c4e1 # master, post-v2.8.0 (subfolder-aware install)
         with:
           lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-
@@ -116,7 +122,7 @@ jobs:
         run: mkdir -p lychee
 
       - name: Collect deployed docs URLs
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@faea714062690f6c2e6f7f388469ec4fa6d9c4e1 # master, post-v2.8.0 (subfolder-aware install)
         with:
           lycheeVersion: ${{ env.LYCHEE_VERSION }}
           output: lychee/deployed-pages.txt
@@ -126,7 +132,7 @@ jobs:
           fail: true
 
       - name: Check deployed docs links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@faea714062690f6c2e6f7f388469ec4fa6d9c4e1 # master, post-v2.8.0 (subfolder-aware install)
         with:
           lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-
@@ -170,7 +176,7 @@ jobs:
         run: mkdir -p lychee
 
       - name: Collect deployed docs URLs
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@faea714062690f6c2e6f7f388469ec4fa6d9c4e1 # master, post-v2.8.0 (subfolder-aware install)
         with:
           lycheeVersion: ${{ env.LYCHEE_VERSION }}
           output: lychee/deployed-pages.txt
@@ -180,7 +186,7 @@ jobs:
           fail: true
 
       - name: Check deployed docs links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        uses: lycheeverse/lychee-action@faea714062690f6c2e6f7f388469ec4fa6d9c4e1 # master, post-v2.8.0 (subfolder-aware install)
         with:
           lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,11 @@ env:
   DOCS_SITE_URL: https://jackin.tailrocks.com
   JACKIN_REPO_BLOB_URL: https://github.com/jackin-project/jackin/blob/main
   JACKIN_REPO_EDIT_URL: https://github.com/jackin-project/jackin/edit/main
+  # Pinned past lychee-action's v0.23.0 default because v0.24.0 is the first
+  # release that extracts <loc> URLs from XML sitemaps (lycheeverse/lychee#2071,
+  # released 2026-04-24). The deploy and check-deployed jobs need that to feed
+  # `--files-from lychee/deployed-pages.txt`. Bump in lockstep across the file.
+  LYCHEE_VERSION: 'v0.24.0'
 
 concurrency:
   group: pages-${{ github.event_name }}-${{ github.ref }}
@@ -57,6 +62,7 @@ jobs:
       - name: Check built site links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-
             --config docs/lychee.toml
             --include-fragments
@@ -112,6 +118,7 @@ jobs:
       - name: Collect deployed docs URLs
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
           output: lychee/deployed-pages.txt
           args: >-
             --dump
@@ -121,6 +128,7 @@ jobs:
       - name: Check deployed docs links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-
             --config docs/lychee.toml
             --include-fragments
@@ -164,6 +172,7 @@ jobs:
       - name: Collect deployed docs URLs
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
           output: lychee/deployed-pages.txt
           args: >-
             --dump
@@ -173,6 +182,7 @@ jobs:
       - name: Check deployed docs links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
           args: >-
             --config docs/lychee.toml
             --include-fragments

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,10 @@ env:
   DOCS_SITE_URL: https://jackin.tailrocks.com
   JACKIN_REPO_BLOB_URL: https://github.com/jackin-project/jackin/blob/main
   JACKIN_REPO_EDIT_URL: https://github.com/jackin-project/jackin/edit/main
+  # TODO(lychee-action-sha-pin): swap the lycheeverse/lychee-action SHA back
+  # to a tagged release SHA once a tag at or after faea714 ships — see
+  # TODO.md "Follow-ups" → "lychee-action-sha-pin".
+  #
   # Pinned past lychee-action's v0.23.0 default because v0.24.x is the first
   # release that extracts <loc> URLs from XML sitemaps (lycheeverse/lychee#2071,
   # released 2026-04-24). The deploy and check-deployed jobs need that to feed


### PR DESCRIPTION
## Summary

Fix the failing `Docs / deploy` workflow on `main` (introduced by #173, [first failure run 24939646854](https://github.com/jackin-project/jackin/actions/runs/24939646854)) by bumping **both** `lycheeverse/lychee-action` and the lychee binary version it installs. Either bump alone is insufficient.

## What broke and why

The `deploy` job's `Check deployed docs links` step exited with:

```
| 🔍 Total       | 0     |
No links were found. This usually indicates a configuration error.
```

The previous step (`Collect deployed docs URLs`) ran `lychee --dump <sitemap-url>` and produced an empty list. **lychee 0.23.0** — which `lycheeverse/lychee-action` v2.8.0 still installs by default — does not parse `<loc>` URLs out of XML sitemaps; its extractors only handle HTML `<a href>` and markdown links. So the dump silently emptied the file, and the follow-up `--files-from` step had nothing to read.

## What lychee already shipped

The bug was already fixed upstream **before** we hit it:

- lycheeverse/lychee#2062 — "Remote XML files are treated as HTML (including sitemap.xml)" (closed 2026-03-13)
- lycheeverse/lychee#1819 — "Parsing sitemaps not working" (closed 2026-03-13)
- lycheeverse/lychee#2071 — `feat: Support sitemap.xml` (PR by @cristiklein, merged 2026-03-13, fixes both above)
- lycheeverse/lychee `lychee-v0.24.0` (released 2026-04-24) — first release containing the fix

So no upstream feature request is needed. We just need to use a lychee version with the fix.

## Why the bump isn't trivial

The naive bump (`lycheeVersion: 'v0.24.0'` only, keeping `lycheeverse/lychee-action` pinned at `8646ba3` / v2.8.0) **does not work**. lychee 0.24.0 changed the release-asset shape in two ways the v2.8.0 action's installer can't handle:

1. **Filename renamed.** v0.23.0 ships `lychee-x86_64-unknown-linux-gnu.tar.gz`; v0.24.0 ships `lychee-lychee-v0.24.0-x86_64-unknown-linux-gnu.tar.gz`. The action hardcodes the old name.
2. **Tarball layout changed.** v0.23.0 had `lychee` at the tarball root; v0.24.x extracts to a `lychee-x86_64-...` subfolder. The action's `install -t .../bin -D /tmp/lychee-download/lychee` can't find it.

Lychee released **v0.24.1** the same day (2026-04-24) which reverted (1) — the asset filename is back to the flat name. But (2) still applies: v0.24.1 is also a subfolder tarball.

`lycheeverse/lychee-action` master picked up the fix in commit [`faea714`](https://github.com/lycheeverse/lychee-action/commit/faea714062690f6c2e6f7f388469ec4fa6d9c4e1) — "bump default to 0.24.1 and auto-detect lychee bin in subfolder (#330)" — but that commit is **not yet released** (latest tag remains v2.8.0).

So the only combination that actually works today is:

| Component | Version |
|---|---|
| lychee binary | `v0.24.1` (sitemap fix, flat asset name) |
| lychee-action | `faea714` (unreleased master, subfolder-aware install) |

## Fix in this PR

- Move all five `lycheeverse/lychee-action` SHA pins from `8646ba3` (v2.8.0) → `faea714` (master, post-v2.8.0).
- Add `LYCHEE_VERSION: 'v0.24.1'` at the workflow `env:` level.
- Add `lycheeVersion: ${{ env.LYCHEE_VERSION }}` to every action call so future bumps are one-line.

The action SHA is still pinned (security model unchanged); the binary version it downloads is parameterised. When `lycheeverse/lychee-action` cuts a tagged release after `faea714`, the SHA pin can be updated to a tagged release.

## Verified locally

```
$ lychee --version
lychee 0.24.1
$ lychee --dump https://jackin.tailrocks.com/sitemap-0.xml | wc -l
45
```

(45 URLs match the live sitemap.)

## Test plan

- [ ] CI `Docs / build` is green on this PR.
- [ ] After merge, the next `push` to `main` triggers `deploy` → `Collect deployed docs URLs` produces a non-empty `lychee/deployed-pages.txt` (≈45 URLs at the time of writing) → `Check deployed docs links` passes.
- [ ] After merge, manual `workflow_dispatch` triggers `check-deployed` with the same shape and goes green.

## Follow-ups

- Watch [`lycheeverse/lychee-action` releases](https://github.com/lycheeverse/lychee-action/releases) for a tagged version after `faea714`. When one lands, swap the SHA back to a release-tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
