### PR TITLE
ci(docs): rename build job to docs-link-check for unique status context

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  docs-link-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -95,7 +95,7 @@ jobs:
           path: docs/dist
 
   deploy:
-    needs: build
+    needs: docs-link-check
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:

--- a/docs/src/content/docs/reference/roadmap/docs-markdown-linting.mdx
+++ b/docs/src/content/docs/reference/roadmap/docs-markdown-linting.mdx
@@ -68,7 +68,7 @@ A single follow-up PR introducing the linter, the config, the CI step, and the c
    - `MD013` (line length) — relax to 120 with `code-blocks = false` and `tables = false`, since prose wraps unhelpfully at narrower widths.
    - Audit `MD033` (no inline HTML), `MD025` (single H1), and `MD026` (trailing punctuation in headings) once a dry run produces a real violation list.
 3. **Cleanup pass.** Run `rumdl check --fix` against `docs/src/content/docs/`. Audit the diff. Hand-fix anything `--fix` cannot resolve. Land the cleanup, the config, and the CI step in the same PR.
-4. **Branch protection.** Add `Docs / build` (which now includes the rumdl step) to the required checks list on `main`. Without this, the gate is advisory.
+4. **Branch protection.** Add `docs-link-check` (which now includes the rumdl step) to the required checks list on `main`. Without this, the gate is advisory.
 5. **Renovate.** Confirm the workflow's Renovate rules cover the new `rvben/rumdl@<sha>` pin so version bumps land as PRs rather than stale.
 
 The cleanup pass is the only step with non-trivial diff size. After landing, ongoing cost is whatever rumdl flags on new MDX — typically zero, since contributors fix violations locally before pushing.


### PR DESCRIPTION
## Summary

Rename the docs link-check job from \`build\` to \`docs-link-check\` so it has a unique check-run name across the repo's workflows.

## Why

When jackin-project/jackin-github-terraform#10 added a required-status-check rule for the docs gate, the rule context was \`\"Docs / build\"\` — the workflow/job display name shown in the GitHub PR UI. But GitHub matches required checks against the bare check-run \`name\`, which for this job is just \`\"build\"\` (verified in #180's run). The mismatch silently turned every PR's \`mergeStateStatus\` to \`BLOCKED\`.

The fix has to land in two places:

1. **Terraform (jackin-project/jackin-github-terraform#11)** — change the rule context from \`\"Docs / build\"\` to a name that actually matches.
2. **Here** — rename the job so the check-run name is unique repo-wide. \`build\` is too generic — any future workflow that adds a \`build:\` job would also satisfy a required check named \`build\`. \`docs-link-check\` makes the gate's intent obvious and keeps it unambiguous.

## What changes

- \`.github/workflows/docs.yml\` job key \`build\` → \`docs-link-check\`. The deploy job's \`needs: build\` follows.
- One prose update in \`docs/src/content/docs/reference/roadmap/docs-markdown-linting.mdx\` that referenced \`Docs / build\` as the required-check name.

That's it. No behavior change in CI itself — same steps, same env, same lychee version. Only the **name** of the check that GitHub Actions reports differs.

## Sequencing (important)

This PR depends on jackin-project/jackin-github-terraform#11 having been **applied** before merge. That PR lists \`[\"build\", \"docs-link-check\"]\` as the required contexts during the transition, so this PR's renamed \`docs-link-check\` check-run satisfies the rule.

If the terraform apply hasn't happened yet, this PR will be blocked by the live \`\"Docs / build\"\` requirement (which will never match again after this rename) — so wait for the apply.

After this merges, a follow-up terraform apply drops \`\"build\"\` from the list, leaving \`[\"docs-link-check\"]\`.

## Test plan

- [ ] CI \`Docs / docs-link-check\` is green on this PR (was \`Docs / build\`; same steps, new name).
- [ ] After merge, future PRs report a check-run named \`docs-link-check\` (verifiable via \`gh api repos/jackin-project/jackin/commits/<sha>/check-runs --jq '.check_runs[].name'\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)