### PR TITLE
docs(roadmap): add multicode-inspired feature program

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -123,6 +123,61 @@ export default defineConfig({
                   ],
                 },
                 {
+                  label: 'Operator surface',
+                  collapsed: true,
+                  items: [
+                    { label: 'Overview', slug: 'reference/roadmap/multicode-inspired-features' },
+                    {
+                      label: 'Phase 1 — Foundation gaps',
+                      collapsed: true,
+                      items: [
+                        { label: 'Workspace description', slug: 'reference/roadmap/workspace-description' },
+                        { label: 'Operator handler system', slug: 'reference/roadmap/operator-handler-system' },
+                        { label: 'Workspace archive', slug: 'reference/roadmap/workspace-archive' },
+                        { label: 'Declarative resource limits', slug: 'reference/roadmap/declarative-resource-limits' },
+                        { label: 'Ephemeral mount modes', slug: 'reference/roadmap/ephemeral-mount-modes' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 2 — Live operator surface',
+                      collapsed: true,
+                      items: [
+                        { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
+                        { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
+                        { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
+                        { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
+                        { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 3 — Persistence & telemetry',
+                      collapsed: true,
+                      items: [
+                        { label: 'Persistent storage layer', slug: 'reference/roadmap/persistent-storage-layer' },
+                        { label: 'Token & cost telemetry', slug: 'reference/roadmap/token-cost-telemetry' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 4 — Fleet operations',
+                      collapsed: true,
+                      items: [
+                        { label: 'Task source abstraction', slug: 'reference/roadmap/task-source-abstraction' },
+                        { label: 'Autonomous task queue', slug: 'reference/roadmap/autonomous-task-queue' },
+                        { label: 'Idle runtime cleanup', slug: 'reference/roadmap/idle-runtime-cleanup' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 5 — Distributed & extensibility',
+                      collapsed: true,
+                      items: [
+                        { label: 'jackin-remote', slug: 'reference/roadmap/jackin-remote' },
+                        { label: 'Credential source pattern', slug: 'reference/roadmap/credential-source-pattern' },
+                        { label: 'Workspace skills mount', slug: 'reference/roadmap/workspace-skills-mount' },
+                      ],
+                    },
+                  ],
+                },
+                {
                   label: 'Codebase health',
                   collapsed: true,
                   items: [

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -64,6 +64,10 @@ The current implementation is Claude-specific end-to-end (manifest schema, deriv
 
 - **[Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/)** — declarative `shared | worktree` mode per mount (clone mode planned for V1.1) so parallel agents stop sharing one working tree
 
+### Operator surface and fleet operations
+
+- **[Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)** — phased program of 18 leaf items closing the gap between jackin's primitives and the operator surface that adjacent tools (notably [`multicode`](https://github.com/yawkat/multicode)) ship today. Covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts — the missing pieces that prevent jackin' from being the canonical orchestrator teams compose on instead of building their own.
+
 <Aside type="tip">
 Detailed design documents for individual TODO items are linked from the sidebar under **Roadmap → Open items** and **Roadmap → Resolved**. Each page is a self-contained proposal with problem statement, options, and related files.
 </Aside>

--- a/docs/src/content/docs/reference/roadmap/agent-runtime-status.mdx
+++ b/docs/src/content/docs/reference/roadmap/agent-runtime-status.mdx
@@ -1,0 +1,183 @@
+---
+title: "Agent Runtime Status (Idle / Busy / Question)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin's CLI is intentionally opaque to agent runtime: the operator launches
+an agent, the agent prints things, the operator interacts with it. There's no
+*structured* observability — jackin has no way to answer "is this agent
+currently busy, idle, or waiting for input?" That makes every downstream
+observability feature impossible:
+
+- The operator console can't show a status column.
+- The autonomous queue (Phase 4) can't dispatch a queued task to an idle
+  agent.
+- Idle-runtime cleanup (Phase 4) has no signal to act on.
+- Cost telemetry (Phase 3) can't correlate token bursts with periods of
+  active work.
+
+Closing this gap is the **load-bearing** Phase 2 item: it's the substrate
+that everything observable depends on.
+
+## Why It Matters
+
+- Without runtime status, the program's autonomous-queue thesis can't work:
+  a queue can't dispatch to a slot if it doesn't know whether the slot is
+  free.
+- The console looks fixed-shape today (one row per workspace + agent
+  picker). multicode's per-row colored status indicator (orange=idle,
+  green=busy, yellow=waiting) is the single biggest UX upgrade their TUI
+  has over jackin's, and it's the same data this gap exposes.
+- Multi-runtime support already needs an adapter seam for runtime-specific
+  behavior (entrypoint, auth, state). Status surfacing is one more
+  responsibility per adapter, which means one more reason to land the
+  adapter abstraction cleanly.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section (implementation-only feature)
+- Source — [`lib/src/services/root_session_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/root_session_service.rs) (SSE event stream → status state)
+- Source — [`lib/src/services/opencode_client_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/opencode_client_service.rs) (the SSE client itself)
+
+multicode subscribes to the OpenCode SSE event stream and derives a
+three-state enum:
+
+- **Idle** — no in-flight tool call, no pending message
+- **Busy** — agent is actively generating or running a tool
+- **Question** — agent is waiting for user input
+
+The state lives on `WorkspaceSnapshot.root_session_status`. The TUI renders
+it as a colored cell next to the workspace name. The transition stream is
+also consumed by the resource-usage poller (so CPU samples are tagged by
+status — not implemented today but visible in their schema).
+
+The implementation cost is small: a parser per-provider that reads SSE/
+event-stream output and emits status events. No agent-runtime changes; just
+a sidecar that watches the agent's emitted protocol.
+
+## Recommended Shape
+
+A small **runtime-status adapter** per supported runtime, bolted onto the
+existing multi-runtime adapter seam (the one that owns
+`derived_image.rs` / `entrypoint.sh` / `instance/auth.rs` / etc. per
+runtime). Each adapter emits status events to a single in-process channel;
+consumers (console, queue, cleanup, telemetry) subscribe to the channel.
+
+### Status enum
+
+```rust
+pub enum AgentStatus {
+    Initializing,
+    Idle,
+    Busy { since: Instant },
+    Question { prompt: Option<String>, since: Instant },
+    Crashed { exit_code: i32 },
+    OomKilled,
+}
+```
+
+`Initializing` covers the gap between container start and the first runtime
+event. `Crashed` and `OomKilled` are surfaced from Docker container state,
+not from the runtime adapter — they're handled by the same mechanism so
+consumers see one stream.
+
+### Per-runtime adapters
+
+- **Claude (today)**. Claude Code emits a streaming JSONL transcript when
+  invoked with `--output-format stream-json` (or similar). The adapter
+  attaches to that stream when available; if not (e.g. the operator is
+  using Claude in a regular interactive session), the adapter falls back
+  to a heartbeat-and-stdin-idle heuristic.
+- **Codex** (when [multi-runtime](/reference/roadmap/multi-runtime-support/)
+  ships). Codex's app-server emits structured events; map those.
+- **Amp** (when multi-runtime ships). Amp's thread API has an explicit
+  status field; surface it.
+
+The adapter is a *separate process or task*, not part of the runtime's
+own startup. It reads the runtime's structured output from a side channel
+(stream-json file, named pipe, server-sent events) and emits status events
+to jackin's status bus. It's allowed to know runtime specifics; the
+consumers are not.
+
+### Status bus
+
+A simple broadcast channel in <RepoFile path="src/runtime/launch.rs" />
+(or a new `src/runtime/status.rs`) that emits
+`(instance_name, status_event)` tuples. Console subscribes for live
+rendering; queue subscribes for dispatch; persistent storage layer
+subscribes to record state transitions.
+
+Consumers should be tolerant of dropped events (broadcast channel with
+bounded capacity); status is always re-derivable from the most recent
+event plus container liveness.
+
+## Scope (V1)
+
+- `AgentStatus` enum + per-instance status state.
+- One status adapter for Claude — the only runtime today. Adapters for
+  Codex and Amp ship alongside their multi-runtime support.
+- A status bus that consumers subscribe to.
+- A fallback heartbeat-and-idle heuristic for Claude when stream-json
+  isn't available, gated behind a `--observable` flag on `jackin load` so
+  operators opt in.
+- Console subscribes to render a status cell next to each workspace.
+  *(The console rendering integration may slip a release behind the
+  status-bus plumbing.)*
+- No persistence in V1 — status is in-memory only. [Persistent storage
+  layer](/reference/roadmap/persistent-storage-layer/) adds a status_log
+  table later.
+
+## Defer
+
+- Heuristic fallbacks for runtimes without structured output. If a runtime
+  doesn't expose status, jackin' shows `Initializing → Unknown` and the
+  operator gets the existing opaque experience.
+- Per-tool granularity (which tool the agent is running right now). V1 is
+  three-state; finer-grained surfacing is a follow-up.
+- Cross-instance status aggregation (a single "fleet view"). Wait until
+  the queue exists.
+
+## Open Questions
+
+- **`--observable` opt-in default.** Should running Claude with stream-json
+  parsing be the default in jackin' (so status surfaces automatically) or
+  opt-in (so the operator's existing interactive flow is unchanged)?
+  Recommended default: *opt-in for V1*, then revisit after operator
+  feedback. stream-json output may interact with how the operator currently
+  uses Claude's TUI.
+- **Heuristic-only fallback.** Is a "no event for 30s and stdin is idle"
+  signal good enough to call an agent Idle? Recommended: *yes for queue
+  dispatch* (false negatives are safe — the queue just doesn't fill the
+  slot); *no for cost telemetry* (false negatives skew samples).
+- **Adapter ownership.** Is the status adapter part of the multi-runtime
+  adapter trait, or a separate runtime-coupled module? Recommended:
+  *separate module* — runtime adapters own launch, auth, entrypoint;
+  status adapters own observability. Different reviewers, different
+  cadence.
+
+## Related Files
+
+- New module (e.g. `src/runtime/status.rs`) — status bus +
+  adapter trait
+- <RepoFile path="src/runtime/launch.rs" /> — wires the adapter into the
+  launch path
+- <RepoFile path="src/console/manager/state.rs" /> — subscribes for
+  rendering
+- Future per-runtime files (Codex / Amp adapters) — bolt into this seam
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Multi-runtime support](/reference/roadmap/multi-runtime-support/) —
+  the runtime adapter abstraction this depends on
+- [Console resource panel](/reference/roadmap/console-resource-panel/) —
+  pairs with status to render the per-workspace observability column
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) — the
+  primary downstream consumer
+- [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/) —
+  another downstream consumer

--- a/docs/src/content/docs/reference/roadmap/agent-tag-protocol.mdx
+++ b/docs/src/content/docs/reference/roadmap/agent-tag-protocol.mdx
@@ -1,0 +1,181 @@
+---
+title: "Agent Tag Protocol (`<jackin:*>` operator-surface markers)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Agents produce useful machine-readable signals during their work — "I'm
+investigating issue #412", "I just opened PR #520", "the repo I'm editing is
+at /workspace/jackin". Today jackin' has no way to *capture* these signals;
+the operator either reads them in the agent's prose output or doesn't see
+them at all. As a result, jackin's UI cannot show live PR status, can't link
+the active workspace to its issue, and can't surface the agent's repo-of-
+record without scraping its stdout.
+
+multicode demonstrates that a tiny opt-in protocol — XML-like tags emitted
+by the agent and parsed by the orchestrator — is sufficient to turn the
+agent into an observable workflow node.
+
+## Why It Matters
+
+- It's the cheapest way to make the operator console *informative* without
+  adding agent-side complexity. Agents emit one line of pseudo-XML; jackin
+  parses, indexes, and renders.
+- It enables the [GitHub link
+  tracking](/reference/roadmap/github-link-tracking/) feature — without a
+  way for the agent to declare "the issue I'm working" the live-status
+  cache has no input.
+- It is **forever** once published. Choosing the namespace and vocabulary
+  carefully now is cheaper than re-doing it later.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Git / GitHub integration](https://github.com/graemerocher/multicode#git--github-integration) (documents the `<multicode:*>` tag emission protocol from the operator's perspective)
+- Skills — [`workspace-skills/machine-readable-issue/SKILL.md`](https://github.com/yawkat/multicode/blob/main/workspace-skills/machine-readable-issue/SKILL.md), [`machine-readable-pr/SKILL.md`](https://github.com/yawkat/multicode/blob/main/workspace-skills/machine-readable-pr/SKILL.md), [`machine-readable-clone/SKILL.md`](https://github.com/yawkat/multicode/blob/main/workspace-skills/machine-readable-clone/SKILL.md) (the skills that instruct agents to emit tags)
+
+```text
+<multicode:issue>https://github.com/example-org/example/issues/12345</multicode:issue>
+<multicode:pr>https://github.com/example-org/example/pull/520</multicode:pr>
+<multicode:repo>/workspace/example</multicode:repo>
+```
+
+Skill markdown files (under `workspace-skills/`) instruct the agent to emit
+these markers when investigating an issue, opening a PR, or working on a
+repo. The TUI parser:
+
+1. Reads the agent's transcript history (SSE events for OpenCode).
+2. Extracts every `<multicode:KIND>VALUE</multicode:KIND>` match into the
+   workspace's `agent_provided` snapshot.
+3. Drives icons + GitHub status polling off the captured links.
+
+Important properties:
+
+- **Skill-driven**, not entrypoint-driven. The runtime doesn't enforce
+  emission; agent classes opt in via the skill the operator includes.
+- **Idempotent**. Re-emitting the same tag is a no-op (deduped by value).
+- **Optional**. Agents that don't emit tags work fine; the UI degrades.
+
+## Recommended Shape
+
+A jackin'-namespaced version with a small core vocabulary, an extension
+point for future kinds, and explicit multi-vendor compatibility (jackin'
+honors `<multicode:*>` too, so an agent class designed for either tool
+keeps working).
+
+### Vocabulary (V1)
+
+| Tag | Value | Purpose |
+|---|---|---|
+| `<jackin:repo>PATH-OR-URL</jackin:repo>` | absolute path inside container or remote URL | Declares the repo the agent is working on |
+| `<jackin:issue>URL</jackin:issue>` | full GitHub issue URL | Declares the issue under investigation |
+| `<jackin:pr>URL</jackin:pr>` | full GitHub PR URL | Declares the PR being authored or reviewed |
+| `<jackin:link>URL</jackin:link>` | any URL | Generic operator-clickable link |
+| `<jackin:status>VALUE</jackin:status>` | freeform short string | Optional human-readable status override (rendered in the console next to runtime status) |
+
+Multi-vendor compat: `<multicode:repo>` etc. parse identically to the
+`<jackin:*>` form. Both populate the same in-memory snapshot. Other
+vendor namespaces can be added behind a feature flag if/when the
+ecosystem demands.
+
+### Parser placement
+
+The parser sits *upstream* of the [agent runtime
+status](/reference/roadmap/agent-runtime-status/) bus — same input
+stream (the runtime's structured output), different consumer. It emits
+`AgentTagEvent` values onto its own channel; downstream consumers
+([GitHub link tracking](/reference/roadmap/github-link-tracking/),
+console rendering, persistent storage) subscribe.
+
+The parser must be **defensive**:
+
+- Tags inside fenced code blocks are ignored (so an agent can document
+  the protocol without triggering it).
+- Malformed tags are silently skipped, never errored.
+- A tag value longer than 4 KiB is dropped with a debug log (defends
+  against runaway emission).
+- Extracted URLs are validated (must parse as URL with `http(s)` scheme;
+  paths must look like absolute paths).
+
+### Skill bundles
+
+To make adoption cheap, a small repo of jackin-managed skills lives at
+`jackin-project/jackin-skills` (or as a section of
+`jackin-project/jackin-marketplace`). Includes:
+
+- `jackin-machine-readable-issue` — instructs the agent to emit
+  `<jackin:issue>` when investigating
+- `jackin-machine-readable-pr` — instructs on PR open/review
+- `jackin-machine-readable-repo` — instructs on workspace identification
+
+Operators add these to their agent class's skill list (mechanism per
+runtime; for Claude, that's the `[claude.plugins]` array).
+
+## Scope (V1)
+
+- The five-tag vocabulary above, with `<jackin:*>` and `<multicode:*>`
+  both honored.
+- Parser module that consumes the runtime's structured output and emits
+  tag events.
+- In-memory per-instance index: `repo: Vec<String>`, `issue: Vec<String>`,
+  `pr: Vec<String>`, `link: Vec<String>`, `status: Option<String>`.
+- Console renders captured links as clickable items next to the agent
+  row (using the [operator handler
+  system](/reference/roadmap/operator-handler-system/) for click).
+- One published skill bundle (separate repo) that agent classes can
+  include to enable emission.
+
+## Defer
+
+- Persistence of tag history. V1 in-memory only;
+  [persistent storage layer](/reference/roadmap/persistent-storage-layer/)
+  adds it later.
+- Per-instance custom-link CRUD from the console (multicode has this).
+  Defer; the agent-emitted set is enough.
+- Tag protocol versioning (`<jackin:repo version="2">...</jackin:repo>`).
+  V1 is unversioned; if we ever need to break compatibility, add the
+  attribute then.
+- Tag emission *from* jackin' to the agent (reverse direction). Out of
+  scope.
+
+## Open Questions
+
+- **Multi-vendor extent.** Just `<multicode:*>`, or also `<conductor:*>`,
+  `<sandbox:*>`, etc.? Recommended: *just multicode for now*; add others
+  on demand. The cost of being multi-vendor is tiny but maintaining the
+  list is real.
+- **Code-block fencing.** Should the parser recognize markdown code
+  fences in the agent's text output, or operate on raw bytes? Recommended:
+  *recognize fences for `<jackin:*>` parsing* — operators discussing the
+  protocol shouldn't accidentally trigger it.
+- **`status` tag semantics.** Is the agent's `<jackin:status>` value
+  authoritative, or just a display hint? Recommended: *display hint only* —
+  the runtime status adapter remains the source of truth.
+- **Self-emission for ecosystem skills.** Should jackin' emit tags on the
+  operator's behalf when, e.g., the operator starts a workspace from a
+  GitHub issue URL? Recommended: *yes, eventually*. The
+  [autonomous queue](/reference/roadmap/autonomous-task-queue/) will
+  emit `<jackin:issue>` on dispatch.
+
+## Related Files
+
+- New module (e.g. `src/runtime/tag_protocol.rs`) —
+  parser + in-memory index
+- <RepoFile path="src/runtime/launch.rs" /> — wires parser into the
+  runtime output stream alongside the status adapter
+- <RepoFile path="src/console/manager/state.rs" /> — link rendering
+- A new repo `jackin-project/jackin-skills` (or section of the existing
+  marketplace) — published skill bundle
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) —
+  parallel consumer of the same runtime output stream
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) —
+  primary consumer of `<jackin:issue>` / `<jackin:pr>`
+- [Operator handler system](/reference/roadmap/operator-handler-system/) —
+  invoked when the operator clicks a captured link

--- a/docs/src/content/docs/reference/roadmap/autonomous-task-queue.mdx
+++ b/docs/src/content/docs/reference/roadmap/autonomous-task-queue.mdx
@@ -1,0 +1,275 @@
+---
+title: "Autonomous Task Queue"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 4, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Once the operator surface is observable (Phase 2) and storage is persistent
+(Phase 3) and tasks come from a pluggable source (the previous leaf), the
+remaining piece is a **dispatcher**: turn tasks into agent invocations,
+respect parallelism limits, recover gracefully on failure, and let the
+operator leave the console running overnight.
+
+This is the headline workflow that justifies the program. Without it, the
+program just makes jackin's existing surface nicer; with it, jackin'
+becomes something an organization deploys instead of building their own.
+
+## Why It Matters
+
+- It's the workflow distinction between "AI coding agent runner" (today)
+  and "AI coding agent platform" (target).
+- Many of the program's smaller leaves only pay off once the queue exists
+  ([archive](/reference/roadmap/workspace-archive/) auto-archive integration,
+  [resource limits](/reference/roadmap/declarative-resource-limits/)
+  budget enforcement, [idle runtime
+  cleanup](/reference/roadmap/idle-runtime-cleanup/)).
+- It's the answer to "I have 50 GitHub issues; can jackin' chip through
+  them overnight?" — currently, no.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Autonomous queueing](https://github.com/graemerocher/multicode#autonomous-queueing) (full operator-facing description of every knob)
+- Config — [`config.toml` `[autonomous]` block](https://github.com/yawkat/multicode/blob/main/config.toml)
+- Source — [`lib/src/manager.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/manager.rs) (dispatch loop)
+
+```toml
+[autonomous]
+max-parallel-issues = 5
+issue-scan-delay-seconds = 900
+scan-on-startup = true
+idle-runtime-cleanup = false
+idle-runtime-cleanup-delay-seconds = 300
+idle-runtime-cleanup-interval-seconds = 900
+idle-runtime-restart = false
+```
+
+Behaviors:
+
+- **Per-workspace queue** with a parallelism cap.
+- **Scan cadence** controls how often the workspace polls its source.
+- **Scan on startup** runs an initial poll the moment the workspace
+  becomes assigned.
+- **Idle runtime cleanup** (separate concern, see
+  [idle runtime cleanup](/reference/roadmap/idle-runtime-cleanup/)).
+
+What multicode does that jackin' should match: per-workspace concurrency
+limit, periodic re-scan, automatic dispatch when a slot frees.
+
+What multicode does that jackin' should *not* match: hardcoded "issue"
+vocabulary, GitHub-only sources, lack of per-task isolation (multicode
+agents share a workspace dir; jackin's worktree isolation gives every
+queued task its own materialized branch).
+
+## Recommended Shape
+
+A queue that's **per-workspace**, dispatches to **per-task isolated
+instances**, and uses jackin's existing primitives for everything except
+the dispatch loop itself.
+
+### Config
+
+```toml
+[workspaces.fix-bugs]
+workdir = "/workspace/example"
+default_agent = "the-architect"
+
+# A workspace can subscribe to one or more task sources.
+task_sources = ["fix-issues", "review-spec"]
+
+[workspaces.fix-bugs.queue]
+max_parallel = 3                   # at most 3 agents at once
+poll_interval_seconds = 600        # re-poll source every 10 min
+poll_on_startup = true             # dispatch immediately on console open
+budget_usd_per_day = 50.00         # optional; skip dispatch when exceeded
+auto_archive_completed = true      # archive instance after task completes
+```
+
+### Mounts
+
+Every queue dispatch creates a per-task instance using **jackin's
+existing isolation primitives** — no new mount type. The workspace's
+mounts are inherited; a worktree-isolated mount becomes a per-instance
+materialized worktree exactly like manual `jackin load`. Each task
+gets a distinct container name, distinct data dir, distinct branch.
+
+The branch name follows the existing convention from
+[per-mount isolation](/reference/roadmap/per-mount-isolation/):
+`jackin/scratch/<container>` where `<container>` includes the unique
+suffix already produced by <RepoFile path="src/instance/naming.rs" />.
+
+### Task → instance materialization
+
+When the queue picks up a Task and an open slot:
+
+1. Generate a per-task instance name, e.g.
+   `jackin-fix-bugs-task-{short_hash_of_task_id}`.
+2. Run the equivalent of `jackin load <agent> <workspace>` with three
+   additions:
+   - `JACKIN_TASK_ID` env var set to the task ID.
+   - `JACKIN_TASK_BODY` env var set to the task body (or, if too long,
+     written to a file inside the container and the env var points at
+     the path).
+   - The agent's first prompt is templated from the task — see
+     "First prompt" below.
+3. Update the `tasks` table: `state = 'in_progress'`,
+   `instance_name = <generated>`.
+4. Subscribe to the [agent runtime
+   status](/reference/roadmap/agent-runtime-status/) bus for that
+   instance to detect completion.
+
+### First prompt
+
+Templated from a per-source-kind handler. For `github_issues`:
+
+```text
+You are working on GitHub issue {issue_url}.
+
+Title: {issue_title}
+
+Body:
+{issue_body}
+
+Read the issue, investigate, and either propose a fix as a PR, post a
+clarifying comment, or document why no action is needed. Emit
+<jackin:issue>{issue_url}</jackin:issue> when you start, and
+<jackin:pr>...</jackin:pr> when you open a PR.
+```
+
+For `file_glob`: simpler — "Read this spec doc and implement it" plus
+the file content.
+
+For `stdin_pipe`: the prompt is the task body verbatim.
+
+The template is editable per-source via a `[task_sources.<name>.prompt_template]`
+key in TOML — operators can tune it.
+
+### Completion detection
+
+The queue considers a task **complete** when:
+
+- The agent's container exits cleanly (exit 0, no OOM), AND
+- A configurable success signal is observed: a `<jackin:pr>` tag was
+  emitted, OR the agent printed a configured success marker, OR the
+  agent's foreground session was finalized clean (no preserved-dirty
+  state).
+
+Completion writes `tasks.state = 'completed'`, records the outcome
+(PR URL if any, exit code, runtime cost from
+[token & cost telemetry](/reference/roadmap/token-cost-telemetry/)),
+and (if `auto_archive_completed = true`) archives the per-task data dir.
+
+Failures (exit non-zero, OOM, missing success signal) write
+`state = 'failed'` and preserve the data dir for inspection. They're
+not auto-retried in V1 — operator-driven re-queue only.
+
+### Budget enforcement
+
+If `budget_usd_per_day` is set, the queue checks the workspace's
+running cost (sum of `tasks.outcome.cost` for tasks completed today
+plus current `usage_samples` for in-flight tasks) before dispatching.
+Over-budget = no dispatch, console shows a "budget exceeded" indicator,
+re-evaluates at next poll.
+
+### Console rendering
+
+When [console resource panel](/reference/roadmap/console-resource-panel/)
+is open, the workspace gets a "Queue" section: pending count,
+in-flight count, completed-today count, failed count. Per-instance
+rows show their task ID alongside.
+
+### CLI
+
+```sh
+jackin queue list <workspace>          # show pending + in-flight + recent completed
+jackin queue feed <workspace>          # read tasks from stdin (stdin_pipe source)
+jackin queue retry <workspace> <id>    # re-queue a failed task
+jackin queue cancel <workspace> <id>   # remove a pending task
+jackin queue pause <workspace>         # stop dispatching new tasks
+jackin queue resume <workspace>        # resume
+```
+
+## Scope (V1)
+
+- Per-workspace `[workspaces.X.queue]` config block.
+- Dispatch loop tied to the workspace's lifecycle (active when the
+  operator console is open *or* when `jackin queue resume <workspace>`
+  is running as a background daemon — see Open Questions).
+- Per-task instance materialization using existing isolation +
+  load primitives.
+- Completion detection via status bus + tag protocol.
+- Budget gating against daily cost.
+- Auto-archive on success when configured.
+- `jackin queue` CLI subcommands above.
+- Console "Queue" panel.
+
+## Defer
+
+- Multi-workspace orchestration ("treat my whole org as one queue").
+  V1: one queue per workspace.
+- Smart retry policies (exponential backoff, jitter). V1: manual
+  retry only.
+- Cross-task dependencies ("task B depends on PR from task A").
+  Out of V1.
+- Webhook-driven dispatch (GitHub webhook → immediate task dispatch
+  instead of polling). Defer; the polling loop is sufficient.
+- Operator-attended task review ("dispatch a task, but pause for
+  approval before opening the PR"). Defer.
+
+## Open Questions
+
+- **Daemon mode.** Does the queue run only while the console is open,
+  or as a background daemon (`jackin daemon start`)? Daemon mode is
+  the right answer for the "leave it overnight" workflow but adds a
+  meaningful operational surface (logs, supervision, restart).
+  Recommended: *V1 ships console-open-only*; daemon is a V1.1 follow-up
+  that lands as a separate roadmap item once the queue's behavior is
+  proven.
+- **Failure replay vs failure quarantine.** When a task fails, should
+  the queue re-poll and re-claim it (potentially looping forever) or
+  quarantine the task ID? Recommended: *quarantine in V1* — manual
+  retry only.
+- **First-prompt template safety.** Templating user-controlled task
+  body into an agent prompt is a prompt-injection surface. Recommended:
+  *document the risk*, render task body inside a clearly-fenced block,
+  trust the agent class's instructions to handle it. This is a known
+  general AI-agent concern; jackin' shouldn't pretend to solve it.
+- **Container-name length.** Per-task instance names will be long
+  (`jackin-fix-bugs-task-<hash>`). Docker accepts up to 253 chars but
+  branch names get attached to logs and dashboards — confirm the
+  rendered length stays readable.
+
+## Related Files
+
+- New module (e.g. `src/queue/dispatcher.rs`) —
+  the dispatch loop
+- `src/queue/task_source.rs` (from previous leaf) —
+  source polling
+- <RepoFile path="src/runtime/launch.rs" /> — invoked by the
+  dispatcher per task; small refactor to accept programmatic
+  invocation instead of CLI args only
+- <RepoFile path="src/instance/naming.rs" /> — per-task instance name
+  generator extension
+- <RepoFile path="src/cli/agent.rs" /> — `jackin queue` subcommands
+- The persistent-storage module — `tasks` table reads/writes
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Task source abstraction](/reference/roadmap/task-source-abstraction/) —
+  required input
+- [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) —
+  required state
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) —
+  required completion-detection signal
+- [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/) —
+  budget gating
+- [Per-mount isolation](/reference/roadmap/per-mount-isolation/) —
+  per-task isolation reuses worktree mode
+- [Workspace archive](/reference/roadmap/workspace-archive/) —
+  auto-archive on completion
+- [Idle runtime cleanup](/reference/roadmap/idle-runtime-cleanup/) —
+  paired Phase 4 item

--- a/docs/src/content/docs/reference/roadmap/console-resource-panel.mdx
+++ b/docs/src/content/docs/reference/roadmap/console-resource-panel.mdx
@@ -1,0 +1,150 @@
+---
+title: "Console Resource Panel (machine + per-agent live usage)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+The operator console renders a fixed view: workspace list, agent picker,
+mounts. It doesn't show *what's happening on the machine*. When five agents
+are running and one is consuming 14 GiB of RAM, the operator finds out by
+watching their machine swap, not by looking at the console.
+
+This is the second major UX gap (after [agent runtime
+status](/reference/roadmap/agent-runtime-status/)). Without it, the
+[declarative resource limits](/reference/roadmap/declarative-resource-limits/)
+work is invisible — operators can't see what the limits are *doing*.
+
+## Why It Matters
+
+- Direct visibility into per-agent CPU/RAM usage closes the feedback loop
+  on resource limits: operator sets `memory_max = 16 GiB`, watches the
+  agent crawl up to 14 GiB, makes an informed decision about whether to
+  raise the limit or kill the agent.
+- The host-level summary (total CPU/RAM used, free, by jackin' vs system)
+  tells the operator at a glance whether they have headroom for another
+  agent.
+- This is one of the surfaces that makes jackin' feel *alive* rather than
+  a one-shot launcher; the gap shows up in every tool comparison.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section (implementation-only feature)
+- Source — [`lib/src/services/resource_usage_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/resource_usage_service.rs) (per-workspace + machine sampling)
+- Source — [`tui/src/render.rs`](https://github.com/yawkat/multicode/blob/main/tui/src/render.rs) (panel rendering)
+
+multicode samples three sources every 2 seconds:
+
+- `/proc/stat` for total CPU usage delta
+- `/proc/meminfo` for RAM
+- `du -sBc` (or platform equivalent) for workspace disk usage
+
+Per-workspace samples come from cgroup files inside the systemd unit:
+`cpuacct.usage_nsec` (delta over the 2s window → percent), `memory.current`
+(current bytes), and `MemoryOomCount` from systemd properties.
+
+The TUI displays these as columns: machine CPU%, machine RAM, per-workspace
+CPU%, per-workspace RAM. RAM cells turn yellow when within 512 MB of
+`memory_max`. OOM kills are highlighted explicitly.
+
+## Recommended Shape
+
+Two distinct concerns plumbed through the same console panel:
+
+1. **Per-agent usage** — live CPU% and RAM bytes per running container,
+   plus configured limit (from
+   [declarative resource limits](/reference/roadmap/declarative-resource-limits/))
+   for context.
+2. **Machine summary** — total host CPU%, total host RAM used/free, total
+   disk space used by `~/.jackin/data/`.
+
+### Per-agent sampling
+
+Use the Docker stats API (`docker stats --no-stream` or, post-[Bollard
+migration](/reference/roadmap/bollard-migration/), the typed
+`ContainerStats` endpoint). Sample every 2 seconds while the console is
+open; pause sampling when the panel is collapsed.
+
+Fields per agent:
+
+- `cpu_percent: f32` (relative to one host core)
+- `memory_bytes: u64` (current RSS-equivalent)
+- `memory_limit_bytes: u64?` (from declared limit; renders "no limit" when absent)
+- `oom_killed: bool` (sticky from last OOM, cleared on container restart)
+
+### Machine sampling
+
+Cross-platform — use the `sysinfo` crate (already a candidate dependency
+for this kind of work) for CPU/RAM. For the data-dir disk usage, walk
+`~/.jackin/data/` once on console open and incrementally on archive
+events; do not poll on every render.
+
+### Console rendering
+
+A new optional panel (toggled with a keystroke, e.g. `t` for "telemetry")
+that splits the bottom of the console into two regions: machine summary
+on the left, per-agent table on the right. When collapsed, the panel is
+absent and sampling pauses.
+
+When [agent runtime
+status](/reference/roadmap/agent-runtime-status/) is in place, the
+per-agent table includes a status column to its left.
+
+## Scope (V1)
+
+- Per-agent CPU%, RAM, RAM-vs-limit, OOM flag — sampled via Docker stats.
+- Machine summary: total CPU%, total RAM, data-dir disk usage.
+- 2-second sample interval while panel is open; paused when closed.
+- Console keystroke toggles the panel; defaults to closed.
+- Sample failures (Docker unreachable, container gone) degrade silently —
+  show "?" cells, not error toasts.
+
+## Defer
+
+- Network I/O bytes per agent. Useful but lower-priority.
+- Disk I/O per agent. Same.
+- Historical graphs (sparklines, rolling 5-minute window). Defer until
+  [persistent storage layer](/reference/roadmap/persistent-storage-layer/)
+  ships and we can keep a rolling sample buffer.
+- Alert thresholds ("notify me when an agent exceeds 90% of limit").
+  Defer; operators can watch the cell color in V1.
+- CSV/Prometheus export. Defer.
+
+## Open Questions
+
+- **Sampling backend abstraction.** Sample-via-Docker today; sample-via-
+  cgroup-files when [selectable
+  backends](/reference/roadmap/selectable-sandbox-backends/) lands. Which
+  module owns the abstraction? Recommended: *the runtime backend trait
+  owns it*, mirroring how each backend already owns mount translation.
+- **Always-on vs on-demand sampling.** multicode samples constantly even
+  when the panel isn't visible, because the data feeds usage aggregation.
+  jackin's V1 doesn't need that yet — pause when closed is the right
+  call. Revisit when [token & cost
+  telemetry](/reference/roadmap/token-cost-telemetry/) needs continuous
+  series.
+- **Keystroke choice.** `t` for telemetry, `r` for resources, `m` for
+  metrics — pick once and document. Defer to console UX review.
+
+## Related Files
+
+- New module (e.g. `src/console/panels/resources.rs`) —
+  panel rendering + sampling loop
+- <RepoFile path="src/console/manager/state.rs" /> — keybinding wiring
+- <RepoFile path="src/runtime/launch.rs" /> — sampling adapter trait
+  starts here, moves into per-backend modules over time
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Declarative resource limits](/reference/roadmap/declarative-resource-limits/) —
+  the configured-limit value the panel renders alongside live usage
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) —
+  status column lives in the same per-agent table
+- [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/) —
+  later turns the per-agent column into a richer telemetry view
+- [Bollard migration](/reference/roadmap/bollard-migration/) — typed
+  Docker stats API simplifies the sampler

--- a/docs/src/content/docs/reference/roadmap/credential-source-pattern.mdx
+++ b/docs/src/content/docs/reference/roadmap/credential-source-pattern.mdx
@@ -1,0 +1,193 @@
+---
+title: "Credential Source Pattern (cross-cutting)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design pattern (Phase 5, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin' resolves credentials in two places today:
+
+- Operator env values that look like `op://...` are routed through the
+  1Password CLI ([1Password integration](/reference/roadmap/onepassword-integration/)).
+- Operator env values that look like `${env.VAR}` are read from the host
+  environment ([env var interpolation](/reference/roadmap/env-var-interpolation/)).
+
+Several upcoming items need *more* sources:
+
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) needs
+  a GitHub PAT.
+- [Task source abstraction](/reference/roadmap/task-source-abstraction/)
+  may need per-source tokens.
+- [Claude auth strategy](/reference/roadmap/claude-auth-strategy/)
+  needs a more durable Claude OAuth flow.
+- A future Linear/JIRA/etc. source needs whatever those services use.
+
+If each item adds its own source resolution code, drift is guaranteed.
+The right move is a single cross-cutting pattern that any feature can
+plug into.
+
+This isn't a feature that ships on its own — it's a refactor that
+unblocks several other features. The leaf exists so the design call is
+made *once*, in one place, instead of being rediscovered five times.
+
+## Why It Matters
+
+- Without a unified pattern, adding a new credential source (Apple
+  Keychain, Linux secret-tool, AWS Secrets Manager, Vault) means
+  touching every consumer.
+- multicode has already tried three sources (`env`, `command`, keychain)
+  for one credential (their GitHub PAT) and converged on a small
+  consistent shape. Borrowing the shape is much cheaper than designing
+  one from scratch.
+- It pairs with [jackin-remote](/reference/roadmap/jackin-remote/) and
+  the future Kubernetes platform — both of which need to know how to
+  resolve credentials *locally* and forward them *remotely*.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Authentication](https://github.com/graemerocher/multicode#authentication) (documents all three sources — keychain, env, command — plus `populate-git-credentials`)
+- Config — [`config.toml` `[github]` block](https://github.com/yawkat/multicode/blob/main/config.toml)
+- Source — [`lib/src/services/config.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/config.rs) (TOML deserializer for the tagged-union token form)
+
+```toml
+[github]
+# One of three forms:
+token = { env = "GITHUB_TOKEN" }
+token = { command = "gh auth token" }
+token = { keychain-service = "multicode.github", keychain-account = "github-mcp-token" }
+```
+
+multicode also exposes `populate-git-credentials = true` for
+auto-injecting the token as a git credential helper inside the
+container.
+
+The shape: a tagged-union TOML value with multiple resolver backends,
+each backend implementing a small trait (`fn resolve() -> Result<SecretString>`).
+Resolution happens at jackin-process startup (or per-invocation,
+depending on the consumer).
+
+## Recommended Shape
+
+A `CredentialSource` type that's accepted anywhere a token/secret is
+needed in TOML. The resolver vocabulary is small and explicit; no
+implicit chains.
+
+### TOML shape
+
+```toml
+# Direct literal — convenience, NOT recommended for real secrets
+some_token = "sk-actual-value"
+
+# Tagged forms
+some_token = { env = "MY_VAR" }
+some_token = { command = "gh auth token" }
+some_token = { op = "op://Vault/Item/Field" }
+some_token = { keychain_service = "jackin.token", keychain_account = "default" }
+some_token = { file = "~/.secrets/token" }
+```
+
+Six backends:
+
+1. **Literal** (string) — for non-secret values; emits a warning if a
+   string field tagged `#[credential]` is supplied as a literal in
+   any operator-config file outside `~/.config/jackin/local.toml`.
+2. **`env`** — read host env var; error if unset.
+3. **`command`** — run a shell command, take stdout (trimmed).
+4. **`op`** — already shipped; routes to 1Password CLI.
+5. **`keychain_*`** — Apple Keychain via `security` CLI on macOS,
+   `secret-tool` on Linux. New backend.
+6. **`file`** — read file contents. Useful for K8s secret mounts and
+   local development.
+
+### Resolution behavior
+
+- Resolution happens at the consumer's first need (lazy), not at
+  config load. This means a misconfigured backend errors only when the
+  feature using it actually runs.
+- Resolved values implement `SecretString` (zeroize-on-drop, no
+  Display impl, redacted in debug logs).
+- Failures are explicit and contextual: `GitHub PAT (configured via [github].token = { command = ... }) failed: <stderr from command>`.
+- Resolved values are not cached across runs of `jackin`. Within one
+  run, they may be cached per-source-instance.
+
+### Consumers
+
+Each consumer (GitHub link tracker, task source, Claude auth, future
+ones) accepts `Option<CredentialSource>` in its config and resolves
+when it needs the value. No consumer reaches around the abstraction.
+
+### Forwarding to containers
+
+`populate_git_credentials` (multicode's name) generalizes to a
+per-credential `forward_to_container = true` flag on the consumer's
+config block. Implementation: jackin' writes the resolved secret into
+a container env var or file mount per the consumer's spec, never to
+the agent's persisted state directory.
+
+## Scope (V1)
+
+- `CredentialSource` enum + TOML deserialization.
+- Six backends: literal, env, command, op (already shipped),
+  keychain_* (new), file (new).
+- `SecretString` newtype with zeroize-on-drop.
+- Replace existing ad-hoc env-var lookups in
+  [Claude auth strategy](/reference/roadmap/claude-auth-strategy/),
+  [1Password integration](/reference/roadmap/onepassword-integration/)
+  with the unified type. (Both are currently partially shipped; the
+  refactor is small.)
+- New consumers (GitHub link tracking, task sources) accept
+  `CredentialSource` from day one.
+- Documentation page: "Credential sources" — explains all six
+  backends, security tradeoffs, recommended pattern per use case.
+
+## Defer
+
+- Vault / AWS Secrets Manager / GCP Secret Manager backends. Defer
+  until a real user asks; the file-mount pattern + K8s secrets covers
+  most of the space.
+- Per-source resolution caching with TTL. Lazy-once-per-run is enough
+  for V1.
+- A `jackin secrets test` CLI that resolves every configured
+  credential and reports status. Useful but small; defer.
+
+## Open Questions
+
+- **Literal-as-secret warning.** Should jackin' refuse to load a
+  literal where a `CredentialSource` is expected (with override flag),
+  or just warn loudly? Recommended: *warn loudly*; the convenience for
+  non-secret tokens (e.g. a Slack webhook URL) outweighs strictness.
+- **Keychain backend implementation.** macOS Keychain is well-defined.
+  Linux `secret-tool` is the most widely available; what about Windows?
+  Recommended: *macOS + Linux in V1, Windows when a user asks*.
+- **Forwarding interaction with [Claude auth
+  strategy](/reference/roadmap/claude-auth-strategy/).** That item is
+  already considering token plumbing; this pattern should *be* the
+  abstraction it uses, not a parallel design. Recommended: *make this
+  leaf land first* so the Claude auth work has the type to use.
+
+## Related Files
+
+- New module (e.g. `src/credential.rs`) —
+  `CredentialSource` enum + resolver
+- <RepoFile path="src/config/mod.rs" /> — TOML deserialization
+- Existing `op://` resolution path — refactored to use the unified
+  type
+- Future consumers — link to this leaf as their credential plumbing
+- New docs page: `docs/src/content/docs/guides/credentials.mdx`
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [1Password integration](/reference/roadmap/onepassword-integration/) —
+  existing consumer; refactored to use the new type
+- [Claude auth strategy](/reference/roadmap/claude-auth-strategy/) —
+  existing consumer; refactored to use the new type
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) —
+  new consumer
+- [Task source abstraction](/reference/roadmap/task-source-abstraction/) —
+  new consumer
+- [jackin-remote](/reference/roadmap/jackin-remote/) — credential
+  forwarding model

--- a/docs/src/content/docs/reference/roadmap/custom-operator-tools.mdx
+++ b/docs/src/content/docs/reference/roadmap/custom-operator-tools.mdx
@@ -1,0 +1,190 @@
+---
+title: "Custom Operator Tools (`[[tool]]` extension points)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Different teams want different operator-side actions: "run my repo's lint
+script against the agent's worktree", "open my org's issue tracker URL for
+the active issue", "snapshot the agent's data dir before a risky test",
+"slack the team that the agent finished". Today the only way to express
+these is to wrap jackin' in shell aliases or external scripts.
+
+multicode addresses this with a `[[tool]]` array: each entry is a hotkey
+that runs a command (or prompts for input and runs a command) when pressed
+in the TUI. Reserved keys (`q`, `a`, `d`, `s`) are off-limits; everything
+else is operator-defined.
+
+## Why It Matters
+
+- It's the difference between jackin' being a *fixed* operator surface and
+  an *extensible* one. The latter is what teams need to standardize on
+  jackin' instead of building custom CLI wrappers.
+- It pairs cleanly with [agent runtime
+  status](/reference/roadmap/agent-runtime-status/) and [tag
+  protocol](/reference/roadmap/agent-tag-protocol/): the captured tags
+  become substitution arguments for the tool command, so a tool can be as
+  simple as "open the issue URL the agent declared".
+- It uses the same handler-resolution machinery as the [operator handler
+  system](/reference/roadmap/operator-handler-system/) — different config
+  surface, same primitives.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section
+- Config — [`config.toml` `[[tool]]` array](https://github.com/yawkat/multicode/blob/main/config.toml) (the example only shows one tool — `bash` on `b` — but the schema is the same)
+- Source — [`tui/src/app.rs`](https://github.com/yawkat/multicode/blob/main/tui/src/app.rs) (tool firing, reserved-key validation)
+
+```toml
+[[tool]]
+type = "exec"
+name = "Run lint"
+key = "l"
+exec = "bun run lint"
+
+[[tool]]
+type = "prompt"
+name = "Slack the team"
+key = "k"
+prompt = "What did the agent ship?"
+```
+
+multicode has two `type` values:
+
+- `exec` — runs the command verbatim (shell-words parsed). The TUI
+  invokes the tool with cwd = workspace dir. Output displayed in a modal.
+- `prompt` — opens an input modal asking the operator's question, then
+  runs an associated command with the operator's answer interpolated.
+  Times out at 300 seconds.
+
+Reserved keys are documented; collisions error at config load.
+
+## Recommended Shape
+
+Same shape, with two extensions: argument substitution from captured
+agent tags, and per-agent-class scoping so a Rust agent gets `cargo`
+shortcuts and a JS agent gets `bun` shortcuts.
+
+### Config
+
+```toml
+# ~/.config/jackin/config.toml
+
+[[tool]]
+key = "l"
+name = "Run lint"
+exec = "cargo clippy"
+# Optional scope filter — only show this tool when the workspace is
+# loaded against a matching agent class. Same selector grammar as
+# [docker.mounts] scope.
+scope = "the-architect"
+
+[[tool]]
+key = "i"
+name = "Open emitted issue"
+exec = "open {issue}"
+# {issue} substitutes the agent's most-recent <jackin:issue> URL.
+# Available substitutions: {repo}, {issue}, {pr}, {link}, {workspace},
+# {instance}, {workdir}.
+
+[[tool]]
+key = "n"
+name = "Note for ops log"
+type = "prompt"
+prompt = "What happened?"
+exec = "echo {input} >> ~/jackin-ops.log"
+```
+
+`type` defaults to `"exec"`. `scope` defaults to no filter (tool always
+visible).
+
+### Reserved keys
+
+jackin's existing reserved keystrokes (the navigation set in the
+console, plus quit/exile/eject) are off-limits. Tool config validation
+errors at config load if a custom tool collides with a reserved key.
+
+### Substitution
+
+When the tool fires, jackin' resolves `{X}` placeholders against the
+selected workspace's runtime state:
+
+- `{instance}` — container name
+- `{workspace}` — workspace name
+- `{workdir}` — primary mount destination inside the container
+- `{host_workdir}` — the materialized host path (worktree if isolated)
+- `{repo}`, `{issue}`, `{pr}`, `{link}` — most-recent value from the
+  [tag protocol](/reference/roadmap/agent-tag-protocol/) index
+- `{input}` — only for `type = "prompt"`; the operator's response
+
+Missing placeholders error at fire time with a helpful message ("no
+`<jackin:issue>` recorded for this instance"); they don't silently
+expand to empty.
+
+### Where commands run
+
+Tools run on the **operator host**, not inside the container. They get
+the operator's environment plus a few injected variables matching the
+substitution set. If a team needs to run *inside* the container, they
+can `docker exec` from the tool command — explicit and intentional.
+
+## Scope (V1)
+
+- `[[tool]]` array at the operator-config level.
+- `type = "exec"` and `type = "prompt"` (default `exec`).
+- `scope` filter on agent class selector.
+- Substitution for `{instance}`, `{workspace}`, `{workdir}`,
+  `{host_workdir}`, `{input}`, plus tag-protocol values once that
+  ships.
+- Reserved-key collision detection at config load.
+- 300-second prompt timeout (matches multicode).
+- Tool firing routes through the
+  [operator handler system](/reference/roadmap/operator-handler-system/)
+  for command resolution and output rendering.
+
+## Defer
+
+- Per-workspace tool overrides. Operator-config-level only in V1.
+- Streaming output for long-running tools. V1 captures and displays
+  on completion, like multicode.
+- Tool authoring helpers (operator-facing CLI for "scaffold a tool
+  config from this command"). Defer until friction surfaces.
+- Tool emission of `<jackin:*>` tags (so a tool can update the
+  per-instance tag index). Interesting; defer.
+- Tool composability (one tool invokes another). Out of scope.
+
+## Open Questions
+
+- **Where does the tool's stdout go?** A modal that overlays the
+  console matches multicode but interrupts flow. A scrolling log
+  panel is friendlier but requires the [console resource
+  panel](/reference/roadmap/console-resource-panel/) infrastructure.
+  Recommended default: *modal for V1*, log panel later.
+- **Do tools work outside the console?** A `jackin tool run <key>`
+  CLI command would be useful for scripting. Recommended: *yes,
+  V1.1*; V1 ships console-only.
+- **Substitution scope when no agent is loaded.** If the operator
+  picks a workspace but no agent has run yet, `{instance}` and
+  `{workdir}` are unset. Recommended: *fire-time error*, never
+  silent empty.
+
+## Related Files
+
+- New module (e.g. `src/console/tools.rs`) — tool
+  config + substitution + firing
+- <RepoFile path="src/config/mod.rs" /> — `[[tool]]` parsing
+- <RepoFile path="src/console/manager/state.rs" /> — keybinding
+  registration and modal rendering
+- The handler system module — output rendering routes through there
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Operator handler system](/reference/roadmap/operator-handler-system/) —
+  shared command-resolution machinery
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) — source
+  of `{repo}`, `{issue}`, `{pr}`, `{link}` substitutions

--- a/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
+++ b/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
@@ -1,0 +1,169 @@
+---
+title: "Declarative Resource Limits per Agent"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 1, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin' runs every agent in a Docker container with whatever resource
+allocation the host gives it. On a developer laptop, six parallel agents can
+each spawn a `cargo build`, exhaust memory, OOM-kill the desktop, or starve
+each other for CPU. There's no operator-facing control for this today; the
+operator's only knob is "launch fewer agents."
+
+Docker exposes the right primitives (`--memory`, `--cpus`, `--ulimit
+nofile=N`, plus `--memory-reservation` for soft limits), but jackin' doesn't
+plumb any of them through.
+
+multicode addresses this directly with three declarative fields:
+`memory-high` (soft limit, triggers reclaim), `memory-max` (hard limit,
+triggers OOM kill), `cpu` (quota as percentage), and `nofile` (FD ceiling on
+Apple-container backends).
+
+## Why It Matters
+
+- **Parallel agents are unsafe today on resource-constrained hosts.** This
+  is a literal correctness gap: a runaway agent can take down the operator's
+  whole machine.
+- **The autonomous queue (Phase 4) is unusable without it.** Five queued
+  agents with default-unlimited memory and CPU is a recipe for OOM kills the
+  moment two of them happen to be running `cargo build` simultaneously.
+- **Cross-backend resource translation is the right home for this design.**
+  Docker, Apple `container`, and the planned [selectable sandbox
+  backends](/reference/roadmap/selectable-sandbox-backends/) each express
+  limits differently — a declarative layer means each backend translates
+  once.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Isolation](https://github.com/graemerocher/multicode#isolation)
+- Config — [`config.toml` `[isolation]` block](https://github.com/yawkat/multicode/blob/main/config.toml) (`memory-high`, `memory-max`, `cpu`)
+
+```toml
+[isolation]
+memory-high = "12 GiB"   # soft limit; triggers cgroup memory.high
+memory-max  = "16 GiB"   # hard limit; triggers OOM at this point
+cpu         = "300%"     # 3 CPU cores worth of quota
+nofile      = 16384      # FD ceiling (Apple container only)
+```
+
+multicode parses these via the `size` crate (decimal `12 GB` and binary
+`16 GiB` both supported), expands shell variables, then maps them onto
+`systemd-run --property MemoryHigh=...` etc. — each backend has its own
+translator, but the config surface is uniform.
+
+multicode also tracks runtime metrics that complement the limits: current
+RAM, CPU %, and crucially **OOM kill count** (sampled from systemd memory
+pressure counter). When an agent gets OOM-killed, the operator sees it.
+
+## Recommended Shape
+
+The right level for these fields is the **agent class manifest**, not the
+operator config or workspace config. Reasoning: limits scale with the
+toolchain (a Rust agent with `cargo build` needs more headroom than a Go
+agent), and the agent class is where toolchain choices live. Operator/
+workspace overrides come later if a use case surfaces.
+
+### Config
+
+```toml
+# jackin.agent.toml
+dockerfile = "Dockerfile"
+
+[runtime.limits]
+memory_high = "12 GiB"     # soft (Docker --memory-reservation)
+memory_max  = "16 GiB"     # hard (Docker --memory)
+cpus        = "3.0"         # Docker --cpus (string for "1.5", "300%")
+nofile      = 16384         # Docker --ulimit nofile=N:N
+
+[runtime.limits.oom]
+preserve_state = true       # don't auto-clean an OOM-killed instance
+notify         = true       # surface OOM in console (depends on Phase 2 status)
+```
+
+`memory_high` is optional; absent means same as `memory_max`. `nofile` is
+optional and defaults to host. `cpus` accepts both fractional and percentage
+forms (`"3.0"` and `"300%"` are equivalent).
+
+### CLI override
+
+```sh
+jackin load <agent> --memory-max 8GiB --cpus 2.0
+```
+
+Operator override is a V1 nicety, not a config-file substitute. Useful for
+"this one launch is on a smaller machine."
+
+### Backend translation
+
+Each backend implements a `ResourceLimits` translator:
+
+- **Docker** (today): `--memory`, `--memory-reservation`, `--cpus`,
+  `--ulimit nofile=N:N`. `oom_score_adj` if needed for preserve-state.
+- **Apple container** (when [selectable
+  backends](/reference/roadmap/selectable-sandbox-backends/) ships): direct
+  per-allocation limits.
+- **systemd-run / bwrap** (if it ever lands): cgroups properties.
+
+A backend that can't honor a declared limit (e.g. `nofile` on a container
+runtime that doesn't expose it) emits a warning at launch and proceeds —
+not a hard error. Operators see the gap; the agent still runs.
+
+## Scope (V1)
+
+- `[runtime.limits]` block on `jackin.agent.toml` with the four fields
+  above.
+- `--memory-max` / `--memory-high` / `--cpus` / `--nofile` flags on
+  `jackin load` for one-shot overrides.
+- Docker translator only in V1 — that's the only backend.
+- `size`-crate-style parsing (binary and decimal); reuse a small parser
+  rather than pulling the dependency.
+- Defaults: no limits applied if the field is absent (matches today).
+- `[runtime.limits.oom]` block: `preserve_state` defaults to true,
+  `notify` defaults to true (no-op until Phase 2 lands).
+
+## Defer
+
+- Per-workspace overrides. Manifest-level only in V1.
+- Disk I/O limits (`--blkio-weight`). Useful but harder to reason about;
+  defer to user request.
+- Network bandwidth limits. Defer indefinitely.
+- Auto-pausing OOM-killed agents instead of killing the container. Docker
+  doesn't expose a clean way; revisit per-backend later.
+
+## Open Questions
+
+- **Should `cpus` accept percentages explicitly?** `"3.0"` is unambiguous
+  for Docker. `"300%"` matches multicode but maps awkwardly to Docker
+  (which doesn't accept the percent sign). Recommended default: *accept
+  both at parse time, normalize to fractional core count internally*.
+- **Should manifest limits be inheritable across agent classes?** If `org/base`
+  declares `memory_max=16GiB` and `org/derived` extends it, does the
+  derived class inherit? Recommended default: *yes, with override semantics*
+  — but agent class inheritance is a separate, larger design question and
+  probably out of scope for V1.
+- **OOM preserve_state interaction with [worktree
+  cleanup](/reference/roadmap/worktree-cleanup-assessment/).** An
+  OOM-killed instance should always preserve. The cleanup helper already
+  handles non-zero exits; OOM is a special case of that. Confirm the
+  existing helper sees OOM as non-zero.
+
+## Related Files
+
+- <RepoFile path="src/manifest/mod.rs" /> — `[runtime.limits]` schema
+- <RepoFile path="src/manifest/validate.rs" /> — limit value validation
+- <RepoFile path="src/runtime/launch.rs" /> — Docker arg construction
+- <RepoFile path="src/cli/agent.rs" /> — `--memory-max` etc. flags
+- New module (e.g. `src/runtime/limits.rs`) — parser and Docker translator
+
+## See Also
+
+- [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) —
+  cross-backend translator lives here long-term
+- [Console resource panel](/reference/roadmap/console-resource-panel/) —
+  consumer of the runtime side (current usage vs configured limit)
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) —
+  queue parallelism limit interacts with per-agent memory limits

--- a/docs/src/content/docs/reference/roadmap/ephemeral-mount-modes.mdx
+++ b/docs/src/content/docs/reference/roadmap/ephemeral-mount-modes.mdx
@@ -1,0 +1,238 @@
+---
+title: "Ephemeral Mount Modes (`tmpfs`, `ephemeral`)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 1, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin's [per-mount isolation](/reference/roadmap/per-mount-isolation/)
+vocabulary is `shared | worktree` (V1), with `clone` planned for V1.1.
+These modes describe **git semantics** for the mounted path. They don't
+cover a different axis the operator also cares about: **storage kind**.
+
+Specifically, two storage shapes have no declarative way to be expressed
+today:
+
+- A path the agent can read and write, but whose contents should NOT
+  appear on the host filesystem and SHOULD reset between launches.
+  (Examples: `~/.gradle/daemon`, an agent's `/var/tmp`, an OpenCode
+  session-state directory that should be per-instance.)
+- A path that lives in tmpfs (memory-backed) for performance or for
+  guaranteed teardown when the container exits. (Examples: `/tmp`, a
+  temporary `~/.ssh` shadow during a rebase script.)
+
+Today an operator can only achieve the first by writing a Docker volume
+into a `--mount` arg and managing its lifecycle by hand, and the second
+by passing `--tmpfs` ad-hoc. Neither lives in `jackin.agent.toml` or the
+workspace config.
+
+multicode confirms this is a real, frequently-used distinction. Their
+example `config.toml` declares 7 paths under `isolated` and 1 under
+`tmpfs` — both essential to keeping concurrent agents from corrupting
+each other's caches and to keeping host state clean.
+
+## Why It Matters
+
+- **Parallel agents share host caches today.** Two agents both running
+  `gradle build` race on `~/.gradle/daemon` because jackin' has no way
+  to declare "this directory is per-instance, not host-shared".
+- **Toolchain hygiene matters at scale.** With the [autonomous task
+  queue](/reference/roadmap/autonomous-task-queue/) in place, an agent
+  fleet runs hundreds of builds a day. Each one should start with a
+  clean per-instance scratch space; today, they don't.
+- **`/tmp` should default to tmpfs.** Many agent classes bake
+  configuration assuming `/tmp` is fast and ephemeral. jackin's default
+  `/tmp` is the container's own filesystem — fine for correctness, but
+  larger and slower than necessary.
+- This is the **only mount-mode gap** found in the verification pass
+  comparing jackin' against multicode's `[isolation]` block. Closing it
+  brings the mount surface to parity.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Isolation](https://github.com/graemerocher/multicode#isolation) (mounting policy and Apple-container subsections describe per-workspace isolation rules)
+- Config — [`config.toml` `[isolation]` block](https://github.com/yawkat/multicode/blob/main/config.toml) — the `isolated = [...]` and `tmpfs = [...]` lists in the example
+
+```toml
+[isolation]
+isolated = [
+  "~/.local/share/opencode",
+  "/var/tmp",
+  "~/.gradle/daemon",
+  "~/.gradle/.tmp",
+  "~/.gradle/kotlin-profile",
+  "~/.local/share/kotlin",
+  "~/.local/state/opencode",
+]
+tmpfs = [
+  "/tmp",
+]
+```
+
+Semantics:
+
+- **`isolated`**: the path inside the workspace is mapped to a
+  per-workspace dedicated mount (or tmpfs overlay). It's writable while
+  the workspace runs but **not visible on the host** and **wiped per
+  workspace start**. Implementation: `bwrap --tmpfs <path>` overlays or
+  a dedicated mount; the path doesn't share with host.
+- **`tmpfs`**: explicit tmpfs mount. Memory-backed, ephemeral, gone on
+  exit. Implementation: `bwrap --tmpfs <path>`.
+
+The two are subtly different: `isolated` may be backed by disk for
+larger working sets (build artifacts), while `tmpfs` is always memory.
+multicode lets the operator pick.
+
+## Recommended Shape
+
+Extend the [per-mount isolation](/reference/roadmap/per-mount-isolation/)
+enum vocabulary by **two more modes**, plus extend the workspace mount
+schema so they don't all need a host `src`.
+
+### Schema extension
+
+The existing per-mount isolation schema requires a host `src`:
+
+```toml
+[[workspaces.X.mounts]]
+src = "~/projects/x"
+dst = "/workspace/x"
+isolation = "worktree"
+```
+
+Add two modes that don't need `src`:
+
+```toml
+[[workspaces.X.mounts]]
+dst = "/tmp"
+isolation = "tmpfs"
+size = "512MiB"          # optional; Docker default 64MiB is small
+
+[[workspaces.X.mounts]]
+dst = "/home/agent/.gradle/daemon"
+isolation = "ephemeral"
+# 'ephemeral' = per-instance Docker volume, persists across container
+# restarts of the same instance, deleted on `purge`. Not bind-mounted
+# to host.
+```
+
+V1 enum vocabulary becomes: `shared | worktree | tmpfs | ephemeral`
+(plus `clone` when V1.1 ships). Validation:
+
+- `tmpfs` and `ephemeral` reject `src` (no host source).
+- `tmpfs` and `ephemeral` reject `readonly` (writability is their
+  whole point; if you want read-only, you want `shared` with
+  `readonly = true`).
+- `tmpfs` accepts an optional `size` field with the same parsing rules
+  as [declarative resource limits](/reference/roadmap/declarative-resource-limits/).
+
+### Backend translation
+
+- **Docker (today)**: `tmpfs` → `--tmpfs <dst>:size=<n>,mode=1777`.
+  `ephemeral` → `--mount type=volume,source=jackin-<container>-<slug>,target=<dst>`,
+  with the volume created on first `load` and deleted by `purge` (the
+  per-instance cleanup helper already enumerates Docker volumes by
+  label; add a label and reuse it).
+- **Apple container** (when [selectable
+  backends](/reference/roadmap/selectable-sandbox-backends/) ships):
+  use the equivalent allocation primitives.
+- **bwrap** (if it ever lands): `--tmpfs` for both modes; the
+  ephemeral case is bwrap's natural shape.
+
+### Agent class declarations
+
+Agent classes can declare ephemeral defaults in `jackin.agent.toml`:
+
+```toml
+[[runtime.mounts]]
+dst = "/home/agent/.gradle/daemon"
+isolation = "ephemeral"
+
+[[runtime.mounts]]
+dst = "/tmp"
+isolation = "tmpfs"
+size = "1GiB"
+```
+
+These are agent-class-level defaults that workspaces inherit unless
+overridden by a workspace mount on the same `dst`. Useful so a Java
+agent class can declare its Gradle hygiene once and every workspace
+gets the right behavior.
+
+## Scope (V1)
+
+- Extend per-mount-isolation enum to `shared | worktree | tmpfs |
+  ephemeral`.
+- TOML schema extension for `dst`-only mounts (no `src`).
+- Optional `size` field on `tmpfs`.
+- Docker translator for both new modes.
+- Per-instance volume label scheme (`jackin.instance=<container>`,
+  `jackin.dst=<slug>`) so cleanup can enumerate.
+- Agent-class-level mount defaults via `[[runtime.mounts]]` in
+  `jackin.agent.toml`; workspace mounts override on `dst`.
+- `purge` cleans up Docker volumes labeled with the instance name.
+- Docs update for [per-mount isolation](/reference/roadmap/per-mount-isolation/)
+  and the architecture reference.
+
+## Defer
+
+- `tmpfs` size enforcement beyond Docker's default behavior. Use
+  Docker's, document the limit.
+- `ephemeral` mode with **persistent** behavior across `purge`
+  (operator-managed volume name). Out of V1; if needed, add a fifth
+  mode `volume = "<name>"` that doesn't auto-clean.
+- File ownership / mode flags on `tmpfs` (`mode = "0700"`). Defer
+  until a use case surfaces.
+- Cross-instance shared ephemeral volumes ("all my Java agents share
+  one Gradle daemon dir"). Out of V1; the use case is handled by
+  shared-cache mounts under
+  [shared cache pattern](/reference/roadmap/per-mount-isolation/) (a
+  shared `~/.gradle` mount overlaid on an isolated source tree).
+
+## Open Questions
+
+- **Naming.** `ephemeral` is descriptive but not great. Alternatives:
+  `instance` (it's per-instance), `volume` (it's a Docker volume),
+  `private` (it's not host-visible). Recommended: *`ephemeral`* —
+  matches the operator's mental model ("this is gone when I purge").
+- **Default `tmpfs` for `/tmp`.** Should every agent class get
+  `/tmp` as tmpfs by default, or stay opt-in? Recommended: *opt-in*
+  for V1 — defaults can change downstream after seeing real usage.
+- **Interaction with [worktree
+  isolation](/reference/roadmap/per-mount-isolation/).** A workspace
+  with a worktree-isolated source mount and a sibling ephemeral
+  mount should compose cleanly (parent-mount-before-child rule).
+  Confirm the existing collapse/ordering logic handles a no-`src`
+  child mount correctly.
+- **Is this its own leaf or an extension to per-mount-isolation?**
+  This leaf treats it as a Phase 1 standalone item because it ships
+  independently and the design doesn't require any per-mount-
+  isolation refactor. The per-mount-isolation doc gets a note
+  pointing here once this is implemented.
+
+## Related Files
+
+- <RepoFile path="src/workspace/mod.rs" /> — `MountConfig`,
+  `MountIsolation` enum extension
+- <RepoFile path="src/workspace/mounts.rs" /> — parser for the new
+  modes; rejects `src` for `tmpfs`/`ephemeral`
+- <RepoFile path="src/runtime/launch.rs" /> — Docker arg construction
+- <RepoFile path="src/runtime/cleanup.rs" /> — volume cleanup on
+  `purge`
+- <RepoFile path="src/manifest/mod.rs" /> — `[[runtime.mounts]]`
+  agent-class defaults
+- <RepoFile path="src/cli/workspace.rs" /> — `--mount-isolation tmpfs`
+  / `ephemeral` in workspace edit/create
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Per-mount isolation](/reference/roadmap/per-mount-isolation/) —
+  the existing modes; this leaf extends the enum vocabulary
+- [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) —
+  cross-backend translation home
+- [Declarative resource limits](/reference/roadmap/declarative-resource-limits/) —
+  shares the size-parsing helper

--- a/docs/src/content/docs/reference/roadmap/github-link-tracking.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-link-tracking.mdx
@@ -1,0 +1,181 @@
+---
+title: "GitHub Link Tracking & Live Status"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Once the agent has emitted `<jackin:issue>` or `<jackin:pr>` tags via the
+[agent tag protocol](/reference/roadmap/agent-tag-protocol/), the operator
+wants to see their *live* state: is the issue still open? Did the PR get
+approved? Did CI go green? Today jackin' has no GitHub status awareness at
+all — the operator switches to a browser tab to check.
+
+Polling GitHub for every link on every console redraw would burn the rate
+limit instantly, so this needs a small cache and an awareness of which
+states change rarely vs frequently.
+
+## Why It Matters
+
+- It's the most operator-visible payoff of the [tag
+  protocol](/reference/roadmap/agent-tag-protocol/) — without live status,
+  the protocol just stores URLs.
+- It lets the autonomous queue (Phase 4) act on PR state ("re-queue a
+  task whose PR was rejected") without re-implementing GitHub polling
+  inside the queue.
+- It's the lowest-risk way to introduce a third-party network dependency
+  (Octocrab) into jackin's runtime — the surface is narrow (read-only
+  status fetches) and the failure mode is obvious (status cell shows "?").
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Git / GitHub integration](https://github.com/graemerocher/multicode#git--github-integration) (status icons + their meanings)
+- Source — [`lib/src/services/github_status_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/github_status_service.rs) (cadence table, octocrab client, SQLite cache)
+- Source — [`lib/src/schema.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/schema.rs) (`github_link_statuses` table definition)
+
+multicode polls GitHub via Octocrab on a per-link cadence that varies by
+state. Cached in per-workspace SQLite (`.multicode/cache.sqlite`), table
+`github_link_statuses`. Refresh windows:
+
+| State | Refresh after |
+|---|---|
+| Open issue | 10 min |
+| Closed issue | 60 min |
+| PR building | 1 min |
+| PR built, review pending | 5 min |
+| PR approved, awaiting merge | 10 min |
+| PR closed/merged | 60 min |
+| On fetch error | 5 min retry |
+
+Cached fields per row include: URL, kind (issue/PR), host, owner, repo,
+resource number, issue state, PR state, build state, review state, draft
+flag, fetched-at, refresh-after, last error.
+
+The TUI renders icons:
+
+- Issue: blue circle (open), gray X (closed)
+- PR: state colors plus draft badge, build status (running/success/fail),
+  review status (none/pending/changes/approved)
+
+## Recommended Shape
+
+Reuse multicode's polling cadence model verbatim — they did the work to
+calibrate it against real GitHub usage. Use Octocrab as the client.
+Persist via the [persistent storage layer](/reference/roadmap/persistent-storage-layer/).
+
+### Auth source
+
+Reuses the [credential source pattern](/reference/roadmap/credential-source-pattern/):
+the operator's GitHub PAT comes from one of `env`, `command`, `op://`,
+or `keychain`. Required scopes: `public_repo` for public repos,
+`repo` for private. `read:user` for resolving avatars later.
+
+The existing `gh` CLI passthrough is *separate* and remains how the
+container talks to GitHub. The link-tracking client is operator-host
+only — the agent doesn't see the token.
+
+### Schema (in the SQLite layer)
+
+```sql
+CREATE TABLE github_link_statuses (
+    url TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,                  -- 'issue' or 'pr'
+    host TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    resource_number INTEGER NOT NULL,
+    issue_state TEXT,                    -- 'open' | 'closed' | NULL
+    pr_state TEXT,                       -- 'open' | 'merged' | 'closed' | NULL
+    build_state TEXT,                    -- 'pending' | 'success' | 'failure' | 'error' | NULL
+    review_state TEXT,                   -- 'none' | 'pending' | 'changes_requested' | 'approved'
+    pr_is_draft BOOLEAN,
+    fetched_at INTEGER NOT NULL,         -- epoch seconds
+    refresh_after INTEGER NOT NULL,      -- epoch seconds
+    last_error TEXT
+);
+```
+
+Cache is per-instance (each `~/.jackin/data/<container>/` has its own
+SQLite). Sharing a cache across instances would be a small efficiency win
+but creates state-isolation questions — defer.
+
+### Fetcher loop
+
+A single async task per running console session (not per-instance) walks
+all known links across instances, picks ones whose `refresh_after` is
+in the past, fetches in batches of N (default 5) to avoid burst rate
+limit consumption, updates the cache.
+
+Failures: log to `last_error`, set `refresh_after = now + 5 min`,
+console renders a yellow "?" until success.
+
+### Console rendering
+
+Each instance row gets a "Links" cell (or expand-to-detail panel) that
+shows captured `<jackin:issue>` and `<jackin:pr>` markers as colored
+icons, with hover/select revealing details. Clicking opens via the
+[`web` handler](/reference/roadmap/operator-handler-system/).
+
+## Scope (V1)
+
+- Octocrab-based fetcher with multicode's cadence table.
+- Per-instance SQLite cache (depends on
+  [persistent storage layer](/reference/roadmap/persistent-storage-layer/)).
+- Console icons for issue/PR state, build, review.
+- Operator-host PAT via the existing credential resolution
+  (`op://`, `${env.VAR}`, literal). New backends added when [credential
+  source pattern](/reference/roadmap/credential-source-pattern/) lands.
+- Console "Links" panel/cell rendering.
+- Click-to-open via the `web` handler from
+  [operator handler system](/reference/roadmap/operator-handler-system/).
+
+## Defer
+
+- Custom-link CRUD from the console (multicode allows manually adding
+  links not emitted by the agent). Useful but waits — the agent-emitted
+  flow covers the 95% case.
+- GitHub Enterprise host support beyond the standard
+  `https://github.com/<owner>/<repo>` URL pattern. multicode supports it;
+  jackin' V1 should too if cost is low (Octocrab handles GHE clients
+  with one extra config line). Confirm in design.
+- PR review summary text (who approved, what comments). Just state in V1.
+- Cross-link aggregation ("show me all open PRs across all instances").
+  Defer until Phase 4.
+- GitLab / Bitbucket. Defer indefinitely; if demand surfaces, abstract
+  the fetcher behind a `LinkProvider` trait.
+
+## Open Questions
+
+- **Per-instance cache vs operator-global.** Per-instance matches
+  jackin's existing data layout but means a link tracked by two
+  instances gets fetched twice. Recommended default: *per-instance for
+  V1*; revisit if rate-limit pressure shows up.
+- **Token scope guidance.** What's the minimum-privilege token the docs
+  should recommend? `public_repo` works for public-only; private repos
+  need `repo`. multicode docs are clear on this; jackin's docs should
+  match.
+- **GitHub App alternative.** Long-term, a GitHub App (with
+  per-installation tokens) is more durable than a PAT. Defer the design
+  but flag it for the multi-tenant Kubernetes future.
+
+## Related Files
+
+- New module (e.g. `src/runtime/link_tracking.rs`) —
+  fetcher loop + cadence + cache writes
+- <RepoFile path="src/console/manager/state.rs" /> — links panel
+- `src/console/manager/render/` — icon rendering
+- The persistent-storage module owns the SQL schema
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) — input
+- [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) —
+  cache home
+- [Operator handler system](/reference/roadmap/operator-handler-system/) —
+  click-to-open target
+- [Credential source pattern](/reference/roadmap/credential-source-pattern/) —
+  GitHub PAT plumbing

--- a/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
+++ b/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
@@ -1,0 +1,171 @@
+---
+title: "Idle Runtime Cleanup Hooks"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 4, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+A long-running agent container accumulates state outside the agent's own
+working set: a Java agent leaves Gradle daemons holding onto a few GB of
+heap; a Node agent leaves npm caches with thousands of file descriptors;
+the runtime itself caches build artifacts indefinitely. After a few hours
+of an idle agent sitting open, that's real resource cost — both on disk
+and in long-lived processes the operator never asked for.
+
+multicode addresses this with declarative idle hooks: after N seconds of
+inactivity, run a cleanup command (`gradle --stop`, etc.); optionally
+recycle the container.
+
+## Why It Matters
+
+- The autonomous queue (Phase 4) keeps containers warm waiting for work.
+  Without cleanup, those warm containers accumulate state every cycle.
+- It's a small feature with disproportionate impact for long-running
+  fleets — exactly the workflow the program targets.
+- It generalizes naturally to anything an agent class wants done while
+  idle (commit checkpoint snapshots, push WIP branches, evict caches).
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Autonomous queueing](https://github.com/graemerocher/multicode#autonomous-queueing) (the `idle-runtime-cleanup`, `idle-runtime-cleanup-delay-seconds`, `idle-runtime-cleanup-interval-seconds`, and `idle-runtime-restart` knobs are documented here)
+- Config — [`config.toml` `[autonomous]` block](https://github.com/yawkat/multicode/blob/main/config.toml)
+
+```toml
+[autonomous]
+idle-runtime-cleanup = true
+idle-runtime-cleanup-delay-seconds = 300       # idle for 5 min before first cleanup
+idle-runtime-cleanup-interval-seconds = 900    # re-run every 15 min while still idle
+idle-runtime-restart = false                   # also recycle the container?
+```
+
+multicode runs `gradle --stop` and (optionally) terminates remaining
+Gradle daemon/worker processes inside Apple-container workspaces. Then,
+if `idle-runtime-restart = true`, recycles the runtime entirely (stops
+the container, starts a new one).
+
+The implementation watches the workspace status (their equivalent of
+[agent runtime status](/reference/roadmap/agent-runtime-status/)) and
+fires when status has been `Idle` for the configured delay.
+
+## Recommended Shape
+
+Generalize the concept: agent classes declare what to run when idle, the
+operator decides whether to enable it, jackin's runtime supervisor fires
+the hook based on observed status.
+
+### Agent class config
+
+```toml
+# jackin.agent.toml
+
+[runtime.idle]
+commands = [
+  "gradle --stop",
+  "find /home/agent/.cache -atime +1 -delete"
+]
+delay_seconds = 300
+interval_seconds = 900
+restart_after_cleanup = false
+```
+
+`commands` is a list — each runs in sequence inside the agent container
+via `docker exec`. They're the agent class's recommendation; the
+*operator* chooses whether to enable.
+
+### Operator opt-in
+
+```toml
+# operator config
+[agents."the-architect"]
+enable_idle_hooks = true   # default false
+```
+
+Defaults to off because:
+
+- The hooks run inside someone else's container based on the agent
+  class's declarations.
+- Some operators want the warm state preserved.
+- Misconfigured commands could break the running agent.
+
+### Trigger
+
+The supervisor watches the [agent runtime
+status](/reference/roadmap/agent-runtime-status/) bus. When an instance
+has been `Idle` for `delay_seconds` continuously:
+
+1. Run `commands[0]`, `commands[1]`, ... in sequence via `docker exec`.
+   Each command gets a 60-second timeout (configurable).
+2. If `restart_after_cleanup = true`, eject and re-load the instance
+   afterward (preserves the data dir, just recycles the container).
+3. Record the cleanup in the persistent storage layer's `tool_history`
+   table (or a dedicated `cleanup_history`).
+4. Re-arm: next cleanup fires `interval_seconds` later if still idle.
+
+A status transition out of `Idle` cancels the pending cleanup.
+
+### Console visibility
+
+The console resource panel (when open) shows "Last cleanup: 4m ago"
+in the per-agent row. CLI: `jackin status <selector>` includes the
+last-cleanup time.
+
+## Scope (V1)
+
+- `[runtime.idle]` block on `jackin.agent.toml`.
+- Operator opt-in via `enable_idle_hooks` per agent class.
+- Idle detection from the status bus.
+- Sequential command execution via `docker exec` with per-command
+  timeout.
+- Optional `restart_after_cleanup` toggle.
+- Console rendering of last-cleanup time.
+- Cleanup history written to the persistent storage layer.
+
+## Defer
+
+- Idle hooks based on resource thresholds ("cleanup when memory > X")
+  in addition to time-based. Defer.
+- Hooks for other states (busy, question). Idle-only in V1.
+- Per-workspace override of idle config. Agent-class-level only in V1.
+- Operator-defined ad-hoc cleanup commands (not in agent class). Defer;
+  use `jackin exec` instead if needed.
+- Notification on cleanup failure beyond a console toast. Defer.
+
+## Open Questions
+
+- **Default delay/interval values.** multicode uses 300s/900s. Are
+  those sensible jackin defaults, or should agent classes be more
+  conservative? Recommended: *match multicode for V1*; tune from
+  feedback.
+- **Cleanup during foreground operator attach.** If the operator is
+  actively `jackin hardline`'d into an idle session, should cleanup
+  fire? multicode runs it regardless. Recommended: *suppress when
+  attached* — the operator's about-to-type-something signal isn't
+  visible to the status adapter.
+- **Recovery from cleanup-broken-container.** If `restart_after_cleanup`
+  is true and the new container fails to come up, the operator's
+  session is unrecoverable from cleanup alone. Recommended: *one
+  retry, then mark instance failed and surface for operator
+  intervention*.
+
+## Related Files
+
+- New module (e.g. `src/runtime/idle.rs`) — supervisor
+- <RepoFile path="src/manifest/mod.rs" /> — `[runtime.idle]` schema
+- <RepoFile path="src/runtime/launch.rs" /> — wires supervisor into
+  instance lifecycle
+- The persistent-storage module — cleanup history table
+- <RepoFile path="src/console/manager/state.rs" /> — last-cleanup
+  display
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) —
+  required idle signal
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) —
+  primary beneficiary (queue-warm containers cleaned regularly)
+- [Console resource panel](/reference/roadmap/console-resource-panel/) —
+  visibility surface

--- a/docs/src/content/docs/reference/roadmap/jackin-remote.mdx
+++ b/docs/src/content/docs/reference/roadmap/jackin-remote.mdx
@@ -1,0 +1,208 @@
+---
+title: "jackin-remote (run on another machine, attend from laptop)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 5, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Some agent workloads don't fit on the operator's laptop. A long parallel
+queue, a CPU-heavy build pipeline, or a memory-hungry indexing job all
+benefit from running on a beefy host (cloud VM, home server, office
+workstation) while the operator continues to use their laptop normally.
+
+Today, jackin' has no story for this. Operators either run jackin' over
+SSH (losing all of the console UX), set up a manual SSH-mounted workspace
+(losing the data-dir guarantees), or simply don't.
+
+multicode addresses this with `multicode-remote`: a small helper binary
+that runs the multicode TUI on the local laptop while the actual agents
+run on a remote machine, with bidirectional rsync of workspace state and
+SSH-relayed handler invocations (open links in the local browser, etc.).
+
+## Why It Matters
+
+- Real workloads — queue-driven fleets, CI-adjacent agent runs — push
+  past laptop resources fast.
+- The Kubernetes platform vision in the [roadmap
+  vision](/reference/roadmap/#vision) addresses this long-term, but is
+  far away. A simpler SSH-bridge sits naturally between local-only and
+  full Kubernetes.
+- It demonstrates that jackin's agent-class + workspace + queue model
+  is location-independent — exactly the kind of property a "general
+  tool" claim needs.
+
+This item is explicitly **deferred** until Phase 1–4 are stable, because
+remote operation only adds value once there's a meaningful workload to
+move off the laptop.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [multicode-remote](https://github.com/graemerocher/multicode#multicode-remote)
+- Source — [`remote/src/main.rs`](https://github.com/yawkat/multicode/blob/main/remote/src/main.rs) (the `multicode-remote` binary entry point)
+- Source — [`remote/src/orchestration.rs`](https://github.com/yawkat/multicode/blob/main/remote/src/orchestration.rs) (SSE relay, file sync, symlink dereferencing)
+- Source — [`lib/src/remote_action.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/remote_action.rs) (handler-relay protocol — `RemoteActionRequest`)
+- Config — [`config.toml` `[remote]` block](https://github.com/yawkat/multicode/blob/main/config.toml) (sync intervals, sync-up/sync-bidi mounts, install command)
+
+`multicode-remote`:
+
+- Cross-compiled binary distributed via `make multicode-remote`.
+- Runs on the local laptop: `multicode-remote --ssh user@host config.toml`.
+- Establishes an SSH session to the remote multicode instance.
+- Rsync syncs workspace state bidirectionally on a configurable interval
+  (default 2 sec). Three sync modes: `sync-up` (one-way local → remote),
+  `sync-bidi` (bidirectional with exclusion patterns), and an explicit
+  install command for first-time remote setup.
+- Relays handler actions: when an agent emits a link the operator
+  clicks, the action fires on the *local* laptop (browser open, IDE
+  launch) even though the agent runs remote.
+- Synchronizes credentials (GitHub PAT, OpenCode auth) up to the remote
+  before agents need them.
+
+## Recommended Shape
+
+The fundamental architecture choice for jackin's version:
+
+**Option A — SSH + rsync**, like multicode-remote. Pros: simple, no new
+protocols, works through any SSH-accessible host. Cons: rsync polling
+adds latency, file-conflict resolution is rsync-shaped (which is fine
+but unsubtle), credential plumbing requires care.
+
+**Option B — Agent gRPC**, jackin' on the remote exposes a typed gRPC
+endpoint, the local UI is a thin client. Pros: low-latency, structured
+events (not file syncs), easier to extend. Cons: another protocol to
+maintain, harder to operate over restrictive networks.
+
+**Option C — Defer to Kubernetes**. Don't build SSH bridge; wait for
+the K8s platform support and let pod-attach be the remote story. Pros:
+one architecture for "remote", not two. Cons: years away; ignores the
+simpler "I have one home server" use case entirely.
+
+Recommendation: **Option A for V1**, designed so the eventual K8s story
+absorbs it without rewrite. Most jackin' state already lives in
+`~/.jackin/data/<container>/` — rsync of that tree over SSH is the
+natural fit.
+
+### Components
+
+```
+jackin-remote (local laptop)
+   └── ssh ──> jackin (remote host)
+       ├── runs agents in Docker as usual
+       └── exposes a small RPC endpoint (over SSH stdin/stdout) for:
+           - status events streamed back
+           - handler invocation requests forwarded back
+```
+
+### Config
+
+```toml
+# ~/.config/jackin/remote.toml (or section of operator config)
+
+[remote.dev-server]
+ssh = "user@dev-server.local"
+remote_jackin_path = "/usr/local/bin/jackin"
+sync_interval_seconds = 2
+
+[[remote.dev-server.sync_up]]
+local = "~/.config/jackin"
+remote = "~/.config/jackin"
+
+[[remote.dev-server.sync_bidi]]
+local = "~/dev/projects"
+remote = "~/dev/projects"
+exclude = ["target/", "node_modules/", ".jackin/"]
+
+[remote.dev-server.install]
+command = "curl -fsSL https://jackin.tailrocks.com/install.sh | bash"
+```
+
+### CLI
+
+```sh
+# Bring up the remote, sync config, run the local console attached to
+# the remote agent fleet:
+jackin --remote dev-server console
+
+# Run a one-off load against the remote:
+jackin --remote dev-server load the-architect
+
+# Sync stale state without launching anything:
+jackin --remote dev-server sync
+```
+
+### Handler relay
+
+When the operator clicks a link in the *local* console, the click fires
+on the *local* host (browser, IDE) — not on the remote. Implementation:
+the remote sends a structured `RemoteAction { kind: web|ide|diff,
+argument: url|path }` event over the SSH channel; the local
+`jackin-remote` decodes it and invokes the configured local handler.
+
+### Credentials
+
+The operator's local credential resolution
+([credential source pattern](/reference/roadmap/credential-source-pattern/))
+runs locally. Resolved credentials are passed to the remote *per
+invocation*, never persisted there. This matches multicode's posture
+and avoids leaving long-lived secrets on a shared host.
+
+## Scope (V1)
+
+- A `jackin-remote` binary, cross-compilable from the same repo.
+- SSH-based control + rsync-based state sync.
+- Per-host config under `[remote.<name>]`.
+- `jackin --remote <name> ...` flag at the top of every subcommand.
+- Local handler relay for `web`, `ide`, `diff`.
+- Local credential resolution; per-invocation push to remote.
+- Install command: one-time bootstrap of the remote host.
+- Console attaches to remote agents transparently.
+
+## Defer
+
+- Multi-remote orchestration ("dispatch this queue across three
+  hosts"). Single-remote in V1.
+- Audio/visual desktop redirection (ssh -Y). Out of scope.
+- Container migration between hosts. Out of scope.
+- Direct gRPC alternative (Option B). Defer; revisit if SSH-bridge
+  pain is real.
+- Mobile / web client. Out of scope.
+
+## Open Questions
+
+- **Sync of `~/.jackin/data/<container>/`.** Does the local copy mirror
+  the remote, or does only the remote keep state? Recommended: *only
+  the remote*. Local copy via rsync is a recovery aid, not a primary
+  copy. Avoids confusing "which side is authoritative" questions.
+- **Status bus over SSH.** [Agent runtime
+  status](/reference/roadmap/agent-runtime-status/) events need to
+  reach the local console. SSE-style stream over the SSH channel is
+  natural. Confirm latency is acceptable for a console redraw.
+- **Kubernetes overlap.** When the K8s platform vision lands, does
+  `jackin-remote` get deprecated, refactored, or absorbed? Recommended:
+  *design now so it can be a thin shim later* — most of the work
+  (handler relay, credential push, console attach) is reusable.
+- **Trust model.** A compromised remote can read everything jackin'
+  knows about. This is implicit in any remote-execution tool;
+  document it clearly. Recommended: *don't try to make remote-host
+  isolation a feature*; that's the wrong scope.
+
+## Related Files
+
+- New crate or workspace member (`jackin-remote/`).
+- <RepoFile path="src/cli/agent.rs" /> — `--remote` flag plumbing
+- New module — SSH bridge + rsync orchestration + handler relay
+- The handler-system module — local-side invocation paths
+- The credential-source module — per-invocation push
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Operator handler system](/reference/roadmap/operator-handler-system/) —
+  local handler invocation
+- [Credential source pattern](/reference/roadmap/credential-source-pattern/) —
+  local resolution → remote push
+- [Roadmap vision](/reference/roadmap/#vision) — the long-term K8s
+  platform direction this lives between

--- a/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
+++ b/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
@@ -1,0 +1,343 @@
+---
+title: "Universal Orchestrator Program (multicode-Inspired)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design program (18 leaf items across 5 phases)
+
+## Goal
+
+Make jackin' the canonical, vendor-neutral orchestrator for parallel AI coding
+agents. Today the project's primitives — Docker isolation, per-mount worktrees,
+multi-runtime support, agent class repos — are the strongest in the space, but
+the **operator-facing surface** (live status, queue, telemetry, remote
+operation) lags behind every adjacent tool: `multicode`, Docker Sandboxes,
+Conductor, the upstream Claude Code devcontainer, and the various private
+internal tools teams keep reinventing.
+
+This program closes that gap. The thesis is that organizations should not be
+re-implementing the same orchestrator stack inside every codebase — instead,
+they should compose on top of jackin's primitives and share the operator
+surface. To make that possible, jackin' needs a small set of foundation
+features it currently lacks: live agent status, persistent operator-facing
+state, declarative resource limits, a task-source abstraction, and credential
+plurality.
+
+The reference comparison is [`yawkat/multicode`](https://github.com/yawkat/multicode)
+(and its [`graemerocher/multicode`](https://github.com/graemerocher/multicode)
+fork), which solves the *fleet-operations* problem on the same substrate
+jackin' already has. multicode's design choices are surveyed in detail below;
+each leaf item links back to the specific multicode mechanism that inspired it
+and explains how the jackin' equivalent should differ.
+
+This master doc is structured exactly like
+[Codebase readability & restructuring](/reference/roadmap/codebase-readability/)
+— phases with one-line rows, each linking to a self-contained leaf item.
+
+## Surface comparison: jackin' vs multicode
+
+This is the exhaustive feature inventory the program is built from. **Have**
+means present in jackin' today; **planned** means a roadmap item already
+exists; **gap** means truly missing. Items in *italics* are addressed by this
+program.
+
+| Concern | multicode | jackin' status |
+|---|---|---|
+| Agent isolation | `bwrap` + `systemd-run`; Apple `container` | Have — Docker + DinD; planned — [selectable backends](/reference/roadmap/selectable-sandbox-backends/) |
+| Per-agent working tree | Workspace dir; one repo per workspace | Have — V1 [worktree isolation](/reference/roadmap/per-mount-isolation/); clone planned |
+| Mount kinds beyond `shared`/`readonly` | `writable`, `readable`, `isolated`, `tmpfs` | Partial — `shared` + `readonly`; *gap on `tmpfs` and ephemeral, see [Ephemeral mount modes](/reference/roadmap/ephemeral-mount-modes/)* |
+| Multi-provider agent runtime | OpenCode + Codex (one per session) | Planned — [multi-runtime](/reference/roadmap/multi-runtime-support/) per-instance |
+| Resource limits per agent | `memory-high`, `memory-max`, `cpu` (cgroups) | *Gap — see [Declarative resource limits](/reference/roadmap/declarative-resource-limits/)* |
+| Live agent status (idle/busy/question) | Yes — derived from opencode SSE events | *Gap — see [Agent runtime status](/reference/roadmap/agent-runtime-status/)* |
+| Live machine resource panel (CPU/RAM/disk) | Yes — `/proc/stat`, `/proc/meminfo`, sampled per 2s | *Gap — see [Console resource panel](/reference/roadmap/console-resource-panel/)* |
+| Per-agent token / cost / OOM tracking | Yes — usage_aggregation_service | *Gap — see [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/)* |
+| Agent → operator tag protocol | Yes — `<multicode:repo>` / `<multicode:issue>` / `<multicode:pr>` | *Gap — see [Agent tag protocol](/reference/roadmap/agent-tag-protocol/)* |
+| Live GitHub link state polling | Yes — octocrab + per-workspace SQLite cache | *Gap — see [GitHub link tracking](/reference/roadmap/github-link-tracking/)* |
+| Persistent storage backend | Per-workspace SQLite + per-workspace JSON | *Gap — see [Persistent storage layer](/reference/roadmap/persistent-storage-layer/)* |
+| Workspace archive / unarchive | Yes — tar.zstd / tar.xz / zip with auto-detect | *Gap — see [Workspace archive](/reference/roadmap/workspace-archive/)* |
+| Per-workspace operator description | Yes — inline-editable note in TUI | *Gap — see [Workspace description](/reference/roadmap/workspace-description/)* |
+| External tool/IDE/diff launcher | Yes — `[handler]` block, `[[tool]]` array | *Gap — see [Operator handler system](/reference/roadmap/operator-handler-system/)* |
+| Custom operator-defined tools | Yes — `[[tool]]` array, hotkey + exec/prompt type | *Gap — see [Custom operator tools](/reference/roadmap/custom-operator-tools/)* |
+| Autonomous task queue | No (manual) — but the substrate (status, persistence) is there | *Gap — see [Autonomous task queue](/reference/roadmap/autonomous-task-queue/)* |
+| Task source abstraction | No — workspaces are manually created | *Gap — see [Task source abstraction](/reference/roadmap/task-source-abstraction/)* |
+| Idle runtime cleanup | Yes — `gradle --stop`, container recycle | *Gap — see [Idle runtime cleanup](/reference/roadmap/idle-runtime-cleanup/)* |
+| Remote orchestration | Yes — `multicode-remote` SSH bridge + rsync | *Gap — see [jackin-remote](/reference/roadmap/jackin-remote/)* |
+| Workspace skills mount | Yes — `add-skills-from` mounts to `~/.config/<provider>/skills/` | *Gap — see [Workspace skills mount](/reference/roadmap/workspace-skills-mount/)* |
+| Credential source plurality | Three backends — `env`, `command`, keychain | Partial — `op://` and `${env.VAR}` shipped; *see [Credential source pattern](/reference/roadmap/credential-source-pattern/)* |
+| GitHub CLI auth passthrough | Yes (read-only mount) | Have |
+| Operator console / TUI | Yes — ratatui, full-time | Have — `jackin console` (less feature-rich than CLI on purpose) |
+| Agent class repo contract | Implicit via `add-skills-from` | Have — `jackin.agent.toml` + `Dockerfile` |
+| Sensitive mount warnings | No | Have |
+
+### Where multicode genuinely shines
+
+The deep-dive identified five areas where multicode's design is materially
+ahead of jackin':
+
+1. **Live observability of the agent.** multicode parses opencode SSE events
+   in real time, derives `Idle | Busy | Question` status, surfaces it as a
+   colored column, and persists token/cost/OOM counts. jackin's CLI is
+   intentionally opaque to agent runtime; closing this gap is the prerequisite
+   for almost everything in Phase 2 onward.
+2. **Per-workspace persistent SQLite.** A small but distinctive choice that
+   underpins their GitHub status cache, archive metadata, custom links, and
+   future telemetry. jackin' currently has zero structured persistence beyond
+   per-instance filesystem state — adding it once enables five other items
+   here.
+3. **The agent → TUI tag protocol.** `<multicode:issue>`, `<multicode:pr>`,
+   `<multicode:repo>` turn the agent into an observable workflow node without
+   tooling having to scrape stdout. The protocol is small, optional, and
+   skill-driven — the right shape to borrow in a vendor-neutral form.
+4. **Per-workspace resource limits as first-class config.** `memory-high` /
+   `memory-max` / `cpu` are declared in TOML and translated to `systemd-run`
+   properties. jackin's Docker substrate has the same primitives via cgroups;
+   the absence is just config-surface design, not a runtime gap.
+5. **Operator extension points.** The `[handler]` block (review viewer, web
+   launcher) and `[[tool]]` array (custom hotkeys with exec/prompt actions)
+   make the TUI an extensible operator surface, not a fixed UI. jackin's
+   console is currently fixed-shape.
+
+### Where jackin' is materially ahead — and should stay ahead
+
+These are the design choices the program intentionally **does not borrow**.
+They are jackin's identity:
+
+- **Cross-platform Docker substrate** vs Linux-only `bwrap`. Switching would
+  forfeit macOS/Windows support; the right shape is the existing
+  [selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/)
+  roadmap.
+- **Per-instance multi-runtime** vs one provider per session. Operators
+  running one Claude agent and one Codex agent in the same console is the
+  jackin' design target;
+  [multi-runtime](/reference/roadmap/multi-runtime-support/) keeps the
+  per-instance boundary deliberately.
+- **Agent class repos as the unit of distribution** vs ad-hoc skill mounts.
+  multicode mounts skill markdown files; jackin' ships full agent classes
+  (Dockerfile + manifest + plugins). Workspace-skills mount is a *complement*
+  to that model, not a replacement.
+- **CLI-first with TUI as a simplified front** vs TUI-first. Niche operator
+  flows belong on the CLI; the console stays approachable. See the
+  `naming conventions` section in <RepoFile path="docs/AGENTS.md" />.
+- **Toolchain-neutral**. multicode bakes in Java/Gradle defaults because it
+  was built for Micronaut. jackin' does not — agent classes carry toolchain
+  choices, the orchestrator stays neutral.
+
+## Phase 1 — Foundation gaps (parallel-safe, low risk)
+
+These are surface-level features that don't touch agent runtime or persistence.
+Each is small enough to be one PR per item and they can land in any order.
+They are the lightest borrows from multicode and the most obvious
+operator-quality wins. Ephemeral mount modes touches isolation but is purely
+additive to the V1 enum.
+
+| Item | Inspiration in multicode | Depends on |
+|---|---|---|
+| [Workspace description](/reference/roadmap/workspace-description/) | Inline-editable note in TUI overview | — |
+| [Operator handler system](/reference/roadmap/operator-handler-system/) | `[handler]` block (review/web) | — |
+| [Workspace archive](/reference/roadmap/workspace-archive/) | TUI `a` archive + auto-detect on startup | — |
+| [Declarative resource limits](/reference/roadmap/declarative-resource-limits/) | `[isolation]` `memory-high`/`memory-max`/`cpu` | — |
+| [Ephemeral mount modes](/reference/roadmap/ephemeral-mount-modes/) | `[isolation] isolated = [...]` and `tmpfs = [...]` | — |
+
+## Phase 2 — Live operator surface
+
+These items make the operator console observable. They touch agent runtime
+output (status), Docker stats (resource panel), agent stdout parsing (tag
+protocol), and a remote API (GitHub polling). They depend on each other only
+loosely — the SQLite layer in Phase 3 is helpful for GitHub link tracking but
+not strictly required for an in-memory V1.
+
+| Item | Inspiration in multicode | Depends on |
+|---|---|---|
+| [Agent runtime status](/reference/roadmap/agent-runtime-status/) | `root_session_status` derived from SSE | Multi-runtime adapter seam |
+| [Console resource panel](/reference/roadmap/console-resource-panel/) | `/proc/stat` + `/proc/meminfo` polling | Resource limits (Phase 1) |
+| [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) | `<multicode:*>` skill-driven tags | Agent runtime status |
+| [GitHub link tracking](/reference/roadmap/github-link-tracking/) | octocrab polling + SQLite cache | Tag protocol; persistent storage (Phase 3) |
+| [Custom operator tools](/reference/roadmap/custom-operator-tools/) | `[[tool]]` array (hotkey + exec/prompt) | Operator handler system (Phase 1) |
+
+## Phase 3 — Persistence & telemetry (foundation for Phase 4)
+
+A small SQLite layer scoped per-instance, plus the cost/token/usage tracking
+that consumes it. This phase is genuinely foundational — three Phase 4 items
+and at least one Phase 2 item rely on it.
+
+| Item | Inspiration in multicode | Depends on |
+|---|---|---|
+| [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) | Per-workspace `.multicode/cache.sqlite` | — |
+| [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/) | `usage_aggregation_service` | Persistent storage; agent runtime status |
+
+## Phase 4 — Fleet operations
+
+The autonomous-queue cluster. Once the operator surface is observable and
+state is persistent, jackin' has every primitive needed to host a queue:
+"point a workspace at a task source, leave it alone, come back to N attempted
+PRs." Each piece is independently usable but the queue itself depends on
+sources, status, and persistence already being in place.
+
+| Item | Inspiration in multicode | Depends on |
+|---|---|---|
+| [Task source abstraction](/reference/roadmap/task-source-abstraction/) | Implicit (autonomous queue scans GitHub issues) | — |
+| [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) | `max-parallel-issues`, `issue-scan-delay-seconds`, etc. | Task source; persistent storage; agent runtime status |
+| [Idle runtime cleanup](/reference/roadmap/idle-runtime-cleanup/) | `idle-runtime-cleanup` toggle, `gradle --stop` | Agent runtime status |
+
+## Phase 5 — Distributed operation & extensibility
+
+These items shift jackin' from "one operator on one machine" to "a tool a team
+or organization composes on." They are large, deferable, and explicitly gated
+on the rest of the program landing first. None of them blocks anything else.
+
+| Item | Inspiration in multicode | Depends on |
+|---|---|---|
+| [jackin-remote](/reference/roadmap/jackin-remote/) | `multicode-remote` SSH bridge + rsync | All Phase 1–3; multi-runtime |
+| [Credential source pattern](/reference/roadmap/credential-source-pattern/) | `[github].token` with `env`, `command`, or keychain backend | — (cross-cutting refactor) |
+| [Workspace skills mount](/reference/roadmap/workspace-skills-mount/) | `add-skills-from` provider-skill bind mounts | Multi-runtime |
+
+## Execution order (recommended)
+
+This is a *guide*, not a constraint — items marked "parallel-safe" can land in
+any order within their phase.
+
+1. **Phase 1 quick wins** — workspace description, archive, handler system,
+   resource limits. Each ships a small PR and shrinks the gap visibly. Aim
+   for these to land while [multi-runtime](/reference/roadmap/multi-runtime-support/)
+   Phase 1 is in flight, since they share neither code nor reviewers.
+2. **Persistent storage layer (Phase 3)** — land this *before* Phase 2's
+   GitHub link tracking and *before* Phase 4 starts. It's small enough to
+   bring forward and large enough downstream that retrofitting hurts. Token &
+   cost telemetry can lag.
+3. **Phase 2 live surface** — agent runtime status first (it's the seam every
+   later observability item depends on). Then console resource panel, tag
+   protocol, GitHub link tracking, custom tools — in roughly that order.
+4. **Phase 4 fleet operations** — task source abstraction, then queue, then
+   idle cleanup. Don't start until Phase 3 storage is shipped.
+5. **Phase 5 distribution & extensibility** — defer until at least Phase 1–3
+   are complete. jackin-remote in particular benefits from the Kubernetes
+   platform work (see [roadmap vision](/reference/roadmap/#vision)) and may be
+   reshaped or absorbed by it.
+
+## Key structural insights
+
+These three observations shaped the phase split:
+
+1. **Live status is the substrate, not a feature.** Almost every multicode
+   capability — autonomous queue, GitHub link cache, idle cleanup, cost
+   tracking — derives from a runtime-aware status stream. Without it, jackin'
+   can't host the rest of the program. That's why
+   [agent runtime status](/reference/roadmap/agent-runtime-status/) leads
+   Phase 2 and is on the dependency edge of three other items.
+2. **Per-instance SQLite enables five separable items.** GitHub cache,
+   archive flag, agent-provided links, custom links, telemetry. Designing it
+   once at Phase 3 instead of bolting per-feature stores onto each Phase 2/4
+   item is the cheapest path. The schema is small (a handful of tables) and
+   the operational story (one DB per `~/.jackin/data/<instance>/`) is
+   already shaped for it.
+3. **The TUI tag protocol is small but consequential.** `<jackin:*>` is a
+   forever decision once published. The leaf doc treats it as a vendor-neutral
+   namespace with skill-driven emission and graceful console degradation —
+   not a runtime contract. That keeps it inside jackin's "agent runtime is
+   opaque" identity while still enabling the live surface multicode shows is
+   useful.
+
+## Out of scope for this program
+
+The following adjacent items have their own roadmap items and are referenced,
+not duplicated, here:
+
+- [Multi-runtime support](/reference/roadmap/multi-runtime-support/) — Codex
+  / Amp / Claude as selectable per-instance runtimes. This program's Phase 2+
+  items assume the runtime adapter seam from that work exists.
+- [Per-mount isolation](/reference/roadmap/per-mount-isolation/) — `worktree`
+  mode shipped in V1; `clone` mode planned for V1.1. This program's queue
+  and parallel-agent assumptions rely on isolated mounts.
+- [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) —
+  cross-backend resource-limit translation lives there, not in this program.
+- [1Password integration](/reference/roadmap/onepassword-integration/) and
+  [Claude auth strategy](/reference/roadmap/claude-auth-strategy/) — both
+  consume the [credential source pattern](/reference/roadmap/credential-source-pattern/)
+  cross-cutting note.
+- [Custom plugin marketplace](/reference/roadmap/custom-plugin-marketplace/) —
+  Claude-specific; orthogonal to the multi-runtime skill-mount approach in
+  Phase 5.
+
+## Open program-level questions
+
+Three calls that affect more than one leaf and should be made before the
+program's first PR lands. Each leaf item that depends on the answer flags it
+explicitly.
+
+1. **TUI tag protocol commitment.** Adopt `<jackin:*>` as a vendor-neutral
+   namespace, decline outright, or keep multi-vendor (`<jackin:*>` plus
+   honoring `<multicode:*>` etc.)? Recommended default: *adopt with namespace,
+   document multi-vendor as future-compatible*.
+2. **Persistent storage scope.** Per-instance SQLite (one DB per agent) or
+   single global SQLite (one DB for the operator)? Recommended default:
+   *per-instance*, mirroring multicode and matching jackin's existing
+   `~/.jackin/data/<instance>/` layout.
+3. **Task source identity.** Is a task source workspace-bound, agent-bound, or
+   operator-global? Recommended default: *workspace-bound*, since the queue's
+   parallelism limit (`max_parallel`) is naturally scoped to one workspace's
+   resources.
+
+## See also
+
+- [Codebase readability & restructuring](/reference/roadmap/codebase-readability/) —
+  the structural reference for this program's tree shape
+- [Multi-runtime support](/reference/roadmap/multi-runtime-support/) — the
+  primary upstream dependency
+- [Per-mount isolation](/reference/roadmap/per-mount-isolation/) — the
+  parallel-agent prerequisite
+- [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) —
+  where cross-backend resource-limit translation lives
+
+## Source materials
+
+The two multicode repositories that informed this program:
+
+- [`yawkat/multicode`](https://github.com/yawkat/multicode) — the original
+  Micronaut-issue orchestrator (OpenCode provider). Canonical source for
+  description, archive, multicode-remote, isolation, GitHub integration,
+  authentication, and the workspace-skills system.
+- [`graemerocher/multicode`](https://github.com/graemerocher/multicode) —
+  fork that adds Codex provider support, an editor-tool selector, and an
+  expanded `[autonomous]` queue config. Canonical source for editor tool,
+  autonomous queueing, agent configuration, and Apple-container Isolation
+  extensions. This fork has the more comprehensive operator-facing README
+  and is preferred for README links.
+
+### README sections referenced by the leaves
+
+| README anchor | Used by |
+|---|---|
+| [Editor Tool](https://github.com/graemerocher/multicode#editor-tool) | [operator-handler-system](/reference/roadmap/operator-handler-system/) |
+| [Workspaces](https://github.com/graemerocher/multicode#workspaces) | (jackin already has) |
+| [Autonomous queueing](https://github.com/graemerocher/multicode#autonomous-queueing) | [task-source-abstraction](/reference/roadmap/task-source-abstraction/), [autonomous-task-queue](/reference/roadmap/autonomous-task-queue/), [idle-runtime-cleanup](/reference/roadmap/idle-runtime-cleanup/) |
+| [Agent configuration](https://github.com/graemerocher/multicode#agent-configuration) | (already covered by [multi-runtime](/reference/roadmap/multi-runtime-support/)) |
+| [Isolation](https://github.com/graemerocher/multicode#isolation) | [declarative-resource-limits](/reference/roadmap/declarative-resource-limits/), [ephemeral-mount-modes](/reference/roadmap/ephemeral-mount-modes/), [workspace-skills-mount](/reference/roadmap/workspace-skills-mount/) |
+| [Git / GitHub integration](https://github.com/graemerocher/multicode#git--github-integration) | [agent-tag-protocol](/reference/roadmap/agent-tag-protocol/), [github-link-tracking](/reference/roadmap/github-link-tracking/) |
+| [Authentication](https://github.com/graemerocher/multicode#authentication) | [credential-source-pattern](/reference/roadmap/credential-source-pattern/) |
+| [Description](https://github.com/graemerocher/multicode#description) | [workspace-description](/reference/roadmap/workspace-description/) |
+| [Archiving](https://github.com/graemerocher/multicode#archiving) | [workspace-archive](/reference/roadmap/workspace-archive/) |
+| [multicode-remote](https://github.com/graemerocher/multicode#multicode-remote) | [jackin-remote](/reference/roadmap/jackin-remote/) |
+
+### Source files referenced by the leaves
+
+For features without dedicated README documentation, leaves link directly to
+multicode source. Use the `yawkat/multicode/main` branch as the canonical
+implementation reference unless otherwise noted.
+
+| Multicode source | Used by |
+|---|---|
+| [`config.toml`](https://github.com/yawkat/multicode/blob/main/config.toml) | reference for every TOML schema borrow |
+| [`lib/src/database.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/database.rs), [`schema.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/schema.rs), [`services/persistent_storage.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/persistent_storage.rs) | [persistent-storage-layer](/reference/roadmap/persistent-storage-layer/) |
+| [`services/github_status_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/github_status_service.rs) | [github-link-tracking](/reference/roadmap/github-link-tracking/) |
+| [`services/usage_aggregation_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/usage_aggregation_service.rs) | [token-cost-telemetry](/reference/roadmap/token-cost-telemetry/) |
+| [`services/resource_usage_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/resource_usage_service.rs) | [console-resource-panel](/reference/roadmap/console-resource-panel/), [token-cost-telemetry](/reference/roadmap/token-cost-telemetry/) |
+| [`services/root_session_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/root_session_service.rs), [`opencode_client_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/opencode_client_service.rs) | [agent-runtime-status](/reference/roadmap/agent-runtime-status/) |
+| [`services/workspace_archive.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/workspace_archive.rs) | [workspace-archive](/reference/roadmap/workspace-archive/), [workspace-description](/reference/roadmap/workspace-description/) |
+| [`lib/src/manager.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/manager.rs) | [autonomous-task-queue](/reference/roadmap/autonomous-task-queue/), [task-source-abstraction](/reference/roadmap/task-source-abstraction/) |
+| [`lib/src/remote_action.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/remote_action.rs), [`remote/src/orchestration.rs`](https://github.com/yawkat/multicode/blob/main/remote/src/orchestration.rs) | [jackin-remote](/reference/roadmap/jackin-remote/) |
+| [`tui/src/app.rs`](https://github.com/yawkat/multicode/blob/main/tui/src/app.rs), [`render.rs`](https://github.com/yawkat/multicode/blob/main/tui/src/render.rs) | [console-resource-panel](/reference/roadmap/console-resource-panel/), [custom-operator-tools](/reference/roadmap/custom-operator-tools/) |
+| [`workspace-skills/`](https://github.com/yawkat/multicode/tree/main/workspace-skills) | [agent-tag-protocol](/reference/roadmap/agent-tag-protocol/), [workspace-skills-mount](/reference/roadmap/workspace-skills-mount/) |
+
+For verification: each leaf's `## Inspiration in multicode` section starts
+with a **Sources** block carrying the same links scoped to that leaf, so
+opening any leaf gives you a one-click path to the multicode reference.

--- a/docs/src/content/docs/reference/roadmap/operator-handler-system.mdx
+++ b/docs/src/content/docs/reference/roadmap/operator-handler-system.mdx
@@ -1,0 +1,166 @@
+---
+title: "Operator Handler System (IDE / diff / browser launchers)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 1, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+When an operator wants to act on something the agent produced — review a
+diff, open the workspace in an IDE, follow a link the agent printed — they
+have to context-switch to a separate shell, copy the path, run the right
+launcher manually. Every adjacent tool in this space (multicode, Conductor,
+Docker Sandboxes) ships an external-launcher abstraction precisely because
+this friction kills the "left it running overnight" workflow.
+
+jackin' has no such abstraction today, so each future feature that needs to
+launch an external tool would invent its own.
+
+## Why It Matters
+
+- The console (today) and any future TUI need to know how to "open" a path,
+  URL, or repo without hardcoding `open` / `xdg-open`.
+- Multiple downstream items in this program need it: [GitHub link
+  tracking](/reference/roadmap/github-link-tracking/) opens issue/PR URLs,
+  [agent tag protocol](/reference/roadmap/agent-tag-protocol/) opens repo
+  paths, [custom operator tools](/reference/roadmap/custom-operator-tools/)
+  expand exec templates that eventually want the same launcher resolution.
+- Designing the abstraction once means cross-platform handling (`open` on
+  macOS, `xdg-open` on Linux, OS-native file URLs) lives in one place.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Editor Tool](https://github.com/graemerocher/multicode#editor-tool) (covers the `[compare]` block for IDE selection)
+- Config — [`config.toml` `[handler]` block](https://github.com/yawkat/multicode/blob/main/config.toml)
+
+```toml
+[handler]
+review = "/usr/bin/smerge ."          # chdir-mode launcher (no {} placeholder)
+review-pty = false                     # allocate a PTY for the launcher?
+web = "/usr/bin/firefox {}"            # template-mode launcher (single {} required)
+```
+
+multicode also exposes a `[compare]` block (in the graemerocher fork) that
+specifies the IDE for "open in editor":
+
+```toml
+[compare]
+tool = "vscode"   # or "intellij"
+command = "..."   # optional override
+```
+
+The TUI keystrokes `r` (review = open diff viewer for repo) and `e` (open in
+IDE) call the resolved handler. Both blocks are loaded once at startup; no
+hot-reload.
+
+## Recommended Shape
+
+One unified `[handler]` block. The `[compare]`-style IDE selector folds in
+as another handler kind, not a separate block.
+
+### Config
+
+```toml
+[handler.diff]
+# Diff viewer for a repo path. Invoked chdir-mode by default (cwd = arg).
+command = "/opt/homebrew/bin/smerge"
+mode = "chdir"
+
+[handler.web]
+# URL launcher.
+command = "open {}"   # macOS default; Linux default would be `xdg-open {}`
+mode = "template"
+
+[handler.ide]
+# IDE on a workspace path. Either a tool name (resolved via well-known list)
+# or a full command.
+tool = "vscode"
+# command = "code -n -g {}"     # optional explicit override
+```
+
+Resolution rules:
+
+- `diff` defaults to `git diff` (in-terminal) if no command is configured.
+- `web` defaults to `xdg-open {}` on Linux, `open {}` on macOS, none on
+  unsupported platforms (handler returns "no web handler configured").
+- `ide.tool` accepts at least `vscode`, `intellij`, `zed`, `cursor`, plus
+  `none` to disable. The well-known table is small and operator-extensible
+  via `command = "..."`.
+- `mode = "chdir"` means the handler runs with cwd set to the argument and
+  no argument substitution; `mode = "template"` requires a single `{}` and
+  substitutes verbatim.
+
+### CLI
+
+```sh
+jackin open <selector>           # IDE handler
+jackin diff <selector>           # diff handler (in-terminal `git diff` by default)
+jackin web <url>                 # web handler — explicit URL form
+```
+
+Subcommands accept the same selector grammar as `jackin load`. They resolve
+the workspace's primary mount path (or, if isolated, the materialized
+worktree path under
+`<data_dir>/jackin-<container>/git/worktree/repo/<dst-tree>/<container>/`)
+before invoking the handler.
+
+### Console
+
+Single keystroke per handler when a workspace row is selected: `o` (open in
+IDE), `d` (diff), `w` (web — only meaningful when a link is selected).
+
+## Scope (V1)
+
+- `[handler.diff]`, `[handler.web]`, `[handler.ide]` config blocks at the
+  operator-config level.
+- Cross-platform defaults baked in for `web` and a sensible default for
+  `diff` (`git diff` in terminal).
+- IDE well-known table covering the four named editors above.
+- CLI subcommands `jackin open`, `jackin diff`, `jackin web`.
+- Console keybindings for diff and IDE.
+- For worktree-isolated mounts, default to opening the materialized
+  worktree; provide a flag (CLI) and Shift-modifier (console) to open the
+  host repo path instead.
+
+## Defer
+
+- Per-workspace handler overrides. Operator-config-level only in V1; if a
+  use case surfaces (e.g. one workspace wants its own IDE), revisit.
+- In-console diff renderer. multicode uses an external viewer; jackin
+  console gets `git diff` in a paged view, that's enough.
+- PTY allocation for the diff handler (`review-pty` in multicode). Defer
+  until someone reports an issue with a TTY-aware diff tool.
+
+## Open Questions
+
+- Where does the operator-config file live for handlers? Options: extend
+  the existing operator config under `[handler]`, or a new
+  `~/.config/jackin/handlers.toml`. Recommended default: *extend operator
+  config* — single-file ergonomics matter.
+- Should `jackin diff` default to in-terminal `git diff` (current
+  recommendation) or refuse to run without a configured handler? Recommended
+  default: *in-terminal default*; explicit configuration is a polish, not a
+  prerequisite.
+- For worktree-isolated mounts, should `jackin open` default to the
+  materialized worktree or the host repo? See default above; this might
+  flip after operators try V1.
+
+## Related Files
+
+- New module (e.g. `src/handler.rs`) — config + resolution + execution
+- <RepoFile path="src/cli/agent.rs" /> — adds `jackin open` / `jackin diff`
+  / `jackin web` subcommands
+- <RepoFile path="src/console/manager/state.rs" /> — keybindings
+- <RepoFile path="src/workspace/resolve.rs" /> — primary-mount resolution
+  for the handler argument
+
+## See Also
+
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) —
+  consumes `web` handler
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) — emitted
+  `<jackin:repo>` tags resolve through `diff` and `ide`
+- [Custom operator tools](/reference/roadmap/custom-operator-tools/) — also
+  uses the handler resolution machinery

--- a/docs/src/content/docs/reference/roadmap/persistent-storage-layer.mdx
+++ b/docs/src/content/docs/reference/roadmap/persistent-storage-layer.mdx
@@ -1,0 +1,230 @@
+---
+title: "Persistent Storage Layer (per-instance SQLite)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 3, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin' currently has zero structured persistence. Per-instance state is
+filesystem-shaped (`~/.jackin/data/<container>/.claude/`,
+`.config/gh/`, `.jackin/plugins.json`, `.jackin/isolation.json`), and the
+operator config is a single TOML file. There's no way to store:
+
+- A history of agent status transitions ("when did this agent last go
+  busy?")
+- Cached GitHub link state (refresh windows, last-fetched, last-error)
+- Token / cost samples over time
+- Tool fire history (audit log)
+- The autonomous queue's pending and completed tasks
+
+Every Phase 2 and Phase 4 item that needs any of the above either does
+its own ad-hoc JSON file (which gets messy) or skips the feature.
+
+This is the **load-bearing** Phase 3 item — the substrate for half of
+the program.
+
+## Why It Matters
+
+- Designing one storage layer once is dramatically cheaper than five
+  ad-hoc state files. The schema is small (a handful of tables); the
+  operational story is simple (one DB per instance, alongside existing
+  state).
+- Several leaves explicitly reference this item:
+  [GitHub link tracking](/reference/roadmap/github-link-tracking/),
+  [token & cost telemetry](/reference/roadmap/token-cost-telemetry/),
+  [autonomous task queue](/reference/roadmap/autonomous-task-queue/),
+  [agent runtime status](/reference/roadmap/agent-runtime-status/)
+  (status_log table), and the auto-archive integration of
+  [workspace archive](/reference/roadmap/workspace-archive/).
+- Adding it after the consumers exist is much more painful than adding
+  it first — that's the case for landing it early in Phase 3 even
+  though no consumer in isolation justifies it.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section (implementation-only feature)
+- Source — [`lib/src/database.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/database.rs) (Diesel + SQLite setup, migrations)
+- Source — [`lib/src/schema.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/schema.rs) (full table definitions)
+- Source — [`lib/src/services/persistent_storage.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/persistent_storage.rs) (read/write helpers)
+- Source — [`lib/diesel.toml`](https://github.com/yawkat/multicode/blob/main/lib/diesel.toml) (migration toolchain config)
+
+- Per-workspace SQLite at `.multicode/cache.sqlite` (one DB per
+  workspace).
+- Schema is small: primarily `github_link_statuses` (URL-keyed cache),
+  plus a handful of metadata tables for archive format and snapshot
+  state.
+- Migrations via Diesel's embedded migrations (build-time SQL files
+  → embedded into the binary).
+- Concurrency via single-writer SQLite, with a brief upsert-retry
+  helper (5 attempts, exponential backoff base 100ms) for the rare
+  contention case.
+
+multicode also keeps a JSON snapshot file (`~/.multicode/workspaces/<key>.json`)
+*alongside* the SQLite — the JSON holds the persistent operator-facing
+state (description, archive flag, agent-provided links) while the SQLite
+holds the cached / queryable parts. We should not split this way; it
+duplicates state. SQLite alone is the right choice for jackin'.
+
+## Recommended Shape
+
+One SQLite database **per instance**, at
+`~/.jackin/data/<container>/jackin.db`. Schema versioned via
+embedded migrations. Async access via `sqlx` (jackin' is already async-
+ready) or `rusqlite` with a small async wrapper — pick once, document
+the rationale in an ADR.
+
+### Tables (V1)
+
+```sql
+-- Status transitions. Rolling N=10000 entries, then trim oldest.
+CREATE TABLE status_log (
+    id INTEGER PRIMARY KEY,
+    occurred_at INTEGER NOT NULL,            -- epoch seconds
+    new_status TEXT NOT NULL,                -- 'idle' | 'busy' | 'question' | ...
+    metadata TEXT                            -- optional JSON blob (e.g. prompt for 'question')
+);
+
+-- Captured agent tag emissions. Idempotent on (kind, value).
+CREATE TABLE agent_tags (
+    kind TEXT NOT NULL,                      -- 'repo' | 'issue' | 'pr' | 'link'
+    value TEXT NOT NULL,
+    first_seen INTEGER NOT NULL,
+    last_seen INTEGER NOT NULL,
+    PRIMARY KEY (kind, value)
+);
+
+-- GitHub link cache. Owned by github-link-tracking; defined here so
+-- the schema is in one place.
+CREATE TABLE github_link_statuses (
+    url TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    host TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    resource_number INTEGER NOT NULL,
+    issue_state TEXT,
+    pr_state TEXT,
+    build_state TEXT,
+    review_state TEXT,
+    pr_is_draft INTEGER,                     -- 0/1
+    fetched_at INTEGER NOT NULL,
+    refresh_after INTEGER NOT NULL,
+    last_error TEXT
+);
+
+-- Token / cost samples. Rolling N=86400 entries (~1/sec for 24h).
+CREATE TABLE usage_samples (
+    occurred_at INTEGER PRIMARY KEY,
+    token_input INTEGER,
+    token_output INTEGER,
+    token_cache_read INTEGER,
+    token_cache_write INTEGER,
+    cost_usd_micros INTEGER                  -- $cost * 1e6, integer-safe
+);
+
+-- Tool fire audit. Rolling N=1000 entries.
+CREATE TABLE tool_history (
+    id INTEGER PRIMARY KEY,
+    occurred_at INTEGER NOT NULL,
+    tool_key TEXT NOT NULL,
+    exit_code INTEGER,
+    duration_ms INTEGER
+);
+
+-- Schema version. One row.
+CREATE TABLE _meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+```
+
+Future leaves add more tables; the migration framework handles upgrades.
+
+### Lifecycle
+
+- **Created on first instance load.** If the file doesn't exist, run
+  the migration suite and set `_meta.schema_version`.
+- **Migrated on subsequent loads.** If `_meta.schema_version` < current,
+  run pending migrations.
+- **Archived with the data dir.**
+  [Workspace archive](/reference/roadmap/workspace-archive/) compresses
+  the whole `~/.jackin/data/<container>/` tree, including the DB.
+- **Deleted with `purge`.** Standard data-dir teardown.
+
+### Concurrency model
+
+Single writer (the running `jackin` process for that instance), many
+readers. Console subscribers may read concurrently. SQLite's WAL mode
+handles this; turn it on at DB creation time. No multi-writer scenarios
+exist in V1 because each instance has at most one running jackin
+process.
+
+### Trimming
+
+Tables with rolling-window semantics (`status_log`, `usage_samples`,
+`tool_history`) get trimmed on every Nth insert (cheap, bounded), not
+on a background timer. Counts above are starting points; tune after
+observing real footprint.
+
+## Scope (V1)
+
+- One SQLite DB per `~/.jackin/data/<container>/`, at `jackin.db`.
+- Schema above; migrations embedded in the binary via the chosen
+  toolkit.
+- WAL mode enabled at creation.
+- Async access via the chosen sqlite client.
+- Rolling-window trim per table.
+- DB creation failure is a hard error at instance load (don't
+  silently start without persistence — would diverge silently).
+- Migration failure halts load with a clear message; operator
+  decides whether to `purge` or wait for a fix.
+
+## Defer
+
+- Cross-instance shared SQLite (one operator-global DB). Per-instance
+  is the right boundary for V1 — independent lifecycle, archive-
+  friendly, no cross-instance state to leak.
+- Encrypted-at-rest. SQLite has SEE; not in V1.
+- Replication / sync. Out of scope.
+- Read-only export / dump command (`jackin debug dump-db <name>`).
+  Useful but small; defer.
+
+## Open Questions
+
+- **`sqlx` vs `rusqlite`.** `sqlx` is async-native and matches jackin's
+  Tokio runtime, but adds a meaningful build-time cost (offline mode
+  with macro-checked queries). `rusqlite` is simpler and battle-tested
+  but blocking — needs `spawn_blocking` discipline. Recommended:
+  *write an ADR* (see [ADR roadmap](/reference/roadmap/architecture-decision-records/));
+  this is the kind of decision that earns one.
+- **Schema in code vs schema in `.sql` files.** Diesel-style embedded
+  migrations are clean but add a new toolchain dependency. A small
+  in-code migration list works fine for V1's table count. Recommended:
+  *in-code for V1*; revisit if the schema explodes.
+- **Per-instance vs single global DB.** Confirmed in the master:
+  *per-instance*. This open question exists only as a checkpoint for
+  the alternate path in case operator feedback shifts the call.
+
+## Related Files
+
+- New module (e.g. `src/storage/mod.rs` or a new
+  crate-internal `storage/`) — DB pool, migrations, query helpers
+- <RepoFile path="src/runtime/launch.rs" /> — DB creation on first load
+- <RepoFile path="src/runtime/cleanup.rs" /> — DB teardown on `purge`
+- Future ADR file under `docs/src/content/docs/internal/adrs/` —
+  sqlx vs rusqlite decision
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Token & cost telemetry](/reference/roadmap/token-cost-telemetry/) —
+  primary V1 consumer
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) —
+  schema home for the link cache
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) —
+  Phase 4 consumer
+- [Architecture Decision Records](/reference/roadmap/architecture-decision-records/) —
+  the right home for the sqlx-vs-rusqlite decision

--- a/docs/src/content/docs/reference/roadmap/task-source-abstraction.mdx
+++ b/docs/src/content/docs/reference/roadmap/task-source-abstraction.mdx
@@ -1,0 +1,210 @@
+---
+title: "Task Source Abstraction"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 4, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+The autonomous-queue idea (next leaf) needs *something to dispatch*. Hardcoding
+"GitHub issues" as the only source — multicode's choice — works for that
+project's Micronaut workflow, but locks jackin' into a single integration. The
+cost of designing a small abstraction up front is low; the cost of retrofitting
+one is high.
+
+The right move is to define a `TaskSource` trait, ship GitHub issues as the
+first concrete implementation, and ensure the queue, console, and persistence
+all see tasks through the trait.
+
+## Why It Matters
+
+- jackin's positioning is "one tool for everyone" — a queue that only ingests
+  GitHub issues is not that tool.
+- Internal teams that use Linear, JIRA, plain text files, or a stdin pipe of
+  prompts are exactly the population the program is targeting. They should be
+  able to plug in without forking jackin'.
+- The trait is small. Defining it now and implementing GitHub against it is
+  perhaps 10% more work than implementing GitHub directly, and it preserves
+  the design optionality for free.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Autonomous queueing](https://github.com/graemerocher/multicode#autonomous-queueing) (closest — describes the GitHub-issue scanner that this leaf generalizes)
+- *No abstraction in multicode* — this leaf proposes a `TaskSource` trait jackin'-side; multicode hardcodes GitHub. Source code: [`lib/src/manager.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/manager.rs) is where their queue logic lives.
+
+multicode's autonomous-issue-scanning has no abstraction — it talks directly
+to GitHub via Octocrab and turns issues into queued workspaces. Their
+config:
+
+```toml
+[autonomous]
+max-parallel-issues = 5
+issue-scan-delay-seconds = 900
+scan-on-startup = true
+```
+
+Each workspace can be assigned to a GitHub repo; the scanner finds open
+issues and queues them.
+
+What's right: per-workspace assignment, scan cadence, parallelism cap.
+What's wrong for jackin': "issues" as the universal noun.
+
+## Recommended Shape
+
+### Trait
+
+```rust
+pub trait TaskSource {
+    /// Stable identifier — written into queue records, used for dedup.
+    fn id(&self) -> &str;
+
+    /// Human-readable description for the console / logs.
+    fn label(&self) -> &str;
+
+    /// Discover newly-available tasks. Idempotent: returning a task that
+    /// the queue has already claimed is fine — the queue de-dupes by
+    /// `Task.id`.
+    async fn poll(&mut self) -> Result<Vec<Task>, TaskSourceError>;
+
+    /// Optional: report task completion back to the source (post a PR
+    /// comment, close the issue, etc.). Default: no-op.
+    async fn report(&mut self, task: &Task, outcome: &TaskOutcome)
+        -> Result<(), TaskSourceError> { Ok(()) }
+}
+
+pub struct Task {
+    pub id: String,                          // stable across polls (e.g. "github:owner/repo#412")
+    pub source: String,                      // source.id()
+    pub kind: TaskKind,                      // Issue | Prompt | File | Custom
+    pub title: String,
+    pub body: String,                        // markdown / freeform input the agent sees
+    pub links: Vec<String>,                  // emitted as <jackin:issue> / <jackin:link>
+    pub labels: Vec<String>,                 // for filtering
+    pub created_at: SystemTime,
+}
+```
+
+### V1 source: GitHub issues
+
+```toml
+[task_sources.fix-issues]
+type = "github_issues"
+repo = "example-org/example"
+labels = ["bug", "good-first-issue"]
+exclude_labels = ["wontfix"]
+state = "open"
+limit_per_poll = 25
+```
+
+GitHub source uses the same Octocrab client and credential resolution as
+[GitHub link tracking](/reference/roadmap/github-link-tracking/). Tasks
+include the issue URL in `links` so the dispatched agent automatically
+sees `<jackin:issue>...</jackin:issue>` (the [tag
+protocol](/reference/roadmap/agent-tag-protocol/) seam emits one for the
+operator's surface as well).
+
+### V1 source: file-glob
+
+```toml
+[task_sources.review-spec]
+type = "file_glob"
+pattern = "specs/*.md"
+poll_interval_seconds = 60
+```
+
+For each matching file, generate a Task whose body is the file content.
+Useful for "dispatch an agent per spec doc". Cheap to implement;
+demonstrates the trait isn't GitHub-only.
+
+### V1 source: stdin-pipe (CLI-only)
+
+```sh
+echo -e "Implement function X\n---\nImplement function Y" | jackin queue feed <workspace>
+```
+
+`---` separates tasks. Single-shot — for scripting and one-off batches.
+Doesn't appear in TOML.
+
+### Persistence
+
+Sources have config in TOML; the queue's view of *tasks* lives in the
+[persistent storage layer](/reference/roadmap/persistent-storage-layer/),
+in a `tasks` table:
+
+```sql
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    source_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    links TEXT,                              -- JSON array
+    labels TEXT,                             -- JSON array
+    discovered_at INTEGER NOT NULL,
+    state TEXT NOT NULL,                     -- 'queued' | 'in_progress' | 'completed' | 'failed'
+    instance_name TEXT,                      -- which jackin instance is/was working it
+    completed_at INTEGER,
+    outcome TEXT
+);
+```
+
+## Scope (V1)
+
+- `TaskSource` trait + `Task` / `TaskOutcome` types.
+- Three concrete implementations: `github_issues`, `file_glob`,
+  `stdin_pipe` (CLI-only).
+- `[task_sources.<name>]` TOML block at operator-config level.
+- Source assignment is per-workspace (`[workspaces.X.task_sources]`
+  array of source names), matching multicode's "workspace assigned to
+  a repo" model.
+- `tasks` schema lives in the persistent storage module.
+- Source poll cadence per source (`poll_interval_seconds` field on the
+  config block).
+
+## Defer
+
+- Linear / JIRA / Slack / Asana sources. Document the trait so
+  third-party crates can implement them; keep jackin' core lean.
+- Multi-source queues with priority. V1: one source per workspace, FIFO
+  within a source.
+- Source `report()` callbacks. The trait has the seam; no V1
+  implementation calls it.
+- Source config hot-reload. Restart the operator's console session.
+
+## Open Questions
+
+- **Source authentication.** GitHub PAT comes from the existing
+  credential pattern; what about a hypothetical JIRA source's API
+  token? Recommended: *each source declares its own credential needs
+  via the [credential source pattern](/reference/roadmap/credential-source-pattern/)*.
+- **Where does a third-party source live?** A Cargo workspace member,
+  a feature flag, a separately-published crate? Recommended: *V1 ships
+  GitHub/file/stdin in tree*; defer the third-party-source story until
+  someone asks.
+- **Task identity stability.** `github:owner/repo#412` is stable; what
+  about `file_glob:specs/foo.md` if the file is renamed? Recommended:
+  *file path is the stable ID*, rename = new task. Operators can
+  re-queue if needed.
+
+## Related Files
+
+- New module (e.g. `src/queue/task_source.rs`) —
+  trait + V1 implementations
+- The persistent-storage module — `tasks` schema
+- <RepoFile path="src/config/mod.rs" /> — `[task_sources]` parsing
+- <RepoFile path="src/workspace/mod.rs" /> — workspace's task_sources
+  field
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) —
+  primary consumer
+- [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) —
+  task storage
+- [Credential source pattern](/reference/roadmap/credential-source-pattern/) —
+  per-source credential resolution
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) — tasks
+  include emitted-link metadata

--- a/docs/src/content/docs/reference/roadmap/token-cost-telemetry.mdx
+++ b/docs/src/content/docs/reference/roadmap/token-cost-telemetry.mdx
@@ -1,0 +1,207 @@
+---
+title: "Token & Cost Telemetry"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 3, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin' has no idea how much an agent has cost the operator. Token usage,
+cache reads/writes, dollar cost — all of it is invisible. For a developer
+running one Claude session this is fine; for a team running several
+parallel agents on different projects, it's expensive ignorance:
+
+- The operator can't tell which workspace burned 10× more tokens than the
+  others.
+- The autonomous queue (Phase 4) can't enforce a per-task or per-day
+  budget.
+- The cost model can't be optimized — operators don't see when prompt
+  caching is saving them money vs. when it isn't.
+
+multicode tracks this per-workspace and renders it in their TUI. The
+telemetry primitives are simple; the value is high.
+
+## Why It Matters
+
+- It's the simplest cost-awareness primitive that doesn't require a
+  vendor-specific billing integration.
+- It makes [declarative resource
+  limits](/reference/roadmap/declarative-resource-limits/) feel
+  finished — operators see RAM/CPU usage, but cost is the dimension they
+  most care about for AI agents.
+- It enables future budget gates ("don't queue another task if this
+  workspace exceeded $X today") without those gates having to reinvent
+  the underlying tracking.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section (implementation-only feature)
+- Source — [`lib/src/services/usage_aggregation_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/usage_aggregation_service.rs) (token + cost aggregation)
+- Source — [`lib/src/services/resource_usage_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/resource_usage_service.rs) (CPU + RAM + OOM sampling)
+
+multicode's `usage_aggregation_service` (see [`lib/src/services/usage_aggregation_service.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/usage_aggregation_service.rs))
+parses the OpenCode message history, sums input/output
+tokens per session, multiplies by a synthetic per-model cost table, and
+exposes:
+
+- `usage_total_tokens: u64`
+- `usage_total_cost: f64`
+- `usage_cpu_percent: u16` (CPU)
+- `usage_ram_bytes: u64` (RAM)
+- `oom_kill_count: u64`
+
+These live on the workspace snapshot (transient — lost across TUI
+restarts). The TUI renders cost and tokens as columns in the workspace
+table.
+
+The cost table is hardcoded per model. Re-using their per-1000-token
+prices and approach is fine; the more interesting work is making
+jackin's pricing pluggable across runtimes.
+
+## Recommended Shape
+
+A small **usage adapter** per runtime, parallel to (and consuming the
+same input stream as) the
+[agent runtime status](/reference/roadmap/agent-runtime-status/) and
+[tag protocol](/reference/roadmap/agent-tag-protocol/) parsers. Output
+samples land in the
+[persistent storage layer](/reference/roadmap/persistent-storage-layer/)'s
+`usage_samples` table.
+
+### Sample event
+
+```rust
+pub struct UsageSample {
+    pub at: SystemTime,
+    pub token_input: u64,
+    pub token_output: u64,
+    pub token_cache_read: u64,
+    pub token_cache_write: u64,
+    pub model: String,                  // 'claude-opus-4-7', 'gpt-5-codex', etc.
+    pub cost_usd_micros: i64,           // computed from a model→price table
+}
+```
+
+`cost_usd_micros` is integer to avoid floating-point summation drift
+across thousands of samples. Renderers divide by 1e6 for display.
+
+### Per-runtime adapters
+
+- **Claude.** Parse the agent's stream-json transcript or the operator-
+  visible Claude billing line; both expose token counts. The adapter
+  emits a `UsageSample` per assistant message with token data.
+- **Codex.** Codex's app-server emits token usage events; map directly.
+- **Amp.** Amp's thread API includes token counts; map.
+
+Each adapter reads the runtime's structured output (same input stream
+as the status adapter) and emits samples. The adapter knows its
+runtime; the consumer doesn't.
+
+### Pricing table
+
+```toml
+# ~/.config/jackin/pricing.toml (or section of operator config)
+
+[pricing.models."claude-opus-4-7"]
+input_per_million = 15.00
+output_per_million = 75.00
+cache_read_per_million = 1.50
+cache_write_per_million = 18.75
+
+[pricing.models."gpt-5-codex"]
+input_per_million = 5.00
+output_per_million = 15.00
+```
+
+Operator-overridable; jackin' ships a default table for current models.
+Stale prices are a documentation issue, not a runtime issue — the
+table is just a multiplier.
+
+When a sample arrives for a model not in the table, jackin' records
+the tokens, leaves cost as null, and prints a one-line warning at next
+console open ("no pricing for model X — tokens tracked but cost unknown").
+
+### Console rendering
+
+The per-agent table (when [console resource
+panel](/reference/roadmap/console-resource-panel/) is open) gains a
+"Cost (today)" column showing the running cost since 00:00 local time.
+A second `Tokens (1h)` column may surface the rolling-1-hour rate;
+defer if cell width gets tight.
+
+A `jackin usage <selector>` CLI command dumps a structured summary
+for scripting:
+
+```sh
+$ jackin usage the-architect --json
+{
+  "instance": "jackin-the-architect",
+  "today_cost_usd": 4.12,
+  "today_tokens": { "input": 124000, "output": 38500, ... },
+  "lifetime_cost_usd": 67.40
+}
+```
+
+## Scope (V1)
+
+- Per-runtime usage adapter consuming the runtime's structured output
+  stream.
+- `UsageSample` events appended to the storage layer's `usage_samples`
+  table.
+- Pricing table with operator override; ship sensible defaults.
+- Console "Cost (today)" column when the resource panel is open.
+- `jackin usage <selector>` CLI with `--json` and human-readable
+  formatting.
+- Cost computed at sample time and stored, not recomputed on render —
+  preserves history when prices change.
+
+## Defer
+
+- Budget gating ("kill the agent or refuse queue dispatch when daily
+  cost exceeds $X"). Useful but waits — it requires the queue to exist
+  first.
+- Multi-currency. USD only in V1; the internal representation is
+  micros-of-USD, conversion is a render-time concern.
+- Org-level aggregation across operators. Out of scope.
+- Token-savings reporting from prompt caching. Tracked as a column;
+  not separately summarized in V1.
+- Per-tool-call cost attribution (which tool call cost the most).
+  Defer; needs richer event extraction than V1's per-message sampling.
+
+## Open Questions
+
+- **What's the canonical input for the Claude usage adapter?** Claude
+  Code's stream-json transcript exposes tokens per message; the
+  question is whether jackin' attaches as a sidecar consumer or
+  intercepts the runtime's stdout. The latter risks interfering with
+  the operator's own view of the agent. Recommended default: *stream-
+  json sidecar*, gated behind the same opt-in as the status adapter.
+- **Default pricing table source.** Hand-maintained in this repo, or
+  fetched from an Anthropic/OpenAI-published source at build time?
+  Recommended: *hand-maintained for V1*; revisit if it stales out fast.
+- **Daily cost reset boundary.** Local midnight, UTC midnight, or
+  rolling 24-hour? Recommended: *local midnight* for the "today"
+  column; CLI exposes any window.
+
+## Related Files
+
+- New module (e.g. `src/runtime/usage.rs`) — adapter
+  trait + sampler
+- The persistent-storage module — owns `usage_samples` schema
+- <RepoFile path="src/cli/agent.rs" /> — `jackin usage` subcommand
+- <RepoFile path="src/console/manager/state.rs" /> — column rendering
+- New config block — `[pricing.models]`
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) —
+  required (sample storage)
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) —
+  parallel consumer of the same input stream
+- [Console resource panel](/reference/roadmap/console-resource-panel/) —
+  rendering home
+- [Autonomous task queue](/reference/roadmap/autonomous-task-queue/) —
+  future budget-gating consumer

--- a/docs/src/content/docs/reference/roadmap/workspace-archive.mdx
+++ b/docs/src/content/docs/reference/roadmap/workspace-archive.mdx
@@ -1,0 +1,173 @@
+---
+title: "Workspace Archive / Unarchive"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 1, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+jackin's workspace lifecycle is binary: a workspace is either *live* (loaded
+or loadable) or *gone* (`workspace remove` deletes the config; `purge`
+deletes the per-instance state). Operators who want to "park" a workspace —
+keep its data but get it out of the active list — have no option.
+
+The gap matters most for workspaces that finished their job but produced
+preserved state: a worktree-isolated mount with unpushed commits, an agent
+session whose history might still be useful, a long-running investigation
+the operator wants to be able to revive in a week.
+
+multicode solves this with archive: compress the workspace directory into a
+single file (`.tar.zstd` / `.tar.xz` / `.zip`), mark it archived, hide it
+from the default view. Unarchive reverses the operation. The TUI auto-detects
+archive files at startup and offers them in a separate "archived" view.
+
+## Why It Matters
+
+- The natural pair to [worktree cleanup
+  assessment](/reference/roadmap/worktree-cleanup-assessment/): when clean
+  exit can't safely delete and the operator doesn't want to inspect
+  immediately, archive is what they should do instead.
+- jackin's per-instance state directories grow without bound today. Even on
+  a developer laptop, six idle agents with persisted Claude history is
+  ~50 MB of clutter. Compressed archives reduce that meaningfully.
+- It pairs naturally with [task queue](/reference/roadmap/autonomous-task-queue/):
+  a queue that has fully processed an issue can auto-archive the resulting
+  per-task workspace if configured to.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Archiving](https://github.com/graemerocher/multicode#archiving)
+- Source — [`lib/src/services/workspace_archive.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/workspace_archive.rs)
+
+multicode's archive lives in `lib/src/services/workspace_archive.rs`
+(in their tree). Behaviors borrowed:
+
+- **Three formats supported** with auto-detect: `.tar.zstd` (default,
+  fastest), `.tar.xz` (smallest), `.zip` (most portable). Format chosen at
+  archive time, recorded in the persistent metadata so unarchive picks the
+  right decoder without trial-and-error.
+- **Auto-detection at startup**: if the workspace directory contains a
+  recognized archive file, treat the workspace as archived without needing
+  explicit config state.
+- **Archive flag in persistent metadata**: `archived: bool` on the workspace
+  snapshot, separate from the file-system existence check. This lets the
+  TUI show archived workspaces in a collapsed section even before the
+  archive file is opened.
+- **TUI keystroke `a`** archives the selected workspace; clicking the
+  collapsed archive header expands the list of archived workspaces.
+
+What jackin' should do *differently*:
+
+- Archives are per-*instance*, not per-workspace. jackin's data unit is
+  `~/.jackin/data/<container>/`, and that's what should compress.
+- Workspace config (TOML) is not archived — only the runtime state is.
+  Reason: archives are recoverable independent of config, and operators
+  often re-edit a workspace's mount list before unarchiving.
+
+## Recommended Shape
+
+### CLI
+
+```sh
+jackin archive <selector>                # archive an instance's data dir
+jackin archive <selector> --format zstd  # default; alternatives: xz, zip
+jackin archive list                      # list archived instances
+jackin unarchive <selector>              # restore to ~/.jackin/data/<container>/
+jackin archive remove <selector>         # delete the archive
+```
+
+Archives live at `~/.jackin/archive/<container>.<ext>` (one tarball per
+instance). `archive list` reads filenames + a tiny index file
+(`~/.jackin/archive/index.json`) for descriptions and timestamps.
+
+### Behavior
+
+- `jackin archive <name>` requires the agent to be ejected first. If the
+  container is running, the command rejects with "eject first" — same
+  guard pattern as `jackin purge`.
+- The compressed file contains the entire `~/.jackin/data/<container>/`
+  tree, including isolation.json, runtime state, agent session history,
+  per-instance git metadata. The host repo's `.git/` is *not* included
+  (that's outside the data dir; the materialized worktree is captured but
+  refs/objects need to be recovered from the host on unarchive — see Open
+  Questions).
+- `jackin unarchive <name>` restores to the same path. Refuses if the data
+  dir already exists (operator must `purge` first or pick a new selector).
+- `jackin archive list` shows: name, format, archive size, archived-at
+  timestamp, optional description (from
+  [workspace-description](/reference/roadmap/workspace-description/) if
+  present at archive time, captured into the index).
+- `jackin console` has an optional "Archived" expandable section in the
+  workspace picker.
+
+### Auto-archive integration
+
+Two hooks where automatic archive makes sense:
+
+- **Foreground session finalization** (the existing `worktree-cleanup-assessment`
+  flow): instead of leaving "preserved_dirty" / "preserved_unpushed" state
+  on disk indefinitely, offer archive as a third option alongside "preserve"
+  and "force delete".
+- **Queue completion** (Phase 4): when the queue finishes a task and the
+  per-task instance has nothing left to inspect, auto-archive if a flag
+  is set on the queue.
+
+## Scope (V1)
+
+- `jackin archive` / `jackin unarchive` / `jackin archive list` /
+  `jackin archive remove` subcommands.
+- Three formats with auto-detect by extension; default `.tar.zstd`.
+- Archive index at `~/.jackin/archive/index.json` (small JSON;
+  description + format + archived-at + size).
+- Refuses on running agents; matches the `purge` guard.
+- Console workspace picker gains an "Archived" collapsible row.
+- Manual archive only; no auto-archive integration in V1 (defer to a
+  follow-up in the same phase if Phase 1 lands cleanly).
+
+## Defer
+
+- Auto-archive integration with worktree cleanup or the queue. V1 is manual.
+- Encrypted archives. Operators who need encryption can use full-disk
+  encryption or wrap the archive file themselves.
+- Off-host archive destinations (S3, network mount). Local-only in V1.
+- Archive of multi-instance bundles ("archive all containers in workspace
+  X"). Per-instance only in V1; bulk operations are a CLI helper later.
+- Including the host repo's `.git/` in the archive for worktree-isolated
+  mounts. The right answer is to recover from the host repo on unarchive
+  (which preserves the original ref-sharing semantics); copying the host
+  `.git/` would break that contract.
+
+## Open Questions
+
+- **Worktree-isolated mounts on unarchive.** If the host repo has moved or
+  been deleted between archive and unarchive, the materialized worktree
+  pointer files reference paths that no longer resolve. V1 should detect
+  this on unarchive, print a clear message, and leave the unarchived data
+  dir in a recoverable state (worktree files present, just no ref
+  resolution until the operator points the host repo back).
+- **Archive index format.** JSON is the simplest; SQLite (see [persistent
+  storage layer](/reference/roadmap/persistent-storage-layer/)) might be
+  the right home if Phase 3 lands first. Recommend *defer* the choice
+  until Phase 3 design solidifies — JSON is a fine V1 placeholder.
+- **Compression level defaults.** zstd 19 vs zstd 3 trade ~3× compression
+  time for ~10% size. multicode uses default. Recommend *zstd default*
+  (level 3); operators who want more can pass `--level`.
+
+## Related Files
+
+- New module (e.g. `src/archive.rs`) — archive/unarchive primitives
+- <RepoFile path="src/cli/cleanup.rs" /> — `archive` / `unarchive`
+  subcommand wiring (sits naturally next to `purge`)
+- <RepoFile path="src/runtime/cleanup.rs" /> — running-agent guard reuse
+- <RepoFile path="src/console/manager/state.rs" /> — archived row in the
+  workspace picker
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Worktree cleanup assessment](/reference/roadmap/worktree-cleanup-assessment/) —
+  the upstream of the auto-archive integration deferred to V1.1
+- [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) —
+  potential home for the archive index

--- a/docs/src/content/docs/reference/roadmap/workspace-description.mdx
+++ b/docs/src/content/docs/reference/roadmap/workspace-description.mdx
@@ -1,0 +1,131 @@
+---
+title: "Workspace Description Field"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 1, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+When an operator manages more than two or three saved workspaces, the
+workspace name and last-used agent are not enough to keep track of what each
+one is for. There's no place to attach a note like "preview branch for issue
+#412" or "isolated copy I'm using to bisect the regression in v0.42".
+
+multicode addresses this with a free-text description field that is shown in
+the overview table and inline-editable from the TUI (`e` keystroke). Operators
+treat it as a sticky reminder.
+
+## Why It Matters
+
+- jackin's `workspace list` and `workspace show` reveal mounts and agent
+  bindings but not *intent* — operators end up encoding intent in the
+  workspace *name*, which is awkward.
+- This is the smallest feature in the [Universal Orchestrator
+  Program](/reference/roadmap/multicode-inspired-features/) that demonstrably
+  improves day-to-day operator UX.
+- It plumbs through the same surfaces that several later items will reuse
+  (workspace config schema, console rendering, future TUI cell rendering),
+  so getting it right once pays forward.
+
+## Inspiration in multicode
+
+**Sources**:
+- README — [Description](https://github.com/graemerocher/multicode#description)
+- Source — [`lib/src/services/workspace_archive.rs`](https://github.com/yawkat/multicode/blob/main/lib/src/services/workspace_archive.rs) (description field is part of `PersistentWorkspaceSnapshot`)
+
+The field lives on `PersistentWorkspaceSnapshot.description`, persisted as a
+JSON-shaped per-workspace metadata file at
+`~/.multicode/workspaces/<key>.json`. The TUI exposes it through
+`EditDescription` mode: select a row, press `e`, type, `Enter` saves, `Esc`
+cancels. No markdown rendering — descriptions are plain text, displayed
+verbatim. There's no length limit enforced beyond what fits the table cell.
+
+## Recommended Shape
+
+A single optional string field on `WorkspaceConfig`, surfaced in the same
+three places jackin already surfaces other workspace metadata.
+
+### Config
+
+```toml
+[workspaces.jackin]
+workdir = "/workspace/jackin"
+description = "Issue #412 isolated repro branch"
+
+[[workspaces.jackin.mounts]]
+src = "~/projects/jackin"
+dst = "/workspace/jackin"
+isolation = "worktree"
+```
+
+`description` is optional; absent means no description (not empty string).
+
+### CLI
+
+```sh
+jackin workspace create my-ws --workdir /workspace/x \
+  --description "Issue #412 isolated repro branch"
+
+jackin workspace edit my-ws --description "..."
+jackin workspace edit my-ws --clear-description
+
+jackin workspace show my-ws  # renders description as a top-level field
+jackin workspace list        # renders a Description column (truncated)
+```
+
+The `--clear-description` flag matches the existing `--clear-default-agent`
+shape in <RepoFile path="src/cli/workspace.rs" />.
+
+### Console
+
+`workspace show` adds a Description row at the top of the panel. The
+console's workspace picker keeps the existing list shape but appends the
+description as a second line under each workspace name (truncated to one
+line; Esc-to-collapse if it ever overflows).
+
+## Scope (V1)
+
+- `description` field on `WorkspaceConfig`, optional string, no length cap
+  in storage (CLI/console truncate at render time).
+- `workspace create --description` and `workspace edit --description` /
+  `--clear-description`.
+- `workspace show` and `workspace list` render the field.
+- Console workspace picker shows the description as a one-line subtitle.
+- Roundtrips cleanly through TOML serialization (preserve operator
+  whitespace; do not collapse multi-line descriptions but render only the
+  first line in lists).
+
+## Defer
+
+- Markdown rendering. Descriptions are plain text.
+- Per-instance descriptions (the operator might want a different description
+  on `agent-smith` vs `the-architect` even when both reference the same
+  workspace). Out of scope; a workspace-level field covers the 95% case.
+- A separate description on agent class manifests
+  (`jackin.agent.toml [identity].description`). Useful and small; deserves
+  its own follow-up so it can be reviewed in isolation.
+
+## Open Questions
+
+- Should the field be a single string or an optional `[description]` block
+  with `text` + `tags`? The block form is over-engineered for V1; recommend
+  *plain string*.
+- How does the field interact with [worktree
+  isolation](/reference/roadmap/per-mount-isolation/)'s preserved-state
+  notices? When jackin' prints "preserved isolated worktree for X", it
+  should include the description if present.
+
+## Related Files
+
+- <RepoFile path="src/workspace/mod.rs" /> — `WorkspaceConfig` gains the field
+- <RepoFile path="src/cli/workspace.rs" /> — CLI flag plumbing
+- <RepoFile path="src/config/workspaces.rs" /> — `workspace show` renderer
+- <RepoFile path="src/console/manager/state.rs" /> — workspace picker
+  rendering
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Custom operator tools](/reference/roadmap/custom-operator-tools/) — also
+  needs a stable workspace-list rendering surface

--- a/docs/src/content/docs/reference/roadmap/workspace-skills-mount.mdx
+++ b/docs/src/content/docs/reference/roadmap/workspace-skills-mount.mdx
@@ -1,0 +1,198 @@
+---
+title: "Workspace Skills Mount (cross-runtime customization)"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 5, [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/))
+
+## Problem
+
+Today, an agent class's behavior is locked at *image build time*: the
+Dockerfile installs whatever plugins/skills/MCP servers, the
+`jackin.agent.toml` declares Claude plugins, and that's that. Operators
+who want to customize behavior per-workspace (different skill set per
+project) or operators who want to share skills across multiple agent
+classes (one team's "code style" instructions used by Claude *and* Codex
+*and* Amp) have no clean path.
+
+multicode addresses this with `add-skills-from`: directories under
+configured paths get bind-mounted into the agent's runtime config dir
+(`~/.config/opencode/skills/<name>/`). The agent picks them up at
+runtime; no rebuild needed. Operators can edit a skill in their normal
+editor and the next agent invocation sees the change.
+
+## Why It Matters
+
+- It's the right shape for *team-level* customization that doesn't
+  belong in either the agent class repo or the operator's personal
+  config.
+- It's runtime-agnostic by design — the same skill markdown bind-mounts
+  into Claude's, Codex's, or Amp's expected skills directory based on
+  the runtime adapter.
+- It complements (doesn't replace) the [custom plugin
+  marketplace](/reference/roadmap/custom-plugin-marketplace/) story:
+  marketplaces distribute *reusable* skills published broadly; the
+  workspace skills mount handles *local* / *team-specific* skills the
+  operator doesn't want to publish.
+- It gives the [tag protocol](/reference/roadmap/agent-tag-protocol/)
+  a natural distribution channel: jackin' can ship a skill bundle that
+  agent classes pull in via this mount, and operators see the protocol
+  "for free" without having to install plugins per agent class.
+
+## Inspiration in multicode
+
+**Sources**:
+- No dedicated README section (mentioned in passing under [Isolation](https://github.com/graemerocher/multicode#isolation) and the [Apple-container OpenCode example](https://github.com/graemerocher/multicode#macos-setup-for-apple-containers))
+- Config — [`config.toml` `[isolation] add-skills-from`](https://github.com/yawkat/multicode/blob/main/config.toml)
+- Skills directory — [`workspace-skills/`](https://github.com/yawkat/multicode/tree/main/workspace-skills) (real examples — `git-commit-coauthorship`, `independent-fix`, `java-install`, `machine-readable-*`, `micronaut-projects-guide`)
+
+```toml
+[isolation]
+add-skills-from = [
+  "./workspace-skills",
+  "~/team-skills/micronaut",
+]
+```
+
+For each path, every immediate subdirectory becomes a skill: the
+subdirectory is bind-mounted to
+`~/.config/opencode/skills/<dir-name>/` inside the workspace's isolate.
+The skill's `SKILL.md` (frontmatter + body) is what OpenCode reads.
+
+The contents in their repo (visible in `workspace-skills/`):
+
+- `git-commit-coauthorship/` — commit attribution rules
+- `independent-fix/` — fix workflow
+- `java-install/` — Java version selection
+- `machine-readable-issue|clone|pr/` — tag-protocol emission
+- `micronaut-projects-guide/` — toolchain hints
+
+## Recommended Shape
+
+The runtime-agnostic version: each runtime adapter owns the *destination*
+inside the container; jackin' owns the *source* selection and bind-mount
+plumbing.
+
+### Config
+
+```toml
+# Operator-level (cross all workspaces) or workspace-level — both
+# accepted, with workspace overriding operator on path conflict.
+
+[skills]
+add_from = [
+  "~/team-skills/jackin-protocols",
+  "~/dotfiles/agent-skills",
+]
+
+# Or per-workspace:
+[workspaces.fix-bugs.skills]
+add_from = ["./project-specific-skills"]
+```
+
+Each path's immediate subdirectories are skills. Each skill has a
+`SKILL.md` at its root (the same structure multicode uses, the same
+structure Claude / Codex / Amp converge on).
+
+### Per-runtime mount destination
+
+Each runtime adapter declares where skills go inside the container:
+
+- **Claude** — `/home/agent/.claude/plugins/jackin-skills/<name>/`
+  (works alongside the existing `[claude.plugins]` install path; jackin
+  treats workspace skills as a special pre-installed plugin namespace).
+- **Codex** — `/home/agent/.codex/skills/<name>/`
+- **Amp** — `/home/agent/.config/amp/skills/<name>/`
+
+If a runtime doesn't support a skills concept natively, the adapter
+mounts at a known path and the agent class's entrypoint (or a small
+adapter shim) is responsible for surfacing it. V1 punts on this case —
+all three planned runtimes (Claude, Codex, Amp) have a skills concept.
+
+### Conflict resolution
+
+Per-path (operator + workspace) order is *additive*: the operator's
+list is read first, the workspace's list is appended. Within the
+combined list, the *last* declaration of a skill name wins (later
+overrides earlier). This is documented behavior, not implicit.
+
+If a skill name collides with one installed via the manifest's
+`[claude.plugins]` (or the per-runtime equivalent), jackin' refuses
+to launch with a clear error — the operator chooses which to keep.
+Silent override here is too dangerous.
+
+### Read-only vs read-write
+
+Default: read-only mount. The agent reads its skills; doesn't modify
+them. Operators editing skill markdown in their editor see changes
+on next agent restart.
+
+Optional: `read_write = true` for the rare case where a skill itself
+captures state (a "remember-this" skill). Not encouraged; documented
+as opt-in.
+
+## Scope (V1)
+
+- `[skills]` block at operator and workspace levels with `add_from`
+  list.
+- Per-runtime mount destination owned by each runtime adapter.
+- Conflict resolution: workspace appends operator; later overrides
+  earlier; manifest-level conflicts error.
+- Read-only by default; opt-in `read_write`.
+- New repo `jackin-project/jackin-skills` ships a published bundle
+  including the [tag protocol](/reference/roadmap/agent-tag-protocol/)
+  emission skills.
+
+## Defer
+
+- Skill version pinning. Skills are filesystem paths; pin the path,
+  not a version. If versioning becomes important, revisit.
+- Skill marketplace integration (browse/install via TUI). The
+  [custom plugin marketplace](/reference/roadmap/custom-plugin-marketplace/)
+  handles published skills; this mount is for local/team ones.
+- Cross-runtime skill format conversion. V1 assumes the markdown
+  format is portable (frontmatter + body); if Claude / Codex / Amp
+  diverge, the runtime adapter handles per-runtime tweaks. Defer
+  active conversion until a divergence shows up.
+- Per-agent-class skill enable/disable from the same
+  `add_from` list. V1 mounts everything; agent classes that don't
+  want a skill can ignore it by name.
+
+## Open Questions
+
+- **Should workspace skills mount into Claude as "plugins" or
+  "skills"?** Claude Code's plugin format is heavier; "skills" via
+  Claude's skills feature is closer to the multicode shape.
+  Recommended: *use Claude skills*; the
+  [multi-runtime](/reference/roadmap/multi-runtime-support/) work
+  needs to confirm Claude's skills plumbing matches.
+- **Skills inside per-mount-isolated worktrees.** If `add_from`
+  references a path inside an isolated workspace mount, the
+  materialized worktree gets the skill inside the container *and*
+  the bind-mount duplicates it — confusing. Recommended: *reject
+  `add_from` paths that resolve under an isolated workspace mount*,
+  with a clear error.
+- **Default skill bundle for jackin'.** Should `jackin-project/jackin-skills`
+  be auto-mounted by default when an operator opts into the
+  `<jackin:*>` tag protocol? Recommended: *no auto-mount*; operators
+  add it explicitly. Avoids surprise.
+
+## Related Files
+
+- New module (e.g. `src/skills.rs`) — collection +
+  validation
+- <RepoFile path="src/runtime/launch.rs" /> — bind-mount plumbing
+- Per-runtime adapter modules (Claude / Codex / Amp) — each owns its
+  mount destination
+- New repo `jackin-project/jackin-skills` — published bundle
+- New docs page: `docs/src/content/docs/guides/skills.mdx`
+
+## See Also
+
+- [Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)
+- [Multi-runtime support](/reference/roadmap/multi-runtime-support/) —
+  per-runtime mount destinations
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) —
+  primary distribution use case for skill bundles
+- [Custom plugin marketplace](/reference/roadmap/custom-plugin-marketplace/) —
+  published-skill distribution; complementary to this leaf


### PR DESCRIPTION
## Summary

- Adds a phased roadmap program (master + 18 leaf items) capturing the operator-surface and fleet-operations gaps between jackin' and adjacent tools, surveyed against [yawkat/multicode](https://github.com/yawkat/multicode) and the [graemerocher/multicode](https://github.com/graemerocher/multicode) fork.
- Structured like [codebase-readability](https://github.com/jackin-project/jackin/blob/main/docs/src/content/docs/reference/roadmap/codebase-readability.mdx) — master doc with phase tables linking to self-contained leaves; each leaf carries a `**Sources**:` block linking back to the multicode README anchor, source file, or `config.toml` schema example so design rationale is verifiable.
- Indexed under a new **Operator surface and fleet operations** section in `roadmap.mdx`, plus an **Operator surface** group in the docs sidebar (`astro.config.ts`) mirroring the **Codebase health** group shape with five phase subgroups.

## Phases (18 leaf items + master)

| Phase | Items |
|---|---|
| 1 — Foundation gaps | `workspace-description`, `operator-handler-system`, `workspace-archive`, `declarative-resource-limits`, `ephemeral-mount-modes` |
| 2 — Live operator surface | `agent-runtime-status`, `console-resource-panel`, `agent-tag-protocol`, `github-link-tracking`, `custom-operator-tools` |
| 3 — Persistence & telemetry | `persistent-storage-layer`, `token-cost-telemetry` |
| 4 — Fleet operations | `task-source-abstraction`, `autonomous-task-queue`, `idle-runtime-cleanup` |
| 5 — Distributed & extensibility | `jackin-remote`, `credential-source-pattern`, `workspace-skills-mount` |

`agent-runtime-status` and `persistent-storage-layer` are flagged as load-bearing — several other leaves depend on them.

## Verification gap surfaced

The hard-verification pass turned up one capability missed by the initial review: multicode's `[isolation] isolated = [...]` and `tmpfs = [...]` mount kinds describe **storage shape** while jackin's existing per-mount-isolation enum (`shared`/`worktree`/`clone`) describes **git semantics** — different axes. Captured as `ephemeral-mount-modes` in Phase 1.

## Test plan

- [x] `bun run build` — clean (88 pages generated, no MDX errors after fixing two `<…>` tokens that tripped the parser)
- [x] `bun run check:repo-links` — clean (every `<RepoFile />` resolves; future-file references use plain code spans per `docs/AGENTS.md`)
- [x] Every internal `/reference/roadmap/<slug>/` cross-link resolves to an existing `.mdx` file
- [x] CI `check` and `docs-link-check` (lychee) green — verifies the multicode external links return 200
- [x] DCO sign-off present on both commits
- [x] Sidebar nav verified by re-running `bun run build` (88 pages, same as pre-nav-change)

## Out of scope (intentionally)

This is design capture, not implementation. Each leaf marks itself "Open — design proposal" and ends with concrete `## Open Questions` for the operator. None of the leaves implements code; they all start with `## Problem` and end with `## Related Files` pointing at where future implementation would land.