### PR TITLE
feat(cli): add jackin help command (cargo-style)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +790,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_mangen",
  "crossterm",
  "dialoguer",
  "directories",
@@ -1460,6 +1471,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tui-widget-list = "0.15"
 dialoguer = "0.12"
 tabled = "0.20.0"
 open = "5.3.4"
+clap_mangen = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -995,6 +995,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 Ok(())
             }
         },
+        Command::Help { .. } => {
+            // Handled upstream in dispatch before reaching this function.
+            unreachable!("Command::Help is dispatched to Action::PrintHelp before run() is called")
+        }
     }
 }
 

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -46,6 +46,8 @@ pub enum Action {
     /// Print top-level `--help` and exit 0. This is the silent fallback
     /// chosen for bare `jackin` on a non-interactive stdout.
     PrintHelpAndExit,
+    /// Display long-form man page help for a command and exit.
+    PrintHelp { command: Vec<String> },
     /// Error: explicit console request on a non-TTY terminal. Carries
     /// `deprecated_alias` so the dispatcher can still emit the `launch`
     /// deprecation warning before the error exit.
@@ -104,6 +106,7 @@ pub fn classify(cli: Cli, tui_capable: bool) -> Action {
                 }
             }
         }
+        Some(Command::Help { command }) => Action::PrintHelp { command },
         Some(other) => Action::RunCommand(other),
         None => {
             if tui_capable {
@@ -279,5 +282,22 @@ mod tests {
         assert!(CONSOLE_REQUIRES_TTY_ERROR.contains("40x15"));
         // The jackin' apostrophe naming rule applies to user-visible strings.
         assert!(CONSOLE_REQUIRES_TTY_ERROR.contains("jackin'"));
+    }
+
+    #[test]
+    fn help_with_no_args_classifies_to_print_help() {
+        let cli = Cli::try_parse_from(["jackin", "help"]).unwrap();
+        let action = classify(cli, true);
+        assert!(matches!(action, Action::PrintHelp { ref command } if command.is_empty()));
+    }
+
+    #[test]
+    fn help_with_args_classifies_to_print_help() {
+        let cli = Cli::try_parse_from(["jackin", "help", "config", "auth"]).unwrap();
+        let action = classify(cli, false);
+        assert!(matches!(
+            action,
+            Action::PrintHelp { ref command } if command == &["config", "auth"]
+        ));
     }
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,0 +1,92 @@
+use std::io::Write;
+
+use anyhow::Context as _;
+use clap::CommandFactory;
+
+use super::Cli;
+
+/// Display long-form man-page help for the given command path.
+///
+/// `command` is a slice of subcommand name tokens, e.g. `["config", "auth"]`.
+/// An empty slice shows help for the root `jackin` command.
+///
+/// Display chain (first available wins):
+///   1. `man <roff-tempfile>` — full roff rendering
+///   2. `less -R <txt-tempfile>` or `more <txt-tempfile>` — paged plain text
+///   3. Raw print to stdout
+pub fn exec(command: &[String]) -> anyhow::Result<()> {
+    let root = Cli::command();
+
+    // Traverse to the requested subcommand (immutable borrow).
+    let mut target: &clap::Command = &root;
+    for part in command {
+        target = target
+            .find_subcommand(part.as_str())
+            .ok_or_else(|| anyhow::anyhow!("no such subcommand: `{}`", command.join(" ")))?;
+    }
+
+    // Generate roff man page content.
+    let mut roff: Vec<u8> = Vec::new();
+    clap_mangen::Man::new(target.clone())
+        .render(&mut roff)
+        .context("failed to render man page")?;
+
+    // Try man(1) with the roff file.
+    if try_man(&roff)? {
+        return Ok(());
+    }
+
+    // Fall back to plain long-help text via pager or raw stdout.
+    let text = target.clone().render_long_help().to_string();
+    if try_pager(text.as_bytes())? {
+        return Ok(());
+    }
+
+    println!("{text}");
+    Ok(())
+}
+
+/// Write `content` to a `.1` temp file and invoke `man`.
+///
+/// Returns `true` if `man` was found and invoked (regardless of its exit
+/// code — the user quitting with `q` exits 1 but the page was shown).
+/// Returns `false` if `man` is not installed.
+fn try_man(content: &[u8]) -> anyhow::Result<bool> {
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".1")
+        .tempfile()
+        .context("failed to create man temp file")?;
+    tmp.write_all(content)
+        .context("failed to write man temp file")?;
+
+    match std::process::Command::new("man").arg(tmp.path()).status() {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).context("man failed unexpectedly"),
+    }
+}
+
+/// Write `content` to a `.txt` temp file and display via `less -R` or `more`.
+///
+/// Returns `true` if a pager was found and invoked.
+/// Returns `false` if neither `less` nor `more` is installed.
+fn try_pager(content: &[u8]) -> anyhow::Result<bool> {
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".txt")
+        .tempfile()
+        .context("failed to create pager temp file")?;
+    tmp.write_all(content)
+        .context("failed to write pager temp file")?;
+
+    let pagers: &[(&str, &[&str])] = &[("less", &["-R"]), ("more", &[])];
+    for (pager, args) in pagers {
+        let mut cmd = std::process::Command::new(pager);
+        cmd.args(*args).arg(tmp.path());
+        match cmd.status() {
+            Ok(_) => return Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).context(format!("{pager} failed unexpectedly")),
+        }
+    }
+    Ok(false)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,7 @@ pub mod agent;
 pub mod cleanup;
 pub mod config;
 pub mod dispatch;
+pub mod help;
 pub mod workspace;
 
 pub use config::{AuthCommand, ConfigCommand, EnvCommand, MountCommand, TrustCommand};
@@ -46,7 +47,14 @@ pub use workspace::{WorkspaceCommand, WorkspaceEnvCommand};
 /// [`ConsoleArgs`] make `jackin --debug` equivalent to
 /// `jackin console --debug`.
 #[derive(Debug, Parser)]
-#[command(name = "jackin", version = env!("JACKIN_VERSION"), styles = HELP_STYLES, before_help = BANNER, disable_help_subcommand = true)]
+#[command(
+    name = "jackin",
+    version = env!("JACKIN_VERSION"),
+    styles = HELP_STYLES,
+    before_help = BANNER,
+    disable_help_subcommand = true,
+    after_help = "Run 'jackin help <command>' for more detailed information."
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,6 +87,19 @@ pub enum Command {
     /// View and modify operator configuration
     #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
     Config(ConfigCommand),
+    /// Print help documentation for a jackin command
+    ///
+    /// With no arguments, displays the jackin manual.
+    /// With a command name, displays the manual for that command:
+    ///
+    ///   jackin help config
+    ///   jackin help config auth
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Help {
+        /// Command path to get help for (e.g. `config auth`)
+        #[arg(trailing_var_arg = true, num_args = 0..)]
+        command: Vec<String>,
+    },
 }
 
 #[cfg(test)]
@@ -166,11 +179,12 @@ mod tests {
     // ── help subcommand disabled ────────────────────────────────────────
 
     #[test]
-    fn root_help_does_not_list_help_subcommand() {
+    fn root_help_lists_help_subcommand() {
+        // Our explicit `help` command must appear in the top-level listing.
         let help = help_text(&["jackin", "--help"]);
         assert!(
-            !help.contains("\n  help"),
-            "root `help` subcommand should be disabled"
+            help.contains("\n  help "),
+            "root `help` subcommand should be listed"
         );
     }
 
@@ -190,6 +204,35 @@ mod tests {
             !help.contains("\n  help"),
             "`workspace help` subcommand should be disabled"
         );
+    }
+
+    // ── Help command ────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_help_with_no_args() {
+        let cli = Cli::try_parse_from(["jackin", "help"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Help { ref command }) if command.is_empty()
+        ));
+    }
+
+    #[test]
+    fn parses_help_with_single_subcommand() {
+        let cli = Cli::try_parse_from(["jackin", "help", "config"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Help { ref command }) if command == &["config"]
+        ));
+    }
+
+    #[test]
+    fn parses_help_with_nested_subcommand() {
+        let cli = Cli::try_parse_from(["jackin", "help", "config", "auth"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Help { ref command }) if command == &["config", "auth"]
+        ));
     }
 
     // ── Subcommand banner consistency ───────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,10 +43,11 @@ fn main() {
             println!();
             std::process::exit(0);
         }
-        Action::PrintHelp { command: _ } => {
-            // Implemented in Task 4 — placeholder to keep binary compiling.
-            eprintln!("error: help not yet implemented");
-            std::process::exit(2);
+        Action::PrintHelp { command } => {
+            if let Err(e) = jackin::cli::help::exec(&command) {
+                jackin::tui::fatal(&format!("{e:#}"));
+                std::process::exit(1);
+            }
         }
         Action::ErrorNotTtyCapable { deprecated_alias } => {
             if deprecated_alias {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,11 @@ fn main() {
             println!();
             std::process::exit(0);
         }
+        Action::PrintHelp { command: _ } => {
+            // Implemented in Task 4 — placeholder to keep binary compiling.
+            eprintln!("error: help not yet implemented");
+            std::process::exit(2);
+        }
         Action::ErrorNotTtyCapable { deprecated_alias } => {
             if deprecated_alias {
                 eprintln!("{}", dispatch::LAUNCH_DEPRECATION_WARNING);

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1,0 +1,68 @@
+//! Integration tests for `jackin help [COMMAND]...`.
+//!
+//! These tests spawn the real binary with a pipe (non-TTY), so `man`
+//! and pagers output to stdout without blocking. The display chain
+//! (man -> less/more -> raw stdout) always produces output — tests
+//! check exit code and non-emptiness, not which fallback fired.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn help_with_no_args_exits_zero_and_produces_output() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .arg("help")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn help_config_exits_zero() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .args(["help", "config"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn help_config_auth_exits_zero_and_mentions_auth() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .args(["help", "config", "auth"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("auth").or(predicate::str::contains("Auth")));
+}
+
+#[test]
+fn help_unknown_subcommand_exits_nonzero() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .args(["help", "doesnotexist"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn help_appears_in_root_help_listing() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\n  help "));
+}
+
+#[test]
+fn root_help_footer_mentions_jackin_help() {
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("jackin help <command>"));
+}


### PR DESCRIPTION
## Summary

- Adds \`jackin help [COMMAND]...\` that shows long-form man page output, mirroring cargo's \`help\` subcommand behavior
- Display chain: \`man\` → \`less -R\` → \`more\` → raw stdout (first available wins)
- Fallback from \`man\` triggered by binary-not-found, not exit code — user quitting with \`q\` counts as shown
- \`jackin <cmd> --help\` unchanged — still shows clap's short summary
- Adds \`Run 'jackin help <command>' for more detailed information.\` footer to root help
- Uses runtime man page generation via \`clap_mangen\` (build-time embedding not feasible without restructuring \`src/cli/\` internal deps)

## Examples

\`\`\`
jackin help                  # full manual for jackin itself
jackin help config           # full manual for config subcommand
jackin help config auth      # full manual for config auth subcommand
jackin help workspace env    # full manual for workspace env subcommand
\`\`\`

## Test plan

- [ ] \`jackin help\` exits 0 and produces non-empty output
- [ ] \`jackin help config auth\` exits 0 and output mentions auth
- [ ] \`jackin help doesnotexist\` exits non-zero
- [ ] \`jackin --help\` footer contains \`jackin help <command>\`
- [ ] \`jackin --help\` lists \`help\` in Commands section
- [ ] \`cargo test --test help\` — 6 integration tests pass
- [ ] \`cargo fmt --check\` passes
- [ ] \`cargo clippy --lib --tests\` — no new errors vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)