### PR TITLE
docs(todo): track small follow-ups and external deps in TODO.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,4 +72,5 @@ Rules in the files below apply to everyone working in the repo — human and age
 - [TESTING.md](TESTING.md) — test runner setup and commands.
 - [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) — navigational map of the codebase, documentation site, Docker assets, and CI workflows.
 - [DEPRECATED.md](DEPRECATED.md) — ledger of deprecated APIs, CLIs, config values, and usage patterns that are still supported but should eventually be removed.
+- [TODO.md](TODO.md) — small follow-up items (especially upstream dependencies waiting on a fix), the per-PR stale-docs checklist, and the convention for code-level `TODO(<topic>)` markers that link back to this file.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contribution flow, DCO v1.1 text, and license terms for external contributors.

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -11,7 +11,7 @@ Quick navigation reference for AI agents working in this repository.
 | `AGENTS.md` | Shared instructions for all AI agents (testing, pre-commit, security) |
 | `CLAUDE.md` | Claude-specific pointer to `AGENTS.md` |
 | `RULES.md` | Project-wide conventions (docs go in `AGENTS.md`, not tool-specific files) |
-| `TODO.md` | Pointer to roadmap docs (full design docs live under `docs/src/content/docs/reference/roadmap/`) |
+| `TODO.md` | Small follow-ups (especially upstream-dependency tracking), per-PR stale-docs checklist, and `TODO(<topic>)` marker convention. Larger feature work lives under `docs/src/content/docs/reference/roadmap/` |
 | `TESTING.md` | Test runner setup, commands, and pre-commit requirements |
 | `release.toml` | Release configuration |
 | `mise.toml` | Tool version management (bun) |

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,55 @@
 # TODO
 
-Roadmap items — open work and resolved design docs — live in the docs
-site, not in this repo. See:
+Two kinds of work live here:
+
+- **[Follow-ups](#follow-ups)** — small items to verify or address periodically. External dependencies waiting on upstream fixes; internal consistency or polish work that's too small for a roadmap doc.
+- **[Stale-docs check](#stale-docs-check-every-pr)** — a per-PR checklist for keeping structure-sensitive docs in sync with code.
+
+Bigger feature work and design proposals live in the [docs roadmap](#roadmap) — a separate place, see below.
+
+## Follow-ups
+
+Small, concrete, verifiable items. Each entry is a heading with a stable anchor so code-level `TODO(<topic>)` markers can link back. Walk this list periodically (monthly is a good cadence; on demand otherwise), update **Last verified**, take action when **Done when** is satisfied.
+
+### Code-level TODO marker convention
+
+When code (or config) has a follow-up tracked in this file, leave a marker in the source at the relevant spot:
+
+```text
+// TODO(<topic>): one-line summary — see TODO.md "Follow-ups" → "<heading>"
+```
+
+`<topic>` is the same kebab-case slug used as the heading anchor below, so a single grep finds both ends:
+
+```sh
+grep -rn 'TODO(<topic>)' .
+```
+
+Markers without a corresponding TODO.md entry are allowed for transient in-flight work, but anything expected to outlive a single PR should have a tracked entry here so it doesn't rot. When an item resolves, remove both the entry and the matching `TODO(<topic>)` markers in the same PR.
+
+### External dependencies
+
+#### `lychee-action-sha-pin` — swap unreleased master SHA for a tagged release
+
+- **What:** in [`.github/workflows/docs.yml`](.github/workflows/docs.yml), revert the `lycheeverse/lychee-action` SHA pin from `faea714062690f6c2e6f7f388469ec4fa6d9c4e1` (master, post-v2.8.0) to a SHA from a tagged release.
+- **Why:** SHA-pinning to a tagged release is more discoverable than pinning to a master commit, surfaces release notes during routine dependency review, and keeps the audit trail aligned with what's published in the marketplace.
+- **Tracking:** <https://github.com/lycheeverse/lychee-action/releases> — first tag at or after commit `faea714` (which introduces v0.24.x subfolder-aware install).
+- **Last verified:** 2026-04-25 — latest tag is `v2.8.0`; `faea714` is current `master` HEAD; pin introduced in [#176](https://github.com/jackin-project/jackin/pull/176).
+- **Done when:** a tag at or after `faea714` ships. Replace the SHA in `docs.yml` with that tag's commit SHA, update the inline comment from "post-v2.8.0 master" to the tag name, and bump `LYCHEE_VERSION` to whatever the new release defaults to (or pin explicitly).
+
+### Internal cleanups
+
+_(none yet)_
+
+## Roadmap
+
+Roadmap items — open work and resolved design docs — live in the docs site, not in this repo. See:
 
 - Overview: [`docs/src/content/docs/reference/roadmap.mdx`](docs/src/content/docs/reference/roadmap.mdx)
 - Per-item design docs: [`docs/src/content/docs/reference/roadmap/`](docs/src/content/docs/reference/roadmap/)
 - Browsable: <https://jackin.tailrocks.com/reference/roadmap/>
 
-To add a new item, create an MDX page under the directory above and
-add a sidebar entry in [`docs/astro.config.ts`](docs/astro.config.ts)
-under `Roadmap → Open items`.
+To add a new item, create an MDX page under the directory above and add a sidebar entry in [`docs/astro.config.ts`](docs/astro.config.ts) under `Roadmap → Open items`.
 
 Each design doc should include (see any existing page as a template):
 
@@ -18,11 +58,11 @@ Each design doc should include (see any existing page as a template):
 - `## Why It Matters`
 - `## Related Files`
 
+Roadmap vs. follow-up: if it needs a problem statement and design discussion, it's a roadmap item. If it's "swap a SHA when upstream releases" or "rename three callers for consistency", it's a follow-up.
+
 ## Stale-docs check (every PR)
 
-Docs rot silently. Every PR must include a one-pass verification that
-structure-sensitive docs still match reality. Treat these as a
-checklist in the PR description — each item takes seconds to check.
+Docs rot silently. Every PR must include a one-pass verification that structure-sensitive docs still match reality. Treat these as a checklist in the PR description — each item takes seconds to check.
 
 ### When your PR touches `src/**`
 
@@ -49,7 +89,4 @@ One command to surface the obvious drift targets:
 git diff --name-only origin/main... | grep -E '^src/|^Cargo\.toml' | head
 ```
 
-If that list is non-empty, walk through the checkboxes above before
-requesting review. The goal is that a new operator opening
-`PROJECT_STRUCTURE.md` or a roadmap doc always sees paths that
-resolve, commands that exist, and behaviors that match current code.
+If that list is non-empty, walk through the checkboxes above before requesting review. The goal is that a new operator opening `PROJECT_STRUCTURE.md` or a roadmap doc always sees paths that resolve, commands that exist, and behaviors that match current code.


### PR DESCRIPTION
## Summary

Repurpose the existing root [`TODO.md`](TODO.md) from a thin roadmap pointer + per-PR checklist into a periodic-review tracker for small items that don't warrant a full roadmap design doc.

## Why

We've started accumulating small follow-ups that need a periodic-review home:

- **External dependencies** waiting on upstream releases — e.g., #176 had to pin `lycheeverse/lychee-action` to a master commit (`faea714`) because the v0.24.x fix is unreleased. We need a tracked place to remember to revert that pin to a tag SHA when upstream cuts a release.
- **Internal small polish** that's too small for a roadmap doc — renames for consistency, single-line cleanups, etc.

These don't fit the existing roadmap (problem statement + design discussion). They also don't fit `DEPRECATED.md` (deprecation ledger). They need a checklist.

## What's in `TODO.md` after this PR

- **Follow-ups section.** Each entry uses a stable kebab-case anchor (`#external-dependencies`, then per-item heading like `### lychee-action-sha-pin — …`) and the recommended fields: **What**, **Why**, **Tracking**, **Last verified**, **Done when**.
- **Code-level marker convention.** Anything that has an in-code anchor uses `// TODO(<topic>): one-line summary — see TODO.md "Follow-ups" → "<heading>"`, where `<topic>` matches the heading anchor. One grep finds both ends:
  ```sh
  grep -rn 'TODO(<topic>)' .
  ```
- **Roadmap pointer** — kept; still the right home for design proposals (now with a one-liner about how to choose between roadmap and follow-up).
- **Stale-docs checklist** — kept; per-PR drift check, unchanged.

## Wiring

- [`AGENTS.md`](AGENTS.md) "Shared conventions" gains a TODO.md bullet (right after `DEPRECATED.md`, since both are ledgers of work to address eventually).
- [`PROJECT_STRUCTURE.md`](PROJECT_STRUCTURE.md) row for `TODO.md` rewritten to describe the dual role.

## Concrete entry today

Just one — the lychee-action SHA pin from #176. Walk-through:

> **What:** swap `.github/workflows/docs.yml`'s `lycheeverse/lychee-action` SHA pin from `faea714062690f6c2e6f7f388469ec4fa6d9c4e1` (master, post-v2.8.0) back to a tagged release SHA.
> **Done when:** a tag at or after `faea714` ships → replace SHA, update inline comment from "post-v2.8.0 master" to the tag name.

I'll add a matching `# TODO(lychee-action-sha-pin)` marker line to `docs.yml` in #176 as a follow-up amendment to that PR (so the marker lives next to the pinned SHA, not in this infra-only PR).

## Code TODO scan

A repo-wide search for `TODO|FIXME|XXX|HACK` in `src/`, `docs/scripts/`, `docs/src/components/`, `docker/`, and top-level config returned **zero** existing markers. So this PR establishes the convention without retro-cataloging — future markers will be added alongside the change that introduces them.

## Test plan

- [ ] CI green.
- [ ] After merge, walk the file once a month: update **Last verified** dates; if **Done when** is satisfied, delete the entry and remove the matching `TODO(<topic>)` marker(s) in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)