### PR TITLE
fix(isolation): address post-review gaps in worktree cleanup assessment

### DIFF
--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -131,10 +131,10 @@ The file lives next to the existing `.claude/` and `.jackin/` per-container stat
 | `original_src` | Resolved host `src` recorded for source-drift detection |
 | `isolation` | Mode (`worktree` in V1) |
 | `worktree_path` | Materialized worktree path on the host |
-| `branch` | Scratch branch name (`jackin/scratch/<container>`) |
+| `scratch_branch` | Scratch branch name (`jackin/scratch/<container>`) |
 | `base_commit` | Host `HEAD` at first materialization |
-| `selector` | Agent selector key |
-| `container` | Final container name |
+| `selector_key` | Agent selector key |
+| `container_name` | Final container name |
 | `status` | `active` \| `preserved_dirty` \| `preserved_unpushed` |
 
 Successful cleanup removes the corresponding record rather than keeping a historical `cleaned` entry.

--- a/src/isolation/finalize.rs
+++ b/src/isolation/finalize.rs
@@ -2,6 +2,8 @@
 //   git status --porcelain
 //   git for-each-ref --format=... refs/heads/
 //   git rev-list <upstream>..<branch>
+//   git symbolic-ref --quiet HEAD          (detached-HEAD guard)
+//   git rev-parse HEAD                     (detached-HEAD guard; only when HEAD is detached)
 //   git worktree remove --force
 //   git branch -D
 // None require network access. The shared finalizer is safe to call
@@ -62,7 +64,7 @@ pub enum PreservedReason {
     /// The working tree is clean but at least one local branch has
     /// commits that we cannot prove have shipped (no upstream, real
     /// commits past upstream, or a git capture failure on the per-branch
-    /// loop). Includes the detached-HEAD-past-base case.
+    /// loop), or HEAD is detached with commits past `base_commit`.
     Unpushed,
 }
 
@@ -277,10 +279,19 @@ enum CleanupAssessment {
 /// |---------------------------------------------------------------|----------|
 /// | tip == `base_commit`                                          | Safe     |
 /// | tip moved, no upstream                                        | Unsafe   |
-/// | tip moved, upstream set, ref present, `rev-list` empty        | Safe     |
-/// | tip moved, upstream set, ref present, `rev-list` non-empty    | Unsafe   |
-/// | tip moved, upstream set, upstream `[gone]` (pruned)           | Safe     |
+/// | tip moved, upstream set, upstream tracking ref not `[gone]`, `rev-list` empty   | Safe  |
+/// | tip moved, upstream set, upstream tracking ref not `[gone]`, `rev-list` non-empty | Unsafe |
+/// | tip moved, upstream `[gone]` (squash-merged + pruned)         | Safe     |
 /// | any `git` capture error                                       | Unsafe   |
+///
+/// After all named branches pass, a detached-HEAD guard runs:
+///
+/// | Detached-HEAD state                                           | Decision |
+/// |---------------------------------------------------------------|----------|
+/// | `symbolic-ref HEAD` succeeds (HEAD on branch)                 | Safe     |
+/// | `symbolic-ref HEAD` fails, `rev-parse HEAD` == `base_commit`  | Safe     |
+/// | `symbolic-ref HEAD` fails, `rev-parse HEAD` != `base_commit`  | Unsafe   |
+/// | `symbolic-ref HEAD` fails, `rev-parse HEAD` also fails        | Unsafe   |
 ///
 /// `[gone]` upstream is treated as Safe because squash-merge with
 /// remote-branch-deletion is the dominant GitHub workflow: there is
@@ -405,7 +416,7 @@ fn assess_cleanup(
         // `[gone]` (or bare `gone` in some git versions) means the
         // upstream ref is configured but the remote-tracking ref was
         // pruned. Treat as Safe — see the policy comment above.
-        if track.contains("gone") {
+        if track == "[gone]" || track == "gone" {
             debug_log!(
                 "isolation",
                 "finalize assess: branch {name} in {wt} has upstream={upstream} marked gone; treating as merged-and-pruned (safe)",
@@ -441,6 +452,61 @@ fn assess_cleanup(
                 wt = record.worktree_path,
             );
             return Ok(CleanupAssessment::PreservedUnpushed);
+        }
+    }
+
+    // Detached-HEAD guard: commits made while HEAD is detached don't
+    // appear under refs/heads/ and slip past the branch loop above.
+    // `symbolic-ref --quiet HEAD` exits 0 on an attached branch and
+    // fails (exit 1) on a detached HEAD — both failure and a capture
+    // error are treated as potentially unsafe.
+    if runner
+        .capture(
+            "git",
+            &[
+                "-C",
+                &record.worktree_path,
+                "symbolic-ref",
+                "--quiet",
+                "HEAD",
+            ],
+            None,
+        )
+        .is_err()
+    {
+        // `symbolic-ref` fails on detached HEAD (exit 1) and on any git
+        // error — both are unsafe until we can verify HEAD is at base.
+        debug_log!(
+            "isolation",
+            "finalize assess: symbolic-ref HEAD failed for {wt} (detached HEAD or error); checking rev-parse HEAD",
+            wt = record.worktree_path,
+        );
+        match runner.capture(
+            "git",
+            &["-C", &record.worktree_path, "rev-parse", "HEAD"],
+            None,
+        ) {
+            Ok(head_sha) if head_sha.trim() == record.base_commit.trim() => {
+                // Detached HEAD parked at base — no unreachable commits.
+            }
+            Ok(head_sha) => {
+                debug_log!(
+                    "isolation",
+                    "finalize assess: detached HEAD {sha} != base {base} in {wt}; preserving as unpushed",
+                    sha = head_sha.trim(),
+                    base = record.base_commit.trim(),
+                    wt = record.worktree_path,
+                );
+                return Ok(CleanupAssessment::PreservedUnpushed);
+            }
+            Err(e) => {
+                debug_log!(
+                    "isolation",
+                    "finalize assess: rev-parse HEAD failed for {wt}: {e}; preserving as unpushed (cannot verify detached HEAD state)",
+                    wt = record.worktree_path,
+                );
+                return Ok(CleanupAssessment::PreservedUnpushed);
+            }
         }
     }
 
@@ -571,10 +637,11 @@ mod tests {
         write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
 
         // Capture queue:
-        //   status --porcelain  (clean)
-        //   for-each-ref refs/heads/  (single scratch branch at base_commit)
+        //   status --porcelain           (clean)
+        //   for-each-ref refs/heads/     (single scratch branch at base_commit)
+        //   symbolic-ref HEAD            (HEAD on scratch branch → attached)
         let branches = format!("{}\n", ferow("jackin/scratch/x", "abc", "", ""));
-        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut runner = fake_with_outputs(&["", &branches, "refs/heads/jackin/scratch/x"]);
         let mut p = NoPrompt;
         let dec = finalize_foreground_session(
             "jackin-x",
@@ -606,11 +673,12 @@ mod tests {
         //   status --porcelain (clean)
         //   for-each-ref -> single branch ahead of base with reachable upstream
         //   rev-list <upstream>..<branch> -> "" (all reachable)
+        //   symbolic-ref HEAD            (HEAD on scratch branch → attached)
         let branches = format!(
             "{}\n",
             ferow("jackin/scratch/x", "newhead", "origin/jackin/scratch/x", "",)
         );
-        let mut runner = fake_with_outputs(&["", &branches, ""]);
+        let mut runner = fake_with_outputs(&["", &branches, "", "refs/heads/jackin/scratch/x"]);
         let mut p = NoPrompt;
         let dec = finalize_foreground_session(
             "jackin-x",
@@ -908,9 +976,8 @@ mod tests {
         write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
         // status clean, for-each-ref returns one branch ahead with
         // upstream still configured (not gone), then rev-list fails.
-        // Without the fail-closed `Err` arm the empty-string fallback
-        // would return SafeToDelete here and the unpushed commits would
-        // be garbage-collected.
+        // The fail-closed Err arm must route to PreservedUnpushed, not
+        // silently treat the failure as "no commits ahead".
         let branches = format!(
             "{}\n",
             ferow(
@@ -1226,13 +1293,14 @@ mod tests {
         //   - scratch at base_commit (no upstream)
         //   - feature/x ahead, upstream set, no [gone]
         // rev-list <upstream>..feature/x → empty (everything pushed)
+        // symbolic-ref HEAD             (HEAD on feature/x → attached)
         let branches = [
             ferow("jackin/scratch/x", "abc", "", ""),
             ferow("feature/x", "newhead", "origin/feature/x", ""),
         ]
         .join("\n")
             + "\n";
-        let mut runner = fake_with_outputs(&["", &branches, ""]);
+        let mut runner = fake_with_outputs(&["", &branches, "", "refs/heads/feature/x"]);
         let mut p = NoPrompt;
         let dec = finalize_foreground_session(
             "jackin-x",
@@ -1267,7 +1335,8 @@ mod tests {
         .join("\n")
             + "\n";
         // No rev-list call expected — `[gone]` short-circuits to Safe.
-        let mut runner = fake_with_outputs(&["", &branches]);
+        // symbolic-ref HEAD  (HEAD on feature/x → attached)
+        let mut runner = fake_with_outputs(&["", &branches, "refs/heads/feature/x"]);
         let mut p = NoPrompt;
         let dec = finalize_foreground_session(
             "jackin-x",
@@ -1364,8 +1433,9 @@ mod tests {
         .join("\n")
             + "\n";
         // status clean, branch enumeration, rev-list for feature/b only
-        // (feature/a short-circuits via [gone], scratch via tip==base).
-        let mut runner = fake_with_outputs(&["", &branches, ""]);
+        // (feature/a short-circuits via [gone], scratch via tip==base),
+        // then symbolic-ref HEAD (HEAD on feature/b → attached).
+        let mut runner = fake_with_outputs(&["", &branches, "", "refs/heads/feature/b"]);
         let mut p = NoPrompt;
         let dec = finalize_foreground_session(
             "jackin-x",
@@ -1471,5 +1541,279 @@ mod tests {
         .unwrap();
         assert_eq!(dec, FinalizeDecision::Preserved);
         assert_eq!(p.seen, vec![PreservedReason::Dirty]);
+    }
+
+    // ---------------------------------------------------------------
+    // Malformed for-each-ref row — fail-closed guard (line 377).
+    // These tests replace the old assess_cleanup_empty_head_*
+    // test (which exercised the removed rev-parse HEAD path). The
+    // equivalent invariant is now: an empty `name` or empty `tip`
+    // in a for-each-ref row must never match base_commit and must
+    // always route to PreservedUnpushed.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn assess_cleanup_malformed_row_empty_name_preserves_unpushed() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // Empty name column — malformed row, fail closed.
+        let branches = format!("{}\n", ferow("", "newhead", "", ""));
+        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Preserved);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
+    }
+
+    #[test]
+    fn assess_cleanup_malformed_row_empty_tip_preserves_unpushed() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // Empty tip column — must not compare equal to any base_commit,
+        // including an empty one; always fails closed.
+        let branches = format!("{}\n", ferow("feature/x", "", "origin/feature/x", ""));
+        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Preserved);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
+    }
+
+    // ---------------------------------------------------------------
+    // Non-interactive PreservedUnpushed path. The non-interactive
+    // eprintln uses per-reason wording; this pins that the Unpushed
+    // arm is reached (FinalizeDecision::Preserved +
+    // CleanupStatus::PreservedUnpushed) when is_interactive=false.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn unpushed_worktree_non_interactive_prints_warning_and_preserves() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // status clean, branch ahead of base with no upstream → PreservedUnpushed
+        let branches = format!("{}\n", ferow("feature/x", "newhead", "", ""));
+        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Preserved);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
+    }
+
+    // ---------------------------------------------------------------
+    // Interactive prompt choices for PreservedUnpushed.
+    // Counterparts to the Dirty interactive tests; pins that the
+    // three-way prompt dispatch works for both preservation paths.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn unpushed_branch_interactive_force_delete_runs_cleanup() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        let branches = format!("{}\n", ferow("feature/x", "newhead", "", ""));
+        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut p = ScriptedPrompt(VecDeque::from([2]));
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            true,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Cleaned);
+        assert!(read_records(dir.path()).unwrap().is_empty());
+        assert!(
+            runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("worktree remove --force"))
+        );
+    }
+
+    #[test]
+    fn unpushed_branch_interactive_return_to_agent_signals_caller() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        let branches = format!("{}\n", ferow("feature/x", "newhead", "", ""));
+        let mut runner = fake_with_outputs(&["", &branches]);
+        let mut p = ScriptedPrompt(VecDeque::from([0]));
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            true,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::ReturnToAgent);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
+    }
+
+    // ---------------------------------------------------------------
+    // Bare `gone` track annotation (no brackets). Some git versions
+    // emit `gone` instead of `[gone]`; both must short-circuit to Safe.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bare_gone_track_is_safe_to_delete() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // Bare `gone` (no brackets) must also short-circuit to Safe.
+        let branches = [
+            ferow("jackin/scratch/x", "abc", "", ""),
+            ferow("feature/x", "newhead", "origin/feature/x", "gone"),
+        ]
+        .join("\n")
+            + "\n";
+        // No rev-list expected — bare `gone` short-circuits just like `[gone]`.
+        // symbolic-ref HEAD  (HEAD on feature/x → attached)
+        let mut runner = fake_with_outputs(&["", &branches, "refs/heads/feature/x"]);
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Cleaned);
+        assert!(read_records(dir.path()).unwrap().is_empty());
+        assert!(
+            !runner.recorded.iter().any(|c| c.contains("rev-list")),
+            "bare gone short-circuit must not invoke rev-list; recorded={:?}",
+            runner.recorded,
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Detached-HEAD guard. Commits made in detached-HEAD mode don't
+    // appear in refs/heads/ and would slip past the branch loop.
+    // `symbolic-ref --quiet HEAD` is the sentinel: Err = detached (or
+    // git error); both are treated as unsafe unless rev-parse HEAD
+    // confirms HEAD is parked at base_commit.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn detached_head_past_base_preserves_unpushed() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // All named branches are safe (scratch at base), but HEAD is
+        // detached and points at a commit past base_commit.
+        let branches = format!("{}\n", ferow("jackin/scratch/x", "abc", "", ""));
+        // Queue: status, for-each-ref, rev-parse HEAD (symbolic-ref fails).
+        let mut runner = fake_failing_capture(&["", &branches, "deadbeef"], "symbolic-ref");
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Preserved);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
+    }
+
+    #[test]
+    fn detached_head_at_base_is_safe_to_delete() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // Detached HEAD parked exactly at base_commit ("abc") — no
+        // unreachable commits; safe to clean.
+        let branches = format!("{}\n", ferow("jackin/scratch/x", "abc", "", ""));
+        // Queue: status, for-each-ref, rev-parse HEAD (= "abc\n" → trims to base_commit).
+        // Using the real git rev-parse output format (trailing newline) so trim() is exercised.
+        let mut runner = fake_failing_capture(&["", &branches, "abc\n"], "symbolic-ref");
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Cleaned);
+        assert!(read_records(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn detached_head_rev_parse_failure_preserves_unpushed() {
+        let dir = TempDir::new().unwrap();
+        let r = rec(dir.path());
+        std::fs::create_dir_all(&r.original_src).unwrap();
+        write_records(dir.path(), std::slice::from_ref(&r)).unwrap();
+        // Both symbolic-ref and rev-parse fail → fail-closed.
+        let branches = format!("{}\n", ferow("jackin/scratch/x", "abc", "", ""));
+        let mut runner = FakeRunner {
+            capture_queue: std::collections::VecDeque::from(vec![String::new(), branches]),
+            fail_on: vec!["symbolic-ref".to_string(), "rev-parse".to_string()],
+            ..FakeRunner::default()
+        };
+        let mut p = NoPrompt;
+        let dec = finalize_foreground_session(
+            "jackin-x",
+            dir.path(),
+            AttachOutcome::stopped(0),
+            false,
+            &mut p,
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(dec, FinalizeDecision::Preserved);
+        let recs = read_records(dir.path()).unwrap();
+        assert_eq!(recs[0].cleanup_status, CleanupStatus::PreservedUnpushed);
     }
 }

--- a/src/isolation/state.rs
+++ b/src/isolation/state.rs
@@ -8,6 +8,12 @@ const ISOLATION_FILE: &str = "isolation.json";
 const STATE_DIR: &str = ".jackin";
 const CURRENT_VERSION: u32 = 1;
 
+/// Persisted cleanup state written into `isolation.json`.
+///
+/// `PreservedDirty` and `PreservedUnpushed` map one-to-one to the
+/// `PreservedReason::Dirty` and `PreservedReason::Unpushed` variants in
+/// `finalize.rs`, which drive the transient prompt wording. When adding a
+/// new preservation cause, update both types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CleanupStatus {

--- a/src/runtime/test_support.rs
+++ b/src/runtime/test_support.rs
@@ -104,6 +104,14 @@ impl CommandRunner for FakeRunner {
         let command = format!("{} {}", program, args.join(" "));
         self.recorded.push(command.clone());
         self.check_command(&command)?;
+        // `unwrap_or_default()` returns `Ok("")` when the queue is exhausted.
+        // Two commands in `assess_cleanup` are dangerous when they silently
+        // receive a phantom `Ok("")`:
+        //   - `rev-list`: empty output = "no commits ahead" → SafeToDelete
+        //   - `symbolic-ref HEAD`: any Ok (including "") = "HEAD on a branch",
+        //     silently skipping the detached-HEAD guard
+        // Always provide one queue entry per expected capture call and
+        // document each in a comment above the `fake_with_outputs` call.
         Ok(self.capture_queue.pop_front().unwrap_or_default())
     }
 }


### PR DESCRIPTION
## Summary

- **Detached-HEAD guard**: `assess_cleanup` now calls `git symbolic-ref --quiet HEAD` after the per-branch loop; on failure it probes `git rev-parse HEAD` vs `base_commit` and routes to `PreservedUnpushed` if they differ or if rev-parse also fails — closing the silent-deletion gap for commits made in detached-HEAD mode
- **`[gone]` exact match**: `track.contains("gone")` tightened to `track == "[gone]" || track == "gone"` to avoid false matches on hypothetical future multi-token track annotations
- **`architecture.mdx` field names**: corrected `branch`/`selector`/`container` → `scratch_branch`/`selector_key`/`container_name` to match `IsolationRecord`
- **9 new tests**: malformed for-each-ref rows, non-interactive `PreservedUnpushed` path, interactive force-delete and return-to-agent for `Unpushed`, bare `gone` form, detached HEAD past base, detached HEAD at base (exercises `trim()`), double capture failure
- **Explicit queue entries**: all 6 `SafeToDelete` tests now provide a `symbolic-ref HEAD` queue entry instead of relying on silent queue-exhaustion `Ok("")`
- **`CleanupStatus` cross-reference**: doc comment added linking it to `PreservedReason` so both types stay in sync
- **`FakeRunner` warning**: documents the `rev-list` and `symbolic-ref HEAD` queue-exhaustion false-positive risk

## Test plan

- [ ] `cargo test --lib isolation::finalize::tests` — 37 tests pass
- [ ] `cargo fmt -- --check` — no formatting diff
- [ ] `cargo clippy -- -D warnings` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)