### PR TITLE
chore(toolchain): pin via rust-toolchain.toml and verify MSRV in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
+          # Toolchain channel comes from rust-toolchain.toml.
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+          # `-D warnings` is enforced explicitly on the clippy step below;
+          # leaving the action's default RUSTFLAGS would also apply it to
+          # `cargo build`/`cargo check`/`cargo nextest run`, which is a
+          # behavioral change we don't want to bundle into this PR.
+          rustflags: ""
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2.75.28
         with:
           tool: cargo-nextest
@@ -33,13 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install MSRV toolchain (1.94.0)
-        run: rustup toolchain install 1.94.0 --profile minimal --no-self-update
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
-          key: msrv-1.94.0
+          # Override rust-toolchain.toml: this job exists specifically to
+          # verify the floor declared in `Cargo.toml`'s `rust-version`.
+          toolchain: "1.94.0"
+          cache-key: msrv-1.94.0
+          rustflags: ""
       - name: cargo check on MSRV
-        run: cargo +1.94.0 check --workspace --all-targets --locked
+        run: cargo check --workspace --all-targets --locked
         env:
           RUSTUP_TOOLCHAIN: "1.94.0"
 
@@ -55,12 +62,12 @@ jobs:
             cross: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
-          targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: validator-${{ matrix.target }}
+          # Toolchain channel comes from rust-toolchain.toml.
+          target: ${{ matrix.target }}
+          cache-key: validator-${{ matrix.target }}
+          rustflags: ""
 
       - name: Install cross
         if: matrix.cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,24 @@ jobs:
       - run: cargo clippy -- -D warnings
       - run: cargo nextest run
 
+  msrv:
+    # Verify that the crate still builds on its declared MSRV
+    # (`rust-version` in Cargo.toml). This is independent of the toolchain
+    # pin in rust-toolchain.toml, which tracks the latest tested stable
+    # used for day-to-day builds.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install MSRV toolchain (1.94.0)
+        run: rustup toolchain install 1.94.0 --profile minimal --no-self-update
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: msrv-1.94.0
+      - name: cargo check on MSRV
+        run: cargo +1.94.0 check --workspace --all-targets --locked
+        env:
+          RUSTUP_TOOLCHAIN: "1.94.0"
+
   build-validator:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        with:
+          # Toolchain channel comes from rust-toolchain.toml.
+          rustflags: ""
       - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2.75.28
         with:
           tool: cargo-nextest
@@ -73,13 +75,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
-          targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ${{ matrix.target }}
+          # Toolchain channel comes from rust-toolchain.toml.
+          target: ${{ matrix.target }}
+          cache-key: ${{ matrix.target }}
+          rustflags: ""
 
       - name: Install cross
         if: matrix.cross

--- a/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
+++ b/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
@@ -11,12 +11,12 @@ Three files each asserted a Rust version independently — <RepoFile path="mise.
 
 ## Resolution
 
-1. <RepoFile path="rust-toolchain.toml" /> is the single source of truth for the "latest tested" channel (`1.95.0`). It is read automatically by `rustup` and `rust-analyzer`.
+1. <RepoFile path="rust-toolchain.toml" /> is the single source of truth for the "latest tested" channel (`1.95.0`). It is read automatically by `rustup`, `rust-analyzer`, mise, and CI.
 2. <RepoFile path="mise.toml" /> opts into mise's `idiomatic_version_file_enable_tools = ["rust"]` setting and no longer hard-codes the rust version, so mise also reads `rust-toolchain.toml`. There is nothing to keep in sync between the two files.
-3. <RepoFile path=".github/workflows/ci.yml" /> has a dedicated `msrv` job that installs `1.94.0` via `rustup` and runs `cargo +1.94.0 check --workspace --all-targets --locked`. If that job fails, either bump `rust-version` in <RepoFile path="Cargo.toml" /> to the new floor or revert the offending change.
+3. <RepoFile path=".github/workflows/ci.yml" /> and <RepoFile path=".github/workflows/release.yml" /> use `actions-rust-lang/setup-rust-toolchain`, which reads `rust-toolchain.toml` automatically. Bumping the latest-tested-stable channel is now a one-line edit to `rust-toolchain.toml`; the workflow files do not carry the version literal.
+4. A dedicated `msrv` job in <RepoFile path=".github/workflows/ci.yml" /> installs `1.94.0` (the floor declared in <RepoFile path="Cargo.toml" />'s `rust-version`) and runs `cargo check --workspace --all-targets --locked`. If that job fails, either bump `rust-version` to the new floor or revert the offending change.
 
 ## Caveats (still relevant)
 
-- `dtolnay/rust-toolchain` does NOT read `rust-toolchain.toml` — its version is encoded in the action SHA. The SHAs in <RepoFile path=".github/workflows/ci.yml" /> and <RepoFile path=".github/workflows/release.yml" /> must be manually kept in sync with the `channel` value in `rust-toolchain.toml` whenever the latest-tested-stable bumps.
-- If `cargo +1.94.0 check` ever starts failing because of a newly stabilized feature, update `rust-version` in <RepoFile path="Cargo.toml" /> to the correct floor and update the MSRV job's pinned `1.94.0` literals together (they are intentionally explicit so the floor is greppable).
+- If the `msrv` job ever starts failing because of a newly stabilized feature, update `rust-version` in <RepoFile path="Cargo.toml" /> to the correct floor and update the MSRV job's pinned `1.94.0` literal together (it is intentionally explicit so the floor is greppable).
 - `u64::is_multiple_of` (used in <RepoFile path="src/tui/animation.rs" /> lines 70, 264, 432, 437) was stabilized in 1.86 — safely within the 1.94 MSRV.

--- a/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
+++ b/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
@@ -11,8 +11,8 @@ Three files each asserted a Rust version independently — <RepoFile path="mise.
 
 ## Resolution
 
-1. <RepoFile path="rust-toolchain.toml" /> pins the canonical "latest tested" channel (`1.95.0`) and is read automatically by `rustup` and `rust-analyzer`. The header comment lists every other file that has to move with it.
-2. <RepoFile path="mise.toml" /> now carries an inline comment cross-referencing `rust-toolchain.toml` so the two pins do not silently drift.
+1. <RepoFile path="rust-toolchain.toml" /> is the single source of truth for the "latest tested" channel (`1.95.0`). It is read automatically by `rustup` and `rust-analyzer`.
+2. <RepoFile path="mise.toml" /> opts into mise's `idiomatic_version_file_enable_tools = ["rust"]` setting and no longer hard-codes the rust version, so mise also reads `rust-toolchain.toml`. There is nothing to keep in sync between the two files.
 3. <RepoFile path=".github/workflows/ci.yml" /> has a dedicated `msrv` job that installs `1.94.0` via `rustup` and runs `cargo +1.94.0 check --workspace --all-targets --locked`. If that job fails, either bump `rust-version` in <RepoFile path="Cargo.toml" /> to the new floor or revert the offending change.
 
 ## Caveats (still relevant)

--- a/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
+++ b/docs/src/content/docs/reference/roadmap/msrv-toolchain.mdx
@@ -3,33 +3,20 @@ title: "MSRV & toolchain pin"
 ---
 import RepoFile from '../../../../components/RepoFile.astro'
 
-**Status**: Open — Phase 1, no confirmation needed
+**Status**: Resolved — `rust-toolchain.toml` added, MSRV verified in CI
 
 ## Problem
 
-Three files each assert a Rust version independently — <RepoFile path="mise.toml" /> (1.95.0), <RepoFile path="Cargo.toml" /> rust-version (1.94), CI SHA (1.95.0). No `rust-toolchain.toml` exists. The declared MSRV of 1.94 is never verified in CI.
+Three files each asserted a Rust version independently — <RepoFile path="mise.toml" /> (1.95.0), <RepoFile path="Cargo.toml" /> rust-version (1.94), CI SHA (1.95.0). No `rust-toolchain.toml` existed. The declared MSRV of 1.94 was never verified in CI.
 
-## Steps
+## Resolution
 
-1. Create `rust-toolchain.toml` at repo root:
-   ```toml
-   [toolchain]
-   channel = "1.95.0"
-   ```
-   `rust-analyzer` reads this automatically for IDE toolchain selection.
+1. <RepoFile path="rust-toolchain.toml" /> pins the canonical "latest tested" channel (`1.95.0`) and is read automatically by `rustup` and `rust-analyzer`. The header comment lists every other file that has to move with it.
+2. <RepoFile path="mise.toml" /> now carries an inline comment cross-referencing `rust-toolchain.toml` so the two pins do not silently drift.
+3. <RepoFile path=".github/workflows/ci.yml" /> has a dedicated `msrv` job that installs `1.94.0` via `rustup` and runs `cargo +1.94.0 check --workspace --all-targets --locked`. If that job fails, either bump `rust-version` in <RepoFile path="Cargo.toml" /> to the new floor or revert the offending change.
 
-2. Update <RepoFile path="mise.toml" /> to add a comment cross-referencing `rust-toolchain.toml`.
+## Caveats (still relevant)
 
-3. Add MSRV check step to <RepoFile path=".github/workflows/ci.yml" />:
-   ```yaml
-   - name: Check MSRV
-     run: cargo +1.94.0 check
-     env:
-       RUSTUP_TOOLCHAIN: "1.94.0"
-   ```
-
-## Caveats
-
-- `dtolnay/rust-toolchain` does NOT read `rust-toolchain.toml` — its version is encoded in the action SHA. The SHA in `ci.yml` and `release.yml` must be manually kept in sync with `rust-toolchain.toml`.
-- If `cargo +1.94.0 check` fails, code uses features stabilized after 1.94 — update `rust-version` in <RepoFile path="Cargo.toml" /> to the correct floor.
+- `dtolnay/rust-toolchain` does NOT read `rust-toolchain.toml` — its version is encoded in the action SHA. The SHAs in <RepoFile path=".github/workflows/ci.yml" /> and <RepoFile path=".github/workflows/release.yml" /> must be manually kept in sync with the `channel` value in `rust-toolchain.toml` whenever the latest-tested-stable bumps.
+- If `cargo +1.94.0 check` ever starts failing because of a newly stabilized feature, update `rust-version` in <RepoFile path="Cargo.toml" /> to the correct floor and update the MSRV job's pinned `1.94.0` literals together (they are intentionally explicit so the floor is greppable).
 - `u64::is_multiple_of` (used in <RepoFile path="src/tui/animation.rs" /> lines 70, 264, 432, 437) was stabilized in 1.86 — safely within the 1.94 MSRV.

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,8 @@
 bun = "1.3.13"
 just = "1.50.0"
 node = "24.15.0"
-# Keep this in sync with `rust-toolchain.toml` (the canonical pin read by
-# rustup and rust-analyzer). The MSRV floor is `rust-version` in Cargo.toml
-# and is verified separately by the `msrv` CI job.
-rust = "1.95.0"
+# rust is read from `rust-toolchain.toml` via the `idiomatic_version_file`
+# setting below — single source of truth for the toolchain channel.
+
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,7 @@
 bun = "1.3.13"
 just = "1.50.0"
 node = "24.15.0"
+# Keep this in sync with `rust-toolchain.toml` (the canonical pin read by
+# rustup and rust-analyzer). The MSRV floor is `rust-version` in Cargo.toml
+# and is verified separately by the `msrv` CI job.
 rust = "1.95.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,6 @@
 # Source of truth for the latest tested Rust channel.
-# Read by rustup, rust-analyzer, and mise (via idiomatic_version_file).
-# When bumping, also update the dtolnay/rust-toolchain action SHAs in
-# .github/workflows/{ci,release}.yml — that action does not read this file.
+# Read by rustup, rust-analyzer, mise (via idiomatic_version_file),
+# and CI (via actions-rust-lang/setup-rust-toolchain).
 # MSRV floor is `rust-version` in Cargo.toml, verified by the `msrv` CI job.
 
 [toolchain]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,19 +1,8 @@
-# Pinned toolchain for local builds and rust-analyzer.
-#
-# `rust-analyzer` and `cargo` (when invoked via rustup) read this file
-# automatically, so contributors don't need to remember which version the
-# project targets. Keep this in sync with:
-#
-#   - mise.toml (`rust = "..."`) — the version mise hands out to operators
-#     who use it for tool management.
-#   - .github/workflows/ci.yml + release.yml — the `dtolnay/rust-toolchain`
-#     action SHAs (the action does NOT read this file; its version is
-#     encoded in the pinned SHA, so the SHAs must be bumped manually
-#     whenever this `channel` changes).
-#
-# The MSRV ("minimum supported Rust version") is declared separately in
-# Cargo.toml as `rust-version`. CI verifies it with the dedicated `msrv`
-# job. This toolchain pin is the *latest* tested version, not the floor.
+# Source of truth for the latest tested Rust channel.
+# Read by rustup, rust-analyzer, and mise (via idiomatic_version_file).
+# When bumping, also update the dtolnay/rust-toolchain action SHAs in
+# .github/workflows/{ci,release}.yml — that action does not read this file.
+# MSRV floor is `rust-version` in Cargo.toml, verified by the `msrv` CI job.
 
 [toolchain]
 channel = "1.95.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,19 @@
+# Pinned toolchain for local builds and rust-analyzer.
+#
+# `rust-analyzer` and `cargo` (when invoked via rustup) read this file
+# automatically, so contributors don't need to remember which version the
+# project targets. Keep this in sync with:
+#
+#   - mise.toml (`rust = "..."`) — the version mise hands out to operators
+#     who use it for tool management.
+#   - .github/workflows/ci.yml + release.yml — the `dtolnay/rust-toolchain`
+#     action SHAs (the action does NOT read this file; its version is
+#     encoded in the pinned SHA, so the SHAs must be bumped manually
+#     whenever this `channel` changes).
+#
+# The MSRV ("minimum supported Rust version") is declared separately in
+# Cargo.toml as `rust-version`. CI verifies it with the dedicated `msrv`
+# job. This toolchain pin is the *latest* tested version, not the floor.
+
+[toolchain]
+channel = "1.95.0"


### PR DESCRIPTION
Closes the **MSRV & toolchain pin** roadmap item ([Codebase health → Phase 1](https://jackin.tailrocks.com/reference/roadmap/msrv-toolchain/)).

## What changed

- **New `rust-toolchain.toml`** at the repo root pins the canonical "latest tested" channel (`1.95.0`). Read automatically by `rustup`, `rust-analyzer`, mise, and CI — there is no longer a version literal duplicated anywhere else.
- **`mise.toml`** opts into mise's `idiomatic_version_file_enable_tools = ["rust"]` setting and no longer hard-codes the rust version, so mise reads `rust-toolchain.toml` directly. Verified locally: `mise current rust` → `1.95.0`.
- **`.github/workflows/ci.yml`** + **`.github/workflows/release.yml`** switch from `dtolnay/rust-toolchain` (whose toolchain version is encoded in the action SHA) to `actions-rust-lang/setup-rust-toolchain` v1.16.0 (`2b1f5e9b…`), which reads `rust-toolchain.toml` automatically and ships its own Swatinem caching. Bumping the latest-tested-stable channel is now a one-line edit to `rust-toolchain.toml`.
- **New `msrv` CI job** installs `1.94.0` (the floor declared in `Cargo.toml`'s `rust-version`) and runs `cargo check --workspace --all-targets --locked`. Today the declared MSRV was never actually verified in CI; it now is. The `1.94.0` literal is intentionally kept explicit here so the floor is greppable.
- **Roadmap entry** flipped to `Resolved` and rewritten to reflect the new architecture (no more "must keep dtolnay SHAs in sync" caveat).

## Behavioral notes / migration risks

- `actions-rust-lang/setup-rust-toolchain` defaults `RUSTFLAGS=-D warnings` for all subsequent cargo invocations. To avoid bundling a behavioral change into this PR, every job sets `rustflags: ""`. Strict-warnings enforcement continues to happen only via the existing explicit `cargo clippy -- -D warnings` step.
- The action's `target` input is singular (vs dtolnay's `targets`); the action splits comma-separated values internally.
- For the `msrv` job, `RUSTUP_TOOLCHAIN: "1.94.0"` is set on the cargo step so the `rust-toolchain.toml` 1.95.0 pin doesn't override the explicitly installed 1.94.0 toolchain via the rustup proxy.

## Test plan

| Check | Result |
| --- | --- |
| `cargo +1.94.1 check --workspace --all-targets` | ✅ (no MSRV violations) |
| `cargo fmt -- --check` | ✅ |
| `cargo clippy -- -D warnings` | ✅ |
| `cargo nextest run` | ✅ 1325 / 1325 |
| `mise current rust` | ✅ `1.95.0` (read from `rust-toolchain.toml`) |
| `bun run build` (docs) | ✅ 69 pages |
| `bun run check:repo-links` | ✅ |
| `bun run check:links` | ✅ 8272 OK, 0 errors |
| YAML parse of `ci.yml` + `release.yml` | ✅ both valid |
| Roadmap sidebar audit (`docs/AGENTS.md`) | ✅ diff empty |

(Local rust 1.94.x available is `1.94.1` rather than the `1.94.0` CI uses; both share the `rust-version = "1.94"` floor and the new CI job will exercise `1.94.0` directly.)
