### PR TITLE
fix(mcp): update shellfirm MCP subcommand from mcp-server to mcp

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -44,7 +44,7 @@ else
     echo "[entrypoint] tirith disabled (JACKIN_DISABLE_TIRITH=1)"
 fi
 if [[ "${JACKIN_DISABLE_SHELLFIRM:-0}" != "1" ]]; then
-    run_maybe_quiet claude mcp add shellfirm -- shellfirm mcp-server || true
+    run_maybe_quiet claude mcp add shellfirm -- shellfirm mcp || true
 else
     echo "[entrypoint] shellfirm disabled (JACKIN_DISABLE_SHELLFIRM=1)"
 fi

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -212,7 +212,7 @@ COPY .jackin-runtime/entrypoint.sh /home/claude/entrypoint.sh"#;
     #[test]
     fn entrypoint_registers_security_tool_mcp_servers() {
         assert!(ENTRYPOINT_SH.contains("claude mcp add tirith -- tirith mcp-server"));
-        assert!(ENTRYPOINT_SH.contains("claude mcp add shellfirm -- shellfirm mcp-server"));
+        assert!(ENTRYPOINT_SH.contains("claude mcp add shellfirm -- shellfirm mcp"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `shellfirm` v0.3.9 renamed the subcommand from `mcp-server` to `mcp`
- `entrypoint.sh` was still calling `shellfirm mcp-server`, causing Claude Code to log `error: unrecognized subcommand 'mcp-server'` and surface "Failed to reconnect to shellfirm" on every session start
- Updated the contract-test assertion in `derived_image.rs` to match

## Test plan

- [ ] Launch a jackin container and verify `/mcp` shows shellfirm connected without errors
- [ ] Confirm `shellfirm mcp` starts successfully inside the container: `shellfirm mcp --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)