### PR TITLE
docs(roadmap): keep sidebar in sync with roadmap directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,7 +69,7 @@ Roadmap items — open work and resolved design docs — live in the docs site, 
 - Per-item design docs: [`docs/src/content/docs/reference/roadmap/`](docs/src/content/docs/reference/roadmap/)
 - Browsable: <https://jackin.tailrocks.com/reference/roadmap/>
 
-To add a new item, create an MDX page under the directory above and add a sidebar entry in [`docs/astro.config.ts`](docs/astro.config.ts) under `Roadmap → Open items`.
+To add a new item, create an MDX page under the directory above and add a sidebar entry in [`docs/astro.config.ts`](docs/astro.config.ts) under `Roadmap → Open items`. Whenever you add, rename, delete, or change a roadmap item's `**Status**` (Open ↔ Resolved), update the sidebar in the same PR — the directory and the sidebar must stay in sync. Operators discover open work through the sidebar; an item reachable only via the overview page or direct URL is effectively hidden. See `docs/AGENTS.md` → "Content Notes" for the audit command that diffs the directory against the sidebar.
 
 Each design doc should include (see any existing page as a template):
 
@@ -100,6 +100,7 @@ Docs rot silently. Every PR must include a one-pass verification that structure-
 
 - [ ] If the PR resolves or advances an item under `docs/src/content/docs/reference/roadmap/`, update that item's `Status` field (`Open | Deferred | Resolved`) and `Related Files` section in the same PR.
 - [ ] If the PR references `src/` paths that have since moved (e.g., a roadmap doc mentions `src/runtime.rs` which is now `src/runtime/`), fix those path references.
+- [ ] If the PR adds, renames, deletes, or moves a roadmap MDX file between status sections, update [`docs/astro.config.ts`](docs/astro.config.ts) so `Reference → Roadmap` (Open / Resolved / Codebase health) matches the directory. Run the audit command in `docs/AGENTS.md` → "Content Notes" → "Roadmap sidebar discipline" to confirm the diff is empty.
 
 ### How to verify
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -133,6 +133,26 @@ bun install --frozen-lockfile
 - `mailto:` links are included in lychee checks, so use real, intentional email
   addresses rather than placeholders.
 - Sidebar and top-nav are configured in `astro.config.ts`.
+- **Roadmap sidebar discipline.** Every MDX file under
+  `src/content/docs/reference/roadmap/` must have a matching entry in
+  the sidebar in `astro.config.ts` (under `Reference → Roadmap → Open
+  items`, `Resolved`, or `Codebase health` as appropriate for its
+  `**Status**` field). Whenever you add, rename, delete, or change the
+  status of a roadmap item — or restructure the directory — verify
+  the sidebar still matches the directory contents in the same PR.
+  Operators rely on the sidebar (not the overview prose) to discover
+  open work, so an item reachable only via direct URL or the
+  overview page is effectively hidden. To audit:
+
+  ```sh
+  ls docs/src/content/docs/reference/roadmap/*.mdx \
+    | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
+  grep -oE "reference/roadmap/[a-z0-9-]+" docs/astro.config.ts \
+    | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-sidebar
+  diff /tmp/roadmap-files /tmp/roadmap-sidebar
+  ```
+
+  The diff must be empty.
 - Use Starlight components for callouts (`<Aside type="note|tip|caution">`),
   steps (`<Steps>` around an `<ol>`), and tabs (`<Tabs><TabItem>`). Import from
   `@astrojs/starlight/components`.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
                     { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
                     { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
                     { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
+                    { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
                     { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
                     { label: 'Rootless DinD', slug: 'reference/roadmap/rootless-dind' },
                     { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },


### PR DESCRIPTION
## Summary

- The `multi-runtime-support` roadmap item was reachable only from the roadmap overview page, not from the sidebar — operators rely on the sidebar to discover open work, so this made the item effectively hidden. Adds the missing entry to `Reference → Roadmap → Open items` in `docs/astro.config.ts`.
- Adds a **Roadmap sidebar discipline** rule to `docs/AGENTS.md` → Content Notes, with a copy-pasteable audit command (`diff` of directory slugs vs. sidebar slugs) that catches both missing entries and misspelled slugs.
- Extends the existing rule in `TODO.md` (was creation-only) to cover renames, deletes, and status-section moves (Open ↔ Resolved), and adds a checkbox to *When your PR touches a roadmap item* pointing at the audit command.

## Test plan

- [x] Audit command (in `docs/AGENTS.md`) reports an empty diff between the roadmap directory and the sidebar
- [x] `cargo fmt -- --check` clean
- [ ] `bun run build` from `docs/` — not run locally (mise trust prompt); CI build will exercise this

🤖 Generated with [Claude Code](https://claude.com/claude-code)