### PR TITLE
refactor(cli): remove auto-generated help subcommand from all subcommands

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -334,6 +334,20 @@ mod tests {
         ));
     }
 
+    // ── help subcommand disabled ────────────────────────────────────────
+
+    #[test]
+    fn config_auth_rejects_help_subcommand() {
+        let err = Cli::try_parse_from(["jackin", "config", "auth", "help"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
+
+    #[test]
+    fn config_mount_rejects_help_subcommand() {
+        let err = Cli::try_parse_from(["jackin", "config", "mount", "help"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
+
     // ── Config mount help ───────────────────────────────────────────────
 
     #[test]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -5,16 +5,16 @@ use super::{BANNER, HELP_STYLES};
 #[derive(Debug, Subcommand, PartialEq, Eq)]
 pub enum ConfigCommand {
     /// Manage global mount configurations
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Mount(MountCommand),
     /// Manage trust for third-party agent sources
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Trust(TrustCommand),
     /// Manage Claude Code authentication forwarding from host
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Auth(AuthCommand),
     /// Manage operator env vars at global and per-agent scope
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Env(EnvCommand),
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -163,6 +163,35 @@ mod tests {
         );
     }
 
+    // ── help subcommand disabled ────────────────────────────────────────
+
+    #[test]
+    fn root_help_does_not_list_help_subcommand() {
+        let help = help_text(&["jackin", "--help"]);
+        assert!(
+            !help.contains("\n  help"),
+            "root `help` subcommand should be disabled"
+        );
+    }
+
+    #[test]
+    fn config_help_does_not_list_help_subcommand() {
+        let help = help_text(&["jackin", "config", "--help"]);
+        assert!(
+            !help.contains("\n  help"),
+            "`config help` subcommand should be disabled"
+        );
+    }
+
+    #[test]
+    fn workspace_help_does_not_list_help_subcommand() {
+        let help = help_text(&["jackin", "workspace", "--help"]);
+        assert!(
+            !help.contains("\n  help"),
+            "`workspace help` subcommand should be disabled"
+        );
+    }
+
     // ── Subcommand banner consistency ───────────────────────────────────
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -46,7 +46,7 @@ pub use workspace::{WorkspaceCommand, WorkspaceEnvCommand};
 /// [`ConsoleArgs`] make `jackin --debug` equivalent to
 /// `jackin console --debug`.
 #[derive(Debug, Parser)]
-#[command(name = "jackin", version = env!("JACKIN_VERSION"), styles = HELP_STYLES, before_help = BANNER)]
+#[command(name = "jackin", version = env!("JACKIN_VERSION"), styles = HELP_STYLES, before_help = BANNER, disable_help_subcommand = true)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -82,10 +82,10 @@ pub enum Command {
     #[command(hide = true)]
     Launch(LaunchArgs),
     /// Manage saved workspaces
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Workspace(WorkspaceCommand),
     /// View and modify operator configuration
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Config(ConfigCommand),
 }
 

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -190,7 +190,7 @@ Examples:
         name: String,
     },
     /// Manage operator env vars at workspace and workspace-agent scope
-    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES)]
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Env(WorkspaceEnvCommand),
 }
 

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -572,6 +572,14 @@ mod tests {
         }
     }
 
+    // ── help subcommand disabled ────────────────────────────────────────
+
+    #[test]
+    fn workspace_rejects_help_subcommand() {
+        let err = Cli::try_parse_from(["jackin", "workspace", "help"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
+
     // ── Workspace subcommand help ───────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `disable_help_subcommand = true` to every clap variant that carries a nested `Subcommand`, removing the redundant `help` entry from all command listings
- Affects root `Cli`, `Command::Workspace`, `Command::Config`, all four `ConfigCommand` variants (`Mount`, `Trust`, `Auth`, `Env`), and `WorkspaceCommand::Env`
- The `-h`/`--help` flags are untouched and all 83 CLI tests pass
- Adds 6 negative tests: help-text absence checks (root, config, workspace) and parse-rejection checks (`config auth help`, `config mount help`, `workspace help`)

## Test plan

- [ ] `jackin config auth` no longer lists `help` under Commands
- [ ] `jackin config` no longer lists `help` under Commands
- [ ] `jackin workspace` no longer lists `help` under Commands
- [ ] `jackin config auth --help` and `jackin config auth -h` still work
- [ ] `cargo test --lib cli::` passes (83 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)