### PR TITLE
chore(deps): bump lychee to v0.24.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,16 +20,10 @@ env:
   # TODO.md "Follow-ups" → "lychee-action-sha-pin".
   #
   # Pinned past lychee-action's v0.23.0 default because v0.24.x is the first
-  # release that extracts <loc> URLs from XML sitemaps (lycheeverse/lychee#2071,
-  # released 2026-04-24). The deploy and check-deployed jobs need that to feed
+  # release that extracts <loc> URLs from XML sitemaps (lycheeverse/lychee#2071).
+  # The deploy and check-deployed jobs need that to feed
   # `--files-from lychee/deployed-pages.txt`.
-  #
-  # Using v0.24.1 specifically: lychee v0.24.0 ships its release tarball with a
-  # newly-added top-level subfolder, which lychee-action v2.8.0 cannot extract.
-  # v0.24.1 keeps the flat tarball layout AND keeps the sitemap fix. The action
-  # SHA above is post-v2.8.0 master (faea714) which adds subfolder-aware install
-  # — required for any future v0.24.0+ rollback. Bump in lockstep across the file.
-  LYCHEE_VERSION: 'v0.24.1'
+  LYCHEE_VERSION: 'v0.24.2'
 
 concurrency:
   group: pages-${{ github.event_name }}-${{ github.ref }}

--- a/TODO.md
+++ b/TODO.md
@@ -34,8 +34,8 @@ Markers without a corresponding TODO.md entry are allowed for transient in-fligh
 - **What:** in [`.github/workflows/docs.yml`](.github/workflows/docs.yml), revert the `lycheeverse/lychee-action` SHA pin from `faea714062690f6c2e6f7f388469ec4fa6d9c4e1` (master, post-v2.8.0) to a SHA from a tagged release.
 - **Why:** SHA-pinning to a tagged release is more discoverable than pinning to a master commit, surfaces release notes during routine dependency review, and keeps the audit trail aligned with what's published in the marketplace.
 - **Tracking:** <https://github.com/lycheeverse/lychee-action/releases> — first tag at or after commit `faea714` (which introduces v0.24.x subfolder-aware install).
-- **Last verified:** 2026-04-25 — latest tag is `v2.8.0`; `faea714` is current `master` HEAD; pin introduced in [#176](https://github.com/jackin-project/jackin/pull/176).
-- **Done when:** a tag at or after `faea714` ships. Replace the SHA in `docs.yml` with that tag's commit SHA, update the inline comment from "post-v2.8.0 master" to the tag name, and bump `LYCHEE_VERSION` to whatever the new release defaults to (or pin explicitly).
+- **Last verified:** 2026-05-01 — latest `lycheeverse/lychee-action` tag is still `v2.8.0`; `faea714` remains current `master` HEAD; pin introduced in [#176](https://github.com/jackin-project/jackin/pull/176). `LYCHEE_VERSION` independently bumped to `v0.24.2` ([release notes](https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.2)) — tarball layout unchanged from v0.24.1 (PR [#2165](https://github.com/lycheeverse/lychee/pull/2165) is binstall-metadata only), so the post-v2.8.0 master SHA is still required.
+- **Done when:** a tag at or after `faea714` ships. Replace the SHA in `docs.yml` with that tag's commit SHA, update the inline comment from "post-v2.8.0 master" to the tag name, and re-confirm `LYCHEE_VERSION` matches whatever the new release defaults to (or keep the explicit pin if newer).
 
 ### Internal cleanups
 


### PR DESCRIPTION
## Summary

- Bumps `LYCHEE_VERSION` in [`.github/workflows/docs.yml`](https://github.com/jackin-project/jackin/blob/main/.github/workflows/docs.yml) from `v0.24.1` → `v0.24.2`. Tarball layout is unchanged from v0.24.1 ([lycheeverse/lychee#2165](https://github.com/lycheeverse/lychee/pull/2165) is binstall-metadata only), so the existing post-v2.8.0 master SHA pin on `lycheeverse/lychee-action` (`faea714` / [lycheeverse/lychee-action#330](https://github.com/lycheeverse/lychee-action/pull/330)) continues to handle subfolder-aware extraction.
- Trims historical archaeology from the `LYCHEE_VERSION` comment block. The durable rationale (sitemap support forces us past lychee-action's v0.23.0 default — [lycheeverse/lychee#2071](https://github.com/lycheeverse/lychee/pull/2071)) stays inline; per-version detail moves to `TODO.md` "Last verified" where state-that-rots belongs.
- Refreshes `TODO.md` "Last verified" for `lychee-action-sha-pin` to 2026-05-01. **The TODO itself stays open** — `lycheeverse/lychee-action` still has no tag past v2.8.0, so the master-SHA pin in `docs.yml` is still required.

## Test plan

- [ ] CI's `docs / docs-link-check` job downloads the v0.24.2 lychee tarball cleanly via the existing `faea714` action SHA (verifies the subfolder-aware install handles v0.24.2's `lychee-<target>/` layout).
- [ ] CI's `docs / deploy` and `docs / check-deployed` jobs (post-merge / scheduled) succeed against the deployed sitemap with v0.24.2 — same `Total / Successful / Errors` shape as the v0.24.1 baseline.
- [ ] `TODO.md` renders cleanly on GitHub (link to lychee v0.24.2 release notes, link to PR #2165 both resolve).