### PR TITLE
docs(sidebar): link worktree-cleanup-assessment under roadmap Open items

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
                     { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },
                     { label: 'Reproducibility & provenance pinning', slug: 'reference/roadmap/reproducibility-pinning' },
                     { label: 'Per-mount isolation', slug: 'reference/roadmap/per-mount-isolation' },
+                    { label: 'Worktree cleanup assessment', slug: 'reference/roadmap/worktree-cleanup-assessment' },
                     { label: 'Devcontainer parity', slug: 'reference/roadmap/devcontainer-parity' },
                     { label: 'Docs markdown linting', slug: 'reference/roadmap/docs-markdown-linting' },
                     { label: 'Open review findings', slug: 'reference/roadmap/open-review-findings' },


### PR DESCRIPTION
## Summary

Follow-up to #190 — the roadmap entry was added in that PR but the Starlight sidebar config in \`docs/astro.config.ts\` enumerates roadmap entries explicitly, so the new page was reachable only by direct URL (https://jackin.tailrocks.com/reference/roadmap/worktree-cleanup-assessment/) and didn't appear in the left-hand nav.

Placed adjacent to **Per-mount isolation** under the "Open items" group rather than at the end of the list because the sidebar order is roughly topical (not alphabetical), and this entry is a direct follow-up to that V1 ship. Adjacency in the sidebar telegraphs the relationship.

One-line diff.

## Test plan

- [ ] \`bun run dev\` and confirm "Worktree cleanup assessment" appears under Reference → Roadmap → Open items, between "Per-mount isolation" and "Devcontainer parity".
- [ ] Lychee link check passes (the deployed-link-check failure on #190 was an unrelated transient 502 on a GitHub Issues link in \`selectable-sandbox-backends.mdx\`, not anything from #190).