### PR TITLE
feat(env): pin 1Password references by UUID with display snapshots

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -76,8 +76,10 @@ Agent-specific attribution trailer requirements (e.g., for the Codex agent) are 
 Before committing **any** change, run all three checks and ensure zero warnings and zero failures:
 
 ```sh
-cargo fmt -- --check && cargo clippy && cargo nextest run
+cargo fmt -- --check && cargo clippy -- -D warnings && cargo nextest run
 ```
+
+The `-- -D warnings` flag promotes clippy warnings to hard errors, matching what CI runs. Without it, lints like `clippy::branches_sharing_code` and `clippy::doc_markdown` exit clippy with status 0 locally but fail CI — wasting a round-trip. Use the strict invocation locally so CI never catches a lint your local check missed.
 
 If formatting fails, run `cargo fmt` to fix it, then re-run the checks.
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -75,6 +75,34 @@ Each entry includes:
   - `src/tui/output.rs::deprecation_warning` — printer used by the
     migration; can stay if other deprecations need it.
 
+### Bare `op://...` strings as env values (runtime resolution)
+
+- **Type:** behavior
+- **Deprecated since:** 2026-04-27 (PR #193)
+- **Replacement:** use the structured `EnvValue::OpRef` inline-table
+  form `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }`.
+  The operator-facing path is `jackin workspace env set <NAME>
+  "op://..."` (the CLI auto-resolves to the pinned form) or via the
+  TUI 1Password picker keystroke.
+- **Behavior today:** workspaces and config TOMLs that contain a
+  scalar `op://...` string as an env value **no longer** have it
+  resolved at launch via `op read`. The string is passed to the
+  container as a literal. No error is emitted; the row renders
+  without the `[op]` marker in the TUI (the visual cue that
+  re-picking is needed).
+- **Remove when:** N/A — the legacy strings still load and flow
+  through without error; only the silent runtime resolution behavior
+  has been removed. There is no planned hard-removal date; the TUI
+  `[op]`-marker cue and the `jackin workspace env set` auto-resolve
+  path are the migration surfaces.
+- **Where:**
+  - `src/operator_env.rs::resolve_env_value` — variant dispatch:
+    only `EnvValue::OpRef` triggers `op read`. `Plain` arm falls
+    through to `dispatch_plain` which never calls the 1Password CLI.
+  - `src/console/manager/render/editor.rs::render_secrets_key_line`
+    — plain rows (including legacy bare `op://...`) render without
+    `[op]` marker, signalling the need to re-pick.
+
 ## How to add an entry
 
 When you deprecate something, append a new section to **Active

--- a/docs/superpowers/specs/2026-04-27-op-id-storage-design.md
+++ b/docs/superpowers/specs/2026-04-27-op-id-storage-design.md
@@ -1,0 +1,429 @@
+# 1Password Reference Storage — UUIDs as Identity, Names as Display
+
+**Status:** Proposed
+**Date:** 2026-04-27
+**Scope:** `jackin` crate only
+**Related:** Builds on `2026-04-23-workspace-env-resolver-design.md` (shipped) and `2026-04-23-toml-edit-migration-design.md` (shipped)
+
+## Problem
+
+Today, jackin stores 1Password references as human-readable URI strings:
+
+```toml
+[env]
+CLAUDE_CODE_OAUTH_TOKEN = "op://Private/Claude/security/auth token"
+```
+
+When the user has multiple items sharing a name within a vault, this fails at launch:
+
+```text
+1Password reference "op://Private/Claude/security/auth token" failed:
+[ERROR] could not get item Private/Claude: More than one item matches "Claude".
+Try again and specify the item by its ID:
+  * for the item "Claude" in vault Private: o6nady73qs3mju64jcq4ztjbdy
+  * for the item "Claude" in vault Private: hyoveft67ghsr2wgou6ettilim
+  * for the item "Claude" in vault Private: xlhmzzy7ctcououatbzwchbppm
+```
+
+The bug surfaces at the worst time — `jackin --debug` is mid-flight, the agent identity has resolved, the user is past the Context7 prompt, and now resolution fails with three opaque UUIDs and no path to recovery in the current command. The 1Password CLI itself produces the error; jackin only propagates it (`operator_env.rs:328`).
+
+The asymmetry is that jackin's picker (`op_picker/mod.rs`) already drills down by **UUID** at every level (account, vault, item, field). Identity is unambiguous *at selection time* — but on commit, the picker discards the IDs and writes the human-readable URI verbatim from `op item get` JSON to the workspace TOML. The disambiguation is lost in serialization.
+
+A second, smaller concern: the breadcrumb in the workspace editor (`render/editor.rs:711-729`) renders cramped because `format!("{key:label_width$}")` pads the key to exactly the longest-key width, leaving zero trailing space when there's only one row.
+
+## Goals
+
+1. **Make resolution unambiguous by construction.** Store the canonical UUID-form `op://` URI as the source of truth. Item-name collisions in 1Password no longer cause launch failures.
+2. **Preserve human-readable display.** Render a snapshot breadcrumb (`Vault / Item / Section → Field`) in the editor so the user can verify which secret is referenced without seeing UUIDs.
+3. **Disambiguate ambiguous picks visually.** When multiple items share a name in the same vault, embed the picked item's subtitle (typically a username) inline in the breadcrumb so the user sees *which* item was selected.
+4. **Accept all official 1Password URI forms as input.** Names, IDs, mixed, special aliases (`password`, `username`, `notes`, `notesPlain`), section-bearing, query-bearing (`?attribute=otp`, `?attr=type`, `?ssh-format=openssh`).
+5. **Keep the CLI ergonomic.** `jackin workspace env set X "op://Private/GitHub/password"` resolves automatically when `op` is available; ambiguity surfaces with actionable suggestions at set-time, not container-launch-time.
+6. **Fix the editor cramping.** Always at least two-space gap between the key column and the value column.
+
+## Non-Goals
+
+- **Account-level scoping at resolve time** (`op read --account`). UUID URIs are unambiguous in practice across accounts; if a multi-account user reports cross-account confusion, add a single optional `account` field to `OpRef`. Non-breaking.
+- **Background refresh of stale `path` snapshots.** Snapshot semantics — the breadcrumb captures what was true at pick time. If the user renames a 1Password item later, the stored path drifts; re-picking is the explicit refresh action. No periodic `op item get` polling.
+- **Migration command for old workspaces.** Lossy upgrade only — bare `op://Vault/Item/Field` strings deserialize as plain literals, lose their `[op]` marker in the TUI, and the user re-picks. No `jackin workspace migrate` subcommand needed.
+- **`${VAR}` substitution inside `op://` URIs.** 1Password's URI grammar allows `op://${APP_ENV}/...`; jackin treats anything containing `${` in an `op://` URI as a plain literal (never resolves). Pinning to UUIDs is incompatible with config-time variable expansion.
+- **Headless `jackin workspace env pick <VAR>` command.** Out of scope; the picker stays TUI-only. CLI auto-resolution covers most cases without a dedicated subcommand.
+- **TUI text-entry auto-resolution.** Typing `op://...` into a value cell is always a literal string — explicit picker invocation is the only path to creating an `OpRef` from the TUI.
+- **Custom error wrapper for resolve-time `op read` failures from `OpRef` values.** UUID URIs cannot trigger the "more than one item matches" error, so no friendly wrap is needed at runtime. The existing variable-name error wrap continues to apply for unrelated failures (signed out, item deleted, field deleted, network).
+
+## Background
+
+Two prior specs in this directory are foundations and have shipped:
+
+- **`2026-04-23-workspace-env-resolver-design.md`** introduced the operator-env layered model (global / per-agent / per-workspace / per-workspace×agent), defined the `op://` / `$VAR` / literal dispatch, and added `OpRunner` with `op read <reference>` subprocess invocation. All env values are stored as `BTreeMap<String, String>` today; dispatch sniffs the string for the `op://` prefix.
+- **`2026-04-23-toml-edit-migration-design.md`** introduced `ConfigEditor` (`src/config/editor.rs`) — a `toml_edit::DocumentMut`-backed writer that preserves comments, blank lines, and key ordering on round-trip. Pre-built env mutators (`set_env_var`, `set_env_comment`, `remove_env_var`) are available for surgical edits.
+
+The picker (`src/console/widgets/op_picker/`) already collects UUIDs from `op vault list --format json`, `op item list --format json`, and `op item get --format json`. Subtitles (used to disambiguate items sharing a title in the picker pane) come from each item's JSON `additional_information` field — populated for login items (typically the username/email), empty for secure notes. See `OpItem` at `operator_env.rs:393-397`.
+
+The breadcrumb renderer at `render/editor.rs:711-729` already produces 3- and 4-segment breadcrumbs (`vault / item / section → field`) by parsing the stored `op://` string with `parse_op_reference`. The cramping bug lives at line 705's `format!("{key:label_width$}")`.
+
+## Design
+
+### Schema
+
+Replace the env value type from `String` to a small untagged enum. Backward-compatible with existing TOML strings; serde picks the variant by structural shape (inline table vs scalar string).
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EnvValue {
+    /// Pinned 1Password reference: UUIDs in `op`, snapshot names in `path`.
+    OpRef(OpRef),
+    /// Literal value, $VAR / ${VAR}, or any string (incl. legacy bare `op://...`
+    /// that downgrades to a literal — see Migration).
+    Plain(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OpRef {
+    /// Canonical `op://` URI. UUID-form preferred; mixed/named forms tolerated
+    /// when hand-edited but not produced by the picker or CLI resolver.
+    /// Format: `op://<vault>/<item>/[<section>/]<field>[?attribute=<name>]`
+    pub op: String,
+
+    /// Snapshot breadcrumb captured at pick / resolve time:
+    ///   `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?attribute=<name>]`
+    /// The `[subtitle]` segment appears only when the item shares its name
+    /// with another item in the same vault at write time.
+    pub path: String,
+}
+```
+
+The four `BTreeMap<String, String>` fields in `AppConfig.env`, `AgentSource.env`, `WorkspaceConfig.env`, and `WorkspaceAgentOverride.env` become `BTreeMap<String, EnvValue>`. The type swap is the largest single change; serde and the existing call sites mostly carry through without redesign.
+
+### On-disk examples
+
+```toml
+[env]
+# Unique item in vault — clean breadcrumb
+STRIPE_KEY = { op = "op://abc.../def.../fld...", path = "Private/Stripe/api key" }
+
+# Three "Claude" items — subtitle embedded to disambiguate which one was picked
+CLAUDE_CODE_OAUTH_TOKEN = { op = "op://abc.../def.../fld...", path = "Private/Claude[alexey@zhokhov.com]/security/auth token" }
+
+# OTP attribute preserved through canonicalization
+GITHUB_OTP = { op = "op://abc.../def.../fld...?attribute=otp", path = "Private/GitHub/one-time password?attribute=otp" }
+
+# Plain literal — unchanged
+DB_URL = "postgres://..."
+
+# Bare op:// — deserializes as Plain literal, no resolution attempted
+LEGACY_TOKEN = "op://Work/db/password"
+```
+
+### 1Password URI grammar (per [official 1Password docs](https://developer.1password.com/docs/cli/secret-reference-syntax))
+
+```
+op://<vault>/<item>[/<section>]/<field>[?<attribute_query>]
+
+vault    := <vault_name> | <vault_uuid>
+item     := <item_name>  | <item_uuid> | <item_name>'['<subtitle>']'
+section  := <section_name> | <section_id>
+field    := <field_label> | <field_id> | <special_alias>
+special_alias := "username" | "password" | "notes" | "notesPlain"
+attribute_query := ("attribute"|"attr") "=" <attr_name>
+                 | "ssh-format=openssh"
+attr_name := "type" | "value" | "id" | "purpose" | "otp"
+           | <file_attr>   (* "type"|"content"|"size"|"id"|"name" *)
+```
+
+Names support alphanumeric, `-`, `_`, `.`, and whitespace (case-insensitive). Names with whitespace must be quoted at the shell level; names with other special characters (e.g. `/`) require ID-form. The `<item_name>'['<subtitle>']'` form is jackin's display extension — accepted as input for disambiguation, written by the picker and CLI when needed.
+
+### Picker behavior (`src/console/widgets/op_picker/mod.rs`)
+
+The commit logic at `op_picker/mod.rs:703-722` changes shape. Today it writes the verbatim `field.reference` from `op item get`. After this change:
+
+```rust
+fn build_op_ref_on_commit(state: &OpPickerState) -> OpRef {
+    let vault = state.selected_vault();   // OpVault { id, name }
+    let item  = state.selected_item();    // OpItem  { id, name, subtitle }
+    let field = state.selected_field();   // OpField { id, label, reference, ... }
+
+    // Section info (id + name) is parsed out of `field.reference` when present —
+    // 1Password's `op item get` puts the human-readable reference there with
+    // section already correctly attributed; we just rewrite vault/item/field
+    // segments to UUID form and preserve the section segment.
+    // canonical_uuid_uri produces: op://<vault.id>/<item.id>/[<section.id>/]<field.id>[?query]
+    let op = canonical_uuid_uri(vault, item, field);
+
+    // Ambiguity check: is the picked item's name shared with any other item
+    // currently listed in the vault? The full item list is in memory.
+    let item_name_collides = state.items_in_vault()
+        .iter()
+        .filter(|i| i.id != item.id && i.name == item.name)
+        .next()
+        .is_some();
+
+    // Defensive: if the item name itself contains brackets, suppress the
+    // subtitle embed to keep `path` parsable. UUID still resolves correctly.
+    let safe_to_embed = !item.name.contains('[') && !item.name.contains(']');
+    let item_segment = if item_name_collides && safe_to_embed && !item.subtitle.is_empty() {
+        format!("{}[{}]", item.name, item.subtitle)
+    } else {
+        item.name.clone()
+    };
+
+    // canonical_display_path produces: <vault.name>/<item_segment>/[<section.name>/]<field.label>[?query]
+    // Section name comes from the same parse of `field.reference` as section.id above.
+    let path = canonical_display_path(vault, item_segment, field);
+
+    OpRef { op, path }
+}
+```
+
+No additional `op` calls are required at commit — the picker has full vault/item/field metadata in memory from its prior list calls.
+
+### CLI behavior (`src/cli/config.rs`, `src/cli/workspace.rs`)
+
+`jackin workspace env set <VAR> <VALUE>` and `jackin config env set <VAR> <VALUE>`:
+
+1. **If `<VALUE>` does not start with `op://`:** store as `EnvValue::Plain(value)`. Done. (No special-casing for `$VAR` syntax — that's still handled at resolve time, not at set time.)
+2. **If `<VALUE>` starts with `op://`:**
+   - Probe `op` CLI availability. If unavailable, error: *"`op` CLI not available; cannot resolve `op://...` reference. Install 1Password CLI, or hand-edit the TOML if you have UUIDs."* No silent fallback to `Plain`.
+   - If `<VALUE>` contains `${`, error: *"jackin does not support shell variable substitution inside `op://` URIs. Use a plain string or substitute before passing."*
+   - Parse the URI loosely: split on `/` after `op://`, peel off any `?attribute=…`/`?attr=…`/`?ssh-format=…` query suffix.
+   - Detect the `[subtitle]` form on the item segment and split into name + subtitle filter.
+   - Resolve via `op` calls (same routines used by the picker):
+     - `op vault list --format json` → match user's vault by name or ID
+     - `op item list --vault <vault> --format json` → match user's item by name (case-insensitive) or ID. If a `[subtitle]` filter is provided on the item segment, narrow further to items whose `additional_information` matches the filter exactly (case-insensitive)
+     - **0 matches:** error *"item `<X>` not found in vault `<Y>`."*
+     - **2+ matches** (no subtitle filter or subtitle didn't narrow): error with a copy-pasteable disambiguation list:
+       ```text
+       3 items named "Claude" in vault "Private". Disambiguate with:
+         op://Private/Claude[alexey@zhokhov.com]/security/auth token
+         op://Private/Claude[alexey@chainargos.com]/security/auth token
+         op://Private/Claude[team@example.com]/security/auth token
+       ```
+       (3 lines for 3 matches; uses each item's subtitle. Items with empty subtitles fall back to short item-id prefixes: `Claude[#o6nady73]`.)
+     - **1 match:** continue.
+   - `op item get <item_id> --format json` → find the field by label / ID / special alias (`password`, `username`, `notes`, `notesPlain`); locate the section if 4-segment.
+   - Compute `item_name_collides` from the vault item list (same rule as picker).
+   - Build the canonical `OpRef`: `op` is UUID-form with optional query suffix preserved verbatim; `path` is human-readable form with `[subtitle]` only when ambiguous.
+   - Persist via `ConfigEditor` (or the workspace editor equivalent). The TOML inline-table form is what gets written.
+
+### TUI text-entry behavior (`src/console/manager/input/editor.rs`)
+
+Typing or pasting any text into a value cell — including `op://...` URIs — produces an `EnvValue::Plain` on commit. No probing, no resolution, no `op` calls. The picker keystroke (existing `[op]` keybinding) is the *only* TUI path to creating an `OpRef`.
+
+This is a deliberate split: the editor is a string editor; the picker is a 1Password-reference editor. Pasting `op://Private/Claude/auth` and pressing Enter stores the literal string `"op://Private/Claude/auth"`. The user explicitly asks for a 1Password reference by invoking the picker.
+
+### Runtime resolver (`src/operator_env.rs`)
+
+The current dispatch sniffs strings for `op://` prefix (`operator_env.rs:31-36`). Replace with structural dispatch on `EnvValue`:
+
+```rust
+fn resolve_env_value(
+    value: &EnvValue,
+    op_runner: &dyn OpCli,
+    layer_label: &str,
+    var_name: &str,
+) -> anyhow::Result<String> {
+    match value {
+        EnvValue::Plain(s) => operator_env::expand_shell_var(s),
+        EnvValue::OpRef(r) => op_runner.read(&r.op).map_err(|e| {
+            anyhow::anyhow!(
+                "{layer_label} env var {var_name:?}: 1Password reference {ref_path:?} failed: {e}",
+                ref_path = r.path
+            )
+        }),
+    }
+}
+```
+
+Notable simplifications:
+
+- `is_op_reference()` is removed from non-display call sites. The discriminator is the enum variant.
+- `parse_op_reference()` is retained for the CLI input path (parses user-typed URIs into segments) and for legacy display fallback (hand-edited `op://Vault/Item/Field` strings in the `op` field of an `OpRef`).
+- The "More than one item matches" error path becomes effectively dead code for `OpRef` values (UUIDs cannot be ambiguous). The existing handlers for non-ambiguity errors (signed out, item deleted, field deleted, `op` not installed, timeout, network) continue to apply unchanged.
+- Bare `op://` strings in `EnvValue::Plain` flow through `expand_shell_var` unchanged — that function leaves anything without `$` alone, so they pass through to the container as literal strings.
+
+### TUI breadcrumb rendering (`src/console/manager/render/editor.rs`)
+
+Two changes to `render_secrets_key_line` (`render/editor.rs:674`).
+
+**(1) Cramming fix.** Replace the `format!("{key:label_width$}")` invocation at line 705 with explicit two-space minimum padding:
+
+```rust
+let key_padded = format!("{key:label_width$}");
+spans.push(Span::styled(key_padded, label_style));
+spans.push(Span::raw("  "));   // always at least two spaces between key and value
+```
+
+`label_width` already represents the longest-key width (computed by the caller); the explicit two spaces guarantee separation regardless of how key/value column widths land.
+
+**(2) Breadcrumb sources from `path`, not raw `op` URI.** A new parser, `parse_path_breadcrumb`, replaces the `parse_op_reference(value)` call for `OpRef` rows:
+
+```rust
+struct PathBreadcrumb {
+    vault: String,
+    item: String,
+    item_subtitle: Option<String>,
+    section: Option<String>,
+    field: String,
+    attribute_query: Option<String>,    // e.g., "?attribute=otp"
+}
+
+fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
+    let (path, attr) = match path.find('?') {
+        Some(i) => (&path[..i], Some(path[i..].to_string())),
+        None    => (path, None),
+    };
+    let segs: Vec<&str> = path.split('/').collect();
+    let (item, item_subtitle) = match segs.get(1) {
+        Some(seg) => split_bracket_subtitle(seg),
+        None      => return None,
+    };
+    let parts = match segs.as_slice() {
+        [vault, _, field]          => Some((vault, None,            *field)),
+        [vault, _, section, field] => Some((vault, Some(*section),  *field)),
+        _ => None,
+    }?;
+    Some(PathBreadcrumb {
+        vault: parts.0.to_string(),
+        item, item_subtitle,
+        section: parts.1.map(str::to_string),
+        field: parts.2.to_string(),
+        attribute_query: attr,
+    })
+}
+
+fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
+    if let Some(open) = s.rfind('[') {
+        if s.ends_with(']') && open < s.len() - 1 {
+            return (s[..open].to_string(), Some(s[open+1..s.len()-1].to_string()));
+        }
+    }
+    (s.to_string(), None)
+}
+```
+
+Spans for the breadcrumb (replacing `editor.rs:711-728`):
+
+```rust
+spans.push(Span::styled(parts.vault, white));
+spans.push(Span::styled(" / ", dim));
+spans.push(Span::styled(parts.item, green));
+if let Some(subtitle) = parts.item_subtitle {
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(subtitle, dim));   // PHOSPHOR_DIM, per Q5b.2
+}
+if let Some(section) = parts.section {
+    spans.push(Span::styled(" / ", dim));
+    spans.push(Span::styled(section, green));
+}
+spans.push(Span::styled(" \u{2192} ", dim));
+spans.push(Span::styled(parts.field, green_bold));
+if let Some(query) = parts.attribute_query {
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(query, dim));
+}
+```
+
+Resulting renders for the screenshot bug:
+
+```text
+[op] CLAUDE_CODE_OAUTH_TOKEN  Private / Claude alexey@zhokhov.com / security → auth token
+[op] STRIPE_KEY               Private / Stripe → api key
+[op] GITHUB_OTP               Private / GitHub → one-time password ?attribute=otp
+```
+
+(The `[op]` marker, mask handling, and value-side rendering for `Plain` values are unchanged.)
+
+## Migration
+
+**Lossy upgrade — no migration command, no error on legacy.**
+
+When jackin loads a workspace TOML containing `MY_VAR = "op://Vault/Item/Field"` (legacy bare-string form):
+
+1. The string deserializes as `EnvValue::Plain("op://Vault/Item/Field")`.
+2. The runtime resolver passes it through `expand_shell_var` (which is a no-op for strings without `$`), and the container receives `MY_VAR=op://Vault/Item/Field` as a literal env value.
+3. The TUI editor renders the row without an `[op]` marker, showing the verbatim string in the value column.
+4. The user notices in the editor that the row is no longer marked `[op]` and re-picks via the picker keystroke (or runs `jackin workspace env set MY_VAR "op://Vault/Item/Field"` to re-resolve via the CLI auto-resolution path).
+
+This is intentional: no error, no warning, no automatic rewrite. The workspace TOML is not modified by jackin without an explicit user action. Visual cue (`[op]` marker absence) is the migration signal.
+
+**No CHANGELOG-blocking compatibility shim** — the existing `is_op_reference()` runtime path is removed, so legacy bare strings *change behavior* (from "resolve as 1Password" to "pass through as literal"). For workspaces actively using bare-string `op://` references, this is a breaking change at upgrade — but recoverable in seconds via the picker.
+
+## Test plan
+
+### Schema round-trip
+- `OpRef` with 3-segment, 4-segment, with subtitle, with `?attribute=otp`, with `?attr=value`, with `?ssh-format=openssh`.
+- `Plain` with literal, `$VAR`, `${VAR}`, bare `op://...`.
+- Untagged enum picks correct variant for inline-table vs scalar string input.
+
+### Path breadcrumb parser
+- 3-segment / 4-segment with and without subtitle.
+- Subtitle containing `/`: handled by `rfind('[')`.
+- Subtitle containing nested `[`: tolerated by the renderer.
+- Item names containing `[`: write-time defensive rule prevents new writes; old reads tolerate.
+- Query-suffix variants: `?attribute=otp`, `?attr=value`, `?ssh-format=openssh`.
+
+### Picker commit (`op_picker/mod.rs` test module)
+- Vault with 1 item named "X" → no subtitle in `path`.
+- Vault with 2+ items named "X" → subtitle embedded.
+- Item with bracket characters in its name → no subtitle embed (defensive).
+- Login item gets subtitle (username); secure note gets empty subtitle (no embed).
+- Section-bearing fields produce 4-segment URIs in both `op` and `path`.
+- 4-segment commit with section UUID in `op`, section name in `path`.
+
+### CLI resolution (`tests/cli_env.rs`)
+- Name-form input → resolves to UUID-form `op`, name-form `path`.
+- UUID-form input → preserved verbatim in `op`, name-form `path` reconstructed via `op item get`.
+- Mixed-form input → resolved to canonical UUID-form.
+- Bracketed input (`Item[subtitle]`) → filters items by subtitle; `path` retains brackets when item is ambiguous.
+- Ambiguous name-form, no subtitle → errors with disambiguation suggestions list.
+- Ambiguous name-form, subtitle still doesn't narrow → errors with item-ID-prefix fallback list.
+- 4-segment with section name; with section UUID.
+- `?attribute=otp` preserved through resolution.
+- `?attr=value`, `?ssh-format=openssh` preserved.
+- Special aliases (`password`, `username`, `notes`, `notesPlain`) resolve to canonical field IDs.
+- `op` unavailable + `op://` input → errors loudly with install hint.
+- `${VAR}` inside `op://` input → errors with substitution-not-supported message.
+- Plain literal input (no `op://` prefix) → stored as `Plain`, no `op` calls, no errors.
+
+### TUI text-entry
+- Pastes `op://...` into value cell + Enter → stored as `Plain`, not `OpRef`.
+- Picker keystroke → opens picker; on commit produces `OpRef`.
+- Hitting `[op]` keybinding on a `Plain` row → starts the picker fresh.
+
+### Renderer
+- Cramming fix verified: longest-key + 2 always.
+- Subtitle rendered in `PHOSPHOR_DIM` between item and the next `/`.
+- 4-segment with subtitle: `vault / item subtitle / section → field`.
+- `?attribute=otp` rendered dimmed at end of breadcrumb.
+- `OpRef` row → breadcrumb. `Plain` row (literal or bare `op://`) → masked or verbatim value, no breadcrumb, no `[op]` marker.
+
+### Runtime resolver
+- `OpRef` → `op read <op>` invoked with the canonical URI; result returned.
+- `Plain` (literal) → returned verbatim.
+- `Plain` containing `$VAR` / `${VAR}` → expanded.
+- `Plain` containing bare `op://...` → returned verbatim (NOT resolved).
+- `op read` failures (not signed in, item deleted, field deleted, network) → propagated with var-name wrap; no extra ambiguity-handling layer.
+
+## Files touched (estimated scope)
+
+| File | Change |
+|---|---|
+| `src/workspace/mod.rs` | Type swap (`String` → `EnvValue`) for `WorkspaceConfig.env`, `WorkspaceAgentOverride.env`. |
+| `src/config/mod.rs` | Type swap for `AppConfig.env`, `AgentSource.env`. |
+| `src/operator_env.rs` | New `EnvValue`/`OpRef` types; `resolve_env_value` enum dispatch; remove `is_op_reference` from non-display sites. |
+| `src/console/widgets/op_picker/mod.rs` | Commit path: write `OpRef` with UUID `op` + ambiguity-aware `path` instead of bare `field.reference` string. |
+| `src/console/manager/render/editor.rs` | New `parse_path_breadcrumb`; subtitle, attribute-query, cramming-fix changes to `render_secrets_key_line`. |
+| `src/cli/config.rs`, `src/cli/workspace.rs` | `env set` auto-resolves `op://`; ambiguity errors with disambiguation list; `op`-unavailable error. |
+| `src/config/editor.rs` | `set_env_var` accepts `EnvValue` so it writes inline tables for `OpRef` and bare strings for `Plain`. |
+| Tests | New + extensions across `operator_env.rs`, `op_picker/mod.rs`, `op_picker/render.rs`, `render/editor.rs`, `cli_env.rs`. |
+
+## References
+
+- 1Password secret-reference syntax: <https://developer.1password.com/docs/cli/secret-reference-syntax>
+- Prior shipped specs in this directory:
+  - `2026-04-23-workspace-env-resolver-design.md`
+  - `2026-04-23-toml-edit-migration-design.md`
+- Picker data structures: `src/operator_env.rs:377-411` (`OpAccount`, `OpVault`, `OpItem`, `OpField`).
+- Current breadcrumb renderer: `src/console/manager/render/editor.rs:674` (`render_secrets_key_line`).
+- Current picker commit logic: `src/console/widgets/op_picker/mod.rs:703-722`.
+- Current runtime dispatch: `src/operator_env.rs:31-36`.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -424,7 +424,11 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                     let scope = agent.map_or(config::EnvScope::Global, config::EnvScope::Agent);
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                    editor.set_env_var(&scope, &key, &value);
+                    editor.set_env_var(
+                        &scope,
+                        &key,
+                        crate::operator_env::EnvValue::Plain(value),
+                    )?;
                     if let Some(ref c) = comment {
                         editor.set_env_comment(&scope, &key, Some(c));
                     }
@@ -453,14 +457,14 @@ pub fn run(cli: Cli) -> Result<()> {
                             config
                                 .env
                                 .iter()
-                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
                                 .collect()
                         },
                         |a| {
                             config.agents.get(a).map_or_else(Vec::new, |src| {
                                 src.env
                                     .iter()
-                                    .map(|(k, v)| (k.clone(), v.clone()))
+                                    .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
                                     .collect()
                             })
                         },
@@ -912,7 +916,11 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                     let scope = workspace_env_scope(workspace, agent);
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                    editor.set_env_var(&scope, &key, &value);
+                    editor.set_env_var(
+                        &scope,
+                        &key,
+                        crate::operator_env::EnvValue::Plain(value),
+                    )?;
                     if let Some(ref c) = comment {
                         editor.set_env_comment(&scope, &key, Some(c));
                     }
@@ -943,10 +951,18 @@ pub fn run(cli: Cli) -> Result<()> {
                 cli::WorkspaceEnvCommand::List { workspace, agent } => {
                     let ws = config.require_workspace(&workspace)?;
                     let vars: Vec<(String, String)> = agent.as_ref().map_or_else(
-                        || ws.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                        || {
+                            ws.env
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                .collect()
+                        },
                         |a| {
                             ws.agents.get(a).map_or_else(Vec::new, |ov| {
-                                ov.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                                ov.env
+                                    .iter()
+                                    .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                    .collect()
                             })
                         },
                     );

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -422,13 +422,10 @@ pub fn run(cli: Cli) -> Result<()> {
                              before setting agent-scoped env vars"
                         );
                     }
+                    let env_value = resolve_env_value_for_cli(&value)?;
                     let scope = agent.map_or(config::EnvScope::Global, config::EnvScope::Agent);
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                    editor.set_env_var(
-                        &scope,
-                        &key,
-                        crate::operator_env::EnvValue::Plain(value),
-                    )?;
+                    editor.set_env_var(&scope, &key, env_value)?;
                     if let Some(ref c) = comment {
                         editor.set_env_comment(&scope, &key, Some(c));
                     }
@@ -914,13 +911,10 @@ pub fn run(cli: Cli) -> Result<()> {
                              before setting agent-scoped env vars"
                         );
                     }
+                    let env_value = resolve_env_value_for_cli(&value)?;
                     let scope = workspace_env_scope(workspace, agent);
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                    editor.set_env_var(
-                        &scope,
-                        &key,
-                        crate::operator_env::EnvValue::Plain(value),
-                    )?;
+                    editor.set_env_var(&scope, &key, env_value)?;
                     if let Some(ref c) = comment {
                         editor.set_env_comment(&scope, &key, Some(c));
                     }
@@ -1002,6 +996,33 @@ pub fn run(cli: Cli) -> Result<()> {
             }
         },
     }
+}
+
+/// Resolve a CLI-supplied env value string into the appropriate [`EnvValue`]
+/// variant. Values starting with `op://` trigger headless resolution via the
+/// 1Password CLI; all other values are stored as [`EnvValue::Plain`] unchanged.
+///
+/// Errors when:
+/// - The value starts with `op://` but the `op` CLI is unavailable.
+/// - The value starts with `op://` and contains `${VAR}` substitution syntax.
+/// - Resolution fails (vault/item/field not found, ambiguity, etc.).
+fn resolve_env_value_for_cli(value: &str) -> anyhow::Result<crate::operator_env::EnvValue> {
+    if !value.starts_with("op://") {
+        return Ok(crate::operator_env::EnvValue::Plain(value.to_string()));
+    }
+
+    // Probe op CLI availability before attempting structural queries.
+    let op_cli = crate::operator_env::OpCli::new();
+    crate::operator_env::OpRunner::probe(&op_cli).map_err(|e| {
+        anyhow::anyhow!(
+            "`op` CLI not available; cannot resolve `op://...` reference. \
+             Install 1Password CLI, or use a non-op:// value.\n\
+             Probe error: {e}"
+        )
+    })?;
+
+    let op_ref = crate::operator_env::resolve_op_uri_to_ref(value, &op_cli)?;
+    Ok(crate::operator_env::EnvValue::OpRef(op_ref))
 }
 
 fn workspace_env_scope(workspace: String, agent: Option<String>) -> config::EnvScope {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -454,14 +454,14 @@ pub fn run(cli: Cli) -> Result<()> {
                             config
                                 .env
                                 .iter()
-                                .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                .map(|(k, v)| (k.clone(), v.as_display_str().to_string()))
                                 .collect()
                         },
                         |a| {
                             config.agents.get(a).map_or_else(Vec::new, |src| {
                                 src.env
                                     .iter()
-                                    .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                    .map(|(k, v)| (k.clone(), v.as_display_str().to_string()))
                                     .collect()
                             })
                         },
@@ -948,14 +948,14 @@ pub fn run(cli: Cli) -> Result<()> {
                         || {
                             ws.env
                                 .iter()
-                                .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                .map(|(k, v)| (k.clone(), v.as_display_str().to_string()))
                                 .collect()
                         },
                         |a| {
                             ws.agents.get(a).map_or_else(Vec::new, |ov| {
                                 ov.env
                                     .iter()
-                                    .map(|(k, v)| (k.clone(), v.as_persisted_str().to_string()))
+                                    .map(|(k, v)| (k.clone(), v.as_display_str().to_string()))
                                     .collect()
                             })
                         },

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -95,10 +95,28 @@ impl ConfigEditor {
         Ok(config)
     }
 
-    pub fn set_env_var(&mut self, scope: &EnvScope, key: &str, value_str: &str) {
+    pub fn set_env_var(
+        &mut self,
+        scope: &EnvScope,
+        key: &str,
+        value: crate::operator_env::EnvValue,
+    ) -> anyhow::Result<()> {
+        use crate::operator_env::EnvValue;
+        use toml_edit::{InlineTable, Item, Value, value as toml_value};
+
         let path = env_scope_path(scope);
         let table = table_path_mut(&mut self.doc, &path);
-        table.insert(key, toml_edit::value(value_str));
+        let item = match value {
+            EnvValue::Plain(s) => toml_value(s),
+            EnvValue::OpRef(r) => {
+                let mut tbl = InlineTable::new();
+                tbl.insert("op", Value::from(r.op));
+                tbl.insert("path", Value::from(r.path));
+                Item::Value(Value::InlineTable(tbl))
+            }
+        };
+        table.insert(key, item);
+        Ok(())
     }
 
     pub fn set_env_comment(&mut self, scope: &EnvScope, key: &str, comment: Option<&str>) {
@@ -532,7 +550,13 @@ mod tests {
         std::fs::write(&paths.config_file, "").unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&EnvScope::Global, "API_TOKEN", "op://Personal/api/token");
+        editor
+            .set_env_var(
+                &EnvScope::Global,
+                "API_TOKEN",
+                "op://Personal/api/token".into(),
+            )
+            .unwrap();
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -557,14 +581,16 @@ workdir = "/workspace/prod"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(
-            &EnvScope::WorkspaceAgent {
-                workspace: "prod".to_string(),
-                agent: "agent-smith".to_string(),
-            },
-            "OPENAI_API_KEY",
-            "op://Work/OpenAI/default",
-        );
+        editor
+            .set_env_var(
+                &EnvScope::WorkspaceAgent {
+                    workspace: "prod".to_string(),
+                    agent: "agent-smith".to_string(),
+                },
+                "OPENAI_API_KEY",
+                "op://Work/OpenAI/default".into(),
+            )
+            .unwrap();
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -592,7 +618,9 @@ API_TOKEN = "old-value"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&EnvScope::Global, "API_TOKEN", "new-value");
+        editor
+            .set_env_var(&EnvScope::Global, "API_TOKEN", "new-value".into())
+            .unwrap();
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -653,7 +681,9 @@ git = "https://example.com/a.git"
 
         let scope = EnvScope::Agent("agent-smith".to_string());
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&scope, "LOG_LEVEL", "debug");
+        editor
+            .set_env_var(&scope, "LOG_LEVEL", "debug".into())
+            .unwrap();
         assert!(
             editor.remove_env_var(&scope, "LOG_LEVEL"),
             "first remove should return true"
@@ -683,7 +713,9 @@ workdir = "/workspace/prod"
 
         let scope = EnvScope::Workspace("prod".to_string());
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&scope, "DB_URL", "op://Work/Prod/db-url");
+        editor
+            .set_env_var(&scope, "DB_URL", "op://Work/Prod/db-url".into())
+            .unwrap();
         assert!(
             editor.remove_env_var(&scope, "DB_URL"),
             "first remove should return true"
@@ -716,7 +748,9 @@ workdir = "/workspace/prod"
             agent: "agent-smith".to_string(),
         };
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&scope, "OPENAI_API_KEY", "op://Work/OpenAI/default");
+        editor
+            .set_env_var(&scope, "OPENAI_API_KEY", "op://Work/OpenAI/default".into())
+            .unwrap();
         assert!(
             editor.remove_env_var(&scope, "OPENAI_API_KEY"),
             "first remove should return true"
@@ -739,8 +773,12 @@ workdir = "/workspace/prod"
         std::fs::write(&paths.config_file, "").unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&EnvScope::Global, "KEY_A", "value-a");
-        editor.set_env_var(&EnvScope::Global, "KEY_B", "value-b");
+        editor
+            .set_env_var(&EnvScope::Global, "KEY_A", "value-a".into())
+            .unwrap();
+        editor
+            .set_env_var(&EnvScope::Global, "KEY_B", "value-b".into())
+            .unwrap();
         editor.save().unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
@@ -835,7 +873,9 @@ API_TOKEN = "op://vault-id/item-id/field"
         std::fs::write(&paths.config_file, original).unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&EnvScope::Global, "OTHER", "z");
+        editor
+            .set_env_var(&EnvScope::Global, "OTHER", "z".into())
+            .unwrap();
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -862,7 +902,9 @@ workdir = "/b"
         std::fs::write(&paths.config_file, original).unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_env_var(&EnvScope::Workspace("a".to_string()), "K", "v");
+        editor
+            .set_env_var(&EnvScope::Workspace("a".to_string()), "K", "v".into())
+            .unwrap();
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
@@ -1014,7 +1056,9 @@ API_TOKEN = "op://Personal/api/token"
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
         // Bypass the CLI pre-flight via the unchecked setter.
-        editor.set_env_var(&EnvScope::Global, "DOCKER_HOST", "tcp://bad");
+        editor
+            .set_env_var(&EnvScope::Global, "DOCKER_HOST", "tcp://bad".into())
+            .unwrap();
 
         let err = editor.save().unwrap_err();
         let msg = format!("{err:#}");
@@ -1548,5 +1592,61 @@ workdir = "/b"
         let mut editor = ConfigEditor::open(&paths).unwrap();
         let err = editor.rename_workspace("a", "").unwrap_err();
         assert!(err.to_string().contains("empty"), "{err}");
+    }
+
+    #[test]
+    fn set_env_var_writes_inline_table_for_op_ref() {
+        use crate::operator_env::{EnvValue, OpRef};
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "[env]\n").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor
+            .set_env_var(
+                &EnvScope::Global,
+                "CLAUDE_CODE_OAUTH_TOKEN",
+                EnvValue::OpRef(OpRef {
+                    op: "op://abc/def/fld".into(),
+                    path: "Private/Claude/security/auth token".into(),
+                }),
+            )
+            .unwrap();
+        editor.save().unwrap();
+
+        let serialized = std::fs::read_to_string(&paths.config_file).unwrap();
+        // Inline-table form, not a scalar string with quoted JSON.
+        assert!(
+            serialized.contains(r#"CLAUDE_CODE_OAUTH_TOKEN = { op = "op://abc/def/fld", path = "Private/Claude/security/auth token" }"#),
+            "expected inline-table emit, got:\n{serialized}"
+        );
+    }
+
+    #[test]
+    fn set_env_var_writes_scalar_string_for_plain() {
+        use crate::operator_env::EnvValue;
+
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "[env]\n").unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor
+            .set_env_var(
+                &EnvScope::Global,
+                "DB_URL",
+                EnvValue::Plain("postgres://localhost".into()),
+            )
+            .unwrap();
+        editor.save().unwrap();
+
+        let serialized = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            serialized.contains(r#"DB_URL = "postgres://localhost""#),
+            "expected scalar-string emit, got:\n{serialized}"
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,7 +109,7 @@ pub struct AgentSource {
     /// `[env]` map when the agent is launched. Values use the
     /// `operator_env` dispatch syntax.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub env: BTreeMap<String, String>,
+    pub env: BTreeMap<String, crate::operator_env::EnvValue>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -125,7 +125,7 @@ pub struct AppConfig {
     /// Global operator env map — the bottom layer. Merged under
     /// per-agent, per-workspace, and per-(workspace × agent) layers.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub env: BTreeMap<String, String>,
+    pub env: BTreeMap<String, crate::operator_env::EnvValue>,
     #[serde(default)]
     pub agents: BTreeMap<String, AgentSource>,
     #[serde(default)]
@@ -726,12 +726,26 @@ OPERATOR_SECRET = "op://Personal/api/token"
 OPERATOR_HOST = "$HOME_VAR"
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.env.get("OPERATOR_GLOBAL").unwrap(), "literal");
         assert_eq!(
-            config.env.get("OPERATOR_SECRET").unwrap(),
+            config
+                .env
+                .get("OPERATOR_GLOBAL")
+                .unwrap()
+                .as_persisted_str(),
+            "literal"
+        );
+        assert_eq!(
+            config
+                .env
+                .get("OPERATOR_SECRET")
+                .unwrap()
+                .as_persisted_str(),
             "op://Personal/api/token"
         );
-        assert_eq!(config.env.get("OPERATOR_HOST").unwrap(), "$HOME_VAR");
+        assert_eq!(
+            config.env.get("OPERATOR_HOST").unwrap().as_persisted_str(),
+            "$HOME_VAR"
+        );
     }
 
     #[test]
@@ -746,7 +760,7 @@ AGENT_TOKEN = "op://Shared/smith/token"
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         let agent = config.agents.get("agent-smith").unwrap();
         assert_eq!(
-            agent.env.get("AGENT_TOKEN").unwrap(),
+            agent.env.get("AGENT_TOKEN").unwrap().as_persisted_str(),
             "op://Shared/smith/token"
         );
     }
@@ -769,7 +783,10 @@ WORKSPACE_VAR = "literal"
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         let ws = config.workspaces.get("big-monorepo").unwrap();
-        assert_eq!(ws.env.get("WORKSPACE_VAR").unwrap(), "literal");
+        assert_eq!(
+            ws.env.get("WORKSPACE_VAR").unwrap().as_persisted_str(),
+            "literal"
+        );
     }
 
     #[test]
@@ -792,7 +809,11 @@ PER_WORKSPACE_PER_AGENT = "specific"
         let ws = config.workspaces.get("big-monorepo").unwrap();
         let override_ = ws.agents.get("agent-smith").unwrap();
         assert_eq!(
-            override_.env.get("PER_WORKSPACE_PER_AGENT").unwrap(),
+            override_
+                .env
+                .get("PER_WORKSPACE_PER_AGENT")
+                .unwrap()
+                .as_persisted_str(),
             "specific"
         );
     }
@@ -836,13 +857,17 @@ OPENAI_API_KEY = "op://Work/big-monorepo/OpenAI"
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         let agent = config.agents.get("chainargos/agent-jones").unwrap();
         assert_eq!(
-            agent.env.get("DATABASE_URL").unwrap(),
+            agent.env.get("DATABASE_URL").unwrap().as_persisted_str(),
             "op://Work/agent-jones/db"
         );
         let ws = config.workspaces.get("big-monorepo").unwrap();
         let override_ = ws.agents.get("chainargos/agent-jones").unwrap();
         assert_eq!(
-            override_.env.get("OPENAI_API_KEY").unwrap(),
+            override_
+                .env
+                .get("OPENAI_API_KEY")
+                .unwrap()
+                .as_persisted_str(),
             "op://Work/big-monorepo/OpenAI"
         );
     }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -348,27 +348,25 @@ fn toggle_focused_row_mask(editor: &mut EditorState<'_>) {
     };
     let key = match row {
         SecretsRow::WorkspaceKeyRow(key) => {
-            // Op:// rows render as breadcrumbs and ignore mask state.
-            let value = editor
+            // OpRef rows render as breadcrumbs and ignore mask state.
+            if editor
                 .pending
                 .env
                 .get(&key)
-                .map(|v| v.as_persisted_str().to_string())
-                .unwrap_or_default();
-            if crate::operator_env::is_op_reference(&value) {
+                .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            {
                 return;
             }
             (SecretsScopeTag::Workspace, key)
         }
         SecretsRow::AgentKeyRow { agent, key } => {
-            let value = editor
+            if editor
                 .pending
                 .agents
                 .get(&agent)
                 .and_then(|o| o.env.get(&key))
-                .map(|v| v.as_persisted_str().to_string())
-                .unwrap_or_default();
-            if crate::operator_env::is_op_reference(&value) {
+                .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            {
                 return;
             }
             (SecretsScopeTag::Agent(agent), key)
@@ -416,17 +414,22 @@ fn open_secrets_enter_modal(editor: &mut EditorState<'_>) {
     };
     match row {
         SecretsRow::WorkspaceKeyRow(key) => {
+            // OpRef rows are not text-editable — operator deletes via
+            // D and re-adds via the source picker.
+            if editor
+                .pending
+                .env
+                .get(&key)
+                .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            {
+                return;
+            }
             let current = editor
                 .pending
                 .env
                 .get(&key)
                 .map(|v| v.as_persisted_str().to_string())
                 .unwrap_or_default();
-            // Op:// rows are not text-editable — operator deletes via
-            // D and re-adds via the source picker.
-            if crate::operator_env::is_op_reference(&current) {
-                return;
-            }
             editor.modal = Some(Modal::TextInput {
                 target: TextInputTarget::EnvValue {
                     scope: SecretsScopeTag::Workspace,
@@ -449,6 +452,15 @@ fn open_secrets_enter_modal(editor: &mut EditorState<'_>) {
             }
         }
         SecretsRow::AgentKeyRow { agent, key } => {
+            if editor
+                .pending
+                .agents
+                .get(&agent)
+                .and_then(|o| o.env.get(&key))
+                .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            {
+                return;
+            }
             let current = editor
                 .pending
                 .agents
@@ -456,9 +468,6 @@ fn open_secrets_enter_modal(editor: &mut EditorState<'_>) {
                 .and_then(|o| o.env.get(&key))
                 .map(|v| v.as_persisted_str().to_string())
                 .unwrap_or_default();
-            if crate::operator_env::is_op_reference(&current) {
-                return;
-            }
             let label = format!("Edit {key}");
             editor.modal = Some(Modal::TextInput {
                 target: TextInputTarget::EnvValue {
@@ -2019,8 +2028,13 @@ mod tests {
         paths.ensure_base_dirs().unwrap();
         let mut config = AppConfig::default();
         let mut ws = empty_ws();
-        ws.env
-            .insert("DB_URL".into(), "op://Work/db/password".into());
+        ws.env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc-vault/abc-item/password".into(),
+                path: "Work/db/password".into(),
+            }),
+        );
 
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
@@ -2057,7 +2071,13 @@ mod tests {
         let mut config = AppConfig::default();
         let mut ws = empty_ws();
         let mut ag_env = std::collections::BTreeMap::new();
-        ag_env.insert("API_TOKEN".into(), "op://acct/Personal/api/token".into());
+        ag_env.insert(
+            "API_TOKEN".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc-vault/abc-item/api-token".into(),
+                path: "Personal/api/token".into(),
+            }),
+        );
         ws.agents.insert(
             "smith".into(),
             crate::workspace::WorkspaceAgentOverride { env: ag_env },
@@ -2227,8 +2247,13 @@ mod tests {
         paths.ensure_base_dirs().unwrap();
         let mut config = AppConfig::default();
         let mut ws = empty_ws();
-        ws.env
-            .insert("DB_URL".into(), "op://Work/db/password".into());
+        ws.env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc-vault/abc-item/password".into(),
+                path: "Work/db/password".into(),
+            }),
+        );
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -920,19 +920,20 @@ pub(super) fn handle_editor_modal(
         }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {
-                ModalOutcome::Commit(path) => {
+                ModalOutcome::Commit(op_ref) => {
                     // Operator picked a Vault → Item → Field path. The
                     // dispatch depends on whether `P` was pressed on a
                     // key row (write directly) or on an `+ Add` sentinel
-                    // (stash the path, ask for the key name first).
+                    // (stash the OpRef, ask for the key name first).
                     let target = editor.pending_picker_target.take();
                     match target {
                         Some((scope, Some(key))) => {
-                            set_pending_env_value(editor, &scope, &key, &path);
+                            set_pending_env_op_ref(editor, &scope, &key, op_ref);
                             editor.modal = None;
                         }
                         Some((scope, None)) => {
-                            editor.pending_picker_value = Some(path);
+                            editor.pending_picker_value =
+                                Some(crate::operator_env::EnvValue::OpRef(op_ref));
                             let label = format!("New environment key for {}", scope_label(&scope));
                             let state = env_key_input_state(editor, &scope, label, "");
                             editor.modal = Some(Modal::TextInput {
@@ -1058,6 +1059,52 @@ fn set_pending_env_value(
     }
 }
 
+/// Write an `OpRef` (picker commit result) into the pending env map.
+fn set_pending_env_op_ref(
+    editor: &mut EditorState<'_>,
+    scope: &SecretsScopeTag,
+    key: &str,
+    op_ref: crate::operator_env::OpRef,
+) {
+    match scope {
+        SecretsScopeTag::Workspace => {
+            editor.pending.env.insert(
+                key.to_string(),
+                crate::operator_env::EnvValue::OpRef(op_ref),
+            );
+        }
+        SecretsScopeTag::Agent(agent) => {
+            let entry = editor.pending.agents.entry(agent.clone()).or_default();
+            entry.env.insert(
+                key.to_string(),
+                crate::operator_env::EnvValue::OpRef(op_ref),
+            );
+            editor.secrets_expanded.insert(agent.clone());
+        }
+    }
+}
+
+/// Write an already-typed `EnvValue` into the pending env map.
+/// Used by the sentinel-add flow where the picker stashed an `OpRef`
+/// before the key name was known.
+fn set_pending_env_value_typed(
+    editor: &mut EditorState<'_>,
+    scope: &SecretsScopeTag,
+    key: &str,
+    value: crate::operator_env::EnvValue,
+) {
+    match scope {
+        SecretsScopeTag::Workspace => {
+            editor.pending.env.insert(key.to_string(), value);
+        }
+        SecretsScopeTag::Agent(agent) => {
+            let entry = editor.pending.agents.entry(agent.clone()).or_default();
+            entry.env.insert(key.to_string(), value);
+            editor.secrets_expanded.insert(agent.clone());
+        }
+    }
+}
+
 pub(super) fn apply_text_input_to_pending(
     target: &TextInputTarget,
     editor: &mut EditorState<'_>,
@@ -1093,10 +1140,10 @@ pub(super) fn apply_text_input_to_pending(
                 return;
             }
             let key = trimmed.to_string();
-            // Sentinel-picker fast path: P committed a path before the
+            // Sentinel-picker fast path: P committed an OpRef before the
             // key existed; both fields land here.
             if let Some(stashed) = editor.pending_picker_value.take() {
-                set_pending_env_value(editor, scope, &key, &stashed);
+                set_pending_env_value_typed(editor, scope, &key, stashed);
                 editor.pending_env_key = None;
                 return;
             }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -2647,4 +2647,49 @@ mod tests {
             e.active_field,
         );
     }
+
+    // ── TUI text-entry regression: typing or pasting op:// must stay Plain ──
+
+    /// Typing or pasting `op://...` into a value cell (text-entry path)
+    /// must always commit as `EnvValue::Plain`. The picker is the ONLY
+    /// TUI path that produces `EnvValue::OpRef`; this test pins that
+    /// invariant so an accidental auto-resolve can never sneak in.
+    ///
+    /// The structural guarantee: `apply_text_input_to_pending` for the
+    /// `EnvValue` target calls `set_pending_env_value`, which
+    /// unconditionally wraps its `&str` argument in
+    /// `EnvValue::Plain(value.to_string())`. There is no `op://` pattern
+    /// match in the text-entry commit path.
+    #[test]
+    fn tui_text_entry_op_uri_always_commits_as_plain() {
+        let mut editor =
+            EditorState::new_edit("CLAUDE_TOKEN_WS".into(), WorkspaceConfig::default());
+
+        let target = TextInputTarget::EnvValue {
+            scope: SecretsScopeTag::Workspace,
+            key: "CLAUDE_TOKEN".into(),
+        };
+
+        // Simulate committing a typed/pasted op:// string via the
+        // text-entry path (Enter in the EnvValue modal).
+        apply_text_input(&target, &mut editor, "op://Vault/Item/Field");
+
+        let stored = editor
+            .pending
+            .env
+            .get("CLAUDE_TOKEN")
+            .expect("CLAUDE_TOKEN must be present after commit");
+
+        assert_eq!(
+            stored,
+            &crate::operator_env::EnvValue::Plain("op://Vault/Item/Field".into()),
+            "text-entry commit of op:// string must store EnvValue::Plain, \
+             not EnvValue::OpRef — the picker is the only path to OpRef"
+        );
+        // Belt-and-suspenders: confirm it is NOT an OpRef.
+        assert!(
+            !matches!(stored, crate::operator_env::EnvValue::OpRef(_)),
+            "text entry must never produce EnvValue::OpRef"
+        );
+    }
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -349,7 +349,12 @@ fn toggle_focused_row_mask(editor: &mut EditorState<'_>) {
     let key = match row {
         SecretsRow::WorkspaceKeyRow(key) => {
             // Op:// rows render as breadcrumbs and ignore mask state.
-            let value = editor.pending.env.get(&key).cloned().unwrap_or_default();
+            let value = editor
+                .pending
+                .env
+                .get(&key)
+                .map(|v| v.as_persisted_str().to_string())
+                .unwrap_or_default();
             if crate::operator_env::is_op_reference(&value) {
                 return;
             }
@@ -361,7 +366,7 @@ fn toggle_focused_row_mask(editor: &mut EditorState<'_>) {
                 .agents
                 .get(&agent)
                 .and_then(|o| o.env.get(&key))
-                .cloned()
+                .map(|v| v.as_persisted_str().to_string())
                 .unwrap_or_default();
             if crate::operator_env::is_op_reference(&value) {
                 return;
@@ -411,7 +416,12 @@ fn open_secrets_enter_modal(editor: &mut EditorState<'_>) {
     };
     match row {
         SecretsRow::WorkspaceKeyRow(key) => {
-            let current = editor.pending.env.get(&key).cloned().unwrap_or_default();
+            let current = editor
+                .pending
+                .env
+                .get(&key)
+                .map(|v| v.as_persisted_str().to_string())
+                .unwrap_or_default();
             // Op:// rows are not text-editable — operator deletes via
             // D and re-adds via the source picker.
             if crate::operator_env::is_op_reference(&current) {
@@ -444,7 +454,7 @@ fn open_secrets_enter_modal(editor: &mut EditorState<'_>) {
                 .agents
                 .get(&agent)
                 .and_then(|o| o.env.get(&key))
-                .cloned()
+                .map(|v| v.as_persisted_str().to_string())
                 .unwrap_or_default();
             if crate::operator_env::is_op_reference(&current) {
                 return;
@@ -1023,14 +1033,17 @@ fn set_pending_env_value(
 ) {
     match scope {
         SecretsScopeTag::Workspace => {
-            editor
-                .pending
-                .env
-                .insert(key.to_string(), value.to_string());
+            editor.pending.env.insert(
+                key.to_string(),
+                crate::operator_env::EnvValue::Plain(value.to_string()),
+            );
         }
         SecretsScopeTag::Agent(agent) => {
             let entry = editor.pending.agents.entry(agent.clone()).or_default();
-            entry.env.insert(key.to_string(), value.to_string());
+            entry.env.insert(
+                key.to_string(),
+                crate::operator_env::EnvValue::Plain(value.to_string()),
+            );
             editor.secrets_expanded.insert(agent.clone());
         }
     }

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -732,7 +732,7 @@ fn append_env_map_diff_lines(
         match original.get(k) {
             Some(ov) if ov == v => {}
             _ => out.push(Line::from(Span::styled(
-                format!("{prefix}  + {k} = {}", v.as_persisted_str()),
+                format!("{prefix}  + {k} = {}", v.as_display_str()),
                 value,
             ))),
         }
@@ -1975,6 +1975,49 @@ mod tests {
         assert!(
             joined.contains("will be subsumed under"),
             "collapse detail must appear: {joined}"
+        );
+    }
+
+    #[test]
+    fn pre_save_diff_renders_op_ref_via_breadcrumb_not_uuid() {
+        use crate::operator_env::{EnvValue, OpRef};
+        use ratatui::style::Style;
+
+        let original = std::collections::BTreeMap::new();
+        let mut pending = std::collections::BTreeMap::new();
+        pending.insert(
+            "TOKEN".to_string(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc/def/fld".to_string(),
+                path: "Private/Claude/auth".to_string(),
+            }),
+        );
+
+        let value_style = Style::default();
+        let dim_style = Style::default();
+        let mut lines = Vec::new();
+        super::append_env_map_diff_lines(
+            &mut lines,
+            None,
+            &original,
+            &pending,
+            value_style,
+            dim_style,
+        );
+
+        let joined: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref().to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+
+        assert!(
+            joined.contains("Private/Claude/auth"),
+            "pre-save diff must render breadcrumb path; got: {joined}"
+        );
+        assert!(
+            !joined.contains("op://abc/def/fld"),
+            "UUID URI must NOT appear in pre-save diff; got: {joined}"
         );
     }
 }

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -698,7 +698,7 @@ fn env_diff_lines(
         .keys()
         .chain(pending.agents.keys())
         .collect();
-    let empty = std::collections::BTreeMap::<String, String>::new();
+    let empty = std::collections::BTreeMap::<String, crate::operator_env::EnvValue>::new();
     for agent in agent_keys {
         let orig_env = original.agents.get(agent).map_or(&empty, |o| &o.env);
         let pend_env = pending.agents.get(agent).map_or(&empty, |p| &p.env);
@@ -721,8 +721,8 @@ fn env_diff_lines(
 fn append_env_map_diff_lines(
     out: &mut Vec<ratatui::text::Line<'static>>,
     indent: Option<&str>,
-    original: &std::collections::BTreeMap<String, String>,
-    pending: &std::collections::BTreeMap<String, String>,
+    original: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pending: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
     value: ratatui::style::Style,
     dim: ratatui::style::Style,
 ) {
@@ -732,7 +732,7 @@ fn append_env_map_diff_lines(
         match original.get(k) {
             Some(ov) if ov == v => {}
             _ => out.push(Line::from(Span::styled(
-                format!("{prefix}  + {k} = {v}"),
+                format!("{prefix}  + {k} = {}", v.as_persisted_str()),
                 value,
             ))),
         }
@@ -806,7 +806,7 @@ fn apply_env_diff(
         .keys()
         .chain(pending.agents.keys())
         .collect();
-    let empty = std::collections::BTreeMap::<String, String>::new();
+    let empty = std::collections::BTreeMap::<String, crate::operator_env::EnvValue>::new();
     for agent in agent_keys {
         let orig_env = original.agents.get(agent).map_or(&empty, |o| &o.env);
         let pend_env = pending.agents.get(agent).map_or(&empty, |p| &p.env);
@@ -821,13 +821,15 @@ fn apply_env_diff(
 fn apply_env_map_diff(
     ce: &mut crate::config::ConfigEditor,
     scope: &EnvScope,
-    original: &std::collections::BTreeMap<String, String>,
-    pending: &std::collections::BTreeMap<String, String>,
+    original: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pending: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
 ) {
     for (k, v) in pending {
         match original.get(k) {
             Some(ov) if ov == v => {}
-            _ => ce.set_env_var(scope, k, v),
+            _ => {
+                let _ = ce.set_env_var(scope, k, v.clone());
+            }
         }
     }
     for k in original.keys() {

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -366,7 +366,7 @@ pub(super) fn commit_editor_save_with_runner(
 
     // `create_workspace`/`edit_workspace` don't touch env — TUI
     // manages env exclusively through this diff loop.
-    apply_env_diff(&mut ce, &current_name, &editor.original, &editor.pending);
+    apply_env_diff(&mut ce, &current_name, &editor.original, &editor.pending)?;
 
     match ce.save() {
         Ok(fresh) => {
@@ -796,9 +796,9 @@ fn apply_env_diff(
     workspace_name: &str,
     original: &crate::workspace::WorkspaceConfig,
     pending: &crate::workspace::WorkspaceConfig,
-) {
+) -> anyhow::Result<()> {
     let ws_scope = EnvScope::Workspace(workspace_name.to_string());
-    apply_env_map_diff(ce, &ws_scope, &original.env, &pending.env);
+    apply_env_map_diff(ce, &ws_scope, &original.env, &pending.env)?;
 
     // Union so agents on only one side are caught.
     let agent_keys: std::collections::BTreeSet<&String> = original
@@ -814,8 +814,9 @@ fn apply_env_diff(
             workspace: workspace_name.to_string(),
             agent: agent.clone(),
         };
-        apply_env_map_diff(ce, &scope, orig_env, pend_env);
+        apply_env_map_diff(ce, &scope, orig_env, pend_env)?;
     }
+    Ok(())
 }
 
 fn apply_env_map_diff(
@@ -823,12 +824,12 @@ fn apply_env_map_diff(
     scope: &EnvScope,
     original: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
     pending: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
-) {
+) -> anyhow::Result<()> {
     for (k, v) in pending {
         match original.get(k) {
             Some(ov) if ov == v => {}
             _ => {
-                let _ = ce.set_env_var(scope, k, v.clone());
+                ce.set_env_var(scope, k, v.clone())?;
             }
         }
     }
@@ -839,6 +840,7 @@ fn apply_env_map_diff(
             let _ = ce.remove_env_var(scope, k);
         }
     }
+    Ok(())
 }
 
 pub(super) fn build_workspace_edit(

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -191,13 +191,13 @@ fn contextual_row_items(state: &EditorState<'_>, op_available: bool) -> Vec<Foot
                     .pending
                     .env
                     .get(key)
-                    .is_some_and(|v| is_op_reference(v)),
+                    .is_some_and(|v| is_op_reference(v.as_persisted_str())),
                 Some(SecretsRow::AgentKeyRow { agent, key }) => state
                     .pending
                     .agents
                     .get(agent)
                     .and_then(|ov| ov.env.get(key))
-                    .is_some_and(|v| is_op_reference(v)),
+                    .is_some_and(|v| is_op_reference(v.as_persisted_str())),
                 _ => false,
             };
             match rows.get(cursor) {
@@ -588,7 +588,12 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
         let cursor_col = if selected { "▸ " } else { "  " };
         match row {
             SecretsRow::WorkspaceKeyRow(key) => {
-                let value = state.pending.env.get(key).cloned().unwrap_or_default();
+                let value = state
+                    .pending
+                    .env
+                    .get(key)
+                    .map(|v| v.as_persisted_str().to_string())
+                    .unwrap_or_default();
                 let masked = !state
                     .unmasked_rows
                     .contains(&(SecretsScopeTag::Workspace, key.clone()));
@@ -632,9 +637,13 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 lines.push(Line::from(spans));
             }
             SecretsRow::AgentKeyRow { agent, key } => {
-                let empty = std::collections::BTreeMap::<String, String>::new();
+                let empty =
+                    std::collections::BTreeMap::<String, crate::operator_env::EnvValue>::new();
                 let pend_env = state.pending.agents.get(agent).map_or(&empty, |o| &o.env);
-                let value = pend_env.get(key).cloned().unwrap_or_default();
+                let value = pend_env
+                    .get(key)
+                    .map(|v| v.as_persisted_str().to_string())
+                    .unwrap_or_default();
                 let masked = !state
                     .unmasked_rows
                     .contains(&(SecretsScopeTag::Agent(agent.clone()), key.clone()));

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -700,6 +700,11 @@ fn render_secrets_key_line(
     };
     let dim = Style::default().fg(PHOSPHOR_DIM);
 
+    // TODO(uuid-pinning, Task 6): replace string-sniff with variant-aware
+    // dispatch on the EnvValue. Until Task 6 lands `parse_path_breadcrumb`,
+    // legacy bare `op://...` strings stored as Plain still render with the
+    // `[op]` marker and breadcrumb here, even though input handlers now
+    // treat them as Plain (no mask toggle, no edit modal).
     // parse_op_reference doubles as the is-op check: Some → op://,
     // None → plain. One scan instead of two.
     let op_parts = parse_op_reference(value);

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -753,6 +753,7 @@ fn render_secrets_key_line(
     const OP_MARKER: &str = "[op] ";
     const NO_MARKER: &str = "     ";
     const MASK: &str = "●●●●●●●●●●●";
+    const OP_REF_REPICK_PLACEHOLDER: &str = "<unparseable path \u{2014} re-pick>";
 
     let label_style = if selected {
         Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
@@ -814,9 +815,11 @@ fn render_secrets_key_line(
     }
 
     // Plain branch: render as masked or literal value.
+    // For an OpRef whose path failed to parse (malformed / empty), show an
+    // explicit re-pick placeholder rather than leaking the UUID URI.
     let plain_str = match value {
         EnvValue::Plain(s) => s.as_str(),
-        EnvValue::OpRef(r) => r.op.as_str(),
+        EnvValue::OpRef(_) => OP_REF_REPICK_PLACEHOLDER,
     };
 
     let value_style = if masked {
@@ -1927,10 +1930,10 @@ mod secrets_tab_render_tests {
     }
 
     /// `OpRef` whose `path` doesn't parse as a 3- or 4-segment breadcrumb.
-    /// The renderer must NOT panic; it falls back to displaying the canonical
-    /// `op://` URI in the value column without the `[op]` marker.
+    /// The renderer must NOT panic; it shows a re-pick placeholder in the
+    /// value column without the `[op]` marker, and must NOT leak the UUID URI.
     #[test]
-    fn renderer_op_ref_with_malformed_path_renders_op_uri_no_marker_no_panic() {
+    fn renderer_op_ref_with_malformed_path_renders_repick_placeholder_no_panic() {
         let mut env = std::collections::BTreeMap::new();
         env.insert(
             "TOKEN".into(),
@@ -1946,21 +1949,23 @@ mod secrets_tab_render_tests {
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
-        // Unmask so the fallback URI is rendered as text rather than ●●●.
+        // Unmask so the placeholder is rendered as text rather than ●●●.
         editor
             .unmasked_rows
             .insert((SecretsScopeTag::Workspace, "TOKEN".into()));
 
         let dump = render_to_dump_wide(&editor);
         // Malformed path → parse_path_breadcrumb returns None → no [op] marker.
+        assert!(!dump.contains("[op]"), "no [op] marker; dump:\n{dump}");
+        // Re-pick placeholder must be shown instead of the UUID URI.
         assert!(
-            !dump.contains("[op]"),
-            "malformed path must not get [op] marker; dump:\n{dump}"
+            dump.contains("<unparseable path \u{2014} re-pick>"),
+            "expected re-pick placeholder; dump:\n{dump}"
         );
-        // The canonical op:// URI is rendered as the fallback value.
+        // UUID URI must NOT be visible to the operator.
         assert!(
-            dump.contains("op://abc/def/fld"),
-            "fallback must render the canonical URI; dump:\n{dump}"
+            !dump.contains("op://abc/def/fld"),
+            "UUID URI must NOT leak; dump:\n{dump}"
         );
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -813,7 +813,7 @@ fn render_secrets_key_line(
     // Plain branch: render as masked or literal value.
     let plain_str = match value {
         EnvValue::Plain(s) => s.as_str(),
-        EnvValue::OpRef(_) => unreachable!("OpRef handled above"),
+        EnvValue::OpRef(r) => r.op.as_str(),
     };
 
     let value_style = if masked {
@@ -1813,6 +1813,46 @@ mod secrets_tab_render_tests {
             dump.contains("one-time password"),
             "field must render; dump:\n{dump}"
         );
+    }
+
+    /// OpRef with BOTH a subtitle disambiguation AND an `?attribute=otp`
+    /// query suffix. Asserts that all six visible pieces appear in the
+    /// expected left-to-right order: vault → item → subtitle → section →
+    /// field → query.
+    #[test]
+    fn renderer_op_ref_with_subtitle_section_and_query_renders_all() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "TOKEN".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc/def/sec/fld?attribute=otp".into(),
+                path: "Private/Claude[alexey@zhokhov.com]/security/auth token?attribute=otp".into(),
+            }),
+        );
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+
+        // Use the wide terminal so no piece is truncated.
+        let dump = render_to_dump_wide(&editor);
+
+        // All visible pieces must appear in order:
+        // vault → item → subtitle → section → field → query.
+        let v_pos = dump.find("Private").expect("vault present");
+        let i_pos = dump.find("Claude").expect("item present");
+        let s_pos = dump.find("alexey@zhokhov.com").expect("subtitle present");
+        let sec_pos = dump.find("security").expect("section present");
+        let f_pos = dump.find("auth token").expect("field present");
+        let q_pos = dump.find("?attribute=otp").expect("query present");
+        assert!(v_pos < i_pos, "vault before item");
+        assert!(i_pos < s_pos, "item before subtitle");
+        assert!(s_pos < sec_pos, "subtitle before section");
+        assert!(sec_pos < f_pos, "section before field");
+        assert!(f_pos < q_pos, "field before query");
     }
 
     /// After Task 6, a `Plain` row containing a bare `op://...` string

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -19,7 +19,7 @@ use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
 };
 use crate::config::AppConfig;
-use crate::operator_env::{EnvValue, parse_op_reference};
+use crate::operator_env::EnvValue;
 
 // ── Editor stage ────────────────────────────────────────────────────
 
@@ -588,12 +588,8 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
         let cursor_col = if selected { "▸ " } else { "  " };
         match row {
             SecretsRow::WorkspaceKeyRow(key) => {
-                let value = state
-                    .pending
-                    .env
-                    .get(key)
-                    .map(|v| v.as_persisted_str().to_string())
-                    .unwrap_or_default();
+                let default_value = EnvValue::Plain(String::new());
+                let value = state.pending.env.get(key).unwrap_or(&default_value);
                 let masked = !state
                     .unmasked_rows
                     .contains(&(SecretsScopeTag::Workspace, key.clone()));
@@ -601,7 +597,7 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                     selected,
                     cursor_col,
                     key,
-                    &value,
+                    value,
                     masked,
                     area.width,
                     label_width,
@@ -640,10 +636,8 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 let empty =
                     std::collections::BTreeMap::<String, crate::operator_env::EnvValue>::new();
                 let pend_env = state.pending.agents.get(agent).map_or(&empty, |o| &o.env);
-                let value = pend_env
-                    .get(key)
-                    .map(|v| v.as_persisted_str().to_string())
-                    .unwrap_or_default();
+                let default_value = EnvValue::Plain(String::new());
+                let value = pend_env.get(key).unwrap_or(&default_value);
                 let masked = !state
                     .unmasked_rows
                     .contains(&(SecretsScopeTag::Agent(agent.clone()), key.clone()));
@@ -651,7 +645,7 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                     selected,
                     cursor_col,
                     key,
-                    &value,
+                    value,
                     masked,
                     area.width,
                     label_width,
@@ -680,8 +674,6 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
 /// Display-side breadcrumb parser for `OpRef.path`.
 /// Grammar: `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?<query>]`
 #[derive(Debug, PartialEq, Eq)]
-// Task 6 wires this in; until then the struct is exercised only by tests.
-#[allow(dead_code)]
 pub(super) struct PathBreadcrumb {
     pub vault: String,
     pub item: String,
@@ -691,8 +683,6 @@ pub(super) struct PathBreadcrumb {
     pub attribute_query: Option<String>,
 }
 
-// Task 6 wires this in; until then the function is exercised only by tests.
-#[allow(dead_code)]
 pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
     if path.is_empty() {
         return None;
@@ -729,7 +719,6 @@ pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
     })
 }
 
-#[allow(dead_code)]
 fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
     if let Some(open) = s.rfind('[')
         && s.ends_with(']')
@@ -743,14 +732,18 @@ fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
     (s.to_string(), None)
 }
 
-/// `op://` rows skip masking and render as a breadcrumb (3-segment:
-/// `vault / item → field`, 4-segment adds `section`). Account scope
-/// isn't part of the `op://` path — see the picker docstring.
+/// `OpRef` rows skip masking and render as a breadcrumb (3-segment:
+/// `vault / item → field`, 4-segment adds `section`). An optional
+/// `[subtitle]` annotation after the item renders in `PHOSPHOR_DIM`; an
+/// optional `?attribute=...` query suffix renders in `PHOSPHOR_DIM` after
+/// the field. `Plain` rows (including legacy bare `op://...` strings)
+/// render as a literal / masked value with no `[op]` marker — the visual
+/// migration signal that the row needs re-picking to upgrade.
 fn render_secrets_key_line(
     selected: bool,
     cursor_col: &str,
     key: &str,
-    value: &str,
+    value: &EnvValue,
     masked: bool,
     area_width: u16,
     label_width: usize,
@@ -766,15 +759,15 @@ fn render_secrets_key_line(
     };
     let dim = Style::default().fg(PHOSPHOR_DIM);
 
-    // TODO(uuid-pinning, Task 6): replace string-sniff with variant-aware
-    // dispatch on the EnvValue. Until Task 6 lands `parse_path_breadcrumb`,
-    // legacy bare `op://...` strings stored as Plain still render with the
-    // `[op]` marker and breadcrumb here, even though input handlers now
-    // treat them as Plain (no mask toggle, no edit modal).
-    // parse_op_reference doubles as the is-op check: Some → op://,
-    // None → plain. One scan instead of two.
-    let op_parts = parse_op_reference(value);
-    let marker = if op_parts.is_some() {
+    // Variant-aware dispatch: only `OpRef` rows render with the `[op]`
+    // marker and breadcrumb. `Plain` values (including legacy bare
+    // `op://...` strings) render as literal / masked — the visual signal
+    // that the row needs re-picking to upgrade to a pinned `OpRef`.
+    let op_breadcrumb = match value {
+        EnvValue::OpRef(r) => parse_path_breadcrumb(&r.path),
+        EnvValue::Plain(_) => None,
+    };
+    let marker = if op_breadcrumb.is_some() {
         OP_MARKER
     } else {
         NO_MARKER
@@ -785,10 +778,10 @@ fn render_secrets_key_line(
         Span::styled(format!("{key:label_width$}"), label_style),
     ];
 
-    // Op:// references render as a breadcrumb regardless of `masked` —
-    // the path is not the credential, so masking it makes the row a
+    // OpRef rows render as a breadcrumb regardless of `masked` — the
+    // path is not the credential, so masking it makes the row a
     // less informative version of itself.
-    if let Some(parts) = op_parts {
+    if let Some(parts) = op_breadcrumb {
         let white_style = Style::default().fg(WHITE);
         let green = Style::default().fg(PHOSPHOR_GREEN);
         let green_bold = Style::default()
@@ -797,17 +790,31 @@ fn render_secrets_key_line(
         spans.push(Span::styled(parts.vault, white_style));
         spans.push(Span::styled(" / ", dim));
         spans.push(Span::styled(parts.item, green));
-        if let Some(section) = parts.section.as_ref() {
+        if let Some(subtitle) = parts.item_subtitle {
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(subtitle, dim));
+        }
+        if let Some(section) = parts.section {
             // 4-segment reference: the field lives inside a named
             // section of the item. Render the section between the
             // item and the field.
             spans.push(Span::styled(" / ", dim));
-            spans.push(Span::styled(section.clone(), green));
+            spans.push(Span::styled(section, green));
         }
         spans.push(Span::styled(" \u{2192} ", dim));
         spans.push(Span::styled(parts.field, green_bold));
+        if let Some(query) = parts.attribute_query {
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(query, dim));
+        }
         return Line::from(spans);
     }
+
+    // Plain branch: render as masked or literal value.
+    let plain_str = match value {
+        EnvValue::Plain(s) => s.as_str(),
+        EnvValue::OpRef(_) => unreachable!("OpRef handled above"),
+    };
 
     let value_style = if masked {
         Style::default().fg(PHOSPHOR_DIM)
@@ -829,12 +836,12 @@ fn render_secrets_key_line(
             .saturating_sub(label_width)
             .saturating_sub(8)
             .max(1);
-        if value.chars().count() > budget {
-            let mut s: String = value.chars().take(budget.saturating_sub(1)).collect();
+        if plain_str.chars().count() > budget {
+            let mut s: String = plain_str.chars().take(budget.saturating_sub(1)).collect();
             s.push('…');
             s
         } else {
-            value.to_string()
+            plain_str.to_string()
         }
     };
     spans.push(Span::styled(rendered_value, value_style));
@@ -1406,7 +1413,13 @@ mod secrets_tab_render_tests {
     #[test]
     fn op_row_breadcrumb_render_three_segment() {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("DB_URL".into(), "op://Work/db/password".into());
+        env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://Work/db/password".into(),
+                path: "Work/db/password".into(),
+            }),
+        );
         let ws = WorkspaceConfig {
             env,
             ..WorkspaceConfig::default()
@@ -1436,15 +1449,15 @@ mod secrets_tab_render_tests {
             !dump.contains("op://"),
             "op:// scheme prefix must not appear in the breadcrumb; dump:\n{dump}"
         );
-        // Mask glyph must not appear on op:// rows even though
+        // Mask glyph must not appear on OpRef rows even though
         // editor defaults to all-masked.
         assert!(
             editor.unmasked_rows.is_empty(),
-            "default state is all-masked; op:// rows must still bypass masking"
+            "default state is all-masked; OpRef rows must still bypass masking"
         );
         assert!(
             !dump.contains("●●●"),
-            "op:// rows must never render the mask glyph; dump:\n{dump}"
+            "OpRef rows must never render the mask glyph; dump:\n{dump}"
         );
     }
 
@@ -1455,7 +1468,10 @@ mod secrets_tab_render_tests {
         let mut env = std::collections::BTreeMap::new();
         env.insert(
             "API_KEY".into(),
-            "op://Personal/API Keys/auth/secret_key".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://Personal/API Keys/auth/secret_key".into(),
+                path: "Personal/API Keys/auth/secret_key".into(),
+            }),
         );
         let ws = WorkspaceConfig {
             env,
@@ -1498,7 +1514,13 @@ mod secrets_tab_render_tests {
     #[test]
     fn op_row_renders_with_op_text_marker() {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("DB_URL".into(), "op://Work/db/password".into());
+        env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://Work/db/password".into(),
+                path: "Work/db/password".into(),
+            }),
+        );
         let ws = WorkspaceConfig {
             env,
             ..WorkspaceConfig::default()
@@ -1510,7 +1532,7 @@ mod secrets_tab_render_tests {
         let dump = render_to_dump(&editor);
         assert!(
             dump.contains("[op]"),
-            "op:// row must render the `[op]` text marker; dump:\n{dump}"
+            "OpRef row must render the `[op]` text marker; dump:\n{dump}"
         );
         assert!(
             !dump.contains("\u{26BF}"),
@@ -1540,7 +1562,13 @@ mod secrets_tab_render_tests {
     #[test]
     fn op_row_marker_column_is_5_chars_wide_with_brackets() {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("DB_URL".into(), "op://Work/db/password".into());
+        env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://Work/db/password".into(),
+                path: "Work/db/password".into(),
+            }),
+        );
         let ws = WorkspaceConfig {
             env,
             ..WorkspaceConfig::default()
@@ -1552,7 +1580,7 @@ mod secrets_tab_render_tests {
         let dump = render_to_dump(&editor);
         assert!(
             dump.contains("[op] "),
-            "op:// row must render the marker as exactly `[op] ` (5 chars \
+            "OpRef row must render the marker as exactly `[op] ` (5 chars \
              including trailing space); dump:\n{dump}"
         );
     }
@@ -1675,6 +1703,150 @@ mod secrets_tab_render_tests {
         assert!(
             !matches!(rows.last(), Some(super::SecretsRow::SectionSpacer)),
             "no trailing spacer after the final section; rows={rows:?}"
+        );
+    }
+
+    /// Helper that renders the Secrets tab to a wider (120-column) terminal
+    /// so long breadcrumbs (subtitle + section + field) are not truncated.
+    fn render_to_dump_wide(editor: &EditorState<'_>) -> String {
+        let config = AppConfig::default();
+        let backend = TestBackend::new(120, 15);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            render_secrets_tab(f, Rect::new(0, 0, 120, 15), editor, &config);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    /// OpRef whose `path` contains the `[subtitle]` disambiguation form.
+    /// The subtitle must appear in the rendered output between the item
+    /// name and the next " / " separator.
+    #[test]
+    fn renderer_op_ref_with_subtitle_renders_text() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "TOKEN".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc/def/fld".into(),
+                path: "Private/Claude[alexey@zhokhov.com]/security/auth token".into(),
+            }),
+        );
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+
+        // Use the wide terminal so the subtitle and field are not truncated.
+        let dump = render_to_dump_wide(&editor);
+        // The row must carry the [op] marker (OpRef variant).
+        assert!(
+            dump.contains("[op]"),
+            "OpRef row with subtitle must render `[op]` marker; dump:\n{dump}"
+        );
+        // Subtitle text must appear in the rendered output.
+        assert!(
+            dump.contains("alexey@zhokhov.com"),
+            "subtitle text must appear in the breadcrumb; dump:\n{dump}"
+        );
+        // Vault, item, section, and field must all render.
+        assert!(dump.contains("Private"), "vault must render; dump:\n{dump}");
+        assert!(
+            dump.contains("Claude"),
+            "item name must render; dump:\n{dump}"
+        );
+        assert!(
+            dump.contains("security"),
+            "section must render; dump:\n{dump}"
+        );
+        assert!(
+            dump.contains("auth token"),
+            "field must render; dump:\n{dump}"
+        );
+    }
+
+    /// OpRef whose `path` carries an `?attribute=otp` query suffix. The
+    /// query must appear in the rendered output after the field name.
+    #[test]
+    fn renderer_op_ref_with_attribute_query_renders_text() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "OTP".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc/def/fld?attribute=otp".into(),
+                path: "Private/GitHub/one-time password?attribute=otp".into(),
+            }),
+        );
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+
+        // Use the wide terminal so `?attribute=otp` is not truncated.
+        let dump = render_to_dump_wide(&editor);
+        // The row must carry the [op] marker.
+        assert!(
+            dump.contains("[op]"),
+            "OpRef row with attribute query must render `[op]` marker; dump:\n{dump}"
+        );
+        // The query suffix must appear in the output.
+        assert!(
+            dump.contains("?attribute=otp"),
+            "attribute query must appear in breadcrumb; dump:\n{dump}"
+        );
+        // Field name must also render.
+        assert!(
+            dump.contains("one-time password"),
+            "field must render; dump:\n{dump}"
+        );
+    }
+
+    /// After Task 6, a `Plain` row containing a bare `op://...` string
+    /// gets NO `[op]` marker — it renders as a literal masked value, the
+    /// visual signal that the operator needs to re-pick it.
+    #[test]
+    fn renderer_plain_with_bare_op_uri_renders_as_literal_no_breadcrumb() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert("DB_URL".into(), "op://Vault/Item/Field".into());
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+
+        let dump = render_to_dump(&editor);
+        // Plain rows carrying a legacy op:// string must NOT render the
+        // [op] marker — the visual distinction signals the need to re-pick.
+        assert!(
+            !dump.contains("[op]"),
+            "Plain rows must NOT carry [op] marker; dump:\n{dump}"
+        );
+        // The breadcrumb separators must not appear — this is a plain
+        // masked/literal row, not a breadcrumb render.
+        assert!(
+            !dump.contains(" / Vault / "),
+            "Plain op:// strings must not render vault breadcrumb; dump:\n{dump}"
+        );
+        // The mask glyph must appear (plain row, masked by default).
+        assert!(
+            dump.contains("●●●"),
+            "Plain row must render masked by default; dump:\n{dump}"
         );
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1923,6 +1923,44 @@ mod secrets_tab_render_tests {
             "no space is the bug; dump:\n{dump}"
         );
     }
+
+    /// `OpRef` whose `path` doesn't parse as a 3- or 4-segment breadcrumb.
+    /// The renderer must NOT panic; it falls back to displaying the canonical
+    /// `op://` URI in the value column without the `[op]` marker.
+    #[test]
+    fn renderer_op_ref_with_malformed_path_renders_op_uri_no_marker_no_panic() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "TOKEN".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc/def/fld".into(),
+                path: "garbage-no-slashes".into(),
+            }),
+        );
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+        // Unmask so the fallback URI is rendered as text rather than ●●●.
+        editor
+            .unmasked_rows
+            .insert((SecretsScopeTag::Workspace, "TOKEN".into()));
+
+        let dump = render_to_dump_wide(&editor);
+        // Malformed path → parse_path_breadcrumb returns None → no [op] marker.
+        assert!(
+            !dump.contains("[op]"),
+            "malformed path must not get [op] marker; dump:\n{dump}"
+        );
+        // The canonical op:// URI is rendered as the fallback value.
+        assert!(
+            dump.contains("op://abc/def/fld"),
+            "fallback must render the canonical URI; dump:\n{dump}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -776,6 +776,7 @@ fn render_secrets_key_line(
         Span::raw(cursor_col.to_string()),
         Span::styled(marker.to_string(), dim),
         Span::styled(format!("{key:label_width$}"), label_style),
+        Span::raw("  "), // always at least two spaces between key and value
     ];
 
     // OpRef rows render as a breadcrumb regardless of `masked` — the
@@ -1887,6 +1888,39 @@ mod secrets_tab_render_tests {
         assert!(
             dump.contains("●●●"),
             "Plain row must render masked by default; dump:\n{dump}"
+        );
+    }
+
+    /// Single env var → label_width equals key length. Without the explicit
+    /// two-space span, the screenshot bug (CLAUDE_CODE_OAUTH_TOKENPrivate / ...)
+    /// recurs.
+    #[test]
+    fn renderer_key_value_separator_always_at_least_two_spaces() {
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "CLAUDE_CODE_OAUTH_TOKEN".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc/def/fld".into(),
+                path: "Private/Claude/security/auth token".into(),
+            }),
+        );
+        let ws = WorkspaceConfig {
+            env,
+            ..WorkspaceConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor.active_field = FieldFocus::Row(0);
+
+        // Use the wide terminal so the breadcrumb is not truncated.
+        let dump = render_to_dump_wide(&editor);
+        assert!(
+            dump.contains("CLAUDE_CODE_OAUTH_TOKEN  Private"),
+            "expected at least 2 spaces between key and breadcrumb; dump:\n{dump}"
+        );
+        assert!(
+            !dump.contains("CLAUDE_CODE_OAUTH_TOKENPrivate"),
+            "no space is the bug; dump:\n{dump}"
         );
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -683,6 +683,7 @@ pub(super) struct PathBreadcrumb {
     pub attribute_query: Option<String>,
 }
 
+/// Parse a snapshot breadcrumb. Returns `None` on empty input or non-3-/4-segment counts.
 pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
     if path.is_empty() {
         return None;
@@ -720,6 +721,7 @@ pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
 }
 
 fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
+    // rfind so an inner '[' in the subtitle is tolerated.
     if let Some(open) = s.rfind('[')
         && s.ends_with(']')
         && open < s.len() - 1
@@ -1856,9 +1858,9 @@ mod secrets_tab_render_tests {
         assert!(f_pos < q_pos, "field before query");
     }
 
-    /// After Task 6, a `Plain` row containing a bare `op://...` string
-    /// gets NO `[op]` marker — it renders as a literal masked value, the
-    /// visual signal that the operator needs to re-pick it.
+    /// A `Plain` row containing a bare `op://...` string gets NO `[op]`
+    /// marker — it renders as a literal masked value, the visual signal
+    /// that the operator needs to re-pick it.
     #[test]
     fn renderer_plain_with_bare_op_uri_renders_as_literal_no_breadcrumb() {
         let mut env = std::collections::BTreeMap::new();

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -19,7 +19,7 @@ use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
 };
 use crate::config::AppConfig;
-use crate::operator_env::{is_op_reference, parse_op_reference};
+use crate::operator_env::{EnvValue, parse_op_reference};
 
 // ── Editor stage ────────────────────────────────────────────────────
 
@@ -185,19 +185,19 @@ fn contextual_row_items(state: &EditorState<'_>, op_available: bool) -> Vec<Foot
             // the operator deletes and re-adds via the source picker — so
             // we drop `Enter edit` and `M mask/unmask` on those rows.
             let rows = secrets_flat_rows(state);
-            // Determine if the focused key row carries an op:// reference.
+            // Determine if the focused key row carries an OpRef value.
             let focused_value_is_op_ref = match rows.get(cursor) {
                 Some(SecretsRow::WorkspaceKeyRow(key)) => state
                     .pending
                     .env
                     .get(key)
-                    .is_some_and(|v| is_op_reference(v.as_persisted_str())),
+                    .is_some_and(|v| matches!(v, EnvValue::OpRef(_))),
                 Some(SecretsRow::AgentKeyRow { agent, key }) => state
                     .pending
                     .agents
                     .get(agent)
                     .and_then(|ov| ov.env.get(key))
-                    .is_some_and(|v| is_op_reference(v.as_persisted_str())),
+                    .is_some_and(|v| matches!(v, EnvValue::OpRef(_))),
                 _ => false,
             };
             match rows.get(cursor) {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -677,6 +677,72 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
+/// Display-side breadcrumb parser for `OpRef.path`.
+/// Grammar: `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?<query>]`
+#[derive(Debug, PartialEq, Eq)]
+// Task 6 wires this in; until then the struct is exercised only by tests.
+#[allow(dead_code)]
+pub(super) struct PathBreadcrumb {
+    pub vault: String,
+    pub item: String,
+    pub item_subtitle: Option<String>,
+    pub section: Option<String>,
+    pub field: String,
+    pub attribute_query: Option<String>,
+}
+
+// Task 6 wires this in; until then the function is exercised only by tests.
+#[allow(dead_code)]
+pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
+    if path.is_empty() {
+        return None;
+    }
+    // Peel off optional `?attribute=...` / `?attr=...` / `?ssh-format=...` query.
+    let (path_no_q, attr) = path
+        .find('?')
+        .map_or((path, None), |i| (&path[..i], Some(path[i..].to_string())));
+    let segs: Vec<&str> = path_no_q.split('/').collect();
+    let (item, item_subtitle, vault, section, field) = match segs.as_slice() {
+        [vault, item_seg, field] => {
+            let (item, sub) = split_bracket_subtitle(item_seg);
+            (item, sub, vault.to_string(), None, field.to_string())
+        }
+        [vault, item_seg, section, field] => {
+            let (item, sub) = split_bracket_subtitle(item_seg);
+            (
+                item,
+                sub,
+                vault.to_string(),
+                Some(section.to_string()),
+                field.to_string(),
+            )
+        }
+        _ => return None,
+    };
+    Some(PathBreadcrumb {
+        vault,
+        item,
+        item_subtitle,
+        section,
+        field,
+        attribute_query: attr,
+    })
+}
+
+#[allow(dead_code)]
+fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
+    if let Some(open) = s.rfind('[')
+        && s.ends_with(']')
+        && open < s.len() - 1
+    {
+        return (
+            s[..open].to_string(),
+            Some(s[open + 1..s.len() - 1].to_string()),
+        );
+    }
+    (s.to_string(), None)
+}
+
 /// `op://` rows skip masking and render as a breadcrumb (3-segment:
 /// `vault / item → field`, 4-segment adds `section`). Account scope
 /// isn't part of the `op://` path — see the picker docstring.
@@ -1704,5 +1770,70 @@ mod eligible_agents_for_override_tests {
         let editor = editor_for(ws_with_overrides(&[], &[]));
         let eligible = eligible_agents_for_override(&editor, &cfg);
         assert!(eligible.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod parse_path_breadcrumb_tests {
+    use super::parse_path_breadcrumb;
+
+    #[test]
+    fn parse_path_breadcrumb_3_segment_no_subtitle() {
+        let p = parse_path_breadcrumb("Private/Stripe/api key").unwrap();
+        assert_eq!(p.vault, "Private");
+        assert_eq!(p.item, "Stripe");
+        assert!(p.item_subtitle.is_none());
+        assert!(p.section.is_none());
+        assert_eq!(p.field, "api key");
+        assert!(p.attribute_query.is_none());
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_3_segment_with_subtitle() {
+        let p = parse_path_breadcrumb("Private/Claude[alexey@zhokhov.com]/auth").unwrap();
+        assert_eq!(p.vault, "Private");
+        assert_eq!(p.item, "Claude");
+        assert_eq!(p.item_subtitle.as_deref(), Some("alexey@zhokhov.com"));
+        assert!(p.section.is_none());
+        assert_eq!(p.field, "auth");
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_4_segment_with_subtitle() {
+        let p = parse_path_breadcrumb("Private/Claude[alexey@zhokhov.com]/security/auth token")
+            .unwrap();
+        assert_eq!(p.vault, "Private");
+        assert_eq!(p.item, "Claude");
+        assert_eq!(p.item_subtitle.as_deref(), Some("alexey@zhokhov.com"));
+        assert_eq!(p.section.as_deref(), Some("security"));
+        assert_eq!(p.field, "auth token");
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_with_attribute_query() {
+        let p = parse_path_breadcrumb("Private/GitHub/one-time password?attribute=otp").unwrap();
+        assert_eq!(p.field, "one-time password");
+        assert_eq!(p.attribute_query.as_deref(), Some("?attribute=otp"));
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_subtitle_containing_brackets() {
+        // rfind('[') means the last [...] is the subtitle.
+        let p = parse_path_breadcrumb("Private/Claude[has [bracket]]/auth").unwrap();
+        assert_eq!(p.item, "Claude[has ");
+        assert_eq!(p.item_subtitle.as_deref(), Some("bracket]"));
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_invalid_too_few_segments() {
+        assert!(parse_path_breadcrumb("Private/Item").is_none());
+        assert!(parse_path_breadcrumb("Private").is_none());
+        assert!(parse_path_breadcrumb("").is_none());
+    }
+
+    #[test]
+    fn parse_path_breadcrumb_invalid_too_many_segments() {
+        // 5+ segments is not a valid 1Password breadcrumb.
+        assert!(parse_path_breadcrumb("a/b/c/d/e").is_none());
     }
 }

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -550,7 +550,7 @@ fn render_environments_subpanel(
             rows.push(EnvRow {
                 name: key.clone(),
                 scope: None,
-                is_op: crate::operator_env::is_op_reference(value),
+                is_op: crate::operator_env::is_op_reference(value.as_persisted_str()),
             });
         }
         for (agent, overrides) in &ws.agents {
@@ -558,7 +558,7 @@ fn render_environments_subpanel(
                 rows.push(EnvRow {
                     name: key.clone(),
                     scope: Some(agent.clone()),
-                    is_op: crate::operator_env::is_op_reference(value),
+                    is_op: crate::operator_env::is_op_reference(value.as_persisted_str()),
                 });
             }
         }

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -550,7 +550,7 @@ fn render_environments_subpanel(
             rows.push(EnvRow {
                 name: key.clone(),
                 scope: None,
-                is_op: crate::operator_env::is_op_reference(value.as_persisted_str()),
+                is_op: matches!(value, crate::operator_env::EnvValue::OpRef(_)),
             });
         }
         for (agent, overrides) in &ws.agents {
@@ -558,7 +558,7 @@ fn render_environments_subpanel(
                 rows.push(EnvRow {
                     name: key.clone(),
                     scope: Some(agent.clone()),
-                    is_op: crate::operator_env::is_op_reference(value.as_persisted_str()),
+                    is_op: matches!(value, crate::operator_env::EnvValue::OpRef(_)),
                 });
             }
         }
@@ -1808,8 +1808,13 @@ mod subpanel_padding_tests {
     #[test]
     fn preview_environments_marks_op_references_with_op_marker() {
         let mut ws = ws_config_with_allowed(&[], None);
-        ws.env
-            .insert("STRIPE_KEY".into(), "op://Vault/Item/field".into());
+        ws.env.insert(
+            "STRIPE_KEY".into(),
+            crate::operator_env::EnvValue::OpRef(crate::operator_env::OpRef {
+                op: "op://abc-vault/abc-item/field".into(),
+                path: "Vault/Item/field".into(),
+            }),
+        );
 
         let backend = TestBackend::new(60, 4);
         let mut term = Terminal::new(backend).unwrap();

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -125,10 +125,10 @@ pub struct EditorState<'a> {
     /// row's value; `Some((scope, None))` opens the `EnvKey` modal
     /// next with the value pre-stashed in `pending_picker_value`.
     pub pending_picker_target: Option<(SecretsScopeTag, Option<String>)>,
-    /// In the sentinel-add flow, holds the picker-supplied path until
-    /// the operator names the key and the `EnvKey` modal commits both
-    /// fields at once.
-    pub pending_picker_value: Option<String>,
+    /// In the sentinel-add flow, holds the picker-supplied `OpRef`
+    /// (wrapped as `EnvValue::OpRef`) until the operator names the key
+    /// and the `EnvKey` modal commits both fields at once.
+    pub pending_picker_value: Option<crate::operator_env::EnvValue>,
 }
 
 /// Save cycle state machine.

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -585,7 +585,7 @@ impl EditorState<'_> {
         for agent in agent_keys {
             let orig = self.original.agents.get(agent).map(|o| &o.env);
             let pend = self.pending.agents.get(agent).map(|p| &p.env);
-            let empty = std::collections::BTreeMap::<String, String>::new();
+            let empty = std::collections::BTreeMap::<String, crate::operator_env::EnvValue>::new();
             let orig_env = orig.unwrap_or(&empty);
             let pend_env = pend.unwrap_or(&empty);
             n += env_change_count(orig_env, pend_env);
@@ -653,8 +653,8 @@ pub fn classify_mount_diffs<'a>(
 }
 
 fn env_change_count(
-    original: &std::collections::BTreeMap<String, String>,
-    pending: &std::collections::BTreeMap<String, String>,
+    original: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pending: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
 ) -> usize {
     let mut n = 0;
     for (k, v) in pending {
@@ -930,7 +930,10 @@ mod tests {
     fn change_count_env_set_counts_as_one() {
         let mut e = EditorState::new_edit("a".into(), empty_ws("/a"));
         assert_eq!(e.change_count(), 0);
-        e.pending.env.insert("DB_URL".into(), "postgres://…".into());
+        e.pending.env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::Plain("postgres://…".into()),
+        );
         assert_eq!(e.change_count(), 1);
     }
 
@@ -939,7 +942,10 @@ mod tests {
     #[test]
     fn change_count_env_remove_counts_as_one() {
         let mut ws = empty_ws("/a");
-        ws.env.insert("DB_URL".into(), "postgres://…".into());
+        ws.env.insert(
+            "DB_URL".into(),
+            crate::operator_env::EnvValue::Plain("postgres://…".into()),
+        );
         let mut e = EditorState::new_edit("a".into(), ws);
         assert_eq!(e.change_count(), 0);
         e.pending.env.remove("DB_URL");
@@ -954,7 +960,10 @@ mod tests {
         // Seed one agent with one env key.
         let mut ws = empty_ws("/a");
         let mut agent_x_env = std::collections::BTreeMap::new();
-        agent_x_env.insert("LOG_LEVEL".into(), "info".into());
+        agent_x_env.insert(
+            "LOG_LEVEL".into(),
+            crate::operator_env::EnvValue::Plain("info".into()),
+        );
         ws.agents.insert(
             "agent-x".into(),
             WorkspaceAgentOverride { env: agent_x_env },
@@ -963,12 +972,10 @@ mod tests {
         assert_eq!(e.change_count(), 0);
 
         // Add a new key to pending.
-        e.pending
-            .agents
-            .get_mut("agent-x")
-            .unwrap()
-            .env
-            .insert("DEBUG".into(), "1".into());
+        e.pending.agents.get_mut("agent-x").unwrap().env.insert(
+            "DEBUG".into(),
+            crate::operator_env::EnvValue::Plain("1".into()),
+        );
         assert_eq!(e.change_count(), 1);
 
         // Remove the original key. Net delta: 2 (one add + one remove).
@@ -991,7 +998,9 @@ mod tests {
         // Workspace env path.
         let mut e = EditorState::new_edit("a".into(), empty_ws("/a"));
         assert!(!e.is_dirty());
-        e.pending.env.insert("K".into(), "v".into());
+        e.pending
+            .env
+            .insert("K".into(), crate::operator_env::EnvValue::Plain("v".into()));
         assert!(e.is_dirty(), "workspace env set must make state dirty");
 
         // Per-agent env path.
@@ -1002,7 +1011,7 @@ mod tests {
             WorkspaceAgentOverride {
                 env: {
                     let mut m = std::collections::BTreeMap::new();
-                    m.insert("K".into(), "v".into());
+                    m.insert("K".into(), crate::operator_env::EnvValue::Plain("v".into()));
                     m
                 },
             },

--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -443,7 +443,7 @@ impl OpPickerState {
             .collect()
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<String> {
+    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<crate::operator_env::OpRef> {
         // Tests bypass render entirely so we drain here too, not just
         // on tick.
         self.poll_load();
@@ -472,7 +472,7 @@ impl OpPickerState {
         }
     }
 
-    fn handle_account_key(&mut self, key: KeyEvent) -> ModalOutcome<String> {
+    fn handle_account_key(&mut self, key: KeyEvent) -> ModalOutcome<crate::operator_env::OpRef> {
         match key.code {
             KeyCode::Esc => ModalOutcome::Cancel,
             KeyCode::Char('r') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -520,7 +520,7 @@ impl OpPickerState {
         }
     }
 
-    fn handle_vault_key(&mut self, key: KeyEvent) -> ModalOutcome<String> {
+    fn handle_vault_key(&mut self, key: KeyEvent) -> ModalOutcome<crate::operator_env::OpRef> {
         match key.code {
             KeyCode::Char('r') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let account_id = self.selected_account_id();
@@ -585,7 +585,7 @@ impl OpPickerState {
         }
     }
 
-    fn handle_item_key(&mut self, key: KeyEvent) -> ModalOutcome<String> {
+    fn handle_item_key(&mut self, key: KeyEvent) -> ModalOutcome<crate::operator_env::OpRef> {
         match key.code {
             KeyCode::Char('r') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let account_id = self.selected_account_id();
@@ -650,7 +650,7 @@ impl OpPickerState {
         }
     }
 
-    fn handle_field_key(&mut self, key: KeyEvent) -> ModalOutcome<String> {
+    fn handle_field_key(&mut self, key: KeyEvent) -> ModalOutcome<crate::operator_env::OpRef> {
         match key.code {
             KeyCode::Char('r') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let account_id = self.selected_account_id();
@@ -699,26 +699,8 @@ impl OpPickerState {
             KeyCode::Enter => {
                 let visible = self.filtered_fields();
                 let cur = self.field_list_state.selected.unwrap_or(0);
-                if let Some(field) = visible.get(cur) {
-                    // Prefer the CLI-emitted `reference` verbatim;
-                    // synthesizing from display names mishandled
-                    // sections, slashes, and whitespace. Synthesis is
-                    // a defensive fallback for fixtures that omit
-                    // `reference`.
-                    let path = if field.reference.is_empty() {
-                        let label = if field.label.is_empty() {
-                            field.id.clone()
-                        } else {
-                            field.label.clone()
-                        };
-                        let vault_name =
-                            self.selected_vault.as_ref().map_or("", |v| v.name.as_str());
-                        let item_name = self.selected_item.as_ref().map_or("", |i| i.name.as_str());
-                        format!("op://{vault_name}/{item_name}/{label}")
-                    } else {
-                        field.reference.clone()
-                    };
-                    return ModalOutcome::Commit(path);
+                if visible.get(cur).is_some() {
+                    return ModalOutcome::Commit(build_op_ref_on_commit(self));
                 }
                 ModalOutcome::Continue
             }
@@ -755,6 +737,91 @@ impl OpPickerState {
             }
         }
     }
+}
+
+/// Build an [`crate::operator_env::OpRef`] from the picker's current
+/// fully-drilled-down state (vault + item + field all selected).
+///
+/// The `op` field uses UUID-form identifiers from the picker's pane
+/// selections. The `path` field uses human-readable names, with an
+/// inline `Item[subtitle]` annotation when the item shares its name
+/// with another item in the same vault (ambiguity-aware).
+///
+/// Bracket-bearing item names suppress the subtitle embed (defensive —
+/// the UUID in `op` still resolves correctly). Empty subtitles also
+/// suppress the embed.
+///
+/// # Panics
+///
+/// Panics if vault, item, or field are not selected — callers must
+/// ensure the picker has fully drilled to the field pane before calling.
+pub(crate) fn build_op_ref_on_commit(state: &OpPickerState) -> crate::operator_env::OpRef {
+    let vault = state
+        .selected_vault
+        .as_ref()
+        .expect("vault must be selected before commit");
+    let item = state
+        .selected_item
+        .as_ref()
+        .expect("item must be selected before commit");
+    let cur = state.field_list_state.selected.unwrap_or(0);
+    let field = state
+        .filtered_fields()
+        .into_iter()
+        .nth(cur)
+        .expect("field must be selected before commit");
+
+    // Ambiguity check: any other item in the vault sharing this name?
+    let item_name_collides = state
+        .items
+        .iter()
+        .any(|i| i.id != item.id && i.name == item.name);
+
+    // Defensive: bracket-bearing names would corrupt the `path` grammar.
+    let safe_to_embed = !item.name.contains('[') && !item.name.contains(']');
+
+    let item_segment = if item_name_collides && safe_to_embed && !item.subtitle.is_empty() {
+        format!("{}[{}]", item.name, item.subtitle)
+    } else {
+        item.name.clone()
+    };
+
+    // Section info comes from parsing the field's emitted reference,
+    // which `op item get` populates with the human-readable path. We
+    // rewrite vault/item/field segments to UUID form and preserve the
+    // section segment.
+    let parsed = crate::operator_env::parse_op_reference(&field.reference);
+
+    let (op, path) = match parsed {
+        Some(p) if p.section.is_some() => {
+            let section_name = p.section.unwrap();
+            (
+                format!(
+                    "op://{}/{}/{}/{}",
+                    vault.id, item.id, section_name, field.id
+                ),
+                format!(
+                    "{}/{}/{}/{}",
+                    vault.name, item_segment, section_name, field.label
+                ),
+            )
+        }
+        _ => {
+            // No section, or reference was empty / unparseable — fall
+            // back to synthesizing from display names.
+            let label = if field.label.is_empty() {
+                field.id.clone()
+            } else {
+                field.label.clone()
+            };
+            (
+                format!("op://{}/{}/{}", vault.id, item.id, field.id),
+                format!("{}/{}/{}", vault.name, item_segment, label),
+            )
+        }
+    };
+
+    crate::operator_env::OpRef { op, path }
 }
 
 /// Classifies by stderr substring because `anyhow::Error` has no
@@ -1057,17 +1124,22 @@ mod tests {
         assert_eq!(visible[0].label, "pw");
     }
 
-    /// Backward-compat fallback: synthesize from display names when
-    /// `OpField::reference` is missing (older fixtures).
+    /// Backward-compat fallback: synthesize from display names (UUID
+    /// form for op, human names for path) when `OpField::reference` is
+    /// missing (older fixtures).
     #[test]
     fn enter_on_field_commits_op_path() {
         let mut s = picker_ready();
-        s.selected_vault = Some(vault("Personal"));
+        s.selected_vault = Some(OpVault {
+            id: "v-Personal".into(),
+            name: "Personal".into(),
+        });
         s.selected_item = Some(OpItem {
             id: "i-api".into(),
             name: "API Keys".into(),
             subtitle: String::new(),
         });
+        s.items = vec![s.selected_item.clone().unwrap()];
         s.fields = vec![
             field("password", "concealed", true),
             field("username", "text", false),
@@ -1077,34 +1149,45 @@ mod tests {
 
         let outcome = s.handle_key(key(KeyCode::Enter));
         match outcome {
-            ModalOutcome::Commit(path) => {
-                assert_eq!(path, "op://Personal/API Keys/password");
+            ModalOutcome::Commit(op_ref) => {
+                assert_eq!(op_ref.op, "op://v-Personal/i-api/password");
+                assert_eq!(op_ref.path, "Personal/API Keys/password");
             }
             other => panic!("expected Commit, got {other:?}"),
         }
     }
 
-    /// Display name with whitespace + section-aware reference must
-    /// commit verbatim, not via synthesized path.
+    /// Section-aware reference: section must be preserved in both `op`
+    /// (UUID-form vault/item/field, section name preserved) and `path`
+    /// (human-readable, section name preserved).
     #[test]
     fn picker_commit_uses_op_provided_reference_not_synthesized() {
         let mut s = picker_ready();
-        s.selected_vault = Some(vault("Personal"));
+        s.selected_vault = Some(OpVault {
+            id: "v-Personal".into(),
+            name: "Personal".into(),
+        });
         s.selected_item = Some(OpItem {
             id: "i-test".into(),
             name: "name with spaces".into(),
             subtitle: String::new(),
         });
+        s.items = vec![s.selected_item.clone().unwrap()];
         s.fields = vec![field_with_reference("api", "op://Personal/test/auth/api")];
         s.field_list_state.select(Some(0));
         s.stage = OpPickerStage::Field;
 
         let outcome = s.handle_key(key(KeyCode::Enter));
         match outcome {
-            ModalOutcome::Commit(path) => {
+            ModalOutcome::Commit(op_ref) => {
+                // Section "auth" must be preserved; vault/item/field use UUIDs.
                 assert_eq!(
-                    path, "op://Personal/test/auth/api",
-                    "picker must commit `field.reference` verbatim, not a synthesized path"
+                    op_ref.op, "op://v-Personal/i-test/auth/api",
+                    "op must use UUID-form vault/item, preserve section, UUID field id"
+                );
+                assert_eq!(
+                    op_ref.path, "Personal/name with spaces/auth/api",
+                    "path must use human-readable names and preserve section"
                 );
             }
             other => panic!("expected Commit, got {other:?}"),
@@ -1707,6 +1790,168 @@ mod tests {
                 Some("acct1".to_string())
             )),
             "worker thread must forward (item_id, vault_id, account_id) verbatim"
+        );
+    }
+
+    // ── build_op_ref_on_commit tests ────────────────────────────────
+
+    /// Build an `OpPickerState` fully drilled down to a field selection,
+    /// bypassing the async worker. `items_in_vault` is the full list
+    /// seeded into `s.items` (used for ambiguity detection).
+    fn test_state_picked(
+        vault: OpVault,
+        items_in_vault: Vec<OpItem>,
+        selected_item: OpItem,
+        field: OpField,
+    ) -> OpPickerState {
+        let mut s = picker_ready();
+        s.selected_vault = Some(vault);
+        s.items = items_in_vault;
+        s.selected_item = Some(selected_item);
+        s.fields = vec![field];
+        s.field_list_state.select(Some(0));
+        s.stage = OpPickerStage::Field;
+        s.load_state = OpLoadState::Ready;
+        s
+    }
+
+    #[test]
+    fn picker_commit_writes_op_ref_with_uuid_form_and_clean_path_when_unique() {
+        let state = test_state_picked(
+            OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![OpItem {
+                id: "i_uuid".into(),
+                name: "Stripe".into(),
+                subtitle: "".into(),
+            }],
+            OpItem {
+                id: "i_uuid".into(),
+                name: "Stripe".into(),
+                subtitle: "".into(),
+            },
+            OpField {
+                id: "f_uuid".into(),
+                label: "api key".into(),
+                reference: "op://Private/Stripe/api key".into(),
+                field_type: "concealed".into(),
+                concealed: true,
+            },
+        );
+        let r = build_op_ref_on_commit(&state);
+        assert_eq!(r.op, "op://v_uuid/i_uuid/f_uuid");
+        assert_eq!(r.path, "Private/Stripe/api key");
+    }
+
+    #[test]
+    fn picker_commit_embeds_subtitle_when_item_name_collides_in_vault() {
+        let claude_a = OpItem {
+            id: "i_uuid_a".into(),
+            name: "Claude".into(),
+            subtitle: "alexey@zhokhov.com".into(),
+        };
+        let claude_b = OpItem {
+            id: "i_uuid_b".into(),
+            name: "Claude".into(),
+            subtitle: "alexey@chainargos.com".into(),
+        };
+        let state = test_state_picked(
+            OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![claude_a.clone(), claude_b.clone()],
+            claude_a.clone(),
+            OpField {
+                id: "f_uuid".into(),
+                label: "auth token".into(),
+                reference: "op://Private/Claude/security/auth token".into(),
+                field_type: "concealed".into(),
+                concealed: true,
+            },
+        );
+        let r = build_op_ref_on_commit(&state);
+        // Section "security" must be preserved in both op and path.
+        assert!(
+            r.op.starts_with("op://v_uuid/i_uuid_a/"),
+            "op had wrong prefix: {}",
+            r.op
+        );
+        assert!(r.op.ends_with("/f_uuid"), "op had wrong suffix: {}", r.op);
+        assert_eq!(
+            r.path,
+            "Private/Claude[alexey@zhokhov.com]/security/auth token"
+        );
+    }
+
+    #[test]
+    fn picker_commit_suppresses_subtitle_when_item_name_has_brackets() {
+        // Defensive: bracket-bearing item names would make `path` ambiguous.
+        let weird_a = OpItem {
+            id: "i_uuid_a".into(),
+            name: "Item [tag]".into(),
+            subtitle: "user@x".into(),
+        };
+        let weird_b = OpItem {
+            id: "i_uuid_b".into(),
+            name: "Item [tag]".into(),
+            subtitle: "user@y".into(),
+        };
+        let state = test_state_picked(
+            OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![weird_a.clone(), weird_b.clone()],
+            weird_a.clone(),
+            OpField {
+                id: "f_uuid".into(),
+                label: "auth".into(),
+                reference: "op://Private/Item [tag]/auth".into(),
+                field_type: "concealed".into(),
+                concealed: false,
+            },
+        );
+        let r = build_op_ref_on_commit(&state);
+        assert_eq!(
+            r.path, "Private/Item [tag]/auth",
+            "no subtitle embed for bracket-bearing item names"
+        );
+    }
+
+    #[test]
+    fn picker_commit_skips_subtitle_when_subtitle_empty() {
+        let note_a = OpItem {
+            id: "i_a".into(),
+            name: "Notes".into(),
+            subtitle: "".into(),
+        };
+        let note_b = OpItem {
+            id: "i_b".into(),
+            name: "Notes".into(),
+            subtitle: "".into(),
+        };
+        let state = test_state_picked(
+            OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![note_a.clone(), note_b.clone()],
+            note_a.clone(),
+            OpField {
+                id: "f_uuid".into(),
+                label: "notesPlain".into(),
+                reference: "op://Private/Notes/notesPlain".into(),
+                field_type: "string".into(),
+                concealed: false,
+            },
+        );
+        let r = build_op_ref_on_commit(&state);
+        assert_eq!(
+            r.path, "Private/Notes/notesPlain",
+            "empty subtitle => no embed even on collision"
         );
     }
 }

--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -829,10 +829,12 @@ pub(crate) fn build_op_ref_on_commit(
                     .iter()
                     .any(|f| f.id != field.id && !f.reference.is_empty());
                 if sibling_has_ref {
-                    eprintln!(
-                        "[jackin debug] op_picker: empty field.reference for {}/{} (id {}); \
-                         sibling fields have references — falling back to 3-segment URI",
-                        vault.name, item.name, field.id
+                    crate::debug_log!(
+                        "op_picker",
+                        "empty field.reference for {}/{} (id {}); sibling fields have references — falling back to 3-segment URI",
+                        vault.name,
+                        item.name,
+                        field.id
                     );
                 }
             }

--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -818,6 +818,25 @@ pub(crate) fn build_op_ref_on_commit(
             } else {
                 field.label.clone()
             };
+
+            // Anomaly detection: if this field's reference is empty but
+            // sibling fields in the same item carry non-empty references,
+            // that suggests a malformed `op item get` emission rather than
+            // a genuine 3-segment field. Log so triage can see it.
+            if field.reference.is_empty() {
+                let sibling_has_ref = state
+                    .fields
+                    .iter()
+                    .any(|f| f.id != field.id && !f.reference.is_empty());
+                if sibling_has_ref {
+                    eprintln!(
+                        "[jackin debug] op_picker: empty field.reference for {}/{} (id {}); \
+                         sibling fields have references — falling back to 3-segment URI",
+                        vault.name, item.name, field.id
+                    );
+                }
+            }
+
             (
                 format!("op://{}/{}/{}", vault.id, item.id, field.id),
                 format!("{}/{}/{}", vault.name, item_segment, label),
@@ -1961,6 +1980,50 @@ mod tests {
             r.path, "Private/Notes/notesPlain",
             "empty subtitle => no embed even on collision"
         );
+    }
+
+    // ── Fix 2B: fallback-to-3-segment preserved when sibling has reference ──
+
+    /// When a field has an empty reference but sibling fields in the same
+    /// item carry non-empty references, the picker still commits a valid
+    /// 3-segment OpRef (the debug log fires but must not panic).
+    #[test]
+    fn picker_commit_3seg_fallback_preserved_when_sibling_has_reference() {
+        let sectioned_field = crate::operator_env::OpField {
+            id: "f_sectioned".into(),
+            label: "password".into(),
+            reference: "op://Private/MyItem/Auth/password".into(),
+            field_type: "CONCEALED".into(),
+            concealed: true,
+        };
+        let no_ref_field = crate::operator_env::OpField {
+            id: "f_noref".into(),
+            label: "notes".into(),
+            reference: String::new(),
+            field_type: "STRING".into(),
+            concealed: false,
+        };
+        let the_item = crate::operator_env::OpItem {
+            id: "i_uuid".into(),
+            name: "MyItem".into(),
+            subtitle: String::new(),
+        };
+        let mut state = test_state_picked(
+            crate::operator_env::OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![the_item.clone()],
+            the_item,
+            no_ref_field.clone(),
+        );
+        // Add the sectioned sibling so the anomaly log path is exercised.
+        state.fields.push(sectioned_field);
+
+        // Must not panic; must produce a 3-segment OpRef.
+        let r = build_op_ref_on_commit(&state, &no_ref_field);
+        assert_eq!(r.op, "op://v_uuid/i_uuid/f_noref");
+        assert_eq!(r.path, "Private/MyItem/notes");
     }
 
     // ── parity tests: build_op_ref_on_commit vs resolve_op_uri_to_ref ──────

--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -699,8 +699,8 @@ impl OpPickerState {
             KeyCode::Enter => {
                 let visible = self.filtered_fields();
                 let cur = self.field_list_state.selected.unwrap_or(0);
-                if visible.get(cur).is_some() {
-                    return ModalOutcome::Commit(build_op_ref_on_commit(self));
+                if let Some(field) = visible.get(cur) {
+                    return ModalOutcome::Commit(build_op_ref_on_commit(self, field));
                 }
                 ModalOutcome::Continue
             }
@@ -739,8 +739,7 @@ impl OpPickerState {
     }
 }
 
-/// Build an [`crate::operator_env::OpRef`] from the picker's current
-/// fully-drilled-down state (vault + item + field all selected).
+/// Build an `OpRef` from the picker's currently-selected vault/item/field.
 ///
 /// The `op` field uses UUID-form identifiers from the picker's pane
 /// selections. The `path` field uses human-readable names, with an
@@ -751,11 +750,22 @@ impl OpPickerState {
 /// the UUID in `op` still resolves correctly). Empty subtitles also
 /// suppress the embed.
 ///
+/// Section info is recovered by parsing `field.reference`, which `op item get`
+/// emits in canonical form (with the section name correctly attributed).
+/// If `field.reference` is empty or unparseable, this falls back to a
+/// 3-segment URI — which produces an UNRESOLVING reference for fields
+/// that actually live inside a section. In production, `op item get`
+/// always populates `reference` for fields, so this fallback is a
+/// safety net rather than a routine path.
+///
 /// # Panics
 ///
-/// Panics if vault, item, or field are not selected — callers must
+/// Panics if vault or item are not selected — callers must
 /// ensure the picker has fully drilled to the field pane before calling.
-pub(crate) fn build_op_ref_on_commit(state: &OpPickerState) -> crate::operator_env::OpRef {
+pub(crate) fn build_op_ref_on_commit(
+    state: &OpPickerState,
+    field: &crate::operator_env::OpField,
+) -> crate::operator_env::OpRef {
     let vault = state
         .selected_vault
         .as_ref()
@@ -764,12 +774,6 @@ pub(crate) fn build_op_ref_on_commit(state: &OpPickerState) -> crate::operator_e
         .selected_item
         .as_ref()
         .expect("item must be selected before commit");
-    let cur = state.field_list_state.selected.unwrap_or(0);
-    let field = state
-        .filtered_fields()
-        .into_iter()
-        .nth(cur)
-        .expect("field must be selected before commit");
 
     // Ambiguity check: any other item in the vault sharing this name?
     let item_name_collides = state
@@ -1817,6 +1821,13 @@ mod tests {
 
     #[test]
     fn picker_commit_writes_op_ref_with_uuid_form_and_clean_path_when_unique() {
+        let field = OpField {
+            id: "f_uuid".into(),
+            label: "api key".into(),
+            reference: "op://Private/Stripe/api key".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
         let state = test_state_picked(
             OpVault {
                 id: "v_uuid".into(),
@@ -1825,22 +1836,16 @@ mod tests {
             vec![OpItem {
                 id: "i_uuid".into(),
                 name: "Stripe".into(),
-                subtitle: "".into(),
+                subtitle: String::new(),
             }],
             OpItem {
                 id: "i_uuid".into(),
                 name: "Stripe".into(),
-                subtitle: "".into(),
+                subtitle: String::new(),
             },
-            OpField {
-                id: "f_uuid".into(),
-                label: "api key".into(),
-                reference: "op://Private/Stripe/api key".into(),
-                field_type: "concealed".into(),
-                concealed: true,
-            },
+            field.clone(),
         );
-        let r = build_op_ref_on_commit(&state);
+        let r = build_op_ref_on_commit(&state, &field);
         assert_eq!(r.op, "op://v_uuid/i_uuid/f_uuid");
         assert_eq!(r.path, "Private/Stripe/api key");
     }
@@ -1857,22 +1862,23 @@ mod tests {
             name: "Claude".into(),
             subtitle: "alexey@chainargos.com".into(),
         };
+        let field = OpField {
+            id: "f_uuid".into(),
+            label: "auth token".into(),
+            reference: "op://Private/Claude/security/auth token".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
         let state = test_state_picked(
             OpVault {
                 id: "v_uuid".into(),
                 name: "Private".into(),
             },
-            vec![claude_a.clone(), claude_b.clone()],
-            claude_a.clone(),
-            OpField {
-                id: "f_uuid".into(),
-                label: "auth token".into(),
-                reference: "op://Private/Claude/security/auth token".into(),
-                field_type: "concealed".into(),
-                concealed: true,
-            },
+            vec![claude_a.clone(), claude_b],
+            claude_a,
+            field.clone(),
         );
-        let r = build_op_ref_on_commit(&state);
+        let r = build_op_ref_on_commit(&state, &field);
         // Section "security" must be preserved in both op and path.
         assert!(
             r.op.starts_with("op://v_uuid/i_uuid_a/"),
@@ -1899,22 +1905,23 @@ mod tests {
             name: "Item [tag]".into(),
             subtitle: "user@y".into(),
         };
+        let field = OpField {
+            id: "f_uuid".into(),
+            label: "auth".into(),
+            reference: "op://Private/Item [tag]/auth".into(),
+            field_type: "concealed".into(),
+            concealed: false,
+        };
         let state = test_state_picked(
             OpVault {
                 id: "v_uuid".into(),
                 name: "Private".into(),
             },
-            vec![weird_a.clone(), weird_b.clone()],
-            weird_a.clone(),
-            OpField {
-                id: "f_uuid".into(),
-                label: "auth".into(),
-                reference: "op://Private/Item [tag]/auth".into(),
-                field_type: "concealed".into(),
-                concealed: false,
-            },
+            vec![weird_a.clone(), weird_b],
+            weird_a,
+            field.clone(),
         );
-        let r = build_op_ref_on_commit(&state);
+        let r = build_op_ref_on_commit(&state, &field);
         assert_eq!(
             r.path, "Private/Item [tag]/auth",
             "no subtitle embed for bracket-bearing item names"
@@ -1926,29 +1933,30 @@ mod tests {
         let note_a = OpItem {
             id: "i_a".into(),
             name: "Notes".into(),
-            subtitle: "".into(),
+            subtitle: String::new(),
         };
         let note_b = OpItem {
             id: "i_b".into(),
             name: "Notes".into(),
-            subtitle: "".into(),
+            subtitle: String::new(),
+        };
+        let field = OpField {
+            id: "f_uuid".into(),
+            label: "notesPlain".into(),
+            reference: "op://Private/Notes/notesPlain".into(),
+            field_type: "string".into(),
+            concealed: false,
         };
         let state = test_state_picked(
             OpVault {
                 id: "v_uuid".into(),
                 name: "Private".into(),
             },
-            vec![note_a.clone(), note_b.clone()],
-            note_a.clone(),
-            OpField {
-                id: "f_uuid".into(),
-                label: "notesPlain".into(),
-                reference: "op://Private/Notes/notesPlain".into(),
-                field_type: "string".into(),
-                concealed: false,
-            },
+            vec![note_a.clone(), note_b],
+            note_a,
+            field.clone(),
         );
-        let r = build_op_ref_on_commit(&state);
+        let r = build_op_ref_on_commit(&state, &field);
         assert_eq!(
             r.path, "Private/Notes/notesPlain",
             "empty subtitle => no embed even on collision"

--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -1962,4 +1962,283 @@ mod tests {
             "empty subtitle => no embed even on collision"
         );
     }
+
+    // ── parity tests: build_op_ref_on_commit vs resolve_op_uri_to_ref ──────
+
+    /// Minimal `OpStructRunner` stub for parity tests (no async needed).
+    struct ParityStub {
+        vaults: Vec<crate::operator_env::OpVault>,
+        items: std::collections::HashMap<String, Vec<crate::operator_env::OpItem>>,
+        fields: std::collections::HashMap<String, Vec<crate::operator_env::OpField>>,
+    }
+
+    impl ParityStub {
+        fn new() -> Self {
+            Self {
+                vaults: Vec::new(),
+                items: std::collections::HashMap::new(),
+                fields: std::collections::HashMap::new(),
+            }
+        }
+
+        fn with_vault(mut self, name: &str, id: &str) -> Self {
+            self.vaults.push(crate::operator_env::OpVault {
+                id: id.to_string(),
+                name: name.to_string(),
+            });
+            self
+        }
+
+        fn with_item(mut self, vault_id: &str, name: &str, id: &str, subtitle: &str) -> Self {
+            self.items
+                .entry(vault_id.to_string())
+                .or_default()
+                .push(crate::operator_env::OpItem {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    subtitle: subtitle.to_string(),
+                });
+            self
+        }
+
+        fn with_field_with_reference(
+            mut self,
+            item_id: &str,
+            label: &str,
+            id: &str,
+            concealed: bool,
+            reference: &str,
+        ) -> Self {
+            self.fields.entry(item_id.to_string()).or_default().push(
+                crate::operator_env::OpField {
+                    id: id.to_string(),
+                    label: label.to_string(),
+                    field_type: if concealed {
+                        "CONCEALED".into()
+                    } else {
+                        "STRING".into()
+                    },
+                    concealed,
+                    reference: reference.to_string(),
+                },
+            );
+            self
+        }
+    }
+
+    impl crate::operator_env::OpStructRunner for ParityStub {
+        fn account_list(&self) -> anyhow::Result<Vec<crate::operator_env::OpAccount>> {
+            Ok(vec![])
+        }
+        fn vault_list(
+            &self,
+            _account: Option<&str>,
+        ) -> anyhow::Result<Vec<crate::operator_env::OpVault>> {
+            Ok(self.vaults.clone())
+        }
+        fn item_list(
+            &self,
+            vault_id: &str,
+            _account: Option<&str>,
+        ) -> anyhow::Result<Vec<crate::operator_env::OpItem>> {
+            Ok(self.items.get(vault_id).cloned().unwrap_or_default())
+        }
+        fn item_get(
+            &self,
+            item_id: &str,
+            _vault_id: &str,
+            _account: Option<&str>,
+        ) -> anyhow::Result<Vec<crate::operator_env::OpField>> {
+            Ok(self.fields.get(item_id).cloned().unwrap_or_default())
+        }
+    }
+
+    /// Fix 1D parity: unique item, 3-segment field → identical OpRef.
+    #[test]
+    fn parity_unique_item_3seg_field_cli_matches_picker() {
+        let field = crate::operator_env::OpField {
+            id: "f_uuid".into(),
+            label: "api key".into(),
+            reference: "op://Private/Stripe/api key".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
+        let the_item = crate::operator_env::OpItem {
+            id: "i_uuid".into(),
+            name: "Stripe".into(),
+            subtitle: String::new(),
+        };
+        let state = test_state_picked(
+            crate::operator_env::OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![the_item.clone()],
+            the_item,
+            field.clone(),
+        );
+        let picker_ref = build_op_ref_on_commit(&state, &field);
+
+        let stub = ParityStub::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "")
+            .with_field_with_reference(
+                "i_uuid",
+                "api key",
+                "f_uuid",
+                true,
+                "op://Private/Stripe/api key",
+            );
+        let cli_ref =
+            crate::operator_env::resolve_op_uri_to_ref("op://Private/Stripe/api key", &stub)
+                .unwrap();
+
+        assert_eq!(cli_ref.op, picker_ref.op, "op URI must match");
+        assert_eq!(cli_ref.path, picker_ref.path, "display path must match");
+    }
+
+    /// Fix 1D parity: ambiguous item with subtitle → both embed subtitle bracket.
+    #[test]
+    fn parity_ambiguous_item_with_subtitle_cli_matches_picker() {
+        let field = crate::operator_env::OpField {
+            id: "f_uuid".into(),
+            label: "auth token".into(),
+            reference: "op://Private/Claude/auth token".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
+        let item_a = crate::operator_env::OpItem {
+            id: "i_uuid_a".into(),
+            name: "Claude".into(),
+            subtitle: "alexey@zhokhov.com".into(),
+        };
+        let item_b = crate::operator_env::OpItem {
+            id: "i_uuid_b".into(),
+            name: "Claude".into(),
+            subtitle: "alexey@chainargos.com".into(),
+        };
+        let state = test_state_picked(
+            crate::operator_env::OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![item_a.clone(), item_b],
+            item_a,
+            field.clone(),
+        );
+        let picker_ref = build_op_ref_on_commit(&state, &field);
+
+        let stub = ParityStub::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid_a", "alexey@zhokhov.com")
+            .with_item("v_uuid", "Claude", "i_uuid_b", "alexey@chainargos.com")
+            .with_field_with_reference(
+                "i_uuid_a",
+                "auth token",
+                "f_uuid",
+                true,
+                "op://Private/Claude/auth token",
+            );
+        let cli_ref = crate::operator_env::resolve_op_uri_to_ref(
+            "op://Private/Claude[alexey@zhokhov.com]/auth token",
+            &stub,
+        )
+        .unwrap();
+
+        assert_eq!(cli_ref.op, picker_ref.op, "op URI must match");
+        assert_eq!(cli_ref.path, picker_ref.path, "display path must match");
+    }
+
+    /// Fix 1D parity: sectioned field → both produce 4-segment OpRef.
+    #[test]
+    fn parity_sectioned_field_cli_matches_picker() {
+        let field = crate::operator_env::OpField {
+            id: "f_uuid".into(),
+            label: "auth token".into(),
+            reference: "op://Private/Claude/Security/auth token".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
+        let the_item = crate::operator_env::OpItem {
+            id: "i_uuid".into(),
+            name: "Claude".into(),
+            subtitle: String::new(),
+        };
+        let state = test_state_picked(
+            crate::operator_env::OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![the_item.clone()],
+            the_item,
+            field.clone(),
+        );
+        let picker_ref = build_op_ref_on_commit(&state, &field);
+
+        let stub = ParityStub::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid", "")
+            .with_field_with_reference(
+                "i_uuid",
+                "auth token",
+                "f_uuid",
+                true,
+                "op://Private/Claude/Security/auth token",
+            );
+        let cli_ref = crate::operator_env::resolve_op_uri_to_ref(
+            "op://Private/Claude/Security/auth token",
+            &stub,
+        )
+        .unwrap();
+
+        assert_eq!(cli_ref.op, picker_ref.op, "op URI must match");
+        assert_eq!(cli_ref.path, picker_ref.path, "display path must match");
+    }
+
+    /// Fix 1D parity: 3-segment user input where field has a section →
+    /// after fix 1A the CLI picks up the section from field.reference,
+    /// matching the picker's output.
+    #[test]
+    fn parity_3seg_input_with_sectioned_field_cli_matches_picker() {
+        let field = crate::operator_env::OpField {
+            id: "f_uuid".into(),
+            label: "auth token".into(),
+            reference: "op://Private/Claude/Security/auth token".into(),
+            field_type: "concealed".into(),
+            concealed: true,
+        };
+        let the_item = crate::operator_env::OpItem {
+            id: "i_uuid".into(),
+            name: "Claude".into(),
+            subtitle: String::new(),
+        };
+        let state = test_state_picked(
+            crate::operator_env::OpVault {
+                id: "v_uuid".into(),
+                name: "Private".into(),
+            },
+            vec![the_item.clone()],
+            the_item,
+            field.clone(),
+        );
+        let picker_ref = build_op_ref_on_commit(&state, &field);
+
+        // CLI path: 3-segment input, but field.reference has "Security"
+        let stub = ParityStub::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid", "")
+            .with_field_with_reference(
+                "i_uuid",
+                "auth token",
+                "f_uuid",
+                true,
+                "op://Private/Claude/Security/auth token",
+            );
+        let cli_ref =
+            crate::operator_env::resolve_op_uri_to_ref("op://Private/Claude/auth token", &stub)
+                .unwrap();
+
+        assert_eq!(cli_ref.op, picker_ref.op, "op URI must match");
+        assert_eq!(cli_ref.path, picker_ref.path, "display path must match");
+    }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -47,7 +47,8 @@ impl ShellRunner {
 
     fn log_command(&self, program: &str, args: &[&str], cwd: Option<&Path>) {
         if self.debug {
-            let cmd = format!("{} {}", program, args.join(" "));
+            let redacted = redact_env_args(args);
+            let cmd = format!("{} {}", program, redacted.join(" "));
             if let Some(dir) = cwd {
                 eprintln!(
                     "{}",
@@ -58,6 +59,40 @@ impl ShellRunner {
             }
         }
     }
+}
+
+/// Mask the value portion of `-e KEY=VALUE` / `--env KEY=VALUE` args so that
+/// secrets resolved into the env (1Password references, host-env passthroughs
+/// like `$GITHUB_TOKEN`, plain literals that may carry tokens) never appear in
+/// `--debug` output. The env var *name* is preserved so the operator can still
+/// see which keys are being injected.
+///
+/// Forms handled:
+/// - `-e KEY=VALUE` → `-e KEY=<redacted>`
+/// - `--env KEY=VALUE` → `--env KEY=<redacted>`
+/// - `-e KEY` (host-env passthrough; the docker CLI inherits the value from
+///   the launching shell — no value present in the argv) → left unchanged.
+///
+/// Other args are passed through unchanged.
+pub(crate) fn redact_env_args(args: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i];
+        if (arg == "-e" || arg == "--env") && i + 1 < args.len() {
+            out.push(arg.to_string());
+            let next = args[i + 1];
+            match next.find('=') {
+                Some(eq) => out.push(format!("{}=<redacted>", &next[..eq])),
+                None => out.push(next.to_string()),
+            }
+            i += 2;
+        } else {
+            out.push(arg.to_string());
+            i += 1;
+        }
+    }
+    out
 }
 
 impl CommandRunner for ShellRunner {
@@ -231,5 +266,118 @@ mod tests {
 
         assert!(output.len() >= 190000);
         assert!(output.starts_with('x'));
+    }
+
+    #[test]
+    fn redact_env_args_masks_dash_e_value() {
+        let args = &[
+            "run",
+            "-e",
+            "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-secretvalue",
+            "image:tag",
+        ];
+        let redacted = redact_env_args(args);
+        assert_eq!(
+            redacted,
+            vec![
+                "run",
+                "-e",
+                "CLAUDE_CODE_OAUTH_TOKEN=<redacted>",
+                "image:tag",
+            ],
+        );
+    }
+
+    #[test]
+    fn redact_env_args_masks_long_env_form() {
+        let args = &["run", "--env", "GITHUB_TOKEN=ghp_secret", "image:tag"];
+        let redacted = redact_env_args(args);
+        assert_eq!(
+            redacted,
+            vec!["run", "--env", "GITHUB_TOKEN=<redacted>", "image:tag"],
+        );
+    }
+
+    #[test]
+    fn redact_env_args_leaves_host_passthrough_form_unchanged() {
+        // `-e KEY` (no `=`) means docker inherits from the host shell.
+        // There's no value in argv to redact.
+        let args = &["run", "-e", "GITHUB_TOKEN", "image:tag"];
+        let redacted = redact_env_args(args);
+        assert_eq!(redacted, vec!["run", "-e", "GITHUB_TOKEN", "image:tag"]);
+    }
+
+    #[test]
+    fn redact_env_args_redacts_multiple_dash_e_values() {
+        let args = &[
+            "run",
+            "-e",
+            "TOKEN=secret-a",
+            "--name",
+            "my-container",
+            "-e",
+            "API_KEY=secret-b",
+            "image:tag",
+        ];
+        let redacted = redact_env_args(args);
+        assert_eq!(
+            redacted,
+            vec![
+                "run",
+                "-e",
+                "TOKEN=<redacted>",
+                "--name",
+                "my-container",
+                "-e",
+                "API_KEY=<redacted>",
+                "image:tag",
+            ],
+        );
+    }
+
+    #[test]
+    fn redact_env_args_passes_non_env_args_through() {
+        // No -e / --env anywhere — args round-trip unchanged.
+        let args = &["build", "-t", "image:tag", "--no-cache", "."];
+        let redacted = redact_env_args(args);
+        assert_eq!(
+            redacted,
+            vec!["build", "-t", "image:tag", "--no-cache", "."],
+        );
+    }
+
+    #[test]
+    fn redact_env_args_handles_empty_value() {
+        // `-e KEY=` (empty value) should still mask, never pass through.
+        let args = &["run", "-e", "EMPTY=", "image:tag"];
+        let redacted = redact_env_args(args);
+        assert_eq!(redacted, vec!["run", "-e", "EMPTY=<redacted>", "image:tag"]);
+    }
+
+    #[test]
+    fn redact_env_args_handles_value_containing_equals() {
+        // Values can contain `=` (e.g. URLs with query strings). Only the
+        // first `=` separates KEY from VALUE; everything after the first
+        // `=` is the value and must be redacted.
+        let args = &[
+            "run",
+            "-e",
+            "DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require",
+            "image:tag",
+        ];
+        let redacted = redact_env_args(args);
+        assert_eq!(
+            redacted,
+            vec!["run", "-e", "DATABASE_URL=<redacted>", "image:tag",],
+        );
+    }
+
+    #[test]
+    fn redact_env_args_handles_dash_e_at_end_with_no_value() {
+        // Defensive: malformed `-e` at end of args (no following arg).
+        // Should not panic; the lone `-e` passes through.
+        let args = &["run", "-e"];
+        let redacted = redact_env_args(args);
+        assert_eq!(redacted, vec!["run", "-e"]);
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -79,8 +79,8 @@ pub(crate) fn redact_env_args(args: &[&str]) -> Vec<String> {
     let mut i = 0;
     while i < args.len() {
         let arg = args[i];
+        out.push(arg.to_string());
         if (arg == "-e" || arg == "--env") && i + 1 < args.len() {
-            out.push(arg.to_string());
             let next = args[i + 1];
             match next.find('=') {
                 Some(eq) => out.push(format!("{}=<redacted>", &next[..eq])),
@@ -88,7 +88,6 @@ pub(crate) fn redact_env_args(args: &[&str]) -> Vec<String> {
             }
             i += 2;
         } else {
-            out.push(arg.to_string());
             i += 1;
         }
     }

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -116,6 +116,7 @@ impl From<String> for EnvValue {
     }
 }
 
+#[cfg(test)]
 impl From<&str> for EnvValue {
     fn from(s: &str) -> Self {
         Self::Plain(s.to_string())

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -116,6 +116,12 @@ impl From<String> for EnvValue {
     }
 }
 
+impl From<&str> for EnvValue {
+    fn from(s: &str) -> Self {
+        Self::Plain(s.to_string())
+    }
+}
+
 #[must_use]
 pub fn is_op_reference(value: &str) -> bool {
     value.starts_with("op://")
@@ -737,11 +743,11 @@ impl std::fmt::Display for EnvLayer {
 /// Later-wins merge. Order, low → high priority:
 /// global → agent → workspace → workspace-agent.
 pub fn merge_layers(
-    global: &std::collections::BTreeMap<String, String>,
-    agent: &std::collections::BTreeMap<String, String>,
-    workspace: &std::collections::BTreeMap<String, String>,
-    workspace_agent: &std::collections::BTreeMap<String, String>,
-) -> std::collections::BTreeMap<String, String> {
+    global: &std::collections::BTreeMap<String, EnvValue>,
+    agent: &std::collections::BTreeMap<String, EnvValue>,
+    workspace: &std::collections::BTreeMap<String, EnvValue>,
+    workspace_agent: &std::collections::BTreeMap<String, EnvValue>,
+) -> std::collections::BTreeMap<String, EnvValue> {
     let mut merged = std::collections::BTreeMap::new();
     for layer in [global, agent, workspace, workspace_agent] {
         for (k, v) in layer {
@@ -756,7 +762,7 @@ pub fn merge_layers(
 /// Conflicts across every layer are aggregated into one error.
 pub fn validate_reserved_names(config: &crate::config::AppConfig) -> anyhow::Result<()> {
     let mut offenses: Vec<String> = Vec::new();
-    let mut record = |layer: EnvLayer, env: &std::collections::BTreeMap<String, String>| {
+    let mut record = |layer: EnvLayer, env: &std::collections::BTreeMap<String, EnvValue>| {
         for key in env.keys() {
             if crate::env_model::is_reserved(key) {
                 offenses.push(format!(
@@ -808,9 +814,9 @@ fn build_attributed_layers(
     let mut attributed: std::collections::BTreeMap<String, (EnvLayer, String)> =
         std::collections::BTreeMap::new();
 
-    let mut record = |layer: EnvLayer, env: &std::collections::BTreeMap<String, String>| {
+    let mut record = |layer: EnvLayer, env: &std::collections::BTreeMap<String, EnvValue>| {
         for (k, v) in env {
-            attributed.insert(k.clone(), (layer.clone(), v.clone()));
+            attributed.insert(k.clone(), (layer.clone(), v.as_persisted_str().to_string()));
         }
     };
 
@@ -1450,10 +1456,10 @@ mod tests {
 
     use std::collections::BTreeMap;
 
-    fn m(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    fn m(pairs: &[(&str, &str)]) -> BTreeMap<String, EnvValue> {
         pairs
             .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .map(|(k, v)| ((*k).to_string(), EnvValue::Plain((*v).to_string())))
             .collect()
     }
 
@@ -1466,8 +1472,8 @@ mod tests {
     #[test]
     fn merge_global_only() {
         let merged = merge_layers(&m(&[("A", "1"), ("B", "2")]), &m(&[]), &m(&[]), &m(&[]));
-        assert_eq!(merged.get("A").map(|v| v.as_str()), Some("1"));
-        assert_eq!(merged.get("B").map(|v| v.as_str()), Some("2"));
+        assert_eq!(merged.get("A").map(|v| v.as_persisted_str()), Some("1"));
+        assert_eq!(merged.get("B").map(|v| v.as_persisted_str()), Some("2"));
     }
 
     #[test]
@@ -1478,8 +1484,11 @@ mod tests {
             &m(&[]),
             &m(&[]),
         );
-        assert_eq!(merged.get("A").map(|v| v.as_str()), Some("global"));
-        assert_eq!(merged.get("B").map(|v| v.as_str()), Some("agent"));
+        assert_eq!(
+            merged.get("A").map(|v| v.as_persisted_str()),
+            Some("global")
+        );
+        assert_eq!(merged.get("B").map(|v| v.as_persisted_str()), Some("agent"));
     }
 
     #[test]
@@ -1490,7 +1499,10 @@ mod tests {
             &m(&[("A", "workspace")]),
             &m(&[]),
         );
-        assert_eq!(merged.get("A").map(|v| v.as_str()), Some("workspace"));
+        assert_eq!(
+            merged.get("A").map(|v| v.as_persisted_str()),
+            Some("workspace")
+        );
     }
 
     #[test]
@@ -1501,7 +1513,10 @@ mod tests {
             &m(&[("A", "workspace")]),
             &m(&[("A", "ws-agent")]),
         );
-        assert_eq!(merged.get("A").map(|v| v.as_str()), Some("ws-agent"));
+        assert_eq!(
+            merged.get("A").map(|v| v.as_persisted_str()),
+            Some("ws-agent")
+        );
     }
 
     #[test]
@@ -1512,17 +1527,17 @@ mod tests {
             &m(&[("W", "w")]),
             &m(&[("X", "x")]),
         );
-        assert_eq!(merged.get("G").map(|v| v.as_str()), Some("g"));
-        assert_eq!(merged.get("A").map(|v| v.as_str()), Some("a"));
-        assert_eq!(merged.get("W").map(|v| v.as_str()), Some("w"));
-        assert_eq!(merged.get("X").map(|v| v.as_str()), Some("x"));
+        assert_eq!(merged.get("G").map(|v| v.as_persisted_str()), Some("g"));
+        assert_eq!(merged.get("A").map(|v| v.as_persisted_str()), Some("a"));
+        assert_eq!(merged.get("W").map(|v| v.as_persisted_str()), Some("w"));
+        assert_eq!(merged.get("X").map(|v| v.as_persisted_str()), Some("x"));
     }
 
     #[test]
     fn validate_reserved_names_rejects_global_reserved() {
         let mut cfg = crate::config::AppConfig::default();
         cfg.env
-            .insert("DOCKER_HOST".to_string(), "whatever".to_string());
+            .insert("DOCKER_HOST".to_string(), "whatever".to_string().into());
 
         let err = validate_reserved_names(&cfg).unwrap_err();
         let msg = err.to_string();
@@ -1540,9 +1555,10 @@ mod tests {
             claude: None,
             env: std::collections::BTreeMap::new(),
         };
-        agent
-            .env
-            .insert("JACKIN_CLAUDE_ENV".to_string(), "whatever".to_string());
+        agent.env.insert(
+            "JACKIN_CLAUDE_ENV".to_string(),
+            "whatever".to_string().into(),
+        );
         cfg.agents.insert("agent-smith".to_string(), agent);
 
         let err = validate_reserved_names(&cfg).unwrap_err();
@@ -1565,7 +1581,7 @@ mod tests {
             ..Default::default()
         };
         ws.env
-            .insert("DOCKER_TLS_VERIFY".to_string(), "0".to_string());
+            .insert("DOCKER_TLS_VERIFY".to_string(), "0".to_string().into());
         cfg.workspaces.insert("big-monorepo".to_string(), ws);
 
         let err = validate_reserved_names(&cfg).unwrap_err();
@@ -1580,7 +1596,7 @@ mod tests {
         let mut override_ = crate::workspace::WorkspaceAgentOverride::default();
         override_
             .env
-            .insert("DOCKER_CERT_PATH".to_string(), "/tmp".to_string());
+            .insert("DOCKER_CERT_PATH".to_string(), "/tmp".to_string().into());
         let mut ws = crate::workspace::WorkspaceConfig {
             workdir: "/x".to_string(),
             mounts: vec![crate::workspace::MountConfig {
@@ -1606,9 +1622,10 @@ mod tests {
     #[test]
     fn validate_reserved_names_reports_all_conflicts_in_one_error() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("DOCKER_HOST".to_string(), "x".to_string());
         cfg.env
-            .insert("DOCKER_TLS_VERIFY".to_string(), "y".to_string());
+            .insert("DOCKER_HOST".to_string(), "x".to_string().into());
+        cfg.env
+            .insert("DOCKER_TLS_VERIFY".to_string(), "y".to_string().into());
 
         let err = validate_reserved_names(&cfg).unwrap_err();
         let msg = err.to_string();
@@ -1619,9 +1636,10 @@ mod tests {
     #[test]
     fn validate_reserved_names_accepts_non_reserved() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("MY_VAR".to_string(), "value".to_string());
         cfg.env
-            .insert("OPERATOR_TOKEN".to_string(), "op://...".to_string());
+            .insert("MY_VAR".to_string(), "value".to_string().into());
+        cfg.env
+            .insert("OPERATOR_TOKEN".to_string(), "op://...".to_string().into());
 
         validate_reserved_names(&cfg).unwrap();
     }
@@ -1640,7 +1658,7 @@ mod tests {
     #[test]
     fn resolve_global_literal_value() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("FOO".to_string(), "bar".to_string());
+        cfg.env.insert("FOO".to_string(), "bar".to_string().into());
         let resolved =
             resolve_operator_env_with(&cfg, None, None, &TestOpRunner::forbidden(), |_| {
                 Err(std::env::VarError::NotPresent)
@@ -1652,7 +1670,7 @@ mod tests {
     #[test]
     fn resolve_layers_apply_in_order_with_workspace_agent_winning() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("X".to_string(), "global".to_string());
+        cfg.env.insert("X".to_string(), "global".to_string().into());
 
         let mut agent_source = crate::config::AgentSource {
             git: "https://example.com/x.git".to_string(),
@@ -1662,7 +1680,7 @@ mod tests {
         };
         agent_source
             .env
-            .insert("X".to_string(), "agent".to_string());
+            .insert("X".to_string(), "agent".to_string().into());
         cfg.agents.insert("agent-smith".to_string(), agent_source);
 
         let mut ws = crate::workspace::WorkspaceConfig {
@@ -1675,9 +1693,11 @@ mod tests {
             }],
             ..Default::default()
         };
-        ws.env.insert("X".to_string(), "workspace".to_string());
+        ws.env
+            .insert("X".to_string(), "workspace".to_string().into());
         let mut wsa = crate::workspace::WorkspaceAgentOverride::default();
-        wsa.env.insert("X".to_string(), "ws-agent".to_string());
+        wsa.env
+            .insert("X".to_string(), "ws-agent".to_string().into());
         ws.agents.insert("agent-smith".to_string(), wsa);
         cfg.workspaces.insert("big-monorepo".to_string(), ws);
 
@@ -1696,8 +1716,10 @@ mod tests {
     #[test]
     fn resolve_reports_all_failures_in_one_error() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("A".to_string(), "$MISSING_A".to_string());
-        cfg.env.insert("B".to_string(), "$MISSING_B".to_string());
+        cfg.env
+            .insert("A".to_string(), "$MISSING_A".to_string().into());
+        cfg.env
+            .insert("B".to_string(), "$MISSING_B".to_string().into());
 
         let err = resolve_operator_env_with(&cfg, None, None, &TestOpRunner::forbidden(), |_| {
             Err(std::env::VarError::NotPresent)
@@ -1729,9 +1751,9 @@ mod tests {
 
         let mut cfg = crate::config::AppConfig::default();
         cfg.env
-            .insert("A".to_string(), "op://Personal/a".to_string());
+            .insert("A".to_string(), "op://Personal/a".to_string().into());
         cfg.env
-            .insert("B".to_string(), "op://Personal/b".to_string());
+            .insert("B".to_string(), "op://Personal/b".to_string().into());
         let runner = ProbeCountingRunner {
             probe_calls: std::cell::Cell::new(0),
             read_calls: std::cell::Cell::new(0),
@@ -1760,7 +1782,8 @@ mod tests {
         }
 
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env.insert("A".to_string(), "literal".to_string());
+        cfg.env
+            .insert("A".to_string(), "literal".to_string().into());
         let runner = ProbeCountingRunner {
             probe_calls: std::cell::Cell::new(0),
         };
@@ -1792,9 +1815,9 @@ mod tests {
 
         let mut cfg = crate::config::AppConfig::default();
         cfg.env
-            .insert("A".to_string(), "op://Personal/a".to_string());
+            .insert("A".to_string(), "op://Personal/a".to_string().into());
         cfg.env
-            .insert("B".to_string(), "op://Personal/b".to_string());
+            .insert("B".to_string(), "op://Personal/b".to_string().into());
         let err = resolve_operator_env_with(&cfg, None, None, &FailingProbeRunner, |_| {
             Err(std::env::VarError::NotPresent)
         })
@@ -1811,7 +1834,7 @@ mod tests {
         let mut cfg = crate::config::AppConfig::default();
         cfg.env.insert(
             "TOKEN".to_string(),
-            "op://Personal/broken/token".to_string(),
+            "op://Personal/broken/token".to_string().into(),
         );
 
         let runner = TestOpRunner::new(Err(anyhow::anyhow!("item not found")));
@@ -1829,8 +1852,10 @@ mod tests {
     #[test]
     fn resolve_host_ref_success_returns_value() {
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env
-            .insert("API_KEY".to_string(), "${MY_HOST_API_KEY}".to_string());
+        cfg.env.insert(
+            "API_KEY".to_string(),
+            "${MY_HOST_API_KEY}".to_string().into(),
+        );
 
         let resolved =
             resolve_operator_env_with(&cfg, None, None, &TestOpRunner::forbidden(), |name| {
@@ -1852,11 +1877,13 @@ mod tests {
     fn launch_diagnostic_normal_mode_prints_counts_only_no_values() {
         let mut cfg = crate::config::AppConfig::default();
         cfg.env
-            .insert("LITERAL_KEY".to_string(), "super-secret".to_string());
+            .insert("LITERAL_KEY".to_string(), "super-secret".to_string().into());
         cfg.env
-            .insert("HOST_KEY".to_string(), "$HOST_VAR".to_string());
-        cfg.env
-            .insert("OP_KEY".to_string(), "op://Personal/item/field".to_string());
+            .insert("HOST_KEY".to_string(), "$HOST_VAR".to_string().into());
+        cfg.env.insert(
+            "OP_KEY".to_string(),
+            "op://Personal/item/field".to_string().into(),
+        );
         let resolved: std::collections::BTreeMap<String, String> = [
             ("LITERAL_KEY".to_string(), "super-secret".to_string()),
             ("HOST_KEY".to_string(), "host-value-secret".to_string()),
@@ -1886,9 +1913,11 @@ mod tests {
     fn launch_diagnostic_debug_mode_prints_references_but_not_values() {
         let mut cfg = crate::config::AppConfig::default();
         cfg.env
-            .insert("LITERAL_KEY".to_string(), "super-secret".to_string());
-        cfg.env
-            .insert("OP_KEY".to_string(), "op://Personal/item/field".to_string());
+            .insert("LITERAL_KEY".to_string(), "super-secret".to_string().into());
+        cfg.env.insert(
+            "OP_KEY".to_string(),
+            "op://Personal/item/field".to_string().into(),
+        );
         let resolved: std::collections::BTreeMap<String, String> = [
             ("LITERAL_KEY".to_string(), "super-secret".to_string()),
             ("OP_KEY".to_string(), "op-value-secret".to_string()),

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -164,13 +164,28 @@ pub struct OpRef {
 
 impl EnvValue {
     /// View the value as the string we'd pass to a downstream container
-    /// for `Plain`, or the canonical `op://` URI for `OpRef`. Resolution
-    /// (calling the 1Password CLI for `OpRef`) happens in `resolve_env_value`,
-    /// not here — this is for display, comparison, and migration paths.
+    /// for `Plain`, or the UUID-form `op://` URI for `OpRef` (see
+    /// `OpRef::op`). Resolution (calling the 1Password CLI for `OpRef`)
+    /// happens in `resolve_env_value`, not here — this is for internal
+    /// merging, comparison, and migration paths.
     pub const fn as_persisted_str(&self) -> &str {
         match self {
             Self::Plain(s) => s.as_str(),
             Self::OpRef(r) => r.op.as_str(),
+        }
+    }
+
+    /// Human-readable display form. For `OpRef`, returns the snapshot
+    /// breadcrumb (e.g. `Private/Claude/security/auth token`). For
+    /// `Plain`, returns the literal value.
+    ///
+    /// Use this on operator-facing surfaces (CLI `env list`, launch
+    /// auth-mode notice). For internal merging or comparison, use
+    /// `as_persisted_str` (which returns the UUID-form URI for `OpRef`).
+    pub const fn as_display_str(&self) -> &str {
+        match self {
+            Self::Plain(s) => s.as_str(),
+            Self::OpRef(r) => r.path.as_str(),
         }
     }
 }
@@ -1471,6 +1486,23 @@ mod tests {
                 None => panic!("op CLI should not have been invoked"),
             }
         }
+    }
+
+    // ---- as_display_str tests --------------------------------------------
+
+    #[test]
+    fn env_value_as_display_str_returns_path_for_op_ref() {
+        let v = EnvValue::OpRef(OpRef {
+            op: "op://abc/def/fld".into(),
+            path: "Private/Claude/auth".into(),
+        });
+        assert_eq!(v.as_display_str(), "Private/Claude/auth");
+    }
+
+    #[test]
+    fn env_value_as_display_str_returns_literal_for_plain() {
+        let v = EnvValue::Plain("postgres://localhost".into());
+        assert_eq!(v.as_display_str(), "postgres://localhost");
     }
 
     // ---- resolve_env_value dispatch tests --------------------------------

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -2543,6 +2543,7 @@ TOKEN = { op = "op://abc/def/fld", path = "Vault/Item/Field", paht = "stray" }
 "#;
         #[derive(serde::Deserialize)]
         struct Wrap {
+            #[allow(dead_code)] // exercised via deserialization, never read in this negative test
             env: std::collections::BTreeMap<String, EnvValue>,
         }
         let result: Result<Wrap, _> = toml::from_str(toml_in);

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -1490,6 +1490,29 @@ mod tests {
         );
     }
 
+    /// Regression pin: workspaces written before this branch have
+    /// `MY_VAR = "op://Vault/Item/Field"` as a scalar string — those
+    /// load as `EnvValue::Plain`. At runtime the resolver must pass
+    /// them through to the container as a literal string: no `op read`
+    /// call, no error.
+    #[test]
+    fn legacy_bare_op_uri_at_runtime_passes_through_literally() {
+        let runner = TestOpRunner::forbidden(); // panics if read() is ever called
+        let v = EnvValue::Plain("op://Vault/Item/Field".into());
+        let r = resolve_env_value("test", "OLD", &v, &runner, |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .expect("must succeed — Plain values never fail unless $VAR is unset");
+        assert_eq!(
+            r, "op://Vault/Item/Field",
+            "Plain bare op:// must pass through literally, not be resolved",
+        );
+        assert!(
+            runner.last_ref.borrow().is_none(),
+            "no op read call must be made for Plain values, even op://-shaped ones",
+        );
+    }
+
     #[test]
     fn dispatch_op_ref_calls_op_read_with_canonical_uri() {
         let runner = TestOpRunner::new(Ok("secret-value".to_string()));

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -165,7 +165,7 @@ pub struct OpRef {
 impl EnvValue {
     /// View the value as the string we'd pass to a downstream container
     /// for `Plain`, or the canonical `op://` URI for `OpRef`. Resolution
-    /// (calling the 1Password CLI for `OpRef`) happens in `dispatch_value`,
+    /// (calling the 1Password CLI for `OpRef`) happens in `resolve_env_value`,
     /// not here — this is for display, comparison, and migration paths.
     pub const fn as_persisted_str(&self) -> &str {
         match self {

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -121,7 +121,10 @@ pub enum EnvValue {
 /// pick, `op` continues to resolve to the same secret while `path`
 /// shows the stale name until the operator re-picks. This is
 /// intentional — paths are advisory text for the editor, not part
-/// of the resolution contract.
+/// of the resolution contract. Drift is operator-visible (the editor
+/// breadcrumb shows the stale name) but resolver-invisible (resolution
+/// uses `op` only). A future "refresh path" feature would need to be
+/// a deliberate metadata pass — never a side-effect of resolution.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OpRef {
@@ -175,11 +178,6 @@ impl From<&str> for EnvValue {
     fn from(s: &str) -> Self {
         Self::Plain(s.to_string())
     }
-}
-
-#[must_use]
-pub fn is_op_reference(value: &str) -> bool {
-    value.starts_with("op://")
 }
 
 /// Structured parts of an `op://...` reference.
@@ -1286,17 +1284,6 @@ fn classify_env_value(value: &EnvValue) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn is_op_reference_recognizes_prefix() {
-        assert!(is_op_reference("op://Personal/api/token"));
-        assert!(is_op_reference("op://acct/Personal/api/token"));
-        assert!(!is_op_reference("plain-literal"));
-        assert!(!is_op_reference("$HOST"));
-        assert!(!is_op_reference("${HOST}"));
-        assert!(!is_op_reference(""));
-        assert!(!is_op_reference("op:/missing"));
-    }
 
     #[test]
     fn parse_op_reference_three_segments() {

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -868,6 +868,165 @@ pub fn validate_reserved_names(config: &crate::config::AppConfig) -> anyhow::Res
     )
 }
 
+/// Resolve a user-supplied `op://...` URI into a canonical [`OpRef`].
+///
+/// Accepts all official 1Password URI forms: names, UUIDs, mixed, with
+/// optional subtitle filter `Item[subtitle]`, optional 4th section segment,
+/// and optional query suffix (`?attribute=otp` etc.). Errors on ambiguity,
+/// missing items or fields, or unsupported `${VAR}` substitution syntax.
+///
+/// The caller must probe `op` CLI availability before calling this
+/// (e.g. via [`OpRunner::probe`]).
+#[allow(clippy::too_many_lines)]
+pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Result<OpRef> {
+    use anyhow::{anyhow, bail};
+
+    if !input.starts_with("op://") {
+        bail!("not an op:// reference: {input}");
+    }
+    if input.contains("${") {
+        bail!(
+            "jackin does not support shell variable substitution inside `op://` URIs \
+             (`{input}`). Use a plain string value, or substitute before passing."
+        );
+    }
+
+    // Peel off optional `?attribute=...` / `?attr=...` / `?ssh-format=...` suffix.
+    let (path_part, query) = input
+        .find('?')
+        .map_or((input, None), |i| (&input[..i], Some(&input[i..])));
+    let body = path_part.strip_prefix("op://").unwrap();
+    let segs: Vec<&str> = body.split('/').collect();
+    let (vault_seg, item_seg, section_seg, field_seg) = match segs.as_slice() {
+        [v, i, f] => (*v, *i, None::<&str>, *f),
+        [v, i, s, f] => (*v, *i, Some(*s), *f),
+        _ => bail!("malformed op:// URI (expected 3 or 4 path segments): {input}"),
+    };
+
+    // Item segment may carry [subtitle] filter — jackin's display extension.
+    // Nested condition makes map_or awkward; allow the if-let pattern here.
+    #[allow(clippy::option_if_let_else)]
+    let (item_name, subtitle_filter): (&str, Option<&str>) = if let Some(open) = item_seg.rfind('[')
+    {
+        if item_seg.ends_with(']') && open < item_seg.len() - 1 {
+            (
+                &item_seg[..open],
+                Some(&item_seg[open + 1..item_seg.len() - 1]),
+            )
+        } else {
+            (item_seg, None)
+        }
+    } else {
+        (item_seg, None)
+    };
+
+    // Resolve vault by name (case-insensitive) or UUID.
+    let vaults = op.vault_list(None)?;
+    let vault = vaults
+        .iter()
+        .find(|v| v.name.eq_ignore_ascii_case(vault_seg) || v.id == vault_seg)
+        .ok_or_else(|| anyhow!("vault not found: {vault_seg:?}"))?;
+
+    // Resolve items in this vault, then filter by name (case-insensitive) or
+    // UUID, and by subtitle filter when present.
+    let items = op.item_list(&vault.id, None)?;
+    let mut matches: Vec<&OpItem> = items
+        .iter()
+        .filter(|i| {
+            (i.name.eq_ignore_ascii_case(item_name) || i.id == item_name)
+                && subtitle_filter.is_none_or(|s| i.subtitle.eq_ignore_ascii_case(s))
+        })
+        .collect();
+
+    if matches.is_empty() {
+        let suffix = subtitle_filter
+            .map(|s| format!("[{s}]"))
+            .unwrap_or_default();
+        bail!(
+            "item {name:?} not found in vault {vault_name:?}",
+            name = format!("{item_name}{suffix}"),
+            vault_name = vault.name
+        );
+    }
+    if matches.len() > 1 {
+        let suggestions: Vec<String> = matches
+            .iter()
+            .map(|i| {
+                let label = if i.subtitle.is_empty() {
+                    format!("{}[#{}]", i.name, &i.id[..i.id.len().min(8)])
+                } else {
+                    format!("{}[{}]", i.name, i.subtitle)
+                };
+                let section_part = section_seg.map(|s| format!("/{s}")).unwrap_or_default();
+                let q = query.unwrap_or("");
+                format!("  op://{}/{label}{section_part}/{field_seg}{q}", vault.name)
+            })
+            .collect();
+        bail!(
+            "{n} items named {name:?} in vault {vault_name:?}. Disambiguate with:\n{lines}",
+            n = matches.len(),
+            name = item_name,
+            vault_name = vault.name,
+            lines = suggestions.join("\n")
+        );
+    }
+    let item = matches.pop().unwrap();
+
+    // Resolve field by label (case-insensitive) or UUID.
+    let fields = op.item_get(&item.id, &vault.id, None)?;
+    let field = fields
+        .iter()
+        .find(|f| {
+            f.label.eq_ignore_ascii_case(field_seg)
+                || f.id == field_seg
+                || matches_special_alias(f, field_seg)
+        })
+        .ok_or_else(|| {
+            anyhow!(
+                "field {field_seg:?} not found in item {name:?}",
+                name = item.name
+            )
+        })?;
+
+    // Compute ambiguity for path snapshot (same rule as picker).
+    let item_name_collides = items.iter().any(|i| i.id != item.id && i.name == item.name);
+    let safe_to_embed = !item.name.contains('[') && !item.name.contains(']');
+    let item_segment = if item_name_collides && safe_to_embed && !item.subtitle.is_empty() {
+        format!("{}[{}]", item.name, item.subtitle)
+    } else {
+        item.name.clone()
+    };
+
+    let q_suffix = query.unwrap_or("");
+    let (op_uri, display_path) = section_seg.map_or_else(
+        || {
+            (
+                format!("op://{}/{}/{}{q_suffix}", vault.id, item.id, field.id),
+                format!("{}/{}/{}{q_suffix}", vault.name, item_segment, field.label),
+            )
+        },
+        |s| {
+            (
+                format!("op://{}/{}/{}/{}{q_suffix}", vault.id, item.id, s, field.id),
+                format!(
+                    "{}/{}/{}/{}{q_suffix}",
+                    vault.name, item_segment, s, field.label
+                ),
+            )
+        },
+    );
+
+    Ok(OpRef {
+        op: op_uri,
+        path: display_path,
+    })
+}
+
+fn matches_special_alias(f: &OpField, seg: &str) -> bool {
+    matches!(seg, "username" | "password" | "notes" | "notesPlain")
+        && f.label.eq_ignore_ascii_case(seg)
+}
+
 /// (key → (layer, value)) precedence-merged across the four config
 /// layers — global, agent, workspace, workspace-agent — for the given
 /// `(agent, workspace)` selection. Later layers overwrite earlier ones,
@@ -2435,5 +2594,228 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
         let serialized = toml::to_string(&parsed).unwrap();
         let reparsed: Wrap = toml::from_str(&serialized).unwrap();
         assert_eq!(parsed, reparsed);
+    }
+
+    // ---- resolve_op_uri_to_ref tests ------------------------------------
+
+    /// Minimal stub for `OpStructRunner` used by `resolve_op_uri_to_ref` unit
+    /// tests. Supports builder methods (`with_vault`, `with_item`, `with_field`)
+    /// and covers only the synchronous path used by the CLI resolver.
+    struct StubOpStructRunner {
+        vaults: Vec<OpVault>,
+        /// (vault_id → items)
+        items: std::collections::HashMap<String, Vec<OpItem>>,
+        /// (item_id → fields)
+        fields: std::collections::HashMap<String, Vec<OpField>>,
+    }
+
+    impl StubOpStructRunner {
+        fn new() -> Self {
+            Self {
+                vaults: Vec::new(),
+                items: std::collections::HashMap::new(),
+                fields: std::collections::HashMap::new(),
+            }
+        }
+
+        fn with_vault(mut self, name: &str, id: &str) -> Self {
+            self.vaults.push(OpVault {
+                id: id.to_string(),
+                name: name.to_string(),
+            });
+            self
+        }
+
+        fn with_item(mut self, vault_id: &str, name: &str, id: &str, subtitle: &str) -> Self {
+            self.items
+                .entry(vault_id.to_string())
+                .or_default()
+                .push(OpItem {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    subtitle: subtitle.to_string(),
+                });
+            self
+        }
+
+        fn with_field(mut self, item_id: &str, label: &str, id: &str, concealed: bool) -> Self {
+            self.fields
+                .entry(item_id.to_string())
+                .or_default()
+                .push(OpField {
+                    id: id.to_string(),
+                    label: label.to_string(),
+                    field_type: if concealed {
+                        "CONCEALED".into()
+                    } else {
+                        "STRING".into()
+                    },
+                    concealed,
+                    reference: String::new(),
+                });
+            self
+        }
+    }
+
+    impl OpStructRunner for StubOpStructRunner {
+        fn account_list(&self) -> anyhow::Result<Vec<OpAccount>> {
+            Ok(vec![])
+        }
+
+        fn vault_list(&self, _account: Option<&str>) -> anyhow::Result<Vec<OpVault>> {
+            Ok(self.vaults.clone())
+        }
+
+        fn item_list(&self, vault_id: &str, _account: Option<&str>) -> anyhow::Result<Vec<OpItem>> {
+            Ok(self.items.get(vault_id).cloned().unwrap_or_default())
+        }
+
+        fn item_get(
+            &self,
+            item_id: &str,
+            _vault_id: &str,
+            _account: Option<&str>,
+        ) -> anyhow::Result<Vec<OpField>> {
+            Ok(self.fields.get(item_id).cloned().unwrap_or_default())
+        }
+    }
+
+    #[test]
+    fn resolve_op_uri_unique_resolves_to_op_ref() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "")
+            .with_field("i_uuid", "api key", "f_uuid", false);
+
+        let result = resolve_op_uri_to_ref("op://Private/Stripe/api key", &stub).unwrap();
+        assert_eq!(result.op, "op://v_uuid/i_uuid/f_uuid");
+        assert_eq!(result.path, "Private/Stripe/api key");
+    }
+
+    #[test]
+    fn resolve_op_uri_ambiguous_errors_with_disambig_list() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_a", "alexey@zhokhov.com")
+            .with_item("v_uuid", "Claude", "i_b", "alexey@chainargos.com")
+            .with_item("v_uuid", "Claude", "i_c", "team@example.com");
+
+        let err = resolve_op_uri_to_ref("op://Private/Claude/auth", &stub).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("3 items"), "msg: {msg}");
+        assert!(msg.contains("Claude[alexey@zhokhov.com]"), "msg: {msg}");
+        assert!(msg.contains("Claude[alexey@chainargos.com]"), "msg: {msg}");
+        assert!(msg.contains("Claude[team@example.com]"), "msg: {msg}");
+    }
+
+    #[test]
+    fn resolve_op_uri_with_subtitle_filter_resolves() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_a", "alexey@zhokhov.com")
+            .with_item("v_uuid", "Claude", "i_b", "alexey@chainargos.com")
+            .with_field("i_a", "auth", "f_uuid_a", false);
+
+        let result =
+            resolve_op_uri_to_ref("op://Private/Claude[alexey@zhokhov.com]/auth", &stub).unwrap();
+        assert_eq!(result.op, "op://v_uuid/i_a/f_uuid_a");
+        // Path retains brackets because the item is ambiguous in the vault.
+        assert_eq!(result.path, "Private/Claude[alexey@zhokhov.com]/auth");
+    }
+
+    #[test]
+    fn resolve_op_uri_plain_literal_not_affected() {
+        // Non-op:// input must be rejected by resolve_op_uri_to_ref.
+        let stub = StubOpStructRunner::new();
+        let err = resolve_op_uri_to_ref("postgres://localhost", &stub).unwrap_err();
+        assert!(err.to_string().contains("not an op://"), "{err}");
+    }
+
+    #[test]
+    fn resolve_op_uri_with_dollar_var_errors() {
+        // `${VAR}` substitution inside op:// URIs is unsupported.
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "");
+
+        let err = resolve_op_uri_to_ref("op://${APP_ENV}/Stripe/api key", &stub).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("substitution") || msg.contains("${"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_op_uri_uuid_form_resolves() {
+        // UUID-form input: the vault/item/field IDs are supplied directly.
+        // vault_list returns a vault whose id matches the input segment.
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "")
+            .with_field("i_uuid", "api key", "f_uuid", false);
+
+        let result = resolve_op_uri_to_ref("op://v_uuid/i_uuid/f_uuid", &stub).unwrap();
+        assert_eq!(result.op, "op://v_uuid/i_uuid/f_uuid");
+        assert_eq!(result.path, "Private/Stripe/api key");
+    }
+
+    #[test]
+    fn resolve_op_uri_with_attribute_query_preserves_query() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "GitHub", "i_uuid", "")
+            .with_field("i_uuid", "one-time password", "f_uuid", false);
+
+        let result =
+            resolve_op_uri_to_ref("op://Private/GitHub/one-time password?attribute=otp", &stub)
+                .unwrap();
+        assert!(result.op.contains("?attribute=otp"), "op: {}", result.op);
+        assert!(
+            result.path.contains("?attribute=otp"),
+            "path: {}",
+            result.path
+        );
+    }
+
+    #[test]
+    fn resolve_op_uri_4_segment_with_section_resolves() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid", "")
+            .with_field("i_uuid", "auth token", "f_uuid", false);
+
+        let result =
+            resolve_op_uri_to_ref("op://Private/Claude/security/auth token", &stub).unwrap();
+        assert_eq!(result.path, "Private/Claude/security/auth token");
+        assert!(result.op.contains("/security/"), "op: {}", result.op);
+    }
+
+    #[test]
+    fn resolve_op_uri_vault_not_found_errors() {
+        let stub = StubOpStructRunner::new().with_vault("Personal", "v1");
+
+        let err = resolve_op_uri_to_ref("op://NoSuchVault/Item/field", &stub).unwrap_err();
+        assert!(err.to_string().contains("vault not found"), "{}", err);
+    }
+
+    #[test]
+    fn resolve_op_uri_item_not_found_errors() {
+        let stub = StubOpStructRunner::new().with_vault("Private", "v_uuid");
+        // No items in the vault.
+
+        let err = resolve_op_uri_to_ref("op://Private/NoSuchItem/field", &stub).unwrap_err();
+        assert!(err.to_string().contains("not found"), "{}", err);
+    }
+
+    #[test]
+    fn resolve_op_uri_field_not_found_errors() {
+        let stub = StubOpStructRunner::new()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "");
+        // No fields on the item.
+
+        let err = resolve_op_uri_to_ref("op://Private/Stripe/api key", &stub).unwrap_err();
+        assert!(err.to_string().contains("not found"), "{}", err);
     }
 }

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -933,8 +933,14 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
     let mut matches: Vec<&OpItem> = items
         .iter()
         .filter(|i| {
-            (i.name.eq_ignore_ascii_case(item_name) || i.id == item_name)
-                && subtitle_filter.is_none_or(|s| i.subtitle.eq_ignore_ascii_case(s))
+            let name_match = i.name.eq_ignore_ascii_case(item_name) || i.id == item_name;
+            let subtitle_match = match subtitle_filter {
+                None => true,
+                // `#<prefix>` → match against item ID prefix (from disambig suggestion).
+                Some(s) if s.starts_with('#') => i.id.starts_with(&s[1..]),
+                Some(s) => i.subtitle.eq_ignore_ascii_case(s),
+            };
+            name_match && subtitle_match
         })
         .collect();
 
@@ -953,7 +959,8 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
             .iter()
             .map(|i| {
                 let label = if i.subtitle.is_empty() {
-                    format!("{}[#{}]", i.name, &i.id[..i.id.len().min(8)])
+                    let id_prefix: String = i.id.chars().take(8).collect();
+                    format!("{}[#{}]", i.name, id_prefix)
                 } else {
                     format!("{}[{}]", i.name, i.subtitle)
                 };
@@ -998,13 +1005,24 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
     let section_from_field = parse_op_reference(&field.reference).and_then(|p| p.section);
 
     let canonical_section = match (section_seg, section_from_field) {
-        // Both present: use canonical (1Password) form.
-        (Some(_), Some(s)) => Some(s),
+        // field.reference has a section: use canonical (1Password) form
+        // regardless of whether the user also typed a section. This covers:
+        //   - (Some(_), Some(s)): both present → prefer field.reference's form.
+        //   - (None, Some(s)): 3-segment input but field lives in a section;
+        //     pick it up so the result matches the picker's output.
+        (_, Some(s)) => Some(s),
         // User typed a section but the field's reference has none — should not
         // happen for sectioned fields; trust the user input as a fallback.
         (Some(user_s), None) => Some(user_s.to_string()),
         // No section anywhere: 3-segment URI.
-        (None, _) => None,
+        (None, None) => None,
+    };
+
+    // Mirror picker's empty-label fallback: use field.id when label is empty.
+    let field_label = if field.label.is_empty() {
+        field.id.as_str()
+    } else {
+        field.label.as_str()
     };
 
     let q_suffix = query.unwrap_or("");
@@ -1012,7 +1030,7 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
         || {
             (
                 format!("op://{}/{}/{}{q_suffix}", vault.id, item.id, field.id),
-                format!("{}/{}/{}{q_suffix}", vault.name, item_segment, field.label),
+                format!("{}/{}/{}{q_suffix}", vault.name, item_segment, field_label),
             )
         },
         |s| {
@@ -1020,7 +1038,7 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
                 format!("op://{}/{}/{}/{}{q_suffix}", vault.id, item.id, s, field.id),
                 format!(
                     "{}/{}/{}/{}{q_suffix}",
-                    vault.name, item_segment, s, field.label
+                    vault.name, item_segment, s, field_label
                 ),
             )
         },
@@ -2934,6 +2952,59 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
         assert!(
             msg.contains("Notes[#fedcba09]"),
             "expected #id-prefix form, got:\n{msg}"
+        );
+    }
+
+    /// Fix 1B: `[#<id-prefix>]` suggestions from disambig error are parseable
+    /// and select the correct item by ID prefix.
+    #[test]
+    fn resolve_op_uri_with_id_prefix_filter_resolves() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Notes", "abcdef1234567890", "")
+            .with_item("v_uuid", "Notes", "fedcba0987654321", "")
+            .with_field("abcdef1234567890", "notesPlain", "f_uuid", false);
+        let r = resolve_op_uri_to_ref("op://Private/Notes[#abcdef12]/notesPlain", &stub).unwrap();
+        assert_eq!(r.op, "op://v_uuid/abcdef1234567890/f_uuid");
+    }
+
+    /// Fix 1C: empty field label falls back to field.id in the display path.
+    #[test]
+    fn resolve_op_uri_empty_field_label_uses_field_id_in_path() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Stripe", "i_uuid", "")
+            .with_field("i_uuid", "", "f_uuid", false);
+        let r = resolve_op_uri_to_ref("op://Private/Stripe/f_uuid", &stub).unwrap();
+        // path must not end with a trailing slash (empty label)
+        assert_eq!(r.path, "Private/Stripe/f_uuid");
+    }
+
+    /// Fix 1A: 3-segment input where the field actually lives in a section
+    /// (per field.reference) must include that section in the result.
+    #[test]
+    fn resolve_op_uri_3seg_input_picks_up_section_from_field_reference() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid", "")
+            .with_field_with_reference(
+                "i_uuid",
+                "auth token",
+                "f_uuid",
+                false,
+                "op://Private/Claude/Security/auth token",
+            );
+        // User supplies 3-segment URI (no section), but field lives in "Security"
+        let r = resolve_op_uri_to_ref("op://Private/Claude/auth token", &stub).unwrap();
+        assert!(
+            r.op.contains("/Security/"),
+            "op must include section from field.reference; got {}",
+            r.op
+        );
+        assert!(
+            r.path.contains("/Security/"),
+            "path must include section from field.reference; got {}",
+            r.path
         );
     }
 }

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -18,6 +18,10 @@ pub trait OpRunner {
 /// `op://...` → `op_runner.read`, `$NAME` / `${NAME}` → `host_env`,
 /// otherwise verbatim. `layer_label` / `var_name` only feed error
 /// messages.
+///
+/// This function is retained for the CLI input parser (Task 8) and for
+/// resolving `EnvValue::Plain` strings (which may contain `$VAR` refs).
+/// Runtime dispatch for `EnvValue` uses `resolve_env_value` instead.
 pub fn dispatch_value<R>(
     layer_label: &str,
     var_name: &str,
@@ -44,6 +48,67 @@ where
         });
     }
 
+    Ok(value.to_string())
+}
+
+/// Resolve a single [`EnvValue`] to its final string, dispatching on the
+/// enum variant rather than lexical string prefix.
+///
+/// - `EnvValue::Plain` passes through `$VAR` / `${VAR}` expansion via
+///   the host environment; bare `op://...` strings stored as `Plain` are
+///   **not** resolved and flow to the container literally.
+/// - `EnvValue::OpRef` shells out to `op read <op>` using the canonical
+///   UUID URI; failures are wrapped with the human-readable `path` for
+///   actionable error messages.
+///
+/// `layer_label` / `var_name` are used only in error messages.
+pub fn resolve_env_value<R, H>(
+    layer_label: &str,
+    var_name: &str,
+    value: &EnvValue,
+    op_runner: &R,
+    host_env: H,
+) -> anyhow::Result<String>
+where
+    R: OpRunner + ?Sized,
+    H: FnMut(&str) -> Result<String, std::env::VarError>,
+{
+    match value {
+        EnvValue::Plain(s) => {
+            // Delegate to the string-based dispatcher but skip the op://
+            // branch — the discriminator is now structural (the enum variant).
+            // Plain("op://...") passes through literally; no op read call.
+            dispatch_plain(layer_label, var_name, s, host_env)
+        }
+        EnvValue::OpRef(r) => op_runner.read(&r.op).map_err(|e| {
+            anyhow::anyhow!(
+                "{layer_label} env var {var_name:?}: 1Password reference {:?} failed: {e}",
+                r.path
+            )
+        }),
+    }
+}
+
+/// Resolve a plain string value: `$NAME` / `${NAME}` → host env lookup,
+/// otherwise verbatim. `op://...` strings are intentionally NOT resolved
+/// here — that branch lives exclusively in [`resolve_env_value`] for
+/// `EnvValue::OpRef`.
+fn dispatch_plain<H>(
+    layer_label: &str,
+    var_name: &str,
+    value: &str,
+    mut host_env: H,
+) -> anyhow::Result<String>
+where
+    H: FnMut(&str) -> Result<String, std::env::VarError>,
+{
+    if let Some(host_name) = parse_host_ref(value) {
+        return host_env(host_name).map_err(|_| {
+            anyhow::anyhow!(
+                "{layer_label} env var {var_name:?}: host env var {host_name:?} is not set"
+            )
+        });
+    }
     Ok(value.to_string())
 }
 
@@ -803,21 +868,21 @@ pub fn validate_reserved_names(config: &crate::config::AppConfig) -> anyhow::Res
     )
 }
 
-/// (key → (layer, `raw_value`)) precedence-merged across the four
-/// config layers — global, agent, workspace, workspace-agent — for the
-/// given `(agent, workspace)` selection. Later layers overwrite earlier
-/// ones, so the final layer attached to each key is the one that wins.
+/// (key → (layer, value)) precedence-merged across the four config
+/// layers — global, agent, workspace, workspace-agent — for the given
+/// `(agent, workspace)` selection. Later layers overwrite earlier ones,
+/// so the final layer attached to each key is the one that wins.
 fn build_attributed_layers(
     config: &crate::config::AppConfig,
     agent_selector: Option<&str>,
     workspace_name: Option<&str>,
-) -> std::collections::BTreeMap<String, (EnvLayer, String)> {
-    let mut attributed: std::collections::BTreeMap<String, (EnvLayer, String)> =
+) -> std::collections::BTreeMap<String, (EnvLayer, EnvValue)> {
+    let mut attributed: std::collections::BTreeMap<String, (EnvLayer, EnvValue)> =
         std::collections::BTreeMap::new();
 
     let mut record = |layer: EnvLayer, env: &std::collections::BTreeMap<String, EnvValue>| {
         for (k, v) in env {
-            attributed.insert(k.clone(), (layer.clone(), v.as_persisted_str().to_string()));
+            attributed.insert(k.clone(), (layer.clone(), v.clone()));
         }
     };
 
@@ -882,18 +947,20 @@ where
     let mut resolved = std::collections::BTreeMap::new();
     let mut errors: Vec<String> = Vec::new();
 
-    // Probe op CLI once up front when any value uses op://, so a
+    // Probe op CLI once up front when any value is an OpRef, so a
     // missing op surfaces as one install-link error not N.
-    let uses_op = attributed.values().any(|(_, v)| is_op_reference(v));
+    let uses_op = attributed
+        .values()
+        .any(|(_, v)| matches!(v, EnvValue::OpRef(_)));
     if uses_op && let Err(e) = op_runner.probe() {
         anyhow::bail!("operator env resolution aborted: {e}");
     }
 
-    for (key, (layer, raw_value)) in &attributed {
+    for (key, (layer, value)) in &attributed {
         let layer_label = format!("{layer}");
-        match dispatch_value(&layer_label, key, raw_value, op_runner, &mut host_env) {
-            Ok(value) => {
-                resolved.insert(key.clone(), value);
+        match resolve_env_value(&layer_label, key, value, op_runner, &mut host_env) {
+            Ok(v) => {
+                resolved.insert(key.clone(), v);
             }
             Err(e) => errors.push(format!("  - {e}")),
         }
@@ -977,20 +1044,20 @@ fn write_launch_diagnostic<W: std::io::Write>(
             .min(40);
         let raw_width = attributed
             .values()
-            .map(|(_, v)| classify_value(v).len())
+            .map(|(_, v)| classify_env_value(v).len())
             .max()
             .unwrap_or(0)
             .min(40);
-        for (key, (layer, raw_value)) in &attributed {
-            let kind = classify_value(raw_value);
+        for (key, (layer, value)) in &attributed {
+            let kind = classify_env_value(value);
             writeln!(w, "  {key:key_width$}  {kind:raw_width$}  ({layer})")?;
         }
         return Ok(());
     }
 
     let (mut op_count, mut host_count, mut literal_count) = (0u32, 0u32, 0u32);
-    for (_, raw) in attributed.values() {
-        match ValueKind::of(raw) {
+    for (_, value) in attributed.values() {
+        match ValueKind::of_env_value(value) {
             ValueKind::Op => op_count += 1,
             ValueKind::Host => host_count += 1,
             ValueKind::Literal => literal_count += 1,
@@ -1015,24 +1082,33 @@ enum ValueKind {
 }
 
 impl ValueKind {
-    fn of(raw: &str) -> Self {
-        if is_op_reference(raw) {
-            Self::Op
-        } else if parse_host_ref(raw).is_some() {
-            Self::Host
-        } else {
-            Self::Literal
+    fn of_env_value(value: &EnvValue) -> Self {
+        match value {
+            EnvValue::OpRef(_) => Self::Op,
+            EnvValue::Plain(s) => {
+                if parse_host_ref(s).is_some() {
+                    Self::Host
+                } else {
+                    Self::Literal
+                }
+            }
         }
     }
 }
 
-/// Value-free label: `op://...` and `$NAME` returned verbatim (the
-/// reference is not secret, the resolved value is); literals collapse
-/// to `"literal"` so the value never reaches stderr.
-fn classify_value(raw: &str) -> String {
-    match ValueKind::of(raw) {
-        ValueKind::Op | ValueKind::Host => raw.to_string(),
-        ValueKind::Literal => "literal".to_string(),
+/// Value-free label: `OpRef` emits the canonical `op://` URI; `$NAME`
+/// host refs are returned verbatim; literals collapse to `"literal"` so
+/// the value never reaches stderr.
+fn classify_env_value(value: &EnvValue) -> String {
+    match value {
+        EnvValue::OpRef(r) => r.op.clone(),
+        EnvValue::Plain(s) => {
+            if parse_host_ref(s).is_some() {
+                s.clone()
+            } else {
+                "literal".to_string()
+            }
+        }
     }
 }
 
@@ -1213,6 +1289,81 @@ mod tests {
                 None => panic!("op CLI should not have been invoked"),
             }
         }
+    }
+
+    // ---- resolve_env_value dispatch tests --------------------------------
+
+    #[test]
+    fn dispatch_plain_returns_literal_unchanged() {
+        let runner = TestOpRunner::forbidden();
+        let v = EnvValue::Plain("hello".into());
+        let r = resolve_env_value("test", "X", &v, &runner, |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .unwrap();
+        assert_eq!(r, "hello");
+        assert!(
+            runner.last_ref.borrow().is_none(),
+            "no op call expected for Plain"
+        );
+    }
+
+    #[test]
+    fn dispatch_plain_with_bare_op_uri_passes_through_literally() {
+        let runner = TestOpRunner::forbidden();
+        let v = EnvValue::Plain("op://Vault/Item/Field".into());
+        let r = resolve_env_value("test", "X", &v, &runner, |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .unwrap();
+        assert_eq!(
+            r, "op://Vault/Item/Field",
+            "bare op:// in Plain must NOT be resolved; passes through to container"
+        );
+        assert!(
+            runner.last_ref.borrow().is_none(),
+            "no op call expected for Plain(op://...)"
+        );
+    }
+
+    #[test]
+    fn dispatch_op_ref_calls_op_read_with_canonical_uri() {
+        let runner = TestOpRunner::new(Ok("secret-value".to_string()));
+        let v = EnvValue::OpRef(OpRef {
+            op: "op://abc/def/fld".into(),
+            path: "Vault/Item/Field".into(),
+        });
+        let r = resolve_env_value("test", "X", &v, &runner, |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .unwrap();
+        assert_eq!(r, "secret-value");
+        assert_eq!(
+            runner.last_ref().as_deref(),
+            Some("op://abc/def/fld"),
+            "must call op read with the canonical UUID URI"
+        );
+    }
+
+    #[test]
+    fn dispatch_op_ref_failure_wraps_error_with_path() {
+        let runner = TestOpRunner::new(Err(anyhow::anyhow!("not signed in")));
+        let v = EnvValue::OpRef(OpRef {
+            op: "op://abc/def/fld".into(),
+            path: "Private/Claude/security/auth token".into(),
+        });
+        let err = resolve_env_value("workspace foo", "TOKEN", &v, &runner, |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("workspace foo"), "msg: {msg}");
+        assert!(msg.contains("TOKEN"), "msg: {msg}");
+        assert!(
+            msg.contains("Private/Claude/security/auth token"),
+            "msg should reference path for the operator, not raw UUID URI: {msg}"
+        );
+        assert!(msg.contains("not signed in"), "msg: {msg}");
     }
 
     #[test]
@@ -1751,10 +1902,20 @@ mod tests {
         }
 
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env
-            .insert("A".to_string(), "op://Personal/a".to_string().into());
-        cfg.env
-            .insert("B".to_string(), "op://Personal/b".to_string().into());
+        cfg.env.insert(
+            "A".to_string(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field-a".to_string(),
+                path: "Personal/ItemA/field-a".to_string(),
+            }),
+        );
+        cfg.env.insert(
+            "B".to_string(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field-b".to_string(),
+                path: "Personal/ItemA/field-b".to_string(),
+            }),
+        );
         let runner = ProbeCountingRunner {
             probe_calls: std::cell::Cell::new(0),
             read_calls: std::cell::Cell::new(0),
@@ -1764,7 +1925,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(runner.probe_calls.get(), 1, "probe must fire exactly once");
-        assert_eq!(runner.read_calls.get(), 2, "each op:// key is resolved");
+        assert_eq!(runner.read_calls.get(), 2, "each OpRef key is resolved");
     }
 
     #[test]
@@ -1815,10 +1976,20 @@ mod tests {
         }
 
         let mut cfg = crate::config::AppConfig::default();
-        cfg.env
-            .insert("A".to_string(), "op://Personal/a".to_string().into());
-        cfg.env
-            .insert("B".to_string(), "op://Personal/b".to_string().into());
+        cfg.env.insert(
+            "A".to_string(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field-a".to_string(),
+                path: "Personal/ItemA/field-a".to_string(),
+            }),
+        );
+        cfg.env.insert(
+            "B".to_string(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field-b".to_string(),
+                path: "Personal/ItemA/field-b".to_string(),
+            }),
+        );
         let err = resolve_operator_env_with(&cfg, None, None, &FailingProbeRunner, |_| {
             Err(std::env::VarError::NotPresent)
         })
@@ -1835,7 +2006,10 @@ mod tests {
         let mut cfg = crate::config::AppConfig::default();
         cfg.env.insert(
             "TOKEN".to_string(),
-            "op://Personal/broken/token".to_string().into(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/token".to_string(),
+                path: "Personal/BrokenItem/token".to_string(),
+            }),
         );
 
         let runner = TestOpRunner::new(Err(anyhow::anyhow!("item not found")));
@@ -1846,7 +2020,8 @@ mod tests {
         .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("TOKEN"), "{msg}");
-        assert!(msg.contains("op://Personal/broken/token"), "{msg}");
+        // Error references the human-readable path, not the raw UUID URI.
+        assert!(msg.contains("Personal/BrokenItem/token"), "{msg}");
         assert!(msg.contains("global [env]"), "{msg}");
     }
 
@@ -1883,7 +2058,10 @@ mod tests {
             .insert("HOST_KEY".to_string(), "$HOST_VAR".to_string().into());
         cfg.env.insert(
             "OP_KEY".to_string(),
-            "op://Personal/item/field".to_string().into(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field".to_string(),
+                path: "Personal/item/field".to_string(),
+            }),
         );
         let resolved: std::collections::BTreeMap<String, String> = [
             ("LITERAL_KEY".to_string(), "super-secret".to_string()),
@@ -1917,7 +2095,10 @@ mod tests {
             .insert("LITERAL_KEY".to_string(), "super-secret".to_string().into());
         cfg.env.insert(
             "OP_KEY".to_string(),
-            "op://Personal/item/field".to_string().into(),
+            EnvValue::OpRef(OpRef {
+                op: "op://abc-vault/abc-item/field".to_string(),
+                path: "Personal/item/field".to_string(),
+            }),
         );
         let resolved: std::collections::BTreeMap<String, String> = [
             ("LITERAL_KEY".to_string(), "super-secret".to_string()),
@@ -1928,10 +2109,12 @@ mod tests {
 
         let rendered = format_launch_diagnostic_for_test(&cfg, None, None, &resolved, true);
 
-        // Debug mode emits references (reference string is config,
-        // not secret) and the "literal" label — never the resolved
-        // value.
-        assert!(rendered.contains("op://Personal/item/field"), "{rendered}");
+        // Debug mode emits the canonical op URI (config, not secret)
+        // and the "literal" label — never the resolved value.
+        assert!(
+            rendered.contains("op://abc-vault/abc-item/field"),
+            "{rendered}"
+        );
         assert!(rendered.contains("literal"), "{rendered}");
         assert!(!rendered.contains("super-secret"), "{rendered}");
         assert!(!rendered.contains("op-value-secret"), "{rendered}");

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -67,6 +67,55 @@ fn parse_host_ref(value: &str) -> Option<&str> {
     None
 }
 
+/// Operator-defined env value. Either a 1Password reference pinned by
+/// UUIDs (with a display snapshot), or any other string value.
+///
+/// Untagged: serde picks the variant by structural shape — inline TOML
+/// table → `OpRef`, scalar string → `Plain`. Legacy bare `op://...`
+/// strings deserialize as `Plain` and are passed through to the
+/// container as literals (no resolution attempt).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EnvValue {
+    OpRef(OpRef),
+    Plain(String),
+}
+
+/// Pinned 1Password reference. `op` is the canonical UUID-form URI we
+/// pass to `op read`; `path` is a snapshot breadcrumb for human-
+/// readable editor display, captured at pick time.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OpRef {
+    /// Canonical `op://` URI. Format:
+    /// `op://<vault_id>/<item_id>/[<section_id>/]<field_id>[?attribute=<name>]`
+    pub op: String,
+
+    /// Snapshot breadcrumb captured at pick / resolve time:
+    /// `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?attribute=<name>]`
+    /// `[subtitle]` is embedded only when the item shares its name with
+    /// another item in the same vault at write time.
+    pub path: String,
+}
+
+impl EnvValue {
+    /// View the value as the string we'd pass to a downstream container
+    /// for `Plain`, or the canonical `op://` URI for `OpRef`. Resolution
+    /// (calling the 1Password CLI for `OpRef`) happens in `dispatch_value`,
+    /// not here — this is for display, comparison, and migration paths.
+    pub const fn as_persisted_str(&self) -> &str {
+        match self {
+            Self::Plain(s) => s.as_str(),
+            Self::OpRef(r) => r.op.as_str(),
+        }
+    }
+}
+
+impl From<String> for EnvValue {
+    fn from(s: String) -> Self {
+        Self::Plain(s)
+    }
+}
+
 #[must_use]
 pub fn is_op_reference(value: &str) -> bool {
     value.starts_with("op://")
@@ -2129,5 +2178,49 @@ mod tests {
             msg.contains("not signed in") || msg.contains("op signin"),
             "expected signed-out detection in error: {msg}"
         );
+    }
+
+    #[test]
+    fn env_value_round_trip_through_toml() {
+        use std::collections::BTreeMap;
+
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+        struct Wrap {
+            env: BTreeMap<String, EnvValue>,
+        }
+
+        let toml_in = r#"
+[env]
+PLAIN = "literal-value"
+HOST_VAR = "${HOME}"
+LEGACY = "op://Vault/Item/Field"
+PINNED = { op = "op://abc/def/fld", path = "Vault/Item/Field" }
+PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
+"#;
+        let parsed: Wrap = toml::from_str(toml_in).unwrap();
+        assert_eq!(
+            parsed.env.get("PLAIN"),
+            Some(&EnvValue::Plain("literal-value".into()))
+        );
+        assert_eq!(
+            parsed.env.get("HOST_VAR"),
+            Some(&EnvValue::Plain("${HOME}".into()))
+        );
+        assert_eq!(
+            parsed.env.get("LEGACY"),
+            Some(&EnvValue::Plain("op://Vault/Item/Field".into()))
+        );
+        assert_eq!(
+            parsed.env.get("PINNED"),
+            Some(&EnvValue::OpRef(OpRef {
+                op: "op://abc/def/fld".into(),
+                path: "Vault/Item/Field".into(),
+            }))
+        );
+
+        // Round-trip back to TOML and re-parse must produce the same map.
+        let serialized = toml::to_string(&parsed).unwrap();
+        let reparsed: Wrap = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed, reparsed);
     }
 }

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -13,44 +13,6 @@ pub trait OpRunner {
     }
 }
 
-/// Dispatch a single env value string to the appropriate resolver.
-///
-/// `op://...` → `op_runner.read`, `$NAME` / `${NAME}` → `host_env`,
-/// otherwise verbatim. `layer_label` / `var_name` only feed error
-/// messages.
-///
-/// This function is retained for the CLI input parser (Task 8) and for
-/// resolving `EnvValue::Plain` strings (which may contain `$VAR` refs).
-/// Runtime dispatch for `EnvValue` uses `resolve_env_value` instead.
-pub fn dispatch_value<R>(
-    layer_label: &str,
-    var_name: &str,
-    value: &str,
-    op_runner: &R,
-    mut host_env: impl FnMut(&str) -> Result<String, std::env::VarError>,
-) -> anyhow::Result<String>
-where
-    R: OpRunner + ?Sized,
-{
-    if is_op_reference(value) {
-        return op_runner.read(value).map_err(|e| {
-            anyhow::anyhow!(
-                "{layer_label} env var {var_name:?}: 1Password reference {value:?} failed: {e}"
-            )
-        });
-    }
-
-    if let Some(host_name) = parse_host_ref(value) {
-        return host_env(host_name).map_err(|_| {
-            anyhow::anyhow!(
-                "{layer_label} env var {var_name:?}: host env var {host_name:?} is not set"
-            )
-        });
-    }
-
-    Ok(value.to_string())
-}
-
 /// Resolve a single [`EnvValue`] to its final string, dispatching on the
 /// enum variant rather than lexical string prefix.
 ///
@@ -62,6 +24,13 @@ where
 ///   actionable error messages.
 ///
 /// `layer_label` / `var_name` are used only in error messages.
+///
+/// # Behavior change
+///
+/// Lexical `op://` detection at runtime is gone — only structural
+/// `EnvValue::OpRef` triggers `op read`. Bare `op://...` strings
+/// stored as `EnvValue::Plain` (e.g. legacy workspace TOMLs) flow
+/// to the container literally.
 pub fn resolve_env_value<R, H>(
     layer_label: &str,
     var_name: &str,
@@ -74,12 +43,7 @@ where
     H: FnMut(&str) -> Result<String, std::env::VarError>,
 {
     match value {
-        EnvValue::Plain(s) => {
-            // Delegate to the string-based dispatcher but skip the op://
-            // branch — the discriminator is now structural (the enum variant).
-            // Plain("op://...") passes through literally; no op read call.
-            dispatch_plain(layer_label, var_name, s, host_env)
-        }
+        EnvValue::Plain(s) => dispatch_plain(layer_label, var_name, s, host_env),
         EnvValue::OpRef(r) => op_runner.read(&r.op).map_err(|e| {
             anyhow::anyhow!(
                 "{layer_label} env var {var_name:?}: 1Password reference {:?} failed: {e}",
@@ -149,7 +113,17 @@ pub enum EnvValue {
 /// Pinned 1Password reference. `op` is the canonical UUID-form URI we
 /// pass to `op read`; `path` is a snapshot breadcrumb for human-
 /// readable editor display, captured at pick time.
+///
+/// # Snapshot semantics
+///
+/// `op` is the source of truth for resolution; `path` is purely
+/// display. If the underlying 1Password item is renamed after the
+/// pick, `op` continues to resolve to the same secret while `path`
+/// shows the stale name until the operator re-picks. This is
+/// intentional — paths are advisory text for the editor, not part
+/// of the resolution contract.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OpRef {
     /// Canonical `op://` URI. Format:
     /// `op://<vault_id>/<item_id>/[<section_id>/]<field_id>[?attribute=<name>]`
@@ -1348,109 +1322,6 @@ mod tests {
         assert!(parse_op_reference("op://only/two").is_none());
         assert!(parse_op_reference("op://a/b/c/d/e").is_none());
         assert!(parse_op_reference("op://").is_none());
-    }
-
-    #[test]
-    fn dispatch_literal_value_returns_literal() {
-        let out = dispatch_value(
-            "global",
-            "FOO",
-            "plain-literal",
-            &TestOpRunner::forbidden(),
-            |n| panic!("host env should not be queried for literal; got {n}"),
-        )
-        .unwrap();
-        assert_eq!(out, "plain-literal");
-    }
-
-    #[test]
-    fn dispatch_host_ref_dollar_name_reads_host_env() {
-        let out = dispatch_value(
-            "global",
-            "MY_VAR",
-            "$OPERATOR_HOST_SOURCE",
-            &TestOpRunner::forbidden(),
-            |name| {
-                assert_eq!(name, "OPERATOR_HOST_SOURCE");
-                Ok("from-host".to_string())
-            },
-        )
-        .unwrap();
-        assert_eq!(out, "from-host");
-    }
-
-    #[test]
-    fn dispatch_host_ref_braced_reads_host_env() {
-        let out = dispatch_value(
-            "global",
-            "MY_VAR",
-            "${OPERATOR_HOST_SOURCE}",
-            &TestOpRunner::forbidden(),
-            |name| {
-                assert_eq!(name, "OPERATOR_HOST_SOURCE");
-                Ok("braced".to_string())
-            },
-        )
-        .unwrap();
-        assert_eq!(out, "braced");
-    }
-
-    /// Set-but-empty (Unix semantics) passes through unchanged; only
-    /// `VarError::NotPresent` is a hard error.
-    #[test]
-    fn dispatch_host_ref_empty_string_passes_through() {
-        let out = dispatch_value(
-            "global",
-            "MAYBE_EMPTY",
-            "$OPERATOR_HOST_EMPTY",
-            &TestOpRunner::forbidden(),
-            |name| {
-                assert_eq!(name, "OPERATOR_HOST_EMPTY");
-                Ok(String::new())
-            },
-        )
-        .unwrap();
-        assert_eq!(out, "");
-    }
-
-    #[test]
-    fn dispatch_host_ref_missing_returns_clear_error() {
-        let err = dispatch_value(
-            "workspace \"big-monorepo\"",
-            "MY_VAR",
-            "$MISSING_HOST_VAR",
-            &TestOpRunner::forbidden(),
-            |_| Err(std::env::VarError::NotPresent),
-        )
-        .unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("MY_VAR"), "expected var name in error: {msg}");
-        assert!(
-            msg.contains("MISSING_HOST_VAR"),
-            "expected host var name in error: {msg}"
-        );
-        assert!(
-            msg.contains("workspace \"big-monorepo\""),
-            "expected layer name in error: {msg}"
-        );
-    }
-
-    #[test]
-    fn dispatch_op_ref_invokes_op_cli() {
-        let runner = TestOpRunner::new(Ok("tok-abc".to_string()));
-        let out = dispatch_value(
-            "agent \"agent-smith\"",
-            "API_TOKEN",
-            "op://Personal/api/token",
-            &runner,
-            |_| panic!("host env should not be queried for op:// refs"),
-        )
-        .unwrap();
-        assert_eq!(out, "tok-abc");
-        assert_eq!(
-            runner.last_ref().as_deref(),
-            Some("op://Personal/api/token")
-        );
     }
 
     struct TestOpRunner {

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -2532,6 +2532,35 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
         assert_eq!(parsed, reparsed);
     }
 
+    #[test]
+    fn op_ref_rejects_unknown_fields_in_inline_table() {
+        // Typo'd inline table: "paht" instead of "path". Should fail
+        // with a clear "unknown field" error, not silently produce an
+        // OpRef with empty path.
+        let toml_in = r#"
+[env]
+TOKEN = { op = "op://abc/def/fld", path = "Vault/Item/Field", paht = "stray" }
+"#;
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            env: std::collections::BTreeMap<String, EnvValue>,
+        }
+        let result: Result<Wrap, _> = toml::from_str(toml_in);
+        let err = result
+            .err()
+            .expect("deny_unknown_fields must reject `paht`");
+        let err_msg = format!("{err}");
+        // Either an "unknown field" error or a fall-through-to-Plain failure
+        // (because OpRef rejected; Plain expects scalar string, not table).
+        // The important thing is it doesn't silently accept the OpRef shape.
+        assert!(
+            err_msg.contains("unknown field")
+                || err_msg.contains("paht")
+                || err_msg.contains("invalid type"),
+            "expected unknown-field or invalid-type error; got: {err_msg}"
+        );
+    }
+
     // ---- resolve_op_uri_to_ref tests ------------------------------------
 
     /// Minimal stub for `OpStructRunner` used by `resolve_op_uri_to_ref` unit
@@ -2751,6 +2780,31 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
             "path: {}",
             result.path
         );
+    }
+
+    #[test]
+    fn resolve_op_uri_with_attr_short_alias_preserves_query() {
+        // 1Password URI grammar accepts `?attr=` as a shorthand for `?attribute=`.
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "GitHub", "i_uuid", "")
+            .with_field("i_uuid", "one-time password", "f_uuid", false);
+        let r = resolve_op_uri_to_ref("op://Private/GitHub/one-time password?attr=type", &stub)
+            .unwrap();
+        assert!(r.op.contains("?attr=type"), "op: {}", r.op);
+        assert!(r.path.contains("?attr=type"), "path: {}", r.path);
+    }
+
+    #[test]
+    fn resolve_op_uri_with_ssh_format_query_preserves_query() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Personal", "v_uuid")
+            .with_item("v_uuid", "MyKey", "i_uuid", "")
+            .with_field("i_uuid", "private key", "f_uuid", false);
+        let r = resolve_op_uri_to_ref("op://Personal/MyKey/private key?ssh-format=openssh", &stub)
+            .unwrap();
+        assert!(r.op.contains("?ssh-format=openssh"), "op: {}", r.op);
+        assert!(r.path.contains("?ssh-format=openssh"), "path: {}", r.path);
     }
 
     #[test]

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -976,11 +976,7 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
     let fields = op.item_get(&item.id, &vault.id, None)?;
     let field = fields
         .iter()
-        .find(|f| {
-            f.label.eq_ignore_ascii_case(field_seg)
-                || f.id == field_seg
-                || matches_special_alias(f, field_seg)
-        })
+        .find(|f| f.label.eq_ignore_ascii_case(field_seg) || f.id == field_seg)
         .ok_or_else(|| {
             anyhow!(
                 "field {field_seg:?} not found in item {name:?}",
@@ -997,8 +993,22 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
         item.name.clone()
     };
 
+    // Use field.reference (1Password's canonical emission) as the authoritative
+    // source for the section segment, mirroring build_op_ref_on_commit.
+    let section_from_field = parse_op_reference(&field.reference).and_then(|p| p.section);
+
+    let canonical_section = match (section_seg, section_from_field) {
+        // Both present: use canonical (1Password) form.
+        (Some(_), Some(s)) => Some(s),
+        // User typed a section but the field's reference has none — should not
+        // happen for sectioned fields; trust the user input as a fallback.
+        (Some(user_s), None) => Some(user_s.to_string()),
+        // No section anywhere: 3-segment URI.
+        (None, _) => None,
+    };
+
     let q_suffix = query.unwrap_or("");
-    let (op_uri, display_path) = section_seg.map_or_else(
+    let (op_uri, display_path) = canonical_section.as_deref().map_or_else(
         || {
             (
                 format!("op://{}/{}/{}{q_suffix}", vault.id, item.id, field.id),
@@ -1020,11 +1030,6 @@ pub fn resolve_op_uri_to_ref(input: &str, op: &dyn OpStructRunner) -> anyhow::Re
         op: op_uri,
         path: display_path,
     })
-}
-
-fn matches_special_alias(f: &OpField, seg: &str) -> bool {
-    matches!(seg, "username" | "password" | "notes" | "notesPlain")
-        && f.label.eq_ignore_ascii_case(seg)
 }
 
 /// (key → (layer, value)) precedence-merged across the four config
@@ -2609,6 +2614,12 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
         fields: std::collections::HashMap<String, Vec<OpField>>,
     }
 
+    impl Default for StubOpStructRunner {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl StubOpStructRunner {
         fn new() -> Self {
             Self {
@@ -2652,6 +2663,34 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
                     },
                     concealed,
                     reference: String::new(),
+                });
+            self
+        }
+
+        /// Like `with_field`, but allows specifying the `reference` string
+        /// (1Password's canonical op:// reference) explicitly. Used by tests
+        /// that exercise section-name canonicalization.
+        fn with_field_with_reference(
+            mut self,
+            item_id: &str,
+            label: &str,
+            id: &str,
+            concealed: bool,
+            reference: &str,
+        ) -> Self {
+            self.fields
+                .entry(item_id.to_string())
+                .or_default()
+                .push(OpField {
+                    id: id.to_string(),
+                    label: label.to_string(),
+                    field_type: if concealed {
+                        "CONCEALED".into()
+                    } else {
+                        "STRING".into()
+                    },
+                    concealed,
+                    reference: reference.to_string(),
                 });
             self
         }
@@ -2706,6 +2745,11 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
         assert!(msg.contains("Claude[alexey@zhokhov.com]"), "msg: {msg}");
         assert!(msg.contains("Claude[alexey@chainargos.com]"), "msg: {msg}");
         assert!(msg.contains("Claude[team@example.com]"), "msg: {msg}");
+        // The full op:// line must be copy-pasteable.
+        assert!(
+            msg.contains("op://Private/Claude[alexey@zhokhov.com]/auth"),
+            "full disambiguation line should be present, got:\n{msg}"
+        );
     }
 
     #[test]
@@ -2817,5 +2861,56 @@ PINNED_AMBIG = { op = "op://abc/def/fld", path = "Vault/Item[sub]/Field" }
 
         let err = resolve_op_uri_to_ref("op://Private/Stripe/api key", &stub).unwrap_err();
         assert!(err.to_string().contains("not found"), "{}", err);
+    }
+
+    #[test]
+    fn resolve_op_uri_normalizes_section_to_field_reference_form() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Claude", "i_uuid", "")
+            .with_field_with_reference(
+                "i_uuid",
+                "auth token",
+                "f_uuid",
+                false,
+                // canonical: "Security" capitalized
+                "op://Private/Claude/Security/auth token",
+            );
+        let r = resolve_op_uri_to_ref(
+            // User types lowercase "security"
+            "op://Private/Claude/security/auth token",
+            &stub,
+        )
+        .unwrap();
+        // Both op and path normalize to the canonical "Security" capitalization.
+        assert!(
+            r.op.contains("/Security/"),
+            "op should use canonical section form, got {}",
+            r.op
+        );
+        assert!(
+            r.path.contains("/Security/"),
+            "path should use canonical section form, got {}",
+            r.path
+        );
+    }
+
+    #[test]
+    fn resolve_op_uri_disambiguation_uses_id_prefix_when_subtitle_empty() {
+        let stub = StubOpStructRunner::default()
+            .with_vault("Private", "v_uuid")
+            .with_item("v_uuid", "Notes", "abcdef1234567890", "")
+            .with_item("v_uuid", "Notes", "fedcba0987654321", "");
+        let err = resolve_op_uri_to_ref("op://Private/Notes/notesPlain", &stub).unwrap_err();
+        let msg = format!("{err:#}");
+        // Empty subtitles fall back to short id prefixes.
+        assert!(
+            msg.contains("Notes[#abcdef12]"),
+            "expected #id-prefix form, got:\n{msg}"
+        );
+        assert!(
+            msg.contains("Notes[#fedcba09]"),
+            "expected #id-prefix form, got:\n{msg}"
+        );
     }
 }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1292,15 +1292,21 @@ fn lookup_operator_env_raw(
     // `or_else`-chaining lets `None` from a later layer fall back to
     // an earlier layer's value.
     let workspace_agent = ws_opt.zip(agent_selector).and_then(|(ws, agent_name)| {
-        ws.agents
-            .get(agent_name)
-            .and_then(|overlay| overlay.env.get(key).cloned())
+        ws.agents.get(agent_name).and_then(|overlay| {
+            overlay
+                .env
+                .get(key)
+                .map(|v| v.as_persisted_str().to_string())
+        })
     });
-    let workspace = ws_opt.and_then(|ws| ws.env.get(key).cloned());
+    let workspace = ws_opt.and_then(|ws| ws.env.get(key).map(|v| v.as_persisted_str().to_string()));
     let agent = agent_selector
         .and_then(|agent_name| config.agents.get(agent_name))
-        .and_then(|a| a.env.get(key).cloned());
-    let global = config.env.get(key).cloned();
+        .and_then(|a| a.env.get(key).map(|v| v.as_persisted_str().to_string()));
+    let global = config
+        .env
+        .get(key)
+        .map(|v| v.as_persisted_str().to_string());
 
     workspace_agent.or(workspace).or(agent).or(global)
 }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1292,21 +1292,15 @@ fn lookup_operator_env_raw(
     // `or_else`-chaining lets `None` from a later layer fall back to
     // an earlier layer's value.
     let workspace_agent = ws_opt.zip(agent_selector).and_then(|(ws, agent_name)| {
-        ws.agents.get(agent_name).and_then(|overlay| {
-            overlay
-                .env
-                .get(key)
-                .map(|v| v.as_persisted_str().to_string())
-        })
+        ws.agents
+            .get(agent_name)
+            .and_then(|overlay| overlay.env.get(key).map(|v| v.as_display_str().to_string()))
     });
-    let workspace = ws_opt.and_then(|ws| ws.env.get(key).map(|v| v.as_persisted_str().to_string()));
+    let workspace = ws_opt.and_then(|ws| ws.env.get(key).map(|v| v.as_display_str().to_string()));
     let agent = agent_selector
         .and_then(|agent_name| config.agents.get(agent_name))
-        .and_then(|a| a.env.get(key).map(|v| v.as_persisted_str().to_string()));
-    let global = config
-        .env
-        .get(key)
-        .map(|v| v.as_persisted_str().to_string());
+        .and_then(|a| a.env.get(key).map(|v| v.as_display_str().to_string()));
+    let global = config.env.get(key).map(|v| v.as_display_str().to_string());
 
     workspace_agent.or(workspace).or(agent).or(global)
 }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -2862,11 +2862,11 @@ plugins = []
         std::fs::create_dir_all(&bin_dir).unwrap();
         let bin_path = bin_dir.join("op");
         // The resolver first runs `op --version` as a reachability probe
-        // when any value carries the `op://` scheme, then calls
-        // `op read op://...`. The fake must handle both.
+        // when any value carries an OpRef, then calls `op read op://...`
+        // with the canonical UUID URI. The fake must handle both.
         std::fs::write(
             &bin_path,
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo '2.30.0'; exit 0; fi\nif [ \"$1\" = \"read\" ] && [ \"$2\" = \"op://Personal/api/token\" ]; then printf '%s' 'resolved-op-token'; exit 0; fi\nexit 99\n",
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo '2.30.0'; exit 0; fi\nif [ \"$1\" = \"read\" ] && [ \"$2\" = \"op://abc-vault/abc-item/api-token\" ]; then printf '%s' 'resolved-op-token'; exit 0; fi\nexit 99\n",
         )
         .unwrap();
         let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
@@ -2876,7 +2876,7 @@ plugins = []
         std::fs::write(
             &paths.config_file,
             r#"[env]
-OPERATOR_TOKEN = "op://Personal/api/token"
+OPERATOR_TOKEN = {op = "op://abc-vault/abc-item/api-token", path = "Personal/api/token"}
 
 [agents.agent-smith]
 git = "https://github.com/jackin-project/jackin-agent-smith.git"

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1264,15 +1264,15 @@ fn verify_token_env_present(
 
 /// Return a printable source reference for `CLAUDE_CODE_OAUTH_TOKEN`
 /// given the raw (unresolved) declaration value from the operator env
-/// config (e.g. `"op://vault/claude/token"` or
-/// `"$CLAUDE_CODE_OAUTH_TOKEN"`). Produces the `"KEY <- value"` form
-/// consumed by `tui::auth_mode_notice`. When `raw` is `None`, falls
-/// back to the bare env-var name.
+/// config (e.g. `"Private/Claude/security/auth token"` or
+/// `"$CLAUDE_CODE_OAUTH_TOKEN"`). Produces the `"KEY ← value"` form
+/// consumed by `tui::auth_mode_notice`. When `raw` is `None` or the
+/// display string is empty, falls back to the bare env-var name.
 fn auth_token_source_reference(raw: Option<&str>) -> String {
-    raw.map_or_else(
-        || "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
-        |value| format!("CLAUDE_CODE_OAUTH_TOKEN \u{2190} {value}"),
-    )
+    match raw {
+        None | Some("") => "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+        Some(value) => format!("CLAUDE_CODE_OAUTH_TOKEN \u{2190} {value}"),
+    }
 }
 
 /// Look up the raw (unresolved) declaration value for `key` in the

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -607,4 +607,32 @@ isolation = "worktree"
             "validate_workspace_config must surface the nested-worktrees error from validate_isolation_layout; got: {msg}",
         );
     }
+
+    // ── Legacy bare op:// migration regression ───────────────────────────────
+
+    /// Pre-Task-3 workspaces may contain bare `op://Vault/Item/Field`
+    /// strings written as scalar TOML values (not the inline-table
+    /// `{ op = "...", path = "..." }` shape produced by the picker).
+    /// They must deserialize without error as `EnvValue::Plain` so the
+    /// user's config remains loadable; at the operator's pace they can
+    /// re-pick via the TUI to get the pinned-UUID form.
+    #[test]
+    fn legacy_bare_op_uri_in_workspace_loads_as_plain_no_error() {
+        let toml_input = r#"
+workdir = "/workspace/proj"
+
+[[mounts]]
+src = "/tmp/proj"
+dst = "/workspace/proj"
+
+[env]
+OLD = "op://Vault/Item/Field"
+"#;
+        let ws: WorkspaceConfig = toml::from_str(toml_input).expect("must parse");
+        assert_eq!(
+            ws.env.get("OLD").expect("OLD env var present"),
+            &crate::operator_env::EnvValue::Plain("op://Vault/Item/Field".into()),
+            "bare op:// scalar must deserialize as Plain, not OpRef",
+        );
+    }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -48,7 +48,7 @@ pub struct WorkspaceConfig {
     /// values use the `operator_env` dispatch syntax
     /// (`op://...` | `$NAME` | `${NAME}` | literal).
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    pub env: std::collections::BTreeMap<String, String>,
+    pub env: std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
     /// Per-(workspace × agent) env overrides, keyed by the agent
     /// selector (e.g. `"agent-smith"` or `"chainargos/agent-brown"`).
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
@@ -93,7 +93,7 @@ impl KeepAwakeConfig {
 #[serde(deny_unknown_fields)]
 pub struct WorkspaceAgentOverride {
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    pub env: std::collections::BTreeMap<String, String>,
+    pub env: std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/tests/cli_env.rs
+++ b/tests/cli_env.rs
@@ -57,13 +57,7 @@ fn seed_workspace(env: &Env, name: &str, workdir: &str) {
 fn config_env_set_global() {
     let env = setup_env();
     jackin(&env)
-        .args([
-            "config",
-            "env",
-            "set",
-            "API_TOKEN",
-            "op://Personal/api/token",
-        ])
+        .args(["config", "env", "set", "API_TOKEN", "my-literal-token"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Set API_TOKEN."));
@@ -73,7 +67,7 @@ fn config_env_set_global() {
         "missing [env] table:\n{contents}"
     );
     assert!(
-        contents.contains("API_TOKEN = \"op://Personal/api/token\""),
+        contents.contains("API_TOKEN = \"my-literal-token\""),
         "missing API_TOKEN entry:\n{contents}"
     );
 }
@@ -115,7 +109,7 @@ fn config_env_set_with_comment() {
             "env",
             "set",
             "OPENAI_KEY",
-            "op://Work/OpenAI/key",
+            "my-key-value",
             "--comment",
             "rotate quarterly",
         ])
@@ -207,7 +201,7 @@ fn workspace_env_set_workspace_scope() {
             "set",
             "prod",
             "DB_URL",
-            "op://Work/Prod/db-url",
+            "postgres://localhost:5432/prod",
         ])
         .assert()
         .success()
@@ -218,7 +212,7 @@ fn workspace_env_set_workspace_scope() {
         "missing [workspaces.prod.env]:\n{contents}"
     );
     assert!(
-        contents.contains("DB_URL = \"op://Work/Prod/db-url\""),
+        contents.contains("DB_URL = \"postgres://localhost:5432/prod\""),
         "missing DB_URL entry:\n{contents}"
     );
 }
@@ -235,7 +229,7 @@ fn workspace_env_set_workspace_agent_scope() {
             "set",
             "prod",
             "OPENAI_KEY",
-            "op://Work/OpenAI/key",
+            "sk-literal-key",
             "--agent",
             "agent-smith",
         ])
@@ -247,7 +241,7 @@ fn workspace_env_set_workspace_agent_scope() {
         "missing [workspaces.prod.agents.agent-smith.env]:\n{contents}"
     );
     assert!(
-        contents.contains("OPENAI_KEY = \"op://Work/OpenAI/key\""),
+        contents.contains("OPENAI_KEY = \"sk-literal-key\""),
         "missing OPENAI_KEY entry:\n{contents}"
     );
 }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -53,7 +53,12 @@ fn seed_config_with_env(
     let host_path = temp_dir.display().to_string();
     let env_map: std::collections::BTreeMap<String, jackin::operator_env::EnvValue> = env
         .into_iter()
-        .map(|(k, v)| (k.to_string(), v.into()))
+        .map(|(k, v)| {
+            (
+                k.to_string(),
+                jackin::operator_env::EnvValue::Plain(v.to_string()),
+            )
+        })
         .collect();
     let ws = WorkspaceConfig {
         workdir: host_path.clone(),
@@ -401,7 +406,10 @@ fn secrets_agent_section_expand_collapse() -> Result<()> {
     // Seed a workspace with one agent override. Using `ConfigEditor`
     // keeps the test aligned with the real save path.
     let mut agent_env = std::collections::BTreeMap::new();
-    agent_env.insert("LOG_LEVEL".into(), "debug".into());
+    agent_env.insert(
+        "LOG_LEVEL".into(),
+        jackin::operator_env::EnvValue::Plain("debug".into()),
+    );
     let mut agents = std::collections::BTreeMap::new();
     agents.insert(
         "agent-smith".into(),
@@ -498,10 +506,10 @@ fn secrets_dirty_detection_and_change_count() -> Result<()> {
     assert!(!editor(&state).is_dirty());
     assert_eq!(editor(&state).change_count(), 0);
 
-    editor_mut(&mut state)
-        .pending
-        .env
-        .insert("NEW_KEY".into(), "v".into());
+    editor_mut(&mut state).pending.env.insert(
+        "NEW_KEY".into(),
+        jackin::operator_env::EnvValue::Plain("v".into()),
+    );
 
     assert!(editor(&state).is_dirty(), "env add must flip is_dirty");
     assert!(
@@ -1579,7 +1587,10 @@ fn env_key_modal_blocks_duplicate_agent_key() -> Result<()> {
     let host_path = temp.path().display().to_string();
 
     let mut agent_env = std::collections::BTreeMap::new();
-    agent_env.insert("LOG_LEVEL".into(), "debug".into());
+    agent_env.insert(
+        "LOG_LEVEL".into(),
+        jackin::operator_env::EnvValue::Plain("debug".into()),
+    );
     let mut agents = std::collections::BTreeMap::new();
     agents.insert(
         "agent-smith".into(),
@@ -1731,7 +1742,10 @@ fn seed_override_picker_workspace(
     let mut agents_map = std::collections::BTreeMap::new();
     for name in with_overrides {
         let mut env = std::collections::BTreeMap::new();
-        env.insert("LOG_LEVEL".into(), "debug".into());
+        env.insert(
+            "LOG_LEVEL".into(),
+            jackin::operator_env::EnvValue::Plain("debug".into()),
+        );
         agents_map.insert((*name).into(), WorkspaceAgentOverride { env });
     }
 

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -51,9 +51,9 @@ fn seed_config_with_env(
     // WorkspaceConfig's workdir-must-equal-or-be-covered-by-mount-dst
     // validation passes.
     let host_path = temp_dir.display().to_string();
-    let env_map: std::collections::BTreeMap<String, String> = env
+    let env_map: std::collections::BTreeMap<String, jackin::operator_env::EnvValue> = env
         .into_iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| (k.to_string(), v.into()))
         .collect();
     let ws = WorkspaceConfig {
         workdir: host_path.clone(),
@@ -258,7 +258,11 @@ fn secrets_edit_value_saves_to_disk() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
 
     assert_eq!(
-        editor(&state).pending.env.get("DB_URL").map(String::as_str),
+        editor(&state)
+            .pending
+            .env
+            .get("DB_URL")
+            .map(|v| v.as_persisted_str()),
         Some("new-value"),
         "pending.env must reflect the edit"
     );
@@ -279,7 +283,7 @@ fn secrets_edit_value_saves_to_disk() -> Result<()> {
         .get("big-monorepo")
         .expect("workspace must still exist");
     assert_eq!(
-        ws.env.get("DB_URL").map(String::as_str),
+        ws.env.get("DB_URL").map(|v| v.as_persisted_str()),
         Some("new-value"),
         "on-disk env must reflect the edit"
     );
@@ -555,7 +559,7 @@ fn secrets_add_new_key_flow() -> Result<()> {
             .pending
             .env
             .get("API_KEY")
-            .map(String::as_str),
+            .map(|v| v.as_persisted_str()),
         Some("s3cret"),
         "pending.env must contain the new key after the three-step add"
     );
@@ -646,7 +650,11 @@ fn op_picker_cancel_closes_modal() -> Result<()> {
     );
     // Cancel is a pure UI action — the on-pending env value is unchanged.
     assert_eq!(
-        editor(&state).pending.env.get("DB_URL").map(String::as_str),
+        editor(&state)
+            .pending
+            .env
+            .get("DB_URL")
+            .map(|v| v.as_persisted_str()),
         Some("untouched"),
         "Esc-cancel must not mutate pending.env"
     );
@@ -725,7 +733,11 @@ fn op_picker_commit_writes_value_directly_to_pending() -> Result<()> {
     // The reference must land directly in pending.env (no text modal
     // intermediate).
     assert_eq!(
-        editor(&state).pending.env.get("DB_URL").map(String::as_str),
+        editor(&state)
+            .pending
+            .env
+            .get("DB_URL")
+            .map(|v| v.as_persisted_str()),
         Some("op://Personal/Database/password"),
         "picker commit must write the op:// reference straight into pending.env[key]"
     );
@@ -841,7 +853,7 @@ fn op_picker_sentinel_p_flow() -> Result<()> {
             .pending
             .env
             .get("API_KEY")
-            .map(String::as_str),
+            .map(|v| v.as_persisted_str()),
         Some("op://Personal/API Keys/credential"),
         "EnvKey commit must write the stashed picker value into pending.env"
     );
@@ -926,7 +938,7 @@ fn enter_on_sentinel_opens_envkey_then_sourcepicker_then_value_modal() -> Result
             .pending
             .env
             .get("API_KEY")
-            .map(String::as_str),
+            .map(|v| v.as_persisted_str()),
         Some("s3cret"),
         "Plain-text source path must land the typed value in pending.env"
     );
@@ -973,7 +985,7 @@ fn env_value_modal_allows_empty_commit() -> Result<()> {
             .pending
             .env
             .get("EMPTY_OK")
-            .map(String::as_str),
+            .map(|v| v.as_persisted_str()),
         Some(""),
         "EnvValue modal must allow committing an empty string \
          (POSIX VAR=\"\" semantics)"
@@ -1257,7 +1269,11 @@ fn op_picker_multi_account_flow() -> Result<()> {
     // operator's default `op` account context.
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert_eq!(
-        editor(&state).pending.env.get("DB_URL").map(String::as_str),
+        editor(&state)
+            .pending
+            .env
+            .get("DB_URL")
+            .map(|v| v.as_persisted_str()),
         Some("op://Shared/Database/password"),
         "multi-account picker commit must produce a Vault/Item/Field path"
     );
@@ -1545,7 +1561,7 @@ fn env_key_modal_blocks_duplicate_workspace_key() -> Result<()> {
             .pending
             .env
             .get("EXISTING")
-            .map(String::as_str),
+            .map(|v| v.as_persisted_str()),
         Some("kept-value"),
         "the pre-existing value must remain untouched"
     );
@@ -1640,7 +1656,10 @@ fn env_key_modal_blocks_duplicate_agent_key() -> Result<()> {
         .expect("agent override must survive");
     assert_eq!(agent_entry.env.len(), 1);
     assert_eq!(
-        agent_entry.env.get("LOG_LEVEL").map(String::as_str),
+        agent_entry
+            .env
+            .get("LOG_LEVEL")
+            .map(|v| v.as_persisted_str()),
         Some("debug"),
         "pre-existing agent value must remain untouched"
     );
@@ -2059,8 +2078,13 @@ fn completing_value_after_agent_pick_creates_section_with_one_var() -> Result<()
         agents.keys().collect::<Vec<_>>()
     );
     assert_eq!(
-        agents.get("agent-smith").unwrap().env.get("API_TOKEN"),
-        Some(&"secret".to_string()),
+        agents
+            .get("agent-smith")
+            .unwrap()
+            .env
+            .get("API_TOKEN")
+            .map(|v| v.as_persisted_str()),
+        Some("secret"),
         "the committed key/value must land in the agent's env map"
     );
     // The section must be auto-expanded.

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -739,15 +739,16 @@ fn op_picker_commit_writes_value_directly_to_pending() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
 
     // The reference must land directly in pending.env (no text modal
-    // intermediate).
+    // intermediate). `as_persisted_str()` on an `OpRef` returns the
+    // UUID-form `op` field (vault uuid=v1, item uuid=i1, field=password).
     assert_eq!(
         editor(&state)
             .pending
             .env
             .get("DB_URL")
             .map(|v| v.as_persisted_str()),
-        Some("op://Personal/Database/password"),
-        "picker commit must write the op:// reference straight into pending.env[key]"
+        Some("op://v1/i1/password"),
+        "picker commit must write the UUID-form op:// reference straight into pending.env[key]"
     );
     assert!(
         editor(&state).modal.is_none(),
@@ -834,7 +835,7 @@ fn op_picker_sentinel_p_flow() -> Result<()> {
     }
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
 
-    // After the picker commits: EnvKey modal is open and the path is
+    // After the picker commits: EnvKey modal is open and the OpRef is
     // stashed on pending_picker_value.
     match &editor(&state).modal {
         Some(Modal::TextInput {
@@ -843,10 +844,15 @@ fn op_picker_sentinel_p_flow() -> Result<()> {
         }) => {}
         other => panic!("expected TextInput(EnvKey) modal; got {other:?}"),
     }
+    // pending_picker_value holds an EnvValue::OpRef; check the `op` field
+    // via as_persisted_str(). UUID form: vault=v1, item=i1, field=credential.
     assert_eq!(
-        editor(&state).pending_picker_value.as_deref(),
-        Some("op://Personal/API Keys/credential"),
-        "picker commit must stash the op:// reference for the EnvKey commit"
+        editor(&state)
+            .pending_picker_value
+            .as_ref()
+            .map(|v| v.as_persisted_str()),
+        Some("op://v1/i1/credential"),
+        "picker commit must stash the UUID-form op:// reference for the EnvKey commit"
     );
 
     // Type the new key name and Enter — the EnvKey commit handler must
@@ -862,8 +868,8 @@ fn op_picker_sentinel_p_flow() -> Result<()> {
             .env
             .get("API_KEY")
             .map(|v| v.as_persisted_str()),
-        Some("op://Personal/API Keys/credential"),
-        "EnvKey commit must write the stashed picker value into pending.env"
+        Some("op://v1/i1/credential"),
+        "EnvKey commit must write the stashed UUID-form OpRef into pending.env"
     );
     assert!(
         editor(&state).pending_picker_value.is_none(),
@@ -1271,10 +1277,10 @@ fn op_picker_multi_account_flow() -> Result<()> {
         }
     }
 
-    // Enter on the Field pane commits the path. The committed reference
-    // is the simple `op://Vault/Item/Field` form — account scoping is
-    // not (yet) embedded in the URL; the launch-time resolver uses the
-    // operator's default `op` account context.
+    // Enter on the Field pane commits the OpRef. The `op` field uses
+    // UUID-form identifiers (vault=v1, item=i1, field=password).
+    // Account scoping is not embedded in the URL; the launch-time
+    // resolver uses the operator's default `op` account context.
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert_eq!(
         editor(&state)
@@ -1282,8 +1288,8 @@ fn op_picker_multi_account_flow() -> Result<()> {
             .env
             .get("DB_URL")
             .map(|v| v.as_persisted_str()),
-        Some("op://Shared/Database/password"),
-        "multi-account picker commit must produce a Vault/Item/Field path"
+        Some("op://v1/i1/password"),
+        "multi-account picker commit must produce a UUID-form op:// reference"
     );
     assert!(editor(&state).modal.is_none());
     Ok(())


### PR DESCRIPTION
## Summary

Switches jackin's 1Password env-var references from name-form `op://Vault/Item/Field` strings (which fail at launch when item names collide in a vault) to a structured `OpRef { op, path }` inline-table:

- `op` carries a UUID-form URI (resolution-stable; immune to 1Password item-name collisions)
- `path` carries a snapshot breadcrumb for human-readable editor display
- Item-level ambiguity is rendered inline via `Item[subtitle]` notation in `path`, captured at pick time

Plus an unrelated security fix that surfaced during review: the `--debug` log was leaking resolved env-var values (including 1Password secrets) verbatim into stderr alongside the `docker run` argv. That's now redacted.

## What's in this PR (26 commits)

**Design spec:** [`docs/superpowers/specs/2026-04-27-op-id-storage-design.md`](https://github.com/jackin-project/jackin/blob/feature/op-uuid-pinning/docs/superpowers/specs/2026-04-27-op-id-storage-design.md)

**Schema:**
- `EnvValue` untagged enum (`OpRef | Plain`) replaces `String` in `BTreeMap<String, EnvValue>` env fields across `AppConfig`, `AgentSource`, `WorkspaceConfig`, `WorkspaceAgentOverride`
- `OpRef { op, path }` struct with `#[serde(deny_unknown_fields)]` and a documented snapshot-drift contract (op is identity, path is display)

**Runtime:**
- Resolver dispatches on enum variant — bare `op://` strings in `Plain` no longer trigger `op read` (they pass through to the container literally)
- `EnvValue::as_persisted_str` (canonical UUID URI) and `EnvValue::as_display_str` (human path) are split — display-only surfaces (`env list`, auth-mode notice, save-diff) use the human form

**Picker (TUI):**
- Commit logic builds canonical UUID-form `op` and ambiguity-aware `path` (embeds `Item[subtitle]` only when item collides in vault)
- Anomalous-emission debug log via `crate::debug_log!("op_picker", ...)` (TUI-safe, `--debug`-gated)

**CLI:**
- `jackin workspace env set` and `jackin config env set` auto-resolve any `op://...` input via `op` CLI listings
- Accepts all official 1Password URI forms: names, UUIDs, mixed, special aliases (`username`/`password`/`notes`/`notesPlain`), section-bearing, query-bearing (`?attribute=otp`, `?attr=...`, `?ssh-format=openssh`)
- Bracketed disambiguation (`Item[subtitle]` and `Item[#id-prefix]`) accepted as input
- Ambiguous inputs error with copy-pasteable disambiguation suggestions
- `op` unavailable → loud install hint; `${VAR}` inside `op://` → rejection (substitution unsupported)

**Editor renderer:**
- Breadcrumb sources from `OpRef.path` (with `[subtitle]` and `?attribute=otp` rendered in `PHOSPHOR_DIM`)
- Two-space gap between key column and value (fixes the `CLAUDE_CODE_OAUTH_TOKENPrivate / ...` cramming bug)
- Malformed-path fallback: explicit `<unparseable path — re-pick>` placeholder (no UUID URI leak)

**Security fix:**
- `ShellRunner::log_command` now redacts `-e KEY=VALUE` / `--env KEY=VALUE` args in `--debug` output. Was leaking resolved secrets to stderr; the original env-resolver spec said "values never leave the process".
**Doc tightening:**
- `COMMITS.md` pre-commit gate now requires `cargo clippy -- -D warnings` to match CI exactly. Previously the doc was lax (`cargo clippy` without `-D warnings`); local checks could pass while CI rejected the same code for lints like `clippy::branches_sharing_code`.


## Migration (lossy upgrade)

Workspace TOMLs containing bare `op://Vault/Item/Field` scalar strings:
- Continue to deserialize without error (as `EnvValue::Plain`)
- At runtime, pass through to the container as literal strings (no `op read` call) — **breaking change**, recorded in `DEPRECATED.md`
- In the editor TUI, render WITHOUT the `[op]` marker

The visual cue (missing `[op]` marker) signals re-pick via the picker keystroke, or `jackin workspace env set MY_VAR "op://..."` to upgrade via the CLI auto-resolution path.

## Foundations

Builds on prior shipped specs:

- `2026-04-23-workspace-env-resolver-design.md` — operator env layered model
- `2026-04-23-toml-edit-migration-design.md` — `ConfigEditor` for comment-preserving writes

## Test plan

- [x] Per-task TDD with two-stage review (spec compliance + code quality) before each commit
- [x] Two rounds of comprehensive PR review (`code-reviewer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`, `comment-analyzer`) with all Critical/Important findings addressed
- [x] Picker↔CLI parity tests (`build_op_ref_on_commit` and `resolve_op_uri_to_ref` produce byte-equivalent OpRefs for the same fixture)
- [x] Migration regression pins (TUI text-entry stays Plain; legacy bare op:// loads as Plain; runtime passthrough verified with zero op reads)
- [x] Renderer malformed-path fallback test (no panic, no UUID leak)
- [x] `--debug` redaction test matrix: `-e KEY=VALUE`, `--env KEY=VALUE`, host-passthrough form, multiple env args, value containing `=`, empty value
- [x] Full suite: 1292/1292 tests pass on HEAD (`4c147c7d`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (matches CI)

## Known limitations / explicitly deferred (follow-up PRs)

- **`OpUri` newtype + private `OpRef` fields.** Type-design analysis flagged this as the strongest next step — would compile-check the canonical-URI contract. Substantial redesign; defer.
- **End-to-end TOML→resolver integration test** (the deferred test-analyzer Critical-2). Each layer is unit-tested; the integration join is not. Defer.
- **Auth-forward TUI surface.** Currently `auth_forward` is editable only via `jackin config auth-forward`. The workspace editor's General tab does not expose it. Out of scope for this PR; tracked as a follow-up.
- **CHANGELOG entry intentionally omitted** (handled at release time via the `jackin-dev:release-notes` skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
