### PR TITLE
fix(tui)!: workspace create mount flow

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -165,12 +165,13 @@ Each entry includes:
   unaffected — it still removes an existing same-path mount from the
   workspace config.
 - **Remove when:** After a deprecation window; delete the `no_workdir_mount`
-  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the discard
-  shim in `src/app/mod.rs` (`let _ = no_workdir_mount;`).
+  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the
+  `tui::deprecation_warning` call in `src/app/mod.rs`.
 - **Where:**
   - `src/cli/workspace.rs` — `WorkspaceCreate::no_workdir_mount` field,
     `hide = true`.
-  - `src/app/mod.rs` — emits the deprecation warning then ignores the flag.
+  - `src/app/mod.rs` — calls `tui::deprecation_warning` when the flag is
+    set, then ignores it.
 
 ## How to add an entry
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -160,16 +160,17 @@ Each entry includes:
 - **Replacement:** `workspace create` requires at least one `--mount` flag.
   The workdir is not auto-mounted.
 - **Behavior today:** Passing `--no-workdir-mount` to `workspace create` is
-  silently accepted but has no effect. The flag is hidden from `--help`.
-  `workspace edit --no-workdir-mount` is unaffected — it still removes an
-  existing same-path mount from the workspace config.
+  accepted, prints a one-line stderr warning, and otherwise has no effect.
+  The flag is hidden from `--help`. `workspace edit --no-workdir-mount` is
+  unaffected — it still removes an existing same-path mount from the
+  workspace config.
 - **Remove when:** After a deprecation window; delete the `no_workdir_mount`
-  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the ignored
-  parameter from `src/workspace/planner.rs::plan_create`.
+  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the discard
+  shim in `src/app/mod.rs` (`let _ = no_workdir_mount;`).
 - **Where:**
   - `src/cli/workspace.rs` — `WorkspaceCreate::no_workdir_mount` field,
     `hide = true`.
-  - `src/workspace/planner.rs::plan_create` — receives but ignores the flag.
+  - `src/app/mod.rs` — emits the deprecation warning then ignores the flag.
 
 ## How to add an entry
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -153,26 +153,6 @@ Each entry includes:
   - `docs/src/content/docs/reference/architecture.mdx` — layout
     diagram reflects the new shape.
 
-### `--no-workdir-mount` flag on `workspace create`
-
-- **Type:** cli
-- **Deprecated since:** 2026-05-04 (PR #213)
-- **Replacement:** `workspace create` requires at least one `--mount` flag.
-  The workdir is not auto-mounted.
-- **Behavior today:** Passing `--no-workdir-mount` to `workspace create` is
-  accepted, prints a one-line stderr warning, and otherwise has no effect.
-  The flag is hidden from `--help`. `workspace edit --no-workdir-mount` is
-  unaffected — it still removes an existing same-path mount from the
-  workspace config.
-- **Remove when:** After a deprecation window; delete the `no_workdir_mount`
-  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the
-  `tui::deprecation_warning` call in `src/app/mod.rs`.
-- **Where:**
-  - `src/cli/workspace.rs` — `WorkspaceCreate::no_workdir_mount` field,
-    `hide = true`.
-  - `src/app/mod.rs` — calls `tui::deprecation_warning` when the flag is
-    set, then ignores it.
-
 ## How to add an entry
 
 When you deprecate something, append a new section to **Active

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -153,6 +153,23 @@ Each entry includes:
   - `docs/src/content/docs/reference/architecture.mdx` — layout
     diagram reflects the new shape.
 
+### `--no-workdir-mount` flag on `workspace create`
+
+- **Status:** Hidden no-op as of PR #213.
+- **Replacement:** `workspace create` now requires at least one `--mount` flag.
+  The workdir is no longer auto-mounted.
+- **Behavior today:** Passing `--no-workdir-mount` to `workspace create` is
+  silently accepted but has no effect. The flag is hidden from `--help`.
+  `workspace edit --no-workdir-mount` is unaffected — it still removes an
+  existing same-path mount from the workspace config.
+- **Remove when:** After a deprecation window; delete the `no_workdir_mount`
+  field from `WorkspaceCreate` in `src/cli/workspace.rs` and the ignored
+  parameter from `src/workspace/planner.rs::plan_create`.
+- **Where:**
+  - `src/cli/workspace.rs` — `WorkspaceCreate::no_workdir_mount` field,
+    `hide = true`.
+  - `src/workspace/planner.rs::plan_create` — receives but ignores the flag.
+
 ## How to add an entry
 
 When you deprecate something, append a new section to **Active

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -155,9 +155,10 @@ Each entry includes:
 
 ### `--no-workdir-mount` flag on `workspace create`
 
-- **Status:** Hidden no-op as of PR #213.
-- **Replacement:** `workspace create` now requires at least one `--mount` flag.
-  The workdir is no longer auto-mounted.
+- **Type:** cli
+- **Deprecated since:** 2026-05-04 (PR #213)
+- **Replacement:** `workspace create` requires at least one `--mount` flag.
+  The workdir is not auto-mounted.
 - **Behavior today:** Passing `--no-workdir-mount` to `workspace create` is
   silently accepted but has no effect. The flag is hidden from `--help`.
   `workspace edit --no-workdir-mount` is unaffected — it still removes an

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -18,16 +18,15 @@ A workspace describes project access, not agent tooling. It answers: which host 
 ### `workspace create`
 
 ```bash
-jackin workspace create <NAME> --workdir <PATH> [OPTIONS]
+jackin workspace create <NAME> --workdir <PATH> --mount <SPEC> [OPTIONS]
 ```
 
 Create a new workspace definition.
 
 | Option | Description |
 |---|---|
-| `--workdir <PATH>` | Working directory (auto-mounted at the same path by default) |
-| `--mount <SPEC>` | Additional bind-mount spec (repeatable) |
-| `--no-workdir-mount` | Don't auto-mount the workdir |
+| `--workdir <PATH>` | Working directory inside the container |
+| `--mount <SPEC>` | Bind-mount spec (repeatable, at least one required) |
 | `--allowed-role <NAME>` | Restrict to these roles (repeatable) |
 | `--default-role <NAME>` | Role to auto-select |
 | `--default-agent <claude\|codex>` | Default agent for this workspace |
@@ -35,17 +34,16 @@ Create a new workspace definition.
 | `--keep-awake` | macOS only: opt this workspace into the keep-awake reconciler. While any agent in the workspace is running, jackin keeps a single detached `caffeinate -imsu` alive so the host stays awake. No-op on Linux/Windows. See [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake). |
 
 ```bash
-jackin workspace create my-app --workdir ~/Projects/my-app
-jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
-jackin workspace create codex-app --workdir ~/Projects/codex-app --default-agent codex
-jackin workspace create monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
-jackin workspace create restricted --workdir ~/app --allowed-role agent-smith --default-role agent-smith
-jackin workspace create remote --workdir ~/Projects/remote --keep-awake
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --mount ~/cache:/cache:ro
+jackin workspace create codex-app --workdir ~/Projects/codex-app --mount ~/Projects/codex-app --default-agent codex
+jackin workspace create monorepo --workdir /workspace --mount ~/src:/workspace
+jackin workspace create restricted --workdir ~/app --mount ~/app --allowed-role agent-smith --default-role agent-smith
+jackin workspace create remote --workdir ~/Projects/remote --mount ~/Projects/remote --keep-awake
 
 # Isolated source mount + shared cache child
 jackin workspace create jackin \
   --workdir /workspace/jackin \
-  --no-workdir-mount \
   --mount ~/projects/jackin:/workspace/jackin \
   --mount ~/.cache/jackin/target:/workspace/jackin/target \
   --mount-isolation /workspace/jackin=worktree

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -99,8 +99,8 @@ jackin eject agent-smith
 
 ```bash
 # Save workspaces for your projects
-jackin workspace create frontend --workdir ~/Projects/frontend
-jackin workspace create backend --workdir ~/Projects/backend
+jackin workspace create frontend --workdir ~/Projects/frontend --mount ~/Projects/frontend
+jackin workspace create backend --workdir ~/Projects/backend --mount ~/Projects/backend
 
 # Load agents into different workspaces
 jackin load agent-smith frontend
@@ -115,7 +115,7 @@ jackin load agent-smith backend
 
 ```bash
 # Same project access boundary, different tool profiles
-jackin workspace create monorepo --workdir ~/Projects/monorepo
+jackin workspace create monorepo --workdir ~/Projects/monorepo --mount ~/Projects/monorepo
 
 jackin load agent-smith monorepo
 jackin load the-architect monorepo

--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -64,6 +64,7 @@ Save mounts as part of a workspace definition:
 ```bash
 jackin workspace create my-app \
   --workdir ~/Projects/my-app \
+  --mount ~/Projects/my-app \
   --mount ~/cache:/cache:ro
 ```
 
@@ -119,8 +120,7 @@ When multiple mount sources are resolved, jackin' combines them in this order:
 
 1. **Global mounts** (from `jackin config mount`)
 2. **Workspace mounts** (from `jackin workspace create`)
-3. **Auto-mounted workdir** (unless `--no-workdir-mount`)
-4. **Load-time mounts** (from `jackin load --mount`)
+3. **Load-time mounts** (from `jackin load --mount`)
 
 <Aside type="caution">
 If two mounts target the same container destination, jackin' stops with an error. It does not silently let the later mount win. This is deliberate because mounts are part of the security boundary.

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -51,7 +51,7 @@ If you regularly work on the same project, a saved workspace turns your mount la
 For projects you work on regularly, save a workspace:
 
 ```bash
-jackin workspace create my-app --workdir ~/Projects/my-app
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app
 ```
 
 Now you can load agents into it from anywhere:
@@ -70,13 +70,10 @@ This is the key pattern to keep in mind: the workspace stays the same because th
 
 ### What `--workdir` does
 
-The `--workdir` path serves two purposes:
-
-1. **Working directory** — the container's `cwd` when the agent starts
-2. **Auto-mount** — by default, the workdir is automatically mounted at the same path inside the container
+The `--workdir` path sets the container's `cwd` when the agent starts. It does not mount anything by itself.
 
 <Aside type="tip">
-The auto-mount keeps host and container paths identical, which avoids confusion when the agent references file paths. This is the common case.
+Use `--mount ~/Projects/my-app` when you want the host and container paths to stay identical. Keeping the paths the same avoids confusion when the agent references files.
 </Aside>
 ### Adding extra mounts
 
@@ -85,6 +82,7 @@ Workspaces can include additional directories beyond the workdir:
 ```bash
 jackin workspace create my-app \
   --workdir ~/Projects/my-app \
+  --mount ~/Projects/my-app \
   --mount ~/cache:/cache:ro \
   --mount ~/shared-libs:/libs:ro
 ```
@@ -96,11 +94,10 @@ If you need the container layout to differ from your host:
 ```bash
 jackin workspace create monorepo \
   --workdir /workspace \
-  --no-workdir-mount \
   --mount ~/src:/workspace
 ```
 
-Here, `--no-workdir-mount` disables the automatic workdir mount, and you provide all mounts explicitly.
+Here, `/workspace` is the container start path and `~/src:/workspace` is the explicit mount that makes it available.
 
 ## Per-mount isolation
 
@@ -255,7 +252,7 @@ You can opt in (or out) from the CLI or the operator console — no need to hand
 
 ```bash
 # Opt in at creation time
-jackin workspace create my-app --workdir ~/Projects/my-app --keep-awake
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --keep-awake
 
 # Toggle on an existing workspace
 jackin workspace edit my-app --keep-awake

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -111,7 +111,7 @@ enabled = true
 | `last_role` | Most recently used role selector for this workspace |
 | `keep_awake.enabled` | macOS-only: keep the host awake while any agent in this workspace is running (see [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake)). On Linux/Windows the flag is silently accepted but has no effect — useful when sharing a `config.toml` across machines, but the host will still sleep. |
 
-When you use `jackin workspace create`, the common case is to make `workdir` and the first mount destination the same absolute path. If you need a different container layout, use `--no-workdir-mount` and define mounts explicitly.
+When you use `jackin workspace create`, `workdir` is only the container start path. Add an explicit `--mount` for every directory the container should see.
 
 ### Global mounts
 

--- a/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
+++ b/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
@@ -71,7 +71,6 @@ TOML is the storage format, not the only user interface. V1 should let operators
 ```sh
 jackin workspace create jackin \
   --workdir /workspace/jackin \
-  --no-workdir-mount \
   --mount ~/projects/jackin:/workspace/jackin \
   --mount-isolation /workspace/jackin=worktree
 

--- a/docs/src/content/docs/reference/roadmap/workspace-description.mdx
+++ b/docs/src/content/docs/reference/roadmap/workspace-description.mdx
@@ -65,6 +65,7 @@ isolation = "worktree"
 
 ```sh
 jackin workspace create my-ws --workdir /workspace/x \
+  --mount ~/projects/x:/workspace/x \
   --description "Issue #412 isolated repro branch"
 
 jackin workspace edit my-ws --description "..."

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -491,11 +491,8 @@ pub fn run(cli: Cli) -> Result<()> {
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
                 if no_workdir_mount {
-                    // Deprecated no-op — surface a one-line warning so
-                    // operators copy-pasting pre-PR-213 invocations notice.
-                    // See DEPRECATED.md `--no-workdir-mount` entry.
-                    eprintln!(
-                        "warning: --no-workdir-mount is deprecated and ignored; workspace create requires explicit --mount"
+                    tui::deprecation_warning(
+                        "--no-workdir-mount is deprecated and ignored; workspace create requires explicit --mount",
                     );
                 }
                 let mut plan = workspace::planner::plan_create(&parsed_mounts)?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -490,7 +490,14 @@ pub fn run(cli: Cli) -> Result<()> {
                     .iter()
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
-                let _ = no_workdir_mount; // Hidden no-op flag — see DEPRECATED.md.
+                if no_workdir_mount {
+                    // Deprecated no-op — surface a one-line warning so
+                    // operators copy-pasting pre-PR-213 invocations notice.
+                    // See DEPRECATED.md `--no-workdir-mount` entry.
+                    eprintln!(
+                        "warning: --no-workdir-mount is deprecated and ignored; workspace create requires explicit --mount"
+                    );
+                }
                 let mut plan = workspace::planner::plan_create(&parsed_mounts)?;
                 workspace::planner::apply_isolation_overrides(
                     &mut plan.final_mounts,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -490,11 +490,8 @@ pub fn run(cli: Cli) -> Result<()> {
                     .iter()
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
-                let mut plan = workspace::planner::plan_create(
-                    &expanded_workdir,
-                    &parsed_mounts,
-                    no_workdir_mount,
-                )?;
+                let _ = no_workdir_mount; // Hidden no-op flag — see DEPRECATED.md.
+                let mut plan = workspace::planner::plan_create(&parsed_mounts)?;
                 workspace::planner::apply_isolation_overrides(
                     &mut plan.final_mounts,
                     &mount_isolation,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -492,7 +492,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     .collect::<Result<Vec<_>>>()?;
                 let mut plan = workspace::planner::plan_create(
                     &expanded_workdir,
-                    parsed_mounts,
+                    &parsed_mounts,
                     no_workdir_mount,
                 )?;
                 workspace::planner::apply_isolation_overrides(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -478,7 +478,6 @@ pub fn run(cli: Cli) -> Result<()> {
                 name,
                 workdir,
                 mounts,
-                no_workdir_mount,
                 allowed_roles,
                 default_role,
                 default_agent,
@@ -490,11 +489,6 @@ pub fn run(cli: Cli) -> Result<()> {
                     .iter()
                     .map(|value| parse_mount_spec_resolved(value))
                     .collect::<Result<Vec<_>>>()?;
-                if no_workdir_mount {
-                    tui::deprecation_warning(
-                        "--no-workdir-mount is deprecated and ignored; workspace create requires explicit --mount",
-                    );
-                }
                 let mut plan = workspace::planner::plan_create(&parsed_mounts)?;
                 workspace::planner::apply_isolation_overrides(
                     &mut plan.final_mounts,

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -24,31 +24,31 @@ fn parse_agent(s: &str) -> Result<crate::agent::Agent, String> {
 pub enum WorkspaceCommand {
     /// Create a new workspace definition
     ///
-    /// By default the workdir path is automatically mounted into the container
-    /// at the same location (host path = container path). Use --no-workdir-mount
-    /// to disable this and provide all mounts explicitly.
+    /// The workdir is the path jackin starts the agent in. It is not mounted
+    /// implicitly; provide one or more --mount entries for the directories the
+    /// container should see.
     #[command(
         before_help = BANNER,
         styles = HELP_STYLES,
         after_long_help = "\
 Examples:
-  jackin workspace create my-app --workdir ~/Projects/my-app
-  jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/cache:/cache:ro
-  jackin workspace create my-app --workdir ~/Projects/my-app --default-agent codex
-  jackin workspace create monorepo --workdir /workspace --no-workdir-mount --mount ~/src:/workspace
-  jackin workspace create restricted --workdir ~/app --allowed-role agent-smith --default-role agent-smith"
+  jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app
+  jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --mount ~/cache:/cache:ro
+  jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --default-agent codex
+  jackin workspace create monorepo --workdir /workspace --mount ~/src:/workspace
+  jackin workspace create restricted --workdir ~/app --mount ~/app --allowed-role agent-smith --default-role agent-smith"
     )]
     Create {
         /// Unique name for this workspace
         name: String,
-        /// Working directory (automatically mounted at the same path unless --no-workdir-mount)
+        /// Working directory inside the container
         #[arg(long)]
         workdir: String,
         /// Additional bind-mount spec as `path[:ro]` or `src:dst[:ro]` (repeatable)
-        #[arg(long = "mount")]
+        #[arg(long = "mount", required = true)]
         mounts: Vec<String>,
-        /// Do not auto-mount the workdir; provide all mounts explicitly with --mount
-        #[arg(long, default_value_t = false)]
+        /// Deprecated compatibility no-op; create now always uses explicit mounts only
+        #[arg(long, hide = true, default_value_t = false)]
         no_workdir_mount: bool,
         /// Restrict which roles may use this workspace (repeatable)
         #[arg(long = "allowed-role")]
@@ -337,8 +337,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_workspace_create_with_workdir_only() {
-        let cli = Cli::try_parse_from([
+    fn workspace_create_requires_explicit_mount() {
+        let err = Cli::try_parse_from([
             "jackin",
             "workspace",
             "create",
@@ -346,15 +346,9 @@ mod tests {
             "--workdir",
             "/tmp/my-app",
         ])
-        .unwrap();
+        .unwrap_err();
 
-        assert!(matches!(
-            cli.command,
-            Some(Command::Workspace(WorkspaceCommand::Create {
-                no_workdir_mount: false,
-                ..
-            }))
-        ));
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]
@@ -430,6 +424,8 @@ mod tests {
             "my-app",
             "--workdir",
             "/tmp/my-app",
+            "--mount",
+            "/tmp/my-app",
             "--keep-awake",
         ])
         .unwrap();
@@ -449,6 +445,8 @@ mod tests {
             "create",
             "my-app",
             "--workdir",
+            "/tmp/my-app",
+            "--mount",
             "/tmp/my-app",
             "--default-agent",
             "codex",
@@ -470,6 +468,8 @@ mod tests {
             "create",
             "my-app",
             "--workdir",
+            "/tmp/my-app",
+            "--mount",
             "/tmp/my-app",
         ])
         .unwrap();
@@ -676,15 +676,20 @@ mod tests {
     // ── Workspace subcommand help ───────────────────────────────────────
 
     #[test]
-    fn workspace_create_help_shows_auto_mount_and_examples() {
+    fn workspace_create_help_shows_explicit_mounts_and_examples() {
         let help = help_text(&["jackin", "workspace", "create", "--help"]);
         assert!(
-            help.contains("automatically mounted"),
-            "auto-mount behavior not documented"
+            help.contains("not mounted implicitly"),
+            "explicit mount behavior not documented"
         );
-        assert!(help.contains("--no-workdir-mount"), "opt-out flag missing");
+        assert!(
+            !help.contains("--no-workdir-mount"),
+            "deprecated no-op flag should stay hidden"
+        );
         assert!(help.contains("Examples:"));
-        assert!(help.contains("jackin workspace create my-app --workdir ~/Projects/my-app"));
+        assert!(help.contains(
+            "jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app"
+        ));
     }
 
     #[test]

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -47,9 +47,6 @@ Examples:
         /// Additional bind-mount spec as `path[:ro]` or `src:dst[:ro]` (repeatable)
         #[arg(long = "mount", required = true)]
         mounts: Vec<String>,
-        /// Deprecated compatibility no-op; create now always uses explicit mounts only
-        #[arg(long, hide = true, default_value_t = false)]
-        no_workdir_mount: bool,
         /// Restrict which roles may use this workspace (repeatable)
         #[arg(long = "allowed-role")]
         allowed_roles: Vec<String>,
@@ -349,30 +346,6 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
-    }
-
-    #[test]
-    fn parses_workspace_create_with_no_workdir_mount() {
-        let cli = Cli::try_parse_from([
-            "jackin",
-            "workspace",
-            "create",
-            "monorepo",
-            "--workdir",
-            "/workspace",
-            "--no-workdir-mount",
-            "--mount",
-            "/tmp/src:/workspace",
-        ])
-        .unwrap();
-
-        assert!(matches!(
-            cli.command,
-            Some(Command::Workspace(WorkspaceCommand::Create {
-                no_workdir_mount: true,
-                ..
-            }))
-        ));
     }
 
     #[test]
@@ -681,10 +654,6 @@ mod tests {
         assert!(
             help.contains("not mounted implicitly"),
             "explicit mount behavior not documented"
-        );
-        assert!(
-            !help.contains("--no-workdir-mount"),
-            "deprecated no-op flag should stay hidden"
         );
         assert!(help.contains("Examples:"));
         assert!(help.contains(

--- a/src/console/manager/github_mounts.rs
+++ b/src/console/manager/github_mounts.rs
@@ -20,7 +20,7 @@
 use crate::console::widgets::github_picker::GithubChoice;
 use crate::workspace::WorkspaceConfig;
 
-use super::mount_info::{GitBranch, GitHost, MountKind, inspect};
+use super::mount_info::{GitBranch, GitOrigin, MountKind, inspect};
 
 /// Project `ws`'s mounts down to the list of GitHub-hosted sources that
 /// expose a resolvable web URL. Mounts with non-GitHub remotes, no
@@ -31,9 +31,7 @@ pub(super) fn resolve_for_workspace(ws: &WorkspaceConfig) -> Vec<GithubChoice> {
         .filter_map(|m| {
             let MountKind::Git {
                 branch,
-                host: GitHost::Github,
-                web_url: Some(url),
-                ..
+                origin: Some(GitOrigin::Github { web_url, .. }),
             } = inspect(&m.src)
             else {
                 return None;
@@ -46,7 +44,7 @@ pub(super) fn resolve_for_workspace(ws: &WorkspaceConfig) -> Vec<GithubChoice> {
             Some(GithubChoice {
                 src: m.src.clone(),
                 branch: branch_label,
-                url,
+                url: web_url,
             })
         })
         .collect()

--- a/src/console/manager/github_mounts.rs
+++ b/src/console/manager/github_mounts.rs
@@ -33,6 +33,7 @@ pub(super) fn resolve_for_workspace(ws: &WorkspaceConfig) -> Vec<GithubChoice> {
                 branch,
                 host: GitHost::Github,
                 web_url: Some(url),
+                ..
             } = inspect(&m.src)
             else {
                 return None;

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1216,7 +1216,10 @@ fn apply_role_input_with_runner(
     let selector = match crate::selector::RoleSelector::parse(raw) {
         Ok(selector) => selector,
         Err(e) => {
-            open_role_resolution_error(editor, raw, None, &e);
+            // The unparseable-selector branch ignores `err`; wrap into
+            // anyhow only to satisfy the typed signature.
+            let err = anyhow::Error::new(e);
+            open_role_resolution_error(editor, raw, None, &err);
             return;
         }
     };
@@ -1272,9 +1275,9 @@ fn open_role_resolution_error(
     editor: &mut EditorState<'_>,
     raw: &str,
     source_url: Option<&String>,
-    err: &dyn std::fmt::Display,
+    err: &anyhow::Error,
 ) {
-    crate::debug_log!("role", "failed to resolve role {raw:?}: {err}");
+    crate::debug_log!("role", "failed to resolve role {raw:?}: {err:?}");
     let message = source_url.map_or_else(
         || {
             format!(
@@ -1307,26 +1310,30 @@ fn open_editor_action_error(editor: &mut EditorState<'_>, err: &dyn std::fmt::Di
     });
 }
 
-fn friendly_role_resolution_error(err: &dyn std::fmt::Display) -> String {
-    let message = err.to_string();
-    if message.contains("repository is not available")
-        || message.contains("git clone")
-        || message.contains("not found")
-    {
-        return "Repository is not available, or you do not have access.".into();
-    }
-    if message.contains("cached role repo remote mismatch") {
-        return "A cached copy already exists for this role, but it points at a different repository."
-            .into();
-    }
-    if let Some(detail) = message.strip_prefix("invalid role repo: ") {
-        return format!(
-            "Repository is not a valid Jackin role: {}.",
-            humanize_invalid_role_repo_detail(detail)
-        );
-    }
-    if message.contains("invalid role repo:") {
-        return "Repository is not a valid Jackin role.".into();
+/// Translate a runtime role-resolution error into the operator-facing
+/// blurb shown beneath the role-input dialog.
+///
+/// Classification is by `downcast_ref::<RepoError>` rather than substring
+/// matching on free text — when adding a `RepoError` variant, add the
+/// corresponding match arm here. The `else` branch handles errors that
+/// were never wrapped as `RepoError` (e.g. fs/IO errors raised before the
+/// clone) and uses a generic message rather than mis-classifying them.
+fn friendly_role_resolution_error(err: &anyhow::Error) -> String {
+    if let Some(repo_err) = err.downcast_ref::<crate::runtime::RepoError>() {
+        return match repo_err {
+            crate::runtime::RepoError::CloneFailed(_) => {
+                "Repository is not available, or you do not have access.".into()
+            }
+            crate::runtime::RepoError::RemoteMismatch => {
+                "A cached copy already exists for this role, but it points at a different \
+                 repository."
+                    .into()
+            }
+            crate::runtime::RepoError::InvalidRoleRepo { detail } => format!(
+                "Repository is not a valid Jackin role: {}.",
+                humanize_invalid_role_repo_detail(detail)
+            ),
+        };
     }
     "Repository could not be used as a Jackin role.".into()
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -264,11 +264,10 @@ pub(super) fn handle_editor_key(
                 let kind = super::super::mount_info::inspect(&m.src);
                 match kind {
                     super::super::mount_info::MountKind::Git {
-                        host: super::super::mount_info::GitHost::Github,
-                        web_url: Some(url),
+                        origin: Some(super::super::mount_info::GitOrigin::Github { web_url, .. }),
                         ..
                     } => {
-                        if let Err(e) = open::that_detached(&url) {
+                        if let Err(e) = open::that_detached(&web_url) {
                             state.toast = Some(Toast {
                                 message: format!("failed to open URL: {e}"),
                                 kind: ToastKind::Error,
@@ -1953,14 +1952,14 @@ plugins = []
 
     #[test]
     fn roles_tab_enter_on_add_role_row_opens_role_input() {
-        let (_tmp, paths, mut config) = {
+        let (tmp, paths, mut config) = {
             let tmp = tempfile::tempdir().unwrap();
             let paths = JackinPaths::for_tests(tmp.path());
             paths.ensure_base_dirs().unwrap();
             let config = config_with_agents(&["agent-smith"]);
             (tmp, paths, config)
         };
-        let cwd = _tmp.path();
+        let cwd = tmp.path();
         let mut state = editor_on_agents_tab(empty_ws(), config.roles.len());
 
         handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter)).unwrap();

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -2257,9 +2257,8 @@ plugins = []
     fn role_input_trusted_existing_role_skips_trust_prompt() {
         // When the config already has a trusted role source the editor
         // must register the cached repo and add it to the workspace
-        // *without* re-prompting for trust. Pre-fix this branch
-        // (`Ok(source) if source.trusted`) was not exercised — only the
-        // trust=false → confirm flow was tested.
+        // *without* re-prompting for trust (`Ok(source) if
+        // source.trusted` branch in `apply_role_input_with_runner`).
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -525,9 +525,14 @@ fn open_agent_override_picker(editor: &mut EditorState<'_>, config: &AppConfig) 
 fn open_role_input(editor: &mut EditorState<'_>, config: &AppConfig) {
     use super::super::super::widgets::text_input::TextInputState;
 
-    let mut state =
-        TextInputState::new_with_forbidden("Add role", "", config.roles.keys().cloned().collect());
-    state.forbidden_label = "role registry".into();
+    let trusted_roles = config
+        .roles
+        .iter()
+        .filter(|(_, source)| source.trusted)
+        .map(|(key, _)| key.clone())
+        .collect();
+    let mut state = TextInputState::new_with_forbidden("Add role", "", trusted_roles);
+    state.forbidden_label = "trusted role registry".into();
     editor.modal = Some(Modal::TextInput {
         target: TextInputTarget::Role,
         state,
@@ -751,8 +756,8 @@ pub(super) fn handle_editor_modal(
                             plan,
                             exit_on_success,
                         };
-                    } else {
-                        apply_editor_confirm(editor, &target);
+                    } else if let Err(e) = apply_editor_confirm(editor, &target, config, paths) {
+                        open_role_resolution_error(editor, "confirmed action", None, &e);
                     }
                 } else if matches!(
                     target,
@@ -1219,26 +1224,20 @@ fn apply_role_input_with_runner(
     let result = (|| -> anyhow::Result<crate::config::RoleSource> {
         let source = candidate_role_source(config, &selector)?;
         crate::runtime::resolve_agent_repo(paths, &selector, &source.git, runner, false)?;
-        let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
-        editor_doc.upsert_agent_source(&key, &source);
-        *config = editor_doc.save()?;
         Ok(source)
     })();
 
-    if let Err(e) = result {
-        let source = candidate_role_source(config, &selector).ok();
-        open_role_resolution_error(editor, raw, source.as_ref().map(|source| &source.git), &e);
-        return;
-    }
-
-    if !editor.pending.allowed_roles.is_empty()
-        && !editor.pending.allowed_roles.iter().any(|role| role == &key)
-    {
-        editor.pending.allowed_roles.push(key.clone());
-    }
-
-    if let Some(idx) = config.roles.keys().position(|role| role == &key) {
-        editor.active_field = FieldFocus::Row(idx);
+    match result {
+        Ok(source) if source.trusted => {
+            if let Err(e) = persist_trusted_role_add(editor, config, paths, &key, source) {
+                open_role_resolution_error(editor, raw, None, &e);
+            }
+        }
+        Ok(source) => open_role_trust_confirm(editor, key, source),
+        Err(e) => {
+            let source = candidate_role_source(config, &selector).ok();
+            open_role_resolution_error(editor, raw, source.as_ref().map(|source| &source.git), &e);
+        }
     }
 }
 
@@ -1286,7 +1285,57 @@ fn open_role_resolution_error(
     });
 }
 
-fn apply_editor_confirm(editor: &mut EditorState<'_>, target: &ConfirmTarget) {
+fn open_role_trust_confirm(
+    editor: &mut EditorState<'_>,
+    key: String,
+    source: crate::config::RoleSource,
+) {
+    let prompt = format!(
+        "Trust role source?\n\
+         Role: {key}\n\
+         Repository:\n\
+         {}\n\
+         Its Dockerfile can run during image builds.\n\
+         The role can access mounted workspace files.",
+        source.git
+    );
+    editor.modal = Some(Modal::Confirm {
+        target: ConfirmTarget::TrustRoleSource { key, source },
+        state: crate::console::widgets::confirm::ConfirmState::new(prompt),
+    });
+}
+
+fn persist_trusted_role_add(
+    editor: &mut EditorState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    key: &str,
+    mut source: crate::config::RoleSource,
+) -> anyhow::Result<()> {
+    source.trusted = true;
+    let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
+    editor_doc.upsert_agent_source(key, &source);
+    *config = editor_doc.save()?;
+
+    if !editor.pending.allowed_roles.is_empty()
+        && !editor.pending.allowed_roles.iter().any(|role| role == key)
+    {
+        editor.pending.allowed_roles.push(key.to_string());
+    }
+
+    if let Some(idx) = config.roles.keys().position(|role| role == key) {
+        editor.active_field = FieldFocus::Row(idx);
+    }
+
+    Ok(())
+}
+
+fn apply_editor_confirm(
+    editor: &mut EditorState<'_>,
+    target: &ConfirmTarget,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+) -> anyhow::Result<()> {
     match target {
         ConfirmTarget::DeleteEnvVar { scope, key } => match scope {
             SecretsScopeTag::Workspace => {
@@ -1308,12 +1357,16 @@ fn apply_editor_confirm(editor: &mut EditorState<'_>, target: &ConfirmTarget) {
                 }
             }
         },
+        ConfirmTarget::TrustRoleSource { key, source } => {
+            persist_trusted_role_add(editor, config, paths, key, source.clone())?;
+        }
         // `DeleteWorkspace` is a list-side target that never reaches the
         // editor modal. `DeleteIsolatedAndSave` is handled inline at the
         // dispatch site because it consumes `plan` and routes through
         // `EditorSaveFlow::PendingCommit`. Both no-op here.
         ConfirmTarget::DeleteWorkspace | ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
     }
+    Ok(())
 }
 
 /// Only `EditAddMountSrc` is meaningful here; the prelude's
@@ -1394,8 +1447,8 @@ mod tests {
     //! Editor-stage tests: tab cycling, modal dispatch, role allow/default
     //! bindings, and mount-row readonly toggle.
     use super::super::super::state::{
-        EditorState, EditorTab, FieldFocus, FileBrowserTarget, ManagerStage, ManagerState, Modal,
-        SecretsScopeTag, TextInputTarget,
+        ConfirmTarget, EditorState, EditorTab, FieldFocus, FileBrowserTarget, ManagerStage,
+        ManagerState, Modal, SecretsScopeTag, TextInputTarget,
     };
     use super::super::test_support::{key, mount};
     use super::{
@@ -1843,7 +1896,7 @@ plugins = []
     }
 
     #[test]
-    fn role_input_resolves_and_persists_namespaced_role() {
+    fn role_input_resolves_then_persists_namespaced_role_after_trust() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();
@@ -1869,15 +1922,60 @@ plugins = []
         );
 
         assert!(
-            editor.modal.is_none(),
-            "successful resolve should close modal"
-        );
-        assert!(
             runner.recorded.iter().any(|cmd| cmd
                 .contains("git clone https://github.com/chainargos/jackin-agent-brown.git")),
             "role add must clone through the normal repo resolver; got {:?}",
             runner.recorded
         );
+
+        match &editor.modal {
+            Some(Modal::Confirm { target, state }) => {
+                assert!(state.prompt.contains("Trust role source?"));
+                assert!(state.prompt.contains("chainargos/agent-brown"));
+                assert!(
+                    state
+                        .prompt
+                        .contains("https://github.com/chainargos/jackin-agent-brown.git"),
+                    "trust prompt should show the repository URL:\n{}",
+                    state.prompt
+                );
+                match target {
+                    ConfirmTarget::TrustRoleSource { key, source } => {
+                        assert_eq!(key, "chainargos/agent-brown");
+                        assert_eq!(
+                            source.git,
+                            "https://github.com/chainargos/jackin-agent-brown.git"
+                        );
+                        assert!(
+                            !source.trusted,
+                            "newly resolved third-party role should require explicit trust first"
+                        );
+                    }
+                    other => panic!("expected TrustRoleSource target; got {other:?}"),
+                }
+            }
+            other => panic!("expected trust Confirm modal; got {other:?}"),
+        }
+        assert!(
+            !editor
+                .pending
+                .allowed_roles
+                .contains(&"chainargos/agent-brown".to_string()),
+            "role should not be allowed before trust confirmation"
+        );
+        assert!(
+            !config.roles.contains_key("chainargos/agent-brown"),
+            "role source should not be added to config before trust confirmation"
+        );
+        let before_trust = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            !before_trust.contains("chainargos/agent-brown"),
+            "role source should not be persisted before trust confirmation:\n{before_trust}"
+        );
+
+        handle_modal_with(&mut editor, key(KeyCode::Char('y')), &mut config, &paths);
+
+        assert!(editor.modal.is_none(), "trust confirmation should close");
         assert!(
             editor
                 .pending
@@ -1893,10 +1991,127 @@ plugins = []
             source.git,
             "https://github.com/chainargos/jackin-agent-brown.git"
         );
+        assert!(source.trusted, "trusted role should be marked trusted");
         let persisted = std::fs::read_to_string(paths.config_file).unwrap();
         assert!(
             persisted.contains("[roles.\"chainargos/agent-brown\"]"),
             "new role source should be persisted:\n{persisted}"
+        );
+        assert!(
+            persisted.contains("trusted = true"),
+            "trusted role should be persisted with trusted = true:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn role_input_trust_decline_does_not_persist_role() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        editor.pending.allowed_roles = vec!["agent-smith".into()];
+        let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || seed_valid_role_repo(&repo_dir)),
+        ));
+
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "chainargos/agent-brown",
+            &mut runner,
+        );
+        assert!(matches!(editor.modal, Some(Modal::Confirm { .. })));
+
+        handle_modal_with(&mut editor, key(KeyCode::Char('n')), &mut config, &paths);
+
+        assert!(editor.modal.is_none(), "decline should close trust prompt");
+        assert!(
+            !editor
+                .pending
+                .allowed_roles
+                .contains(&"chainargos/agent-brown".to_string()),
+            "declined role must not be added to the custom allow-list"
+        );
+        assert!(
+            !config.roles.contains_key("chainargos/agent-brown"),
+            "declined role must not mutate in-memory config"
+        );
+        let persisted = std::fs::read_to_string(paths.config_file).unwrap();
+        assert!(
+            !persisted.contains("chainargos/agent-brown"),
+            "declined role must not be persisted:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn role_input_existing_untrusted_role_can_be_validated_and_trusted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        config.roles.insert(
+            "chainargos/agent-brown".into(),
+            crate::config::RoleSource {
+                git: "https://github.com/chainargos/jackin-agent-brown.git".into(),
+                trusted: false,
+                ..Default::default()
+            },
+        );
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        editor.pending.allowed_roles = vec!["agent-smith".into()];
+        let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || seed_valid_role_repo(&repo_dir)),
+        ));
+
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "chainargos/agent-brown",
+            &mut runner,
+        );
+        assert!(matches!(
+            editor.modal,
+            Some(Modal::Confirm {
+                target: ConfirmTarget::TrustRoleSource { .. },
+                ..
+            })
+        ));
+
+        handle_modal_with(&mut editor, key(KeyCode::Char('y')), &mut config, &paths);
+
+        assert!(
+            config
+                .roles
+                .get("chainargos/agent-brown")
+                .is_some_and(|source| source.trusted),
+            "existing untrusted role should become trusted after confirmation"
+        );
+        assert!(
+            editor
+                .pending
+                .allowed_roles
+                .contains(&"chainargos/agent-brown".to_string()),
+            "trusted role should be added to the custom allow-list"
+        );
+        let persisted = std::fs::read_to_string(paths.config_file).unwrap();
+        assert!(
+            persisted.contains("trusted = true"),
+            "confirmed role should persist trust:\n{persisted}"
         );
     }
 

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -2246,6 +2246,59 @@ plugins = []
     }
 
     #[test]
+    fn role_input_trusted_existing_role_skips_trust_prompt() {
+        // When the config already has a trusted role source the editor
+        // must register the cached repo and add it to the workspace
+        // *without* re-prompting for trust. Pre-fix this branch
+        // (`Ok(source) if source.trusted`) was not exercised — only the
+        // trust=false → confirm flow was tested.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        config.roles.insert(
+            "chainargos/agent-brown".into(),
+            crate::config::RoleSource {
+                git: "https://github.com/chainargos/jackin-agent-brown.git".into(),
+                trusted: true,
+                ..Default::default()
+            },
+        );
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        editor.pending.allowed_roles = vec!["agent-smith".into()];
+        let data_dir = paths.data_dir.clone();
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || seed_first_temp_valid_role_repo(&data_dir)),
+        ));
+
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "chainargos/agent-brown",
+            &mut runner,
+        );
+
+        assert!(
+            editor.modal.is_none(),
+            "trusted existing role must not open the trust-confirm modal: {:?}",
+            editor.modal
+        );
+        assert!(
+            editor
+                .pending
+                .allowed_roles
+                .contains(&"chainargos/agent-brown".to_string()),
+            "trusted role should be added to the custom allow-list directly: {:?}",
+            editor.pending.allowed_roles
+        );
+    }
+
+    #[test]
     fn role_input_clone_failure_reports_candidate_repository_url() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1195,39 +1195,39 @@ fn apply_role_input(
     paths: &JackinPaths,
     value: &str,
 ) {
+    let mut runner = crate::docker::ShellRunner::default();
+    apply_role_input_with_runner(editor, config, paths, value, &mut runner);
+}
+
+fn apply_role_input_with_runner(
+    editor: &mut EditorState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    value: &str,
+    runner: &mut impl crate::docker::CommandRunner,
+) {
     let raw = value.trim();
     let selector = match crate::selector::RoleSelector::parse(raw) {
         Ok(selector) => selector,
         Err(e) => {
-            editor.modal = Some(Modal::ErrorPopup {
-                state: crate::console::widgets::error_popup::ErrorPopupState::new(
-                    "Role not found",
-                    format!(
-                        "Could not resolve role {raw:?}. Use a configured role such as \
-                         \"agent-smith\" or a GitHub selector like \"owner/agent-name\". {e}"
-                    ),
-                ),
-            });
+            open_role_resolution_error(editor, raw, None, &e);
             return;
         }
     };
 
     let key = selector.key();
-    let result = (|| -> anyhow::Result<()> {
-        let (source, _) = config.resolve_role_source(&selector)?;
+    let result = (|| -> anyhow::Result<crate::config::RoleSource> {
+        let source = candidate_role_source(config, &selector)?;
+        crate::runtime::resolve_agent_repo(paths, &selector, &source.git, runner, false)?;
         let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
         editor_doc.upsert_agent_source(&key, &source);
         *config = editor_doc.save()?;
-        Ok(())
+        Ok(source)
     })();
 
     if let Err(e) = result {
-        editor.modal = Some(Modal::ErrorPopup {
-            state: crate::console::widgets::error_popup::ErrorPopupState::new(
-                "Role not found",
-                format!("Could not resolve role {raw:?}: {e}"),
-            ),
-        });
+        let source = candidate_role_source(config, &selector).ok();
+        open_role_resolution_error(editor, raw, source.as_ref().map(|source| &source.git), &e);
         return;
     }
 
@@ -1240,6 +1240,50 @@ fn apply_role_input(
     if let Some(idx) = config.roles.keys().position(|role| role == &key) {
         editor.active_field = FieldFocus::Row(idx);
     }
+}
+
+fn candidate_role_source(
+    config: &AppConfig,
+    selector: &crate::selector::RoleSelector,
+) -> anyhow::Result<crate::config::RoleSource> {
+    let mut candidate = config.clone();
+    match candidate.resolve_role_source(selector) {
+        Ok((source, _)) => Ok(source),
+        Err(_) if selector.namespace.is_none() => Ok(crate::config::RoleSource {
+            git: format!(
+                "https://github.com/jackin-project/jackin-{}.git",
+                selector.name
+            ),
+            trusted: false,
+            claude: None,
+            env: std::collections::BTreeMap::new(),
+        }),
+        Err(err) => Err(err),
+    }
+}
+
+fn open_role_resolution_error(
+    editor: &mut EditorState<'_>,
+    raw: &str,
+    source_url: Option<&String>,
+    err: &dyn std::fmt::Display,
+) {
+    let mut message = format!(
+        "Could not resolve role {raw:?}. Use a configured role such as \
+         \"agent-smith\" or a GitHub selector like \"owner/agent-name\"."
+    );
+    if let Some(source_url) = source_url {
+        message.push_str("\n\nLooked for repository:\n");
+        message.push_str(source_url);
+    }
+    message.push_str("\n\n");
+    message.push_str(&err.to_string());
+    editor.modal = Some(Modal::ErrorPopup {
+        state: crate::console::widgets::error_popup::ErrorPopupState::new(
+            "Role not found",
+            message,
+        ),
+    });
 }
 
 fn apply_editor_confirm(editor: &mut EditorState<'_>, target: &ConfirmTarget) {
@@ -1354,7 +1398,10 @@ mod tests {
         SecretsScopeTag, TextInputTarget,
     };
     use super::super::test_support::{key, mount};
-    use super::{apply_file_browser_to_editor, apply_text_input_to_pending, handle_editor_modal};
+    use super::{
+        apply_file_browser_to_editor, apply_role_input_with_runner, apply_text_input_to_pending,
+        handle_editor_modal,
+    };
     use crate::config::AppConfig;
     use crate::console::manager::input::handle_key;
     use crate::console::op_cache::OpCache;
@@ -1415,6 +1462,24 @@ mod tests {
         }
         config.workspaces.insert("ws".into(), empty_ws());
         config
+    }
+
+    fn seed_valid_role_repo(repo_dir: &std::path::Path) {
+        std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
     }
 
     fn editor_on_agents_tab<'a>(ws: WorkspaceConfig, row: usize) -> ManagerState<'a> {
@@ -1787,19 +1852,31 @@ mod tests {
 
         let mut editor = EditorState::new_edit("ws".into(), empty_ws());
         editor.pending.allowed_roles = vec!["agent-smith".into()];
-        editor.modal = Some(Modal::TextInput {
-            target: TextInputTarget::Role,
-            state: crate::console::widgets::text_input::TextInputState::new(
-                "Add role",
-                "chainargos/agent-brown",
-            ),
-        });
+        let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || seed_valid_role_repo(&repo_dir)),
+        ));
 
-        handle_modal_with(&mut editor, key(KeyCode::Enter), &mut config, &paths);
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "chainargos/agent-brown",
+            &mut runner,
+        );
 
         assert!(
             editor.modal.is_none(),
             "successful resolve should close modal"
+        );
+        assert!(
+            runner.recorded.iter().any(|cmd| cmd
+                .contains("git clone https://github.com/chainargos/jackin-agent-brown.git")),
+            "role add must clone through the normal repo resolver; got {:?}",
+            runner.recorded
         );
         assert!(
             editor
@@ -1820,6 +1897,54 @@ mod tests {
         assert!(
             persisted.contains("[roles.\"chainargos/agent-brown\"]"),
             "new role source should be persisted:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn role_input_clone_failure_reports_candidate_repository_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner
+            .fail_with
+            .push(("git clone".into(), "repository not found".into()));
+
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "the-architect2",
+            &mut runner,
+        );
+
+        match &editor.modal {
+            Some(Modal::ErrorPopup { state }) => {
+                assert_eq!(state.title, "Role not found");
+                assert!(state.message.contains("Could not resolve role"));
+                assert!(
+                    state
+                        .message
+                        .contains("https://github.com/jackin-project/jackin-the-architect2.git"),
+                    "message should show the repository URL that was tried:\n{}",
+                    state.message
+                );
+                assert!(state.message.contains("repository not found"));
+            }
+            other => panic!("expected ErrorPopup for failed clone; got {other:?}"),
+        }
+        assert!(
+            !config.roles.contains_key("the-architect2"),
+            "failed clone must not add the role to in-memory config"
+        );
+        let persisted = std::fs::read_to_string(paths.config_file).unwrap();
+        assert!(
+            !persisted.contains("the-architect2"),
+            "failed clone must not persist the role:\n{persisted}"
         );
     }
 

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1445,11 +1445,10 @@ fn apply_editor_confirm(
         ConfirmTarget::TrustRoleSource { key, source } => {
             persist_trusted_role_add(editor, config, paths, key, source.clone())?;
         }
-        // `DeleteWorkspace` is a list-side target that never reaches the
-        // editor modal. `DeleteIsolatedAndSave` is handled inline at the
-        // dispatch site because it consumes `plan` and routes through
-        // `EditorSaveFlow::PendingCommit`. Both no-op here.
-        ConfirmTarget::DeleteWorkspace | ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
+        // `DeleteIsolatedAndSave` is handled inline at the dispatch
+        // site because it consumes `plan` and routes through
+        // `EditorSaveFlow::PendingCommit`. No-op here.
+        ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
     }
     Ok(())
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -757,7 +757,7 @@ pub(super) fn handle_editor_modal(
                             exit_on_success,
                         };
                     } else if let Err(e) = apply_editor_confirm(editor, &target, config, paths) {
-                        open_role_resolution_error(editor, "confirmed action", None, &e);
+                        open_editor_action_error(editor, &e);
                     }
                 } else if matches!(
                     target,
@@ -1200,7 +1200,9 @@ fn apply_role_input(
     paths: &JackinPaths,
     value: &str,
 ) {
-    let mut runner = crate::docker::ShellRunner::default();
+    let mut runner = crate::docker::ShellRunner {
+        debug: crate::tui::is_debug_mode(),
+    };
     apply_role_input_with_runner(editor, config, paths, value, &mut runner);
 }
 
@@ -1223,15 +1225,21 @@ fn apply_role_input_with_runner(
     let key = selector.key();
     let result = (|| -> anyhow::Result<crate::config::RoleSource> {
         let source = candidate_role_source(config, &selector)?;
-        crate::runtime::resolve_agent_repo(paths, &selector, &source.git, runner, false)?;
+        let source_to_register = source.clone();
+        crate::runtime::register_agent_repo(
+            paths,
+            &selector,
+            &source.git,
+            runner,
+            crate::tui::is_debug_mode(),
+            || persist_role_source_registration(config, paths, &key, &source_to_register),
+        )?;
         Ok(source)
     })();
 
     match result {
         Ok(source) if source.trusted => {
-            if let Err(e) = persist_trusted_role_add(editor, config, paths, &key, source) {
-                open_role_resolution_error(editor, raw, None, &e);
-            }
+            add_role_to_workspace_editor(editor, config, &key);
         }
         Ok(source) => open_role_trust_confirm(editor, key, source),
         Err(e) => {
@@ -1267,16 +1275,21 @@ fn open_role_resolution_error(
     source_url: Option<&String>,
     err: &dyn std::fmt::Display,
 ) {
-    let mut message = format!(
-        "Could not resolve role {raw:?}. Use a configured role such as \
-         \"agent-smith\" or a GitHub selector like \"owner/agent-name\"."
+    crate::debug_log!("role", "failed to resolve role {raw:?}: {err}");
+    let message = source_url.map_or_else(
+        || {
+            format!(
+                "Could not understand role {raw:?}.\n\nUse a configured role such as \
+             \"agent-smith\" or a GitHub selector like \"owner/agent-name\"."
+            )
+        },
+        |source_url| {
+            format!(
+                "Could not resolve role {raw:?}.\n\nLooked for repository:\n{source_url}\n\n{}",
+                friendly_role_resolution_error(err)
+            )
+        },
     );
-    if let Some(source_url) = source_url {
-        message.push_str("\n\nLooked for repository:\n");
-        message.push_str(source_url);
-    }
-    message.push_str("\n\n");
-    message.push_str(&err.to_string());
     editor.modal = Some(Modal::ErrorPopup {
         state: crate::console::widgets::error_popup::ErrorPopupState::new(
             "Role not found",
@@ -1285,24 +1298,85 @@ fn open_role_resolution_error(
     });
 }
 
+fn open_editor_action_error(editor: &mut EditorState<'_>, err: &dyn std::fmt::Display) {
+    crate::debug_log!("editor", "failed to apply confirmed editor action: {err}");
+    editor.modal = Some(Modal::ErrorPopup {
+        state: crate::console::widgets::error_popup::ErrorPopupState::new(
+            "Could not apply change",
+            format!("The change could not be saved.\n\n{err}"),
+        ),
+    });
+}
+
+fn friendly_role_resolution_error(err: &dyn std::fmt::Display) -> String {
+    let message = err.to_string();
+    if message.contains("repository is not available")
+        || message.contains("git clone")
+        || message.contains("not found")
+    {
+        return "Repository is not available, or you do not have access.".into();
+    }
+    if message.contains("cached role repo remote mismatch") {
+        return "A cached copy already exists for this role, but it points at a different repository."
+            .into();
+    }
+    if let Some(detail) = message.strip_prefix("invalid role repo: ") {
+        return format!(
+            "Repository is not a valid Jackin role: {}.",
+            humanize_invalid_role_repo_detail(detail)
+        );
+    }
+    if message.contains("invalid role repo:") {
+        return "Repository is not a valid Jackin role.".into();
+    }
+    "Repository could not be used as a Jackin role.".into()
+}
+
+fn humanize_invalid_role_repo_detail(detail: &str) -> String {
+    if let Some(path) = detail.strip_prefix("missing ") {
+        let file = std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(path);
+        return format!("missing {file}");
+    }
+    detail.trim_end_matches('.').to_string()
+}
+
 fn open_role_trust_confirm(
     editor: &mut EditorState<'_>,
     key: String,
     source: crate::config::RoleSource,
 ) {
-    let prompt = format!(
-        "Trust role source?\n\
-         Role: {key}\n\
-         Repository:\n\
-         {}\n\
-         Its Dockerfile can run during image builds.\n\
-         The role can access mounted workspace files.",
-        source.git
-    );
+    let prompt = format!("{key}\n{}", source.git);
     editor.modal = Some(Modal::Confirm {
         target: ConfirmTarget::TrustRoleSource { key, source },
-        state: crate::console::widgets::confirm::ConfirmState::new(prompt),
+        state: crate::console::widgets::confirm::ConfirmState::role_trust(prompt),
     });
+}
+
+fn persist_role_source_registration(
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    key: &str,
+    source: &crate::config::RoleSource,
+) -> anyhow::Result<()> {
+    let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
+    editor_doc.upsert_agent_source(key, source);
+    *config = editor_doc.save()?;
+    Ok(())
+}
+
+fn add_role_to_workspace_editor(editor: &mut EditorState<'_>, config: &AppConfig, key: &str) {
+    if !editor.pending.allowed_roles.is_empty()
+        && !editor.pending.allowed_roles.iter().any(|role| role == key)
+    {
+        editor.pending.allowed_roles.push(key.to_string());
+    }
+
+    if let Some(idx) = config.roles.keys().position(|role| role == key) {
+        editor.active_field = FieldFocus::Row(idx);
+    }
 }
 
 fn persist_trusted_role_add(
@@ -1313,20 +1387,8 @@ fn persist_trusted_role_add(
     mut source: crate::config::RoleSource,
 ) -> anyhow::Result<()> {
     source.trusted = true;
-    let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
-    editor_doc.upsert_agent_source(key, &source);
-    *config = editor_doc.save()?;
-
-    if !editor.pending.allowed_roles.is_empty()
-        && !editor.pending.allowed_roles.iter().any(|role| role == key)
-    {
-        editor.pending.allowed_roles.push(key.to_string());
-    }
-
-    if let Some(idx) = config.roles.keys().position(|role| role == key) {
-        editor.active_field = FieldFocus::Row(idx);
-    }
-
+    persist_role_source_registration(config, paths, key, &source)?;
+    add_role_to_workspace_editor(editor, config, key);
     Ok(())
 }
 
@@ -1533,6 +1595,26 @@ plugins = []
 "#,
         )
         .unwrap();
+    }
+
+    fn first_temp_role_repo(data_dir: &std::path::Path) -> std::path::PathBuf {
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.is_dir()
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.starts_with("role-resolve-"))
+            })
+            .expect("role registration temp dir should exist before git clone side-effect")
+            .join("repo")
+    }
+
+    fn seed_first_temp_valid_role_repo(data_dir: &std::path::Path) {
+        seed_valid_role_repo(&first_temp_role_repo(data_dir));
     }
 
     fn editor_on_agents_tab<'a>(ws: WorkspaceConfig, row: usize) -> ManagerState<'a> {
@@ -1906,11 +1988,12 @@ plugins = []
         let mut editor = EditorState::new_edit("ws".into(), empty_ws());
         editor.pending.allowed_roles = vec!["agent-smith".into()];
         let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
-        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let cached_repo = crate::repo::CachedRepo::new(&paths, &selector);
+        let data_dir = paths.data_dir.clone();
         let mut runner = crate::runtime::FakeRunner::default();
         runner.side_effects.push((
             "git clone".to_string(),
-            Box::new(move || seed_valid_role_repo(&repo_dir)),
+            Box::new(move || seed_first_temp_valid_role_repo(&data_dir)),
         ));
 
         apply_role_input_with_runner(
@@ -1927,10 +2010,33 @@ plugins = []
             "role add must clone through the normal repo resolver; got {:?}",
             runner.recorded
         );
+        let clone_cmd = runner
+            .recorded
+            .iter()
+            .find(|cmd| {
+                cmd.contains("git clone https://github.com/chainargos/jackin-agent-brown.git")
+            })
+            .expect("clone command should be recorded");
+        assert!(
+            clone_cmd.contains(paths.data_dir.to_str().unwrap()),
+            "role add should clone into a temp dir under data_dir first: {clone_cmd}"
+        );
+        assert!(
+            !clone_cmd.contains(paths.roles_dir.to_str().unwrap()),
+            "role add must not clone directly into the final role cache: {clone_cmd}"
+        );
+        assert!(
+            cached_repo.repo_dir.join("jackin.role.toml").is_file(),
+            "validated clone should be moved into the role cache"
+        );
 
         match &editor.modal {
             Some(Modal::Confirm { target, state }) => {
-                assert!(state.prompt.contains("Trust role source?"));
+                assert_eq!(state.title, "Trust role source");
+                assert_eq!(
+                    state.presentation,
+                    crate::console::widgets::confirm::ConfirmPresentation::RoleTrust
+                );
                 assert!(state.prompt.contains("chainargos/agent-brown"));
                 assert!(
                     state
@@ -1964,13 +2070,20 @@ plugins = []
             "role should not be allowed before trust confirmation"
         );
         assert!(
-            !config.roles.contains_key("chainargos/agent-brown"),
-            "role source should not be added to config before trust confirmation"
+            config
+                .roles
+                .get("chainargos/agent-brown")
+                .is_some_and(|source| !source.trusted),
+            "validated role source should be registered untrusted before trust confirmation"
         );
         let before_trust = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(
-            !before_trust.contains("chainargos/agent-brown"),
-            "role source should not be persisted before trust confirmation:\n{before_trust}"
+            before_trust.contains("[roles.\"chainargos/agent-brown\"]"),
+            "validated role source should be persisted before trust confirmation:\n{before_trust}"
+        );
+        assert!(
+            !before_trust.contains("trusted = true"),
+            "role source should remain untrusted before trust confirmation:\n{before_trust}"
         );
 
         handle_modal_with(&mut editor, key(KeyCode::Char('y')), &mut config, &paths);
@@ -2004,7 +2117,7 @@ plugins = []
     }
 
     #[test]
-    fn role_input_trust_decline_does_not_persist_role() {
+    fn role_input_trust_decline_keeps_registered_role_untrusted() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();
@@ -2013,12 +2126,11 @@ plugins = []
 
         let mut editor = EditorState::new_edit("ws".into(), empty_ws());
         editor.pending.allowed_roles = vec!["agent-smith".into()];
-        let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
-        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let data_dir = paths.data_dir.clone();
         let mut runner = crate::runtime::FakeRunner::default();
         runner.side_effects.push((
             "git clone".to_string(),
-            Box::new(move || seed_valid_role_repo(&repo_dir)),
+            Box::new(move || seed_first_temp_valid_role_repo(&data_dir)),
         ));
 
         apply_role_input_with_runner(
@@ -2041,13 +2153,20 @@ plugins = []
             "declined role must not be added to the custom allow-list"
         );
         assert!(
-            !config.roles.contains_key("chainargos/agent-brown"),
-            "declined role must not mutate in-memory config"
+            config
+                .roles
+                .get("chainargos/agent-brown")
+                .is_some_and(|source| !source.trusted),
+            "declined role should remain registered but untrusted"
         );
         let persisted = std::fs::read_to_string(paths.config_file).unwrap();
         assert!(
-            !persisted.contains("chainargos/agent-brown"),
-            "declined role must not be persisted:\n{persisted}"
+            persisted.contains("[roles.\"chainargos/agent-brown\"]"),
+            "declined role source should remain registered:\n{persisted}"
+        );
+        assert!(
+            !persisted.contains("trusted = true"),
+            "declined role must not be persisted as trusted:\n{persisted}"
         );
     }
 
@@ -2069,12 +2188,11 @@ plugins = []
 
         let mut editor = EditorState::new_edit("ws".into(), empty_ws());
         editor.pending.allowed_roles = vec!["agent-smith".into()];
-        let selector = crate::selector::RoleSelector::parse("chainargos/agent-brown").unwrap();
-        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        let data_dir = paths.data_dir.clone();
         let mut runner = crate::runtime::FakeRunner::default();
         runner.side_effects.push((
             "git clone".to_string(),
-            Box::new(move || seed_valid_role_repo(&repo_dir)),
+            Box::new(move || seed_first_temp_valid_role_repo(&data_dir)),
         ));
 
         apply_role_input_with_runner(
@@ -2148,7 +2266,23 @@ plugins = []
                     "message should show the repository URL that was tried:\n{}",
                     state.message
                 );
-                assert!(state.message.contains("repository not found"));
+                assert!(
+                    state
+                        .message
+                        .contains("Repository is not available, or you do not have access."),
+                    "message should explain the repository is unavailable:\n{}",
+                    state.message
+                );
+                assert!(
+                    !state.message.contains("git clone"),
+                    "user-facing popup should not include raw clone commands:\n{}",
+                    state.message
+                );
+                assert!(
+                    !state.message.contains(paths.roles_dir.to_str().unwrap()),
+                    "user-facing popup should not expose the final role cache path:\n{}",
+                    state.message
+                );
             }
             other => panic!("expected ErrorPopup for failed clone; got {other:?}"),
         }
@@ -2160,6 +2294,69 @@ plugins = []
         assert!(
             !persisted.contains("the-architect2"),
             "failed clone must not persist the role:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn role_input_invalid_repo_reports_role_contract_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        let data_dir = paths.data_dir.clone();
+        let mut runner = crate::runtime::FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || {
+                let repo_dir = first_temp_role_repo(&data_dir);
+                std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
+                std::fs::write(
+                    repo_dir.join("Dockerfile"),
+                    "FROM projectjackin/construct:trixie\n",
+                )
+                .unwrap();
+            }),
+        ));
+
+        apply_role_input_with_runner(
+            &mut editor,
+            &mut config,
+            &paths,
+            "chainargos/agent-brown",
+            &mut runner,
+        );
+
+        match &editor.modal {
+            Some(Modal::ErrorPopup { state }) => {
+                assert_eq!(state.title, "Role not found");
+                assert!(
+                    state.message.contains(
+                        "Repository is not a valid Jackin role: missing jackin.role.toml."
+                    ),
+                    "message should explain the failed role validation:\n{}",
+                    state.message
+                );
+                assert!(
+                    state
+                        .message
+                        .contains("https://github.com/chainargos/jackin-agent-brown.git"),
+                    "message should show the repository URL that was tried:\n{}",
+                    state.message
+                );
+            }
+            other => panic!("expected ErrorPopup for invalid role repo; got {other:?}"),
+        }
+        assert!(
+            !config.roles.contains_key("chainargos/agent-brown"),
+            "invalid role repo must not register the role source"
+        );
+        let persisted = std::fs::read_to_string(paths.config_file).unwrap();
+        assert!(
+            !persisted.contains("chainargos/agent-brown"),
+            "invalid role repo must not persist the role:\n{persisted}"
         );
     }
 
@@ -2185,7 +2382,7 @@ plugins = []
         match &editor.modal {
             Some(Modal::ErrorPopup { state }) => {
                 assert_eq!(state.title, "Role not found");
-                assert!(state.message.contains("Could not resolve role"));
+                assert!(state.message.contains("Could not understand role"));
             }
             other => panic!("expected ErrorPopup for invalid selector; got {other:?}"),
         }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1347,10 +1347,11 @@ fn open_role_trust_confirm(
     key: String,
     source: crate::config::RoleSource,
 ) {
-    let prompt = format!("{key}\n{}", source.git);
+    let state =
+        crate::console::widgets::confirm::ConfirmState::role_trust(key.clone(), source.git.clone());
     editor.modal = Some(Modal::Confirm {
         target: ConfirmTarget::TrustRoleSource { key, source },
-        state: crate::console::widgets::confirm::ConfirmState::role_trust(prompt),
+        state,
     });
 }
 
@@ -2032,17 +2033,15 @@ plugins = []
         match &editor.modal {
             Some(Modal::Confirm { target, state }) => {
                 assert_eq!(state.title, "Trust role source");
+                let crate::console::widgets::confirm::ConfirmKind::RoleTrust { role, repository } =
+                    &state.kind
+                else {
+                    panic!("expected RoleTrust kind, got {:?}", state.kind);
+                };
+                assert_eq!(role, "chainargos/agent-brown");
                 assert_eq!(
-                    state.presentation,
-                    crate::console::widgets::confirm::ConfirmPresentation::RoleTrust
-                );
-                assert!(state.prompt.contains("chainargos/agent-brown"));
-                assert!(
-                    state
-                        .prompt
-                        .contains("https://github.com/chainargos/jackin-agent-brown.git"),
-                    "trust prompt should show the repository URL:\n{}",
-                    state.prompt
+                    repository, "https://github.com/chainargos/jackin-agent-brown.git",
+                    "trust prompt should show the repository URL"
                 );
                 match target {
                     ConfirmTarget::TrustRoleSource { key, source } => {

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1328,7 +1328,7 @@ pub(super) fn apply_file_browser_to_editor(
     match target {
         FileBrowserTarget::EditAddMountSrc => {
             // Defer the mount push to the choice modal: in the common case
-            // the operator will take "Use same path" (dst = src) and we skip the
+            // the operator will take "Mount at same path" (dst = src) and we skip the
             // TextInput entirely. Only the `Edit destination` branch pushes
             // a provisional mount and opens the TextInput.
             editor.modal = Some(Modal::MountDstChoice {
@@ -1614,14 +1614,14 @@ mod tests {
     }
 
     #[test]
-    fn editor_use_same_path_commits_mount_with_dst_equal_src() {
-        // Use-same-path shortcut on the choice modal → push MountConfig with dst = src
+    fn editor_mount_same_path_commits_mount_with_dst_equal_src() {
+        // Mount-at-same-path shortcut on the choice modal → push MountConfig with dst = src
         // and close the modal. No TextInput should appear.
         let mut editor = editor_with_browser_committed("/host/path");
-        handle_modal(&mut editor, key(KeyCode::Char('u')));
+        handle_modal(&mut editor, key(KeyCode::Char('m')));
         assert!(
             editor.modal.is_none(),
-            "Use same path must close the modal; got {:?}",
+            "Mount at same path must close the modal; got {:?}",
             editor.modal
         );
         assert_eq!(editor.pending.mounts.len(), 1, "exactly one mount pushed");
@@ -1629,7 +1629,7 @@ mod tests {
         assert_eq!(m.src, "/host/path");
         assert_eq!(
             m.dst, "/host/path",
-            "Use-same-path fast path sets dst = src"
+            "Mount-at-same-path fast path sets dst = src"
         );
         assert!(!m.readonly);
     }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1223,8 +1223,9 @@ fn apply_role_input_with_runner(
     let selector = match crate::selector::RoleSelector::parse(raw) {
         Ok(selector) => selector,
         Err(e) => {
-            // The unparseable-selector branch ignores `err`; wrap into
-            // anyhow only to satisfy the typed signature.
+            // open_role_resolution_error debug-logs the error chain; the
+            // user-facing message in the no-source-url branch is a generic
+            // "Could not understand role" hint, not the parse error itself.
             let err = anyhow::Error::new(e);
             open_role_resolution_error(editor, raw, None, &err);
             return;
@@ -1320,13 +1321,20 @@ fn open_editor_action_error(editor: &mut EditorState<'_>, err: &dyn std::fmt::Di
 /// Translate a runtime role-resolution error into the operator-facing
 /// blurb shown beneath the role-input dialog.
 ///
-/// Classification is by `downcast_ref::<RepoError>` rather than substring
-/// matching on free text — when adding a `RepoError` variant, add the
-/// corresponding match arm here. The `else` branch handles errors that
-/// were never wrapped as `RepoError` (e.g. fs/IO errors raised before the
-/// clone) and uses a generic message rather than mis-classifying them.
+/// Classification walks the entire `err.chain()` looking for a
+/// `RepoError` rather than substring-matching free text or only
+/// inspecting the root. Walking the chain ensures classification still
+/// works after a future caller wraps the typed error with
+/// `with_context(...)`. When adding a `RepoError` variant, add the
+/// corresponding match arm here. The fallback branch handles errors
+/// that were never wrapped as `RepoError` (e.g. fs/IO errors raised
+/// before the clone) and uses a generic message rather than
+/// mis-classifying them.
 fn friendly_role_resolution_error(err: &anyhow::Error) -> String {
-    if let Some(repo_err) = err.downcast_ref::<crate::runtime::RepoError>() {
+    let typed = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<crate::runtime::RepoError>());
+    if let Some(repo_err) = typed {
         return match repo_err {
             crate::runtime::RepoError::CloneFailed(_) => {
                 "Repository is not available, or you do not have access.".into()

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1336,24 +1336,33 @@ fn friendly_role_resolution_error(err: &anyhow::Error) -> String {
                  repository."
                     .into()
             }
-            crate::runtime::RepoError::InvalidRoleRepo { detail } => format!(
+            crate::runtime::RepoError::InvalidRoleRepo(detail) => format!(
                 "Repository is not a valid Jackin role: {}.",
-                humanize_invalid_role_repo_detail(detail)
+                humanize_invalid_role_repo(detail)
             ),
         };
     }
     "Repository could not be used as a Jackin role.".into()
 }
 
-fn humanize_invalid_role_repo_detail(detail: &str) -> String {
-    if let Some(path) = detail.strip_prefix("missing ") {
-        let file = std::path::Path::new(path)
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or(path);
-        return format!("missing {file}");
+/// Render a `RoleRepoValidationError` for the role-input popup.
+///
+/// `Missing(path)` is shown as the basename only — the full repo path
+/// is operator-noise here since the popup already says which role they
+/// asked for. Other variants fall back to the typed `Display` impl with
+/// any trailing period trimmed (the surrounding sentence adds its own).
+fn humanize_invalid_role_repo(err: &crate::repo::RoleRepoValidationError) -> String {
+    use crate::repo::RoleRepoValidationError as V;
+    match err {
+        V::Missing(path) => {
+            let file = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map_or_else(|| path.display().to_string(), str::to_string);
+            format!("missing {file}")
+        }
+        _ => err.to_string().trim_end_matches('.').to_string(),
     }
-    detail.trim_end_matches('.').to_string()
 }
 
 fn open_role_trust_confirm(

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1223,9 +1223,6 @@ fn apply_role_input_with_runner(
     let selector = match crate::selector::RoleSelector::parse(raw) {
         Ok(selector) => selector,
         Err(e) => {
-            // open_role_resolution_error debug-logs the error chain; the
-            // user-facing message in the no-source-url branch is a generic
-            // "Could not understand role" hint, not the parse error itself.
             let err = anyhow::Error::new(e);
             open_role_resolution_error(editor, raw, None, &err);
             return;
@@ -1321,20 +1318,15 @@ fn open_editor_action_error(editor: &mut EditorState<'_>, err: &dyn std::fmt::Di
 /// Translate a runtime role-resolution error into the operator-facing
 /// blurb shown beneath the role-input dialog.
 ///
-/// Classification walks the entire `err.chain()` looking for a
-/// `RepoError` rather than substring-matching free text or only
-/// inspecting the root. Walking the chain ensures classification still
-/// works after a future caller wraps the typed error with
-/// `with_context(...)`. When adding a `RepoError` variant, add the
-/// corresponding match arm here. The fallback branch handles errors
-/// that were never wrapped as `RepoError` (e.g. fs/IO errors raised
-/// before the clone) and uses a generic message rather than
-/// mis-classifying them.
+/// When adding a `RepoError` variant, add the corresponding match arm
+/// here. Errors that were never wrapped as `RepoError` (e.g. fs/IO
+/// errors raised before the clone) hit the fallback branch — generic
+/// rather than mis-classified.
 fn friendly_role_resolution_error(err: &anyhow::Error) -> String {
-    let typed = err
+    if let Some(repo_err) = err
         .chain()
-        .find_map(|cause| cause.downcast_ref::<crate::runtime::RepoError>());
-    if let Some(repo_err) = typed {
+        .find_map(|cause| cause.downcast_ref::<crate::runtime::RepoError>())
+    {
         return match repo_err {
             crate::runtime::RepoError::CloneFailed(_) => {
                 "Repository is not available, or you do not have access.".into()

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1153,7 +1153,14 @@ pub(super) fn apply_text_input_to_pending(
                 last.dst = value.to_string();
             }
         }
-        TextInputTarget::Role => {}
+        TextInputTarget::Role => {
+            // Role text-input is dispatched via apply_role_input before
+            // reaching this match — landing here means a future caller
+            // wired Role through the wrong path. Panic so the regression
+            // is loud at the point of misuse rather than silently
+            // discarding the user's input.
+            unreachable!("TextInputTarget::Role is dispatched via apply_role_input");
+        }
         TextInputTarget::EnvKey { scope } => {
             // Empty key re-opens the EnvKey modal with the inline
             // "cannot be empty" label instead of committing.

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1441,7 +1441,7 @@ fn dispatch_editor_mount_dst_choice(
 ) {
     use crate::console::widgets::mount_dst_choice::MountDstChoice;
     match outcome {
-        ModalOutcome::Commit(MountDstChoice::Ok) => {
+        ModalOutcome::Commit(MountDstChoice::SamePath) => {
             if target == FileBrowserTarget::EditAddMountSrc {
                 editor.pending.mounts.push(crate::workspace::MountConfig {
                     src: src.to_string(),

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -173,8 +173,16 @@ pub(super) fn handle_editor_key(
             EditorTab::Secrets => {
                 open_secrets_enter_modal(editor);
             }
-            EditorTab::Roles => {}
+            EditorTab::Roles => {
+                let FieldFocus::Row(n) = editor.active_field;
+                if n == config.roles.len() {
+                    open_role_input(editor, config);
+                }
+            }
         },
+        KeyCode::Char('a' | 'A') if editor.active_tab == EditorTab::Roles => {
+            open_role_input(editor, config);
+        }
         KeyCode::Char(' ') if editor.active_tab == EditorTab::Roles => {
             toggle_agent_allowed_at_cursor(editor, config);
         }
@@ -290,7 +298,8 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         // 0=Name, 1=Working dir, 2=Keep awake
         EditorTab::General => 2,
         EditorTab::Mounts => editor.pending.mounts.len(),
-        EditorTab::Roles => config.roles.len().saturating_sub(1),
+        // One extra sentinel row: + Add role.
+        EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
         EditorTab::Secrets => 0,
     }
@@ -513,6 +522,18 @@ fn open_agent_override_picker(editor: &mut EditorState<'_>, config: &AppConfig) 
     });
 }
 
+fn open_role_input(editor: &mut EditorState<'_>, config: &AppConfig) {
+    use super::super::super::widgets::text_input::TextInputState;
+
+    let mut state =
+        TextInputState::new_with_forbidden("Add role", "", config.roles.keys().cloned().collect());
+    state.forbidden_label = "role registry".into();
+    editor.modal = Some(Modal::TextInput {
+        target: TextInputTarget::Role,
+        state,
+    });
+}
+
 fn open_secrets_delete_confirm(editor: &mut EditorState<'_>) {
     use crate::console::widgets::confirm::ConfirmState;
     let FieldFocus::Row(n) = editor.active_field;
@@ -655,7 +676,8 @@ pub(super) fn handle_editor_modal(
     key: KeyEvent,
     op_available: bool,
     op_cache: std::rc::Rc<std::cell::RefCell<crate::console::op_cache::OpCache>>,
-    config: &AppConfig,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
 ) {
     let Some(modal) = editor.modal.as_mut() else {
         return;
@@ -666,7 +688,11 @@ pub(super) fn handle_editor_modal(
                 ModalOutcome::Commit(value) => {
                     let target = target.clone();
                     editor.modal = None;
-                    apply_text_input_to_pending(&target, editor, &value, op_available);
+                    if target == TextInputTarget::Role {
+                        apply_role_input(editor, config, paths, &value);
+                    } else {
+                        apply_text_input_to_pending(&target, editor, &value, op_available);
+                    }
                 }
                 ModalOutcome::Cancel => {
                     // Cancel of EnvKey/EnvValue must drop both the
@@ -1123,6 +1149,7 @@ pub(super) fn apply_text_input_to_pending(
                 last.dst = value.to_string();
             }
         }
+        TextInputTarget::Role => {}
         TextInputTarget::EnvKey { scope } => {
             // Empty key re-opens the EnvKey modal with the inline
             // "cannot be empty" label instead of committing.
@@ -1159,6 +1186,59 @@ pub(super) fn apply_text_input_to_pending(
             set_pending_env_value(editor, scope, key, value);
             editor.pending_env_key = None;
         }
+    }
+}
+
+fn apply_role_input(
+    editor: &mut EditorState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    value: &str,
+) {
+    let raw = value.trim();
+    let selector = match crate::selector::RoleSelector::parse(raw) {
+        Ok(selector) => selector,
+        Err(e) => {
+            editor.modal = Some(Modal::ErrorPopup {
+                state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                    "Role not found",
+                    format!(
+                        "Could not resolve role {raw:?}. Use a configured role such as \
+                         \"agent-smith\" or a GitHub selector like \"owner/agent-name\". {e}"
+                    ),
+                ),
+            });
+            return;
+        }
+    };
+
+    let key = selector.key();
+    let result = (|| -> anyhow::Result<()> {
+        let (source, _) = config.resolve_role_source(&selector)?;
+        let mut editor_doc = crate::config::ConfigEditor::open(paths)?;
+        editor_doc.upsert_agent_source(&key, &source);
+        *config = editor_doc.save()?;
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        editor.modal = Some(Modal::ErrorPopup {
+            state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                "Role not found",
+                format!("Could not resolve role {raw:?}: {e}"),
+            ),
+        });
+        return;
+    }
+
+    if !editor.pending.allowed_roles.is_empty()
+        && !editor.pending.allowed_roles.iter().any(|role| role == &key)
+    {
+        editor.pending.allowed_roles.push(key.clone());
+    }
+
+    if let Some(idx) = config.roles.keys().position(|role| role == &key) {
+        editor.active_field = FieldFocus::Row(idx);
     }
 }
 
@@ -1248,7 +1328,7 @@ pub(super) fn apply_file_browser_to_editor(
     match target {
         FileBrowserTarget::EditAddMountSrc => {
             // Defer the mount push to the choice modal: in the common case
-            // the operator will take "OK" (dst = src) and we skip the
+            // the operator will take "Use same path" (dst = src) and we skip the
             // TextInput entirely. Only the `Edit destination` branch pushes
             // a provisional mount and opens the TextInput.
             editor.modal = Some(Modal::MountDstChoice {
@@ -1288,12 +1368,26 @@ mod tests {
     /// editor-modal tests don't exercise the `SourcePicker` /
     /// `OpPicker` branches that need real wiring; defaults are fine.
     fn handle_modal(editor: &mut EditorState<'_>, k: crossterm::event::KeyEvent) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        handle_modal_with(editor, k, &mut config, &paths);
+    }
+
+    fn handle_modal_with(
+        editor: &mut EditorState<'_>,
+        k: crossterm::event::KeyEvent,
+        config: &mut AppConfig,
+        paths: &JackinPaths,
+    ) {
         handle_editor_modal(
             editor,
             k,
             false,
             std::rc::Rc::new(std::cell::RefCell::new(OpCache::default())),
-            &AppConfig::default(),
+            config,
+            paths,
         );
     }
 
@@ -1520,20 +1614,23 @@ mod tests {
     }
 
     #[test]
-    fn editor_ok_commits_mount_with_dst_equal_src() {
-        // OK shortcut on the choice modal → push MountConfig with dst = src
+    fn editor_use_same_path_commits_mount_with_dst_equal_src() {
+        // Use-same-path shortcut on the choice modal → push MountConfig with dst = src
         // and close the modal. No TextInput should appear.
         let mut editor = editor_with_browser_committed("/host/path");
-        handle_modal(&mut editor, key(KeyCode::Char('o')));
+        handle_modal(&mut editor, key(KeyCode::Char('u')));
         assert!(
             editor.modal.is_none(),
-            "OK must close the modal; got {:?}",
+            "Use same path must close the modal; got {:?}",
             editor.modal
         );
         assert_eq!(editor.pending.mounts.len(), 1, "exactly one mount pushed");
         let m = &editor.pending.mounts[0];
         assert_eq!(m.src, "/host/path");
-        assert_eq!(m.dst, "/host/path", "OK fast-path sets dst = src");
+        assert_eq!(
+            m.dst, "/host/path",
+            "Use-same-path fast path sets dst = src"
+        );
         assert!(!m.readonly);
     }
 
@@ -1653,6 +1750,110 @@ mod tests {
     }
 
     // ── Roles tab: `*` default-toggle binding ───────────────────────
+
+    #[test]
+    fn roles_tab_enter_on_add_role_row_opens_role_input() {
+        let (_tmp, paths, mut config) = {
+            let tmp = tempfile::tempdir().unwrap();
+            let paths = JackinPaths::for_tests(tmp.path());
+            paths.ensure_base_dirs().unwrap();
+            let config = config_with_agents(&["agent-smith"]);
+            (tmp, paths, config)
+        };
+        let cwd = _tmp.path();
+        let mut state = editor_on_agents_tab(empty_ws(), config.roles.len());
+
+        handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter)).unwrap();
+
+        let ManagerStage::Editor(e) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        match &e.modal {
+            Some(Modal::TextInput { target, state }) => {
+                assert_eq!(target, &TextInputTarget::Role);
+                assert_eq!(state.label, "Add role");
+            }
+            other => panic!("expected TextInput(Role); got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn role_input_resolves_and_persists_namespaced_role() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = config_with_agents(&["agent-smith"]);
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        editor.pending.allowed_roles = vec!["agent-smith".into()];
+        editor.modal = Some(Modal::TextInput {
+            target: TextInputTarget::Role,
+            state: crate::console::widgets::text_input::TextInputState::new(
+                "Add role",
+                "chainargos/agent-brown",
+            ),
+        });
+
+        handle_modal_with(&mut editor, key(KeyCode::Enter), &mut config, &paths);
+
+        assert!(
+            editor.modal.is_none(),
+            "successful resolve should close modal"
+        );
+        assert!(
+            editor
+                .pending
+                .allowed_roles
+                .contains(&"chainargos/agent-brown".to_string()),
+            "custom allow-list should include the newly resolved role"
+        );
+        let source = config
+            .roles
+            .get("chainargos/agent-brown")
+            .expect("role source must be added to config");
+        assert_eq!(
+            source.git,
+            "https://github.com/chainargos/jackin-agent-brown.git"
+        );
+        let persisted = std::fs::read_to_string(paths.config_file).unwrap();
+        assert!(
+            persisted.contains("[roles.\"chainargos/agent-brown\"]"),
+            "new role source should be persisted:\n{persisted}"
+        );
+    }
+
+    #[test]
+    fn role_input_rejects_invalid_selector_with_error_popup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        std::fs::write(&paths.config_file, toml::to_string(&config).unwrap()).unwrap();
+
+        let mut editor = EditorState::new_edit("ws".into(), empty_ws());
+        editor.modal = Some(Modal::TextInput {
+            target: TextInputTarget::Role,
+            state: crate::console::widgets::text_input::TextInputState::new(
+                "Add role",
+                "Chain Argus Agent Brown",
+            ),
+        });
+
+        handle_modal_with(&mut editor, key(KeyCode::Enter), &mut config, &paths);
+
+        match &editor.modal {
+            Some(Modal::ErrorPopup { state }) => {
+                assert_eq!(state.title, "Role not found");
+                assert!(state.message.contains("Could not resolve role"));
+            }
+            other => panic!("expected ErrorPopup for invalid selector; got {other:?}"),
+        }
+        assert!(
+            config.roles.is_empty(),
+            "invalid selector must not mutate config"
+        );
+    }
 
     #[test]
     fn agents_tab_star_sets_default_on_allowed_agent() {

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -70,7 +70,7 @@ pub fn handle_key(
     if let ManagerStage::Editor(editor) = &mut state.stage
         && editor.modal.is_some()
     {
-        editor::handle_editor_modal(editor, key, op_available, op_cache, config);
+        editor::handle_editor_modal(editor, key, op_available, op_cache, config, paths);
 
         // Drain the ConfirmSave → commit signal FIRST. The modal handler
         // only closes the modal and stashes the plan; this outer layer

--- a/src/console/manager/input/prelude.rs
+++ b/src/console/manager/input/prelude.rs
@@ -110,7 +110,7 @@ pub(super) fn handle_prelude_modal(
                     prelude.modal = None;
                     prelude.last_browser_cwd = browser_cwd;
                     prelude.accept_mount_src(path);
-                    // Offer the 3-button choice: use same path (dst=src, skip TextInput),
+                    // Offer the 3-button choice: mount at same path (dst=src, skip TextInput),
                     // Edit destination (open TextInput), or Cancel.
                     let src = prelude
                         .pending_mount_src
@@ -212,7 +212,7 @@ pub(super) fn handle_prelude_modal(
                 ModalOutcome::Cancel => {
                     // Step-back: rewind to whichever dst-step the operator
                     // took — TextInputDst if they edited the destination,
-                    // otherwise MountDstChoice (fast-path use same path).
+                    // otherwise MountDstChoice (fast-path mount at same path).
                     if prelude.used_edit_dst {
                         let current_dst = prelude.pending_mount_dst.clone().unwrap_or_default();
                         prelude.modal = Some(Modal::TextInput {
@@ -313,22 +313,22 @@ mod tests {
     }
 
     #[test]
-    fn prelude_use_same_path_chains_to_workdir_pick_with_dst_equal_src() {
-        // Use-same-path on the choice modal should: (a) set prelude.pending_mount_dst
+    fn prelude_mount_same_path_chains_to_workdir_pick_with_dst_equal_src() {
+        // Mount-at-same-path on the choice modal should: (a) set prelude.pending_mount_dst
         // to src, (b) advance the step to PickWorkdir, (c) open the
         // WorkdirPick modal pre-loaded with the staged mount.
         let mut prelude = prelude_with_browser_committed("/home/user/project");
-        handle_prelude_modal(&mut prelude, key(KeyCode::Char('u')));
+        handle_prelude_modal(&mut prelude, key(KeyCode::Char('m')));
 
         assert!(
             matches!(prelude.modal, Some(Modal::WorkdirPick { .. })),
-            "Use same path must chain to WorkdirPick; got {:?}",
+            "Mount at same path must chain to WorkdirPick; got {:?}",
             prelude.modal
         );
         assert_eq!(
             prelude.pending_mount_dst.as_deref(),
             Some("/home/user/project"),
-            "Use-same-path fast path stores dst = src on the prelude"
+            "Mount-at-same-path fast path stores dst = src on the prelude"
         );
         assert!(!prelude.pending_readonly);
         assert!(matches!(
@@ -439,10 +439,10 @@ mod tests {
 
     #[test]
     fn prelude_esc_at_workdir_pick_returns_to_mount_dst_choice_fast_path() {
-        // When the operator took the use-same-path fast path for dst, Esc on
+        // When the operator took the mount-at-same-path fast path for dst, Esc on
         // WorkdirPick must step back to MountDstChoice.
         let mut prelude = prelude_with_browser_committed("/home/user/project");
-        handle_prelude_modal(&mut prelude, key(KeyCode::Char('u'))); // same path → WorkdirPick
+        handle_prelude_modal(&mut prelude, key(KeyCode::Char('m'))); // same path → WorkdirPick
         assert!(matches!(prelude.modal, Some(Modal::WorkdirPick { .. })));
 
         handle_prelude_modal(&mut prelude, key(KeyCode::Esc));

--- a/src/console/manager/input/prelude.rs
+++ b/src/console/manager/input/prelude.rs
@@ -28,7 +28,7 @@ pub(super) fn handle_prelude_key(
 /// Prelude-side transition: mount-src and mount-dst are both known, now
 /// advance to the `PickWorkdir` step by opening a `WorkdirPick` modal.
 ///
-/// Factored out so both the `MountDstChoice::Ok` path (no `TextInput`) and
+/// Factored out so both the `MountDstChoice::SamePath` path (no `TextInput`) and
 /// the `TextInputDst` commit path (operator edited dst) end the same way.
 /// Callers are responsible for having already pushed the mount dst onto
 /// the prelude (via `accept_mount_dst`).
@@ -142,7 +142,7 @@ pub(super) fn handle_prelude_modal(
                 return;
             };
             match outcome {
-                ModalOutcome::Commit(MountDstChoice::Ok) => {
+                ModalOutcome::Commit(MountDstChoice::SamePath) => {
                     // Fast path: dst = src, skip TextInput, chain straight
                     // to WorkdirPick (mirrors the post-TextInputDst tail).
                     let default_dst = prelude.default_mount_dst().unwrap_or_default();

--- a/src/console/manager/input/prelude.rs
+++ b/src/console/manager/input/prelude.rs
@@ -110,7 +110,7 @@ pub(super) fn handle_prelude_modal(
                     prelude.modal = None;
                     prelude.last_browser_cwd = browser_cwd;
                     prelude.accept_mount_src(path);
-                    // Offer the 3-button choice: OK (dst=src, skip TextInput),
+                    // Offer the 3-button choice: use same path (dst=src, skip TextInput),
                     // Edit destination (open TextInput), or Cancel.
                     let src = prelude
                         .pending_mount_src
@@ -212,7 +212,7 @@ pub(super) fn handle_prelude_modal(
                 ModalOutcome::Cancel => {
                     // Step-back: rewind to whichever dst-step the operator
                     // took — TextInputDst if they edited the destination,
-                    // otherwise MountDstChoice (fast-path OK).
+                    // otherwise MountDstChoice (fast-path use same path).
                     if prelude.used_edit_dst {
                         let current_dst = prelude.pending_mount_dst.clone().unwrap_or_default();
                         prelude.modal = Some(Modal::TextInput {
@@ -313,22 +313,22 @@ mod tests {
     }
 
     #[test]
-    fn prelude_ok_chains_to_workdir_pick_with_dst_equal_src() {
-        // OK on the choice modal should: (a) set prelude.pending_mount_dst
+    fn prelude_use_same_path_chains_to_workdir_pick_with_dst_equal_src() {
+        // Use-same-path on the choice modal should: (a) set prelude.pending_mount_dst
         // to src, (b) advance the step to PickWorkdir, (c) open the
         // WorkdirPick modal pre-loaded with the staged mount.
         let mut prelude = prelude_with_browser_committed("/home/user/project");
-        handle_prelude_modal(&mut prelude, key(KeyCode::Char('o')));
+        handle_prelude_modal(&mut prelude, key(KeyCode::Char('u')));
 
         assert!(
             matches!(prelude.modal, Some(Modal::WorkdirPick { .. })),
-            "OK must chain to WorkdirPick; got {:?}",
+            "Use same path must chain to WorkdirPick; got {:?}",
             prelude.modal
         );
         assert_eq!(
             prelude.pending_mount_dst.as_deref(),
             Some("/home/user/project"),
-            "OK fast-path stores dst = src on the prelude"
+            "Use-same-path fast path stores dst = src on the prelude"
         );
         assert!(!prelude.pending_readonly);
         assert!(matches!(
@@ -439,10 +439,10 @@ mod tests {
 
     #[test]
     fn prelude_esc_at_workdir_pick_returns_to_mount_dst_choice_fast_path() {
-        // When the operator took the OK (fast path) for dst, Esc on
+        // When the operator took the use-same-path fast path for dst, Esc on
         // WorkdirPick must step back to MountDstChoice.
         let mut prelude = prelude_with_browser_committed("/home/user/project");
-        handle_prelude_modal(&mut prelude, key(KeyCode::Char('o'))); // OK → WorkdirPick
+        handle_prelude_modal(&mut prelude, key(KeyCode::Char('u'))); // same path → WorkdirPick
         assert!(matches!(prelude.modal, Some(Modal::WorkdirPick { .. })));
 
         handle_prelude_modal(&mut prelude, key(KeyCode::Esc));

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1129,9 +1129,8 @@ mod tests {
     fn editor_save_create_with_no_name_routes_to_error_flow() {
         // begin_editor_save in Create mode must gate ConfirmSave on
         // pending_name being set. Without a name the inline banner reads
-        // "missing workspace name" — pre-fix this branch was untested
-        // even though it's the central failure surface for the rewritten
-        // workspace-create flow.
+        // "missing workspace name" — gating prevents the operator from
+        // committing a nameless workspace.
         let ws = WorkspaceConfig {
             workdir: "/seed".into(),
             mounts: vec![mount("/seed", "/seed")],

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1126,6 +1126,83 @@ mod tests {
     }
 
     #[test]
+    fn editor_save_create_with_no_name_routes_to_error_flow() {
+        // begin_editor_save in Create mode must gate ConfirmSave on
+        // pending_name being set. Without a name the inline banner reads
+        // "missing workspace name" — pre-fix this branch was untested
+        // even though it's the central failure surface for the rewritten
+        // workspace-create flow.
+        let ws = WorkspaceConfig {
+            workdir: "/seed".into(),
+            mounts: vec![mount("/seed", "/seed")],
+            ..Default::default()
+        };
+        let (tmp, paths, config) = setup_with_workspace("seed", ws).unwrap();
+
+        let cwd = tmp.path();
+        let mut state = ManagerState::from_config(&config, cwd);
+        let mut editor = EditorState::new_create();
+        editor.pending.workdir = "/w".into();
+        editor.pending.mounts = vec![mount("/w", "/w")];
+        // pending_name intentionally None → save must route to Error.
+        state.stage = ManagerStage::Editor(editor);
+
+        begin_editor_save(&mut state, &config, false).unwrap();
+
+        let ManagerStage::Editor(e) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(e.modal.is_none(), "no confirm modal when name missing");
+        assert_eq!(
+            e.save_flow.error_message().expect("error banner expected"),
+            "missing workspace name"
+        );
+        // On-disk config unchanged.
+        let reloaded = AppConfig::load_or_init(&paths).unwrap();
+        assert!(!reloaded.workspaces.contains_key("w"));
+    }
+
+    #[test]
+    fn editor_save_create_with_invalid_mount_routes_to_error_flow() {
+        // Create-mode planner errors (here a ReadonlyMismatch — `/work/sub`
+        // ro under `/work` rw) surface as the inline banner, mirroring the
+        // edit-mode behavior covered by
+        // `readonly_mismatch_produces_error_banner_no_write`.
+        let ws = WorkspaceConfig {
+            workdir: "/seed".into(),
+            mounts: vec![mount("/seed", "/seed")],
+            ..Default::default()
+        };
+        let (tmp, paths, config) = setup_with_workspace("seed", ws).unwrap();
+
+        let cwd = tmp.path();
+        let mut state = ManagerState::from_config(&config, cwd);
+        let mut editor = EditorState::new_create();
+        editor.pending_name = Some("test".into());
+        editor.pending.workdir = "/work".into();
+        editor.pending.mounts = vec![mount("/work", "/work"), ro_mount("/work/sub", "/work/sub")];
+        state.stage = ManagerStage::Editor(editor);
+
+        begin_editor_save(&mut state, &config, false).unwrap();
+
+        let ManagerStage::Editor(e) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(e.modal.is_none(), "no confirm modal when planner rejects");
+        let banner = e
+            .save_flow
+            .error_message()
+            .expect("readonly mismatch should produce banner");
+        assert!(
+            banner.contains("readonly"),
+            "banner should mention readonly: {banner}"
+        );
+        // On-disk config unchanged.
+        let reloaded = AppConfig::load_or_init(&paths).unwrap();
+        assert!(!reloaded.workspaces.contains_key("test"));
+    }
+
+    #[test]
     fn pre_existing_collapse_produces_prune_error_banner() {
         let ws = WorkspaceConfig {
             workdir: "/work".into(),

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -98,7 +98,7 @@ pub(super) fn begin_editor_save(
             }
             match crate::workspace::planner::plan_create(
                 &editor.pending.workdir,
-                editor.pending.mounts.clone(),
+                &editor.pending.mounts,
                 false,
             ) {
                 Err(e) => {

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -96,11 +96,7 @@ pub(super) fn begin_editor_save(
                 };
                 return Ok(());
             }
-            match crate::workspace::planner::plan_create(
-                &editor.pending.workdir,
-                &editor.pending.mounts,
-                false,
-            ) {
+            match crate::workspace::planner::plan_create(&editor.pending.mounts) {
                 Err(e) => {
                     editor.save_flow = EditorSaveFlow::Error {
                         message: e.to_string(),

--- a/src/console/manager/mount_info.rs
+++ b/src/console/manager/mount_info.rs
@@ -9,32 +9,51 @@ pub enum MountKind {
     Missing,
     /// Path exists, not a git repo.
     Folder,
-    /// Path is a git working copy.
+    /// Path is a git working copy. `origin` is `None` when the repo has no
+    /// resolvable `origin` remote at all.
     Git {
         branch: GitBranch,
-        /// Which host the remote `origin` lives on — affects the label
-        /// (`github` vs `git`) and whether a web URL is resolvable.
-        host: GitHost,
-        /// Raw `origin` remote URL as read from git config, when present.
-        /// Example: `<https://github.com/owner/repo.git>`.
-        remote_url: Option<String>,
-        /// URL for the branch on the git host, if resolvable.
-        /// Only populated for `GitHost::Github`; always `None` for `Other`.
-        /// Example: `<https://github.com/owner/repo/tree/main>`
-        web_url: Option<String>,
+        origin: Option<GitOrigin>,
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GitHost {
-    /// Remote `origin` points at `github.com` in any of the supported forms
-    /// (SSH `git@github.com:`, HTTPS `https://github.com/...`, or
-    /// `ssh://git@github.com/...`).
-    Github,
-    /// Anything else — self-hosted gitea/forgejo, GitLab, Bitbucket,
-    /// Azure DevOps, or a repo with no resolvable remote. Label collapses
-    /// to the generic `git` prefix.
-    Other,
+/// Classification of a git repo's `origin` remote.
+///
+/// The two variants encode the "github vs other" distinction together
+/// with the URLs that are reachable for that classification, so callers
+/// can't ask for a web URL on a non-github remote or carry around an
+/// unsynchronized `(host, remote_url, web_url)` triple.
+#[derive(Debug, Clone)]
+pub enum GitOrigin {
+    /// Remote `origin` points at `github.com` (SSH `git@github.com:`,
+    /// HTTPS `https://github.com/...`, or `ssh://git@github.com/...`).
+    /// `web_url` is the resolved branch/commit page on github.com.
+    Github { remote_url: String, web_url: String },
+    /// Self-hosted gitea/forgejo, GitLab, Bitbucket, Azure DevOps, etc.
+    /// We expose the raw remote URL but no web URL — we don't speak the
+    /// branch-URL conventions of these hosts.
+    Other { remote_url: String },
+}
+
+impl GitOrigin {
+    /// `https://...` URL for the branch on github.com when applicable.
+    /// `None` for non-github remotes — callers asking for an "open in
+    /// browser" URL should gate on this rather than synthesizing one.
+    pub fn web_url(&self) -> Option<&str> {
+        match self {
+            Self::Github { web_url, .. } => Some(web_url),
+            Self::Other { .. } => None,
+        }
+    }
+
+    /// Display prefix used by `MountKind::label`. Github gets a distinct
+    /// prefix so the operator knows "open in browser" is wired up.
+    const fn display_prefix(&self) -> &'static str {
+        match self {
+            Self::Github { .. } => "github",
+            Self::Other { .. } => "git",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -55,16 +74,11 @@ pub fn inspect(src: &str) -> MountKind {
     }
     resolve_gitdirs(path).map_or(MountKind::Folder, |(work_dir, config_dir)| {
         // Branch comes from the worktree-specific gitdir (HEAD is per-worktree
-        // even when the config lives in the common dir), while the remote URL
+        // even when the config lives in the common dir), while the origin URL
         // and host classification come from the common dir's `config`.
         let branch = parse_head(&work_dir);
-        let (host, remote_url, web_url) = resolve_host_and_url(&config_dir, &branch);
-        MountKind::Git {
-            branch,
-            host,
-            remote_url,
-            web_url,
-        }
+        let origin = resolve_origin(&config_dir, &branch);
+        MountKind::Git { branch, origin }
     })
 }
 
@@ -150,38 +164,36 @@ fn parse_head(git_dir: &Path) -> GitBranch {
     )
 }
 
-/// Parse `<config_dir>/config` to find the origin remote's URL, classify
-/// the host, and (for GitHub only) transform into a web URL for the given
-/// branch. The config dir is the main repo's `.git` for worktrees (see
-/// `resolve_gitdirs`) and the per-repo `.git` for plain clones/submodules.
+/// Parse `<config_dir>/config` to find the origin remote's URL and
+/// classify it. The config dir is the main repo's `.git` for worktrees
+/// (see `resolve_gitdirs`) and the per-repo `.git` for plain
+/// clones/submodules.
 ///
-/// Returns `(GitHost, remote_url, web_url)`:
-/// - `GitHost::Github` + raw origin + branch/commit web URL when origin lives on github.com
-/// - `GitHost::Other` + raw origin + no web URL for any other host
-/// - `GitHost::Other` + no URLs when no remote is set
-fn resolve_host_and_url(
-    config_dir: &Path,
-    branch: &GitBranch,
-) -> (GitHost, Option<String>, Option<String>) {
+/// Returns:
+/// - `Some(GitOrigin::Github { ... })` when origin lives on github.com
+///   and resolves into a branch/commit web URL.
+/// - `Some(GitOrigin::Other { ... })` for any other host, or for a
+///   github URL whose web shape we can't synthesize (degenerate case).
+/// - `None` when no remote is set.
+fn resolve_origin(config_dir: &Path, branch: &GitBranch) -> Option<GitOrigin> {
     let config_path = config_dir.join("config");
-    let Ok(content) = std::fs::read_to_string(&config_path) else {
-        return (GitHost::Other, None, None);
-    };
-    let Some(remote_url) = parse_remote_origin_url(&content) else {
-        return (GitHost::Other, None, None);
-    };
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let remote_url = parse_remote_origin_url(&content)?;
     if !remote_points_at_github(&remote_url) {
-        return (GitHost::Other, Some(remote_url), None);
+        return Some(GitOrigin::Other { remote_url });
     }
     let Some(base) = remote_to_web(&remote_url) else {
-        return (GitHost::Other, Some(remote_url), None);
+        return Some(GitOrigin::Other { remote_url });
     };
-    let url = match branch {
+    let web_url = match branch {
         GitBranch::Named(b) => format!("{base}/tree/{b}"),
         GitBranch::Detached { short_sha } => format!("{base}/commit/{short_sha}"),
         GitBranch::Unknown => base,
     };
-    (GitHost::Github, Some(remote_url), Some(url))
+    Some(GitOrigin::Github {
+        remote_url,
+        web_url,
+    })
 }
 
 /// Cheap predicate — does this remote URL live on `github.com`?
@@ -266,11 +278,8 @@ impl MountKind {
         match self {
             Self::Missing => "missing".to_string(),
             Self::Folder => "folder".to_string(),
-            Self::Git { branch, host, .. } => {
-                let prefix = match host {
-                    GitHost::Github => "github",
-                    GitHost::Other => "git",
-                };
+            Self::Git { branch, origin } => {
+                let prefix = origin.as_ref().map_or("git", |o| o.display_prefix());
                 match branch {
                     GitBranch::Named(b) => format!("{prefix} · {b}"),
                     GitBranch::Detached { short_sha } => {
@@ -346,7 +355,7 @@ mod tests {
     }
 
     #[test]
-    fn inspect_classifies_github_remote_as_github_host() {
+    fn inspect_classifies_github_remote_as_github_origin() {
         let temp = tempdir().unwrap();
         let git_dir = temp.path().join(".git");
         std::fs::create_dir(&git_dir).unwrap();
@@ -361,19 +370,17 @@ mod tests {
         let result = inspect(temp.path().to_str().unwrap());
         match result {
             MountKind::Git {
-                host,
-                web_url: Some(url),
+                origin: Some(GitOrigin::Github { web_url, .. }),
                 ..
             } => {
-                assert_eq!(host, GitHost::Github);
-                assert_eq!(url, "https://github.com/owner/repo/tree/main");
+                assert_eq!(web_url, "https://github.com/owner/repo/tree/main");
             }
-            other => panic!("expected Git {{ host: Github, web_url: Some }}, got {other:?}"),
+            other => panic!("expected Git {{ origin: Some(Github), .. }}, got {other:?}"),
         }
     }
 
     #[test]
-    fn inspect_classifies_gitlab_remote_as_other_host_with_no_url() {
+    fn inspect_classifies_gitlab_remote_as_other_origin() {
         let temp = tempdir().unwrap();
         let git_dir = temp.path().join(".git");
         std::fs::create_dir(&git_dir).unwrap();
@@ -387,19 +394,18 @@ mod tests {
         .unwrap();
         let result = inspect(temp.path().to_str().unwrap());
         match result {
-            MountKind::Git { host, web_url, .. } => {
-                assert_eq!(host, GitHost::Other);
-                assert!(
-                    web_url.is_none(),
-                    "non-GitHub remote must not yield a web URL: {web_url:?}"
-                );
+            MountKind::Git {
+                origin: Some(GitOrigin::Other { remote_url }),
+                ..
+            } => {
+                assert_eq!(remote_url, "git@gitlab.com:owner/repo.git");
             }
-            other => panic!("expected Git {{ host: Other }}, got {other:?}"),
+            other => panic!("expected Git {{ origin: Some(Other), .. }}, got {other:?}"),
         }
     }
 
     #[test]
-    fn inspect_classifies_repo_without_remote_as_other_host() {
+    fn inspect_classifies_repo_without_remote_as_no_origin() {
         let temp = tempdir().unwrap();
         let git_dir = temp.path().join(".git");
         std::fs::create_dir(&git_dir).unwrap();
@@ -407,11 +413,8 @@ mod tests {
         // No config file at all — simulates `git init` without a remote.
         let result = inspect(temp.path().to_str().unwrap());
         match result {
-            MountKind::Git { host, web_url, .. } => {
-                assert_eq!(host, GitHost::Other);
-                assert!(web_url.is_none());
-            }
-            other => panic!("expected Git {{ host: Other }}, got {other:?}"),
+            MountKind::Git { origin: None, .. } => {}
+            other => panic!("expected Git {{ origin: None, .. }}, got {other:?}"),
         }
     }
 
@@ -482,22 +485,20 @@ mod tests {
         match result {
             MountKind::Git {
                 branch: GitBranch::Named(b),
-                host,
-                remote_url: Some(remote),
-                web_url: Some(url),
+                origin:
+                    Some(GitOrigin::Github {
+                        remote_url,
+                        web_url,
+                    }),
             } => {
                 assert_eq!(b, "feature-x", "branch should come from worktree HEAD");
-                assert_eq!(remote, "git@github.com:owner/repo.git");
                 assert_eq!(
-                    host,
-                    GitHost::Github,
-                    "host must be resolved from commondir's config"
+                    remote_url, "git@github.com:owner/repo.git",
+                    "origin must be resolved from commondir's config"
                 );
-                assert_eq!(url, "https://github.com/owner/repo/tree/feature-x");
+                assert_eq!(web_url, "https://github.com/owner/repo/tree/feature-x");
             }
-            other => panic!(
-                "expected Git {{ host: Github, web_url: Some, branch: feature-x }}, got {other:?}"
-            ),
+            other => panic!("expected Git {{ origin: Github, branch: feature-x }}, got {other:?}"),
         }
     }
 
@@ -541,13 +542,15 @@ mod tests {
         match result {
             MountKind::Git {
                 branch: GitBranch::Named(b),
-                host: GitHost::Github,
-                remote_url: Some(remote),
-                web_url: Some(url),
+                origin:
+                    Some(GitOrigin::Github {
+                        remote_url,
+                        web_url,
+                    }),
             } => {
                 assert_eq!(b, "abs-branch");
-                assert_eq!(remote, "https://github.com/owner/repo.git");
-                assert_eq!(url, "https://github.com/owner/repo/tree/abs-branch");
+                assert_eq!(remote_url, "https://github.com/owner/repo.git");
+                assert_eq!(web_url, "https://github.com/owner/repo/tree/abs-branch");
             }
             other => {
                 panic!("expected Github worktree resolution via absolute commondir, got {other:?}")
@@ -587,15 +590,56 @@ mod tests {
         match result {
             MountKind::Git {
                 branch: GitBranch::Named(b),
-                host: GitHost::Github,
-                remote_url: Some(remote),
-                web_url: Some(url),
+                origin:
+                    Some(GitOrigin::Github {
+                        remote_url,
+                        web_url,
+                    }),
             } => {
                 assert_eq!(b, "submain");
-                assert_eq!(remote, "git@github.com:owner/submod.git");
-                assert_eq!(url, "https://github.com/owner/submod/tree/submain");
+                assert_eq!(remote_url, "git@github.com:owner/submod.git");
+                assert_eq!(web_url, "https://github.com/owner/submod/tree/submain");
             }
-            other => panic!("expected submodule to resolve with GitHost::Github, got {other:?}"),
+            other => panic!("expected submodule to resolve with GitOrigin::Github, got {other:?}"),
+        }
+    }
+
+    /// Build a `MountKind::Git` value for label tests from a github
+    /// `owner/repo` slug and a branch. The remote and web URLs are derived
+    /// from the slug + branch using the same shapes `resolve_origin`
+    /// produces for real github remotes — keeps tests focused on label
+    /// behavior instead of URL bookkeeping.
+    fn github_mount(owner_repo: &str, branch: GitBranch) -> MountKind {
+        let base = format!("https://github.com/{owner_repo}");
+        let web_url = match &branch {
+            GitBranch::Named(b) => format!("{base}/tree/{b}"),
+            GitBranch::Detached { short_sha } => format!("{base}/commit/{short_sha}"),
+            GitBranch::Unknown => base.clone(),
+        };
+        MountKind::Git {
+            branch,
+            origin: Some(GitOrigin::Github {
+                remote_url: format!("{base}.git"),
+                web_url,
+            }),
+        }
+    }
+
+    /// Build a `MountKind::Git` for label tests with a non-github origin.
+    fn other_mount(remote_url: &str, branch: GitBranch) -> MountKind {
+        MountKind::Git {
+            branch,
+            origin: Some(GitOrigin::Other {
+                remote_url: remote_url.into(),
+            }),
+        }
+    }
+
+    /// Build a `MountKind::Git` for label tests with no resolvable origin.
+    fn no_origin_mount(branch: GitBranch) -> MountKind {
+        MountKind::Git {
+            branch,
+            origin: None,
         }
     }
 
@@ -606,37 +650,20 @@ mod tests {
         assert_eq!(MountKind::Missing.label(), "missing");
         assert_eq!(MountKind::Folder.label(), "folder");
         assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Named("main".into()),
-                host: GitHost::Other,
-                remote_url: None,
-                web_url: None,
-            }
-            .label(),
+            no_origin_mount(GitBranch::Named("main".into())).label(),
             "git · main"
         );
         assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Detached {
+            other_mount(
+                "git@gitlab.com:o/r.git",
+                GitBranch::Detached {
                     short_sha: "abc1234".into()
                 },
-                host: GitHost::Other,
-                remote_url: None,
-                web_url: None,
-            }
+            )
             .label(),
             "git · detached abc1234"
         );
-        assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Unknown,
-                host: GitHost::Other,
-                remote_url: None,
-                web_url: None,
-            }
-            .label(),
-            "git"
-        );
+        assert_eq!(no_origin_mount(GitBranch::Unknown).label(), "git");
     }
 
     #[test]
@@ -644,35 +671,21 @@ mod tests {
         // GitHub-hosted mounts get a `github · …` prefix so the operator
         // can tell which rows have an "open in browser" affordance.
         assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Named("main".into()),
-                host: GitHost::Github,
-                remote_url: Some("https://github.com/owner/repo.git".into()),
-                web_url: Some("https://github.com/owner/repo/tree/main".into()),
-            }
-            .label(),
+            github_mount("owner/repo", GitBranch::Named("main".into())).label(),
             "github · main"
         );
         assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Detached {
+            github_mount(
+                "owner/repo",
+                GitBranch::Detached {
                     short_sha: "abc1234".into()
                 },
-                host: GitHost::Github,
-                remote_url: Some("https://github.com/owner/repo.git".into()),
-                web_url: Some("https://github.com/owner/repo/commit/abc1234".into()),
-            }
+            )
             .label(),
             "github · detached abc1234"
         );
         assert_eq!(
-            MountKind::Git {
-                branch: GitBranch::Unknown,
-                host: GitHost::Github,
-                remote_url: Some("https://github.com/owner/repo.git".into()),
-                web_url: Some("https://github.com/owner/repo".into()),
-            }
-            .label(),
+            github_mount("owner/repo", GitBranch::Unknown).label(),
             "github"
         );
     }

--- a/src/console/manager/mount_info.rs
+++ b/src/console/manager/mount_info.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
-pub enum MountKind {
+pub(crate) enum MountKind {
     /// Path doesn't exist on disk. Nothing to inspect.
     Missing,
     /// Path exists, not a git repo.
@@ -24,28 +24,31 @@ pub enum MountKind {
 /// can't ask for a web URL on a non-github remote or hold separate
 /// `host`, `remote_url`, and `web_url` fields that drift out of sync.
 #[derive(Debug, Clone)]
-pub enum GitOrigin {
+pub(crate) enum GitOrigin {
     /// Remote `origin` points at `github.com` (SSH `git@github.com:`,
     /// HTTPS `https://github.com/...`, or `ssh://git@github.com/...`).
     /// `web_url` is the resolved branch/commit page on github.com.
-    Github { remote_url: String, web_url: String },
+    ///
+    /// `remote_url` is preserved here for diagnostic and Debug output
+    /// even though no production reader currently destructures it; the
+    /// `dead_code` allow keeps the value carried in the variant so a
+    /// future caller (e.g. error chains showing the operator-typed URL)
+    /// doesn't have to plumb it back in separately.
+    Github {
+        #[allow(dead_code)]
+        remote_url: String,
+        web_url: String,
+    },
     /// Self-hosted gitea/forgejo, GitLab, Bitbucket, Azure DevOps, etc.
     /// We expose the raw remote URL but no web URL — we don't speak the
     /// branch-URL conventions of these hosts.
-    Other { remote_url: String },
+    Other {
+        #[allow(dead_code)]
+        remote_url: String,
+    },
 }
 
 impl GitOrigin {
-    /// `https://...` URL for the branch on github.com when applicable.
-    /// `None` for non-github remotes — callers asking for an "open in
-    /// browser" URL should gate on this rather than synthesizing one.
-    pub fn web_url(&self) -> Option<&str> {
-        match self {
-            Self::Github { web_url, .. } => Some(web_url),
-            Self::Other { .. } => None,
-        }
-    }
-
     /// Display prefix used by `MountKind::label`. Github gets a distinct
     /// prefix so the operator knows "open in browser" is wired up.
     const fn display_prefix(&self) -> &'static str {
@@ -57,13 +60,13 @@ impl GitOrigin {
 }
 
 #[derive(Debug, Clone)]
-pub enum GitBranch {
+pub(crate) enum GitBranch {
     Named(String),
     Detached { short_sha: String },
     Unknown,
 }
 
-pub fn inspect(src: &str) -> MountKind {
+pub(crate) fn inspect(src: &str) -> MountKind {
     let path = Path::new(src);
     if !path.exists() {
         return MountKind::Missing;
@@ -274,7 +277,7 @@ impl MountKind {
     /// remotes have an `o`-opens-in-browser affordance wired up; everything
     /// else (self-hosted gitea, gitlab, no remote, …) keeps the generic
     /// `git · …` prefix.
-    pub fn label(&self) -> String {
+    pub(crate) fn label(&self) -> String {
         match self {
             Self::Missing => "missing".to_string(),
             Self::Folder => "folder".to_string(),

--- a/src/console/manager/mount_info.rs
+++ b/src/console/manager/mount_info.rs
@@ -21,8 +21,8 @@ pub enum MountKind {
 ///
 /// The two variants encode the "github vs other" distinction together
 /// with the URLs that are reachable for that classification, so callers
-/// can't ask for a web URL on a non-github remote or carry around an
-/// unsynchronized `(host, remote_url, web_url)` triple.
+/// can't ask for a web URL on a non-github remote or hold separate
+/// `host`, `remote_url`, and `web_url` fields that drift out of sync.
 #[derive(Debug, Clone)]
 pub enum GitOrigin {
     /// Remote `origin` points at `github.com` (SSH `git@github.com:`,
@@ -75,7 +75,7 @@ pub fn inspect(src: &str) -> MountKind {
     resolve_gitdirs(path).map_or(MountKind::Folder, |(work_dir, config_dir)| {
         // Branch comes from the worktree-specific gitdir (HEAD is per-worktree
         // even when the config lives in the common dir), while the origin URL
-        // and host classification come from the common dir's `config`.
+        // and its github/other classification come from the common dir's `config`.
         let branch = parse_head(&work_dir);
         let origin = resolve_origin(&config_dir, &branch);
         MountKind::Git { branch, origin }
@@ -92,8 +92,8 @@ pub fn inspect(src: &str) -> MountKind {
 /// own `HEAD` but no `config` of its own — instead, a `commondir` file
 /// points at the main repo's git-dir, where the remote URL lives.
 ///
-/// Without following the `commondir` redirect, `resolve_host_and_url`
-/// reads nothing, `GitHost` falls through to `Other`, and the label
+/// Without following the `commondir` redirect, `resolve_origin`
+/// reads nothing, the origin resolves to `None`, and the label
 /// renders as `git · branch` instead of `github · branch`.
 fn resolve_gitdirs(workdir: &Path) -> Option<(PathBuf, PathBuf)> {
     let dotgit = workdir.join(".git");
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn remote_to_web_returns_none_for_gitlab() {
         // GitLab is a non-GitHub host — `remote_to_web` no longer synthesises
-        // a web URL for it. (Classification falls through to `GitHost::Other`
+        // a web URL for it. (Classification falls through to `GitOrigin::Other`
         // at the `resolve_host_and_url` layer.)
         assert_eq!(remote_to_web("git@gitlab.com:owner/repo.git"), None);
         assert_eq!(remote_to_web("https://gitlab.com/owner/repo.git"), None);

--- a/src/console/manager/mount_info.rs
+++ b/src/console/manager/mount_info.rs
@@ -15,6 +15,9 @@ pub enum MountKind {
         /// Which host the remote `origin` lives on — affects the label
         /// (`github` vs `git`) and whether a web URL is resolvable.
         host: GitHost,
+        /// Raw `origin` remote URL as read from git config, when present.
+        /// Example: `<https://github.com/owner/repo.git>`.
+        remote_url: Option<String>,
         /// URL for the branch on the git host, if resolvable.
         /// Only populated for `GitHost::Github`; always `None` for `Other`.
         /// Example: `<https://github.com/owner/repo/tree/main>`
@@ -55,10 +58,11 @@ pub fn inspect(src: &str) -> MountKind {
         // even when the config lives in the common dir), while the remote URL
         // and host classification come from the common dir's `config`.
         let branch = parse_head(&work_dir);
-        let (host, web_url) = resolve_host_and_url(&config_dir, &branch);
+        let (host, remote_url, web_url) = resolve_host_and_url(&config_dir, &branch);
         MountKind::Git {
             branch,
             host,
+            remote_url,
             web_url,
         }
     })
@@ -151,29 +155,33 @@ fn parse_head(git_dir: &Path) -> GitBranch {
 /// branch. The config dir is the main repo's `.git` for worktrees (see
 /// `resolve_gitdirs`) and the per-repo `.git` for plain clones/submodules.
 ///
-/// Returns `(GitHost, Option<String>)`:
-/// - `GitHost::Github` + `Some(url)` when origin lives on github.com
-/// - `GitHost::Other` + `None` for any other host, or when no remote is set
-fn resolve_host_and_url(config_dir: &Path, branch: &GitBranch) -> (GitHost, Option<String>) {
+/// Returns `(GitHost, remote_url, web_url)`:
+/// - `GitHost::Github` + raw origin + branch/commit web URL when origin lives on github.com
+/// - `GitHost::Other` + raw origin + no web URL for any other host
+/// - `GitHost::Other` + no URLs when no remote is set
+fn resolve_host_and_url(
+    config_dir: &Path,
+    branch: &GitBranch,
+) -> (GitHost, Option<String>, Option<String>) {
     let config_path = config_dir.join("config");
     let Ok(content) = std::fs::read_to_string(&config_path) else {
-        return (GitHost::Other, None);
+        return (GitHost::Other, None, None);
     };
     let Some(remote_url) = parse_remote_origin_url(&content) else {
-        return (GitHost::Other, None);
+        return (GitHost::Other, None, None);
     };
     if !remote_points_at_github(&remote_url) {
-        return (GitHost::Other, None);
+        return (GitHost::Other, Some(remote_url), None);
     }
     let Some(base) = remote_to_web(&remote_url) else {
-        return (GitHost::Other, None);
+        return (GitHost::Other, Some(remote_url), None);
     };
     let url = match branch {
         GitBranch::Named(b) => format!("{base}/tree/{b}"),
         GitBranch::Detached { short_sha } => format!("{base}/commit/{short_sha}"),
         GitBranch::Unknown => base,
     };
-    (GitHost::Github, Some(url))
+    (GitHost::Github, Some(remote_url), Some(url))
 }
 
 /// Cheap predicate — does this remote URL live on `github.com`?
@@ -475,9 +483,11 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Named(b),
                 host,
+                remote_url: Some(remote),
                 web_url: Some(url),
             } => {
                 assert_eq!(b, "feature-x", "branch should come from worktree HEAD");
+                assert_eq!(remote, "git@github.com:owner/repo.git");
                 assert_eq!(
                     host,
                     GitHost::Github,
@@ -532,9 +542,11 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Named(b),
                 host: GitHost::Github,
+                remote_url: Some(remote),
                 web_url: Some(url),
             } => {
                 assert_eq!(b, "abs-branch");
+                assert_eq!(remote, "https://github.com/owner/repo.git");
                 assert_eq!(url, "https://github.com/owner/repo/tree/abs-branch");
             }
             other => {
@@ -576,9 +588,11 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Named(b),
                 host: GitHost::Github,
+                remote_url: Some(remote),
                 web_url: Some(url),
             } => {
                 assert_eq!(b, "submain");
+                assert_eq!(remote, "git@github.com:owner/submod.git");
                 assert_eq!(url, "https://github.com/owner/submod/tree/submain");
             }
             other => panic!("expected submodule to resolve with GitHost::Github, got {other:?}"),
@@ -595,6 +609,7 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Named("main".into()),
                 host: GitHost::Other,
+                remote_url: None,
                 web_url: None,
             }
             .label(),
@@ -606,6 +621,7 @@ mod tests {
                     short_sha: "abc1234".into()
                 },
                 host: GitHost::Other,
+                remote_url: None,
                 web_url: None,
             }
             .label(),
@@ -615,6 +631,7 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Unknown,
                 host: GitHost::Other,
+                remote_url: None,
                 web_url: None,
             }
             .label(),
@@ -630,6 +647,7 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Named("main".into()),
                 host: GitHost::Github,
+                remote_url: Some("https://github.com/owner/repo.git".into()),
                 web_url: Some("https://github.com/owner/repo/tree/main".into()),
             }
             .label(),
@@ -641,6 +659,7 @@ mod tests {
                     short_sha: "abc1234".into()
                 },
                 host: GitHost::Github,
+                remote_url: Some("https://github.com/owner/repo.git".into()),
                 web_url: Some("https://github.com/owner/repo/commit/abc1234".into()),
             }
             .label(),
@@ -650,6 +669,7 @@ mod tests {
             MountKind::Git {
                 branch: GitBranch::Unknown,
                 host: GitHost::Github,
+                remote_url: Some("https://github.com/owner/repo.git".into()),
                 web_url: Some("https://github.com/owner/repo".into()),
             }
             .label(),

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -57,7 +57,7 @@ pub fn render_editor(
 
     let mut items: Vec<FooterItem> = Vec::new();
 
-    let row_items = contextual_row_items(state, op_available);
+    let row_items = contextual_row_items(state, config, op_available);
     if !row_items.is_empty() {
         items.extend(row_items);
         items.push(FooterItem::GroupSep);
@@ -105,7 +105,11 @@ pub fn render_editor(
 /// Compute a row-specific hint fragment based on the active tab and cursor.
 /// Returns an empty vec when the current position has no action.
 #[allow(clippy::too_many_lines)]
-fn contextual_row_items(state: &EditorState<'_>, op_available: bool) -> Vec<FooterItem> {
+fn contextual_row_items(
+    state: &EditorState<'_>,
+    config: &AppConfig,
+    op_available: bool,
+) -> Vec<FooterItem> {
     let FieldFocus::Row(cursor) = state.active_field;
     match state.active_tab {
         EditorTab::General => {
@@ -172,13 +176,22 @@ fn contextual_row_items(state: &EditorState<'_>, op_available: bool) -> Vec<Foot
                 vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")]
             }
         }
-        EditorTab::Roles => vec![
-            FooterItem::Key("Space"),
-            FooterItem::Text("allow/disallow"),
-            FooterItem::Sep,
-            FooterItem::Key("*"),
-            FooterItem::Text("set/unset default"),
-        ],
+        EditorTab::Roles => {
+            if cursor < config.roles.len() {
+                vec![
+                    FooterItem::Key("Space"),
+                    FooterItem::Text("allow/disallow"),
+                    FooterItem::Sep,
+                    FooterItem::Key("*"),
+                    FooterItem::Text("set/unset default"),
+                    FooterItem::Sep,
+                    FooterItem::Key("A"),
+                    FooterItem::Text("add role"),
+                ]
+            } else {
+                vec![FooterItem::Key("Enter/A"), FooterItem::Text("add role")]
+            }
+        }
         EditorTab::Secrets => {
             // Row-specific hints depend on which SecretsRow kind the cursor
             // is sitting on. Op:// rows are read-only at the value level —
@@ -503,6 +516,18 @@ fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, conf
         };
         lines.push(Line::from(Span::styled(text, style)));
     }
+    let sentinel_idx = config.roles.len();
+    let sentinel_selected = cursor == sentinel_idx;
+    let sentinel_prefix = if sentinel_selected { "▸ " } else { "  " };
+    let sentinel_style = if sentinel_selected {
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(WHITE)
+    };
+    lines.push(Line::from(Span::styled(
+        format!("{sentinel_prefix}+ Add role"),
+        sentinel_style,
+    )));
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
@@ -860,6 +885,7 @@ mod contextual_row_items_tests {
 
     use super::super::FooterItem;
     use super::contextual_row_items;
+    use crate::config::{AppConfig, RoleSource};
     use crate::console::manager::state::{EditorState, EditorTab, FieldFocus};
     use crate::workspace::{MountConfig, WorkspaceConfig};
 
@@ -909,6 +935,14 @@ mod contextual_row_items_tests {
         editor
     }
 
+    fn config_with_agents(names: &[&str]) -> AppConfig {
+        let mut config = AppConfig::default();
+        for name in names {
+            config.roles.insert((*name).into(), RoleSource::default());
+        }
+        config
+    }
+
     #[test]
     fn github_mount_row_includes_open_in_github_hint() {
         // Build a synthetic GitHub repo on-disk so `mount_info::inspect`
@@ -926,7 +960,8 @@ mod contextual_row_items_tests {
         .unwrap();
 
         let editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
-        let hint = contextual_row_items(&editor, true);
+        let config = AppConfig::default();
+        let hint = contextual_row_items(&editor, &config, true);
         let keys = key_glyphs(&hint);
         let labels = text_labels(&hint);
         assert!(
@@ -947,7 +982,8 @@ mod contextual_row_items_tests {
         // Plain folder (no .git) — no GitHub URL, so `O` must not appear.
         let tmp = tempfile::tempdir().unwrap();
         let editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
-        let hint = contextual_row_items(&editor, true);
+        let config = AppConfig::default();
+        let hint = contextual_row_items(&editor, &config, true);
         let keys = key_glyphs(&hint);
         assert!(
             !keys.contains(&"O"),
@@ -965,7 +1001,8 @@ mod contextual_row_items_tests {
         // hint composes alongside D/A even without the O extension.
         let tmp = tempfile::tempdir().unwrap();
         let editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
-        let hint = contextual_row_items(&editor, true);
+        let config = AppConfig::default();
+        let hint = contextual_row_items(&editor, &config, true);
         let keys = key_glyphs(&hint);
         let labels = text_labels(&hint);
         assert!(
@@ -985,7 +1022,8 @@ mod contextual_row_items_tests {
         let tmp = tempfile::tempdir().unwrap();
         let mut editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
         editor.active_field = FieldFocus::Row(editor.pending.mounts.len());
-        let hint = contextual_row_items(&editor, true);
+        let config = AppConfig::default();
+        let hint = contextual_row_items(&editor, &config, true);
         let keys = key_glyphs(&hint);
         assert!(
             !keys.contains(&"R"),
@@ -1002,21 +1040,22 @@ mod contextual_row_items_tests {
         // General row 0 Edit + Create uses only `Enter`, which is multi-char.
         let tmp = tempfile::tempdir().unwrap();
         let editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
+        let config = config_with_agents(&["agent-smith"]);
 
         // Mounts data-row hint.
-        let mounts_row = contextual_row_items(&editor, true);
+        let mounts_row = contextual_row_items(&editor, &config, true);
         assert_hint_hotkeys_uppercase(&mounts_row, "Mounts row 0");
 
         // Mounts sentinel "+ Add mount" row.
         let mut sentinel_editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
         sentinel_editor.active_field = FieldFocus::Row(sentinel_editor.pending.mounts.len());
-        let sentinel_row = contextual_row_items(&sentinel_editor, true);
+        let sentinel_row = contextual_row_items(&sentinel_editor, &config, true);
         assert_hint_hotkeys_uppercase(&sentinel_row, "Mounts sentinel");
 
         // Roles tab uses Space + `*` — both multi-char / non-alpha.
         let mut roles_editor = editor_at_mounts_row0(tmp.path().to_str().unwrap());
         roles_editor.active_tab = EditorTab::Roles;
-        let roles_row = contextual_row_items(&roles_editor, true);
+        let roles_row = contextual_row_items(&roles_editor, &config, true);
         assert_hint_hotkeys_uppercase(&roles_row, "Roles");
     }
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -147,8 +147,7 @@ fn contextual_row_items(
                     && matches!(
                         super::super::mount_info::inspect(&m.src),
                         super::super::mount_info::MountKind::Git {
-                            host: super::super::mount_info::GitHost::Github,
-                            web_url: Some(_),
+                            origin: Some(super::super::mount_info::GitOrigin::Github { .. }),
                             ..
                         }
                     )
@@ -946,7 +945,7 @@ mod contextual_row_items_tests {
     #[test]
     fn github_mount_row_includes_open_in_github_hint() {
         // Build a synthetic GitHub repo on-disk so `mount_info::inspect`
-        // classifies the source as `MountKind::Git { host: Github, web_url: Some }`.
+        // classifies the source as `MountKind::Git { origin: Some(GitOrigin::Github { .. }) }`.
         let tmp = tempfile::tempdir().unwrap();
         let git_dir = tmp.path().join(".git");
         std::fs::create_dir(&git_dir).unwrap();

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -47,7 +47,14 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         Modal::ErrorPopup { state } => {
             // 2 borders + 2-col left gutter for safety.
             let inner_width = (outer.width * 60 / 100).saturating_sub(4);
-            (60, error_popup::required_height(state, inner_width))
+            // Allow the popup to grow with the terminal so multi-line
+            // anyhow chains (the root cause is usually at the bottom)
+            // don't get clipped.
+            let max_rows = outer.height.saturating_sub(2);
+            (
+                60,
+                error_popup::required_height(state, inner_width, max_rows),
+            )
         }
         Modal::OpPicker { .. } => (80, 22),
         Modal::RolePicker { state } | Modal::RoleOverridePicker { state } => {

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -30,7 +30,9 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
 
     let (pct_w, height_rows) = match modal {
         Modal::TextInput { .. } => (60, 6),
-        Modal::Confirm { state, .. } => (60, confirm::required_height(state)),
+        Modal::Confirm { state, .. } => {
+            (confirm::width_pct(state), confirm::required_height(state))
+        }
         Modal::SaveDiscardCancel { .. } => (70, 7),
         Modal::FileBrowser { .. } => (70, 22),
         Modal::WorkdirPick { .. } => (60, 12),

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -17,13 +17,24 @@ use super::centered_rect_fixed;
 /// `input::file_browser_modal_rect` re-uses it for mouse hit-testing
 /// so the two views stay in sync.
 pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Rect) -> Rect {
+    if matches!(modal, Modal::MountDstChoice { .. }) {
+        let w = outer.width.min(80);
+        let h = 8.min(outer.height);
+        return Rect {
+            x: outer.x + outer.width.saturating_sub(w) / 2,
+            y: outer.y + outer.height.saturating_sub(h) / 2,
+            width: w,
+            height: h,
+        };
+    }
+
     let (pct_w, height_rows) = match modal {
         Modal::TextInput { .. } => (60, 6),
         Modal::Confirm { state, .. } => (60, confirm::required_height(state)),
         Modal::SaveDiscardCancel { .. } => (70, 7),
         Modal::FileBrowser { .. } => (70, 22),
         Modal::WorkdirPick { .. } => (60, 12),
-        Modal::MountDstChoice { .. } => (80, 9),
+        Modal::MountDstChoice { .. } => unreachable!("handled above"),
         Modal::GithubPicker { state } => {
             let rows = (state.choices.len() as u16).saturating_add(5).min(15);
             (60, rows)

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -284,7 +284,6 @@ pub enum FileBrowserTarget {
 
 #[derive(Debug, Clone)]
 pub enum ConfirmTarget {
-    DeleteWorkspace,
     DeleteEnvVar {
         scope: SecretsScopeTag,
         key: String,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -289,6 +289,10 @@ pub enum ConfirmTarget {
         scope: SecretsScopeTag,
         key: String,
     },
+    TrustRoleSource {
+        key: String,
+        source: crate::config::RoleSource,
+    },
     /// Source-drift confirmation (Task 10.3): operator's edit changes the
     /// `src` of one or more mounts that have preserved isolated state on
     /// stopped containers. Carries the planner's pending save material so

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -271,6 +271,7 @@ pub enum TextInputTarget {
     Name,
     Workdir,
     MountDst,
+    Role,
     EnvKey { scope: SecretsScopeTag },
     EnvValue { scope: SecretsScopeTag, key: String },
 }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -149,6 +149,74 @@ const fn consumes_letter_input(state: &ConsoleState) -> bool {
     false
 }
 
+const fn modal_debug_name(modal: &crate::console::manager::state::Modal<'_>) -> &'static str {
+    use crate::console::manager::state::Modal;
+    match modal {
+        Modal::TextInput { .. } => "TextInput",
+        Modal::FileBrowser { .. } => "FileBrowser",
+        Modal::MountDstChoice { .. } => "MountDstChoice",
+        Modal::WorkdirPick { .. } => "WorkdirPick",
+        Modal::Confirm { .. } => "Confirm",
+        Modal::SaveDiscardCancel { .. } => "SaveDiscardCancel",
+        Modal::GithubPicker { .. } => "GithubPicker",
+        Modal::ConfirmSave { .. } => "ConfirmSave",
+        Modal::ErrorPopup { .. } => "ErrorPopup",
+        Modal::OpPicker { .. } => "OpPicker",
+        Modal::RolePicker { .. } => "RolePicker",
+        Modal::RoleOverridePicker { .. } => "RoleOverridePicker",
+        Modal::SourcePicker { .. } => "SourcePicker",
+        Modal::ScopePicker { .. } => "ScopePicker",
+    }
+}
+
+fn console_location_debug(console_state: &ConsoleState) -> String {
+    if console_state.quit_confirm.is_some() {
+        return "quit-confirm".into();
+    }
+
+    let ConsoleStage::Manager(ms) = &console_state.stage;
+    let list_modal = ms.list_modal.as_ref().map_or_else(String::new, |modal| {
+        format!(" list_modal={}", modal_debug_name(modal))
+    });
+    let location = match &ms.stage {
+        crate::console::manager::state::ManagerStage::List => "list".to_string(),
+        crate::console::manager::state::ManagerStage::Editor(editor) => {
+            let modal = editor.modal.as_ref().map_or("none", modal_debug_name);
+            format!(
+                "editor mode={:?} tab={:?} field={:?} modal={modal}",
+                editor.mode, editor.active_tab, editor.active_field
+            )
+        }
+        crate::console::manager::state::ManagerStage::CreatePrelude(prelude) => {
+            let modal = prelude.modal.as_ref().map_or("none", modal_debug_name);
+            format!("create-prelude step={:?} modal={modal}", prelude.step)
+        }
+        crate::console::manager::state::ManagerStage::ConfirmDelete { .. } => {
+            "confirm-delete".to_string()
+        }
+    };
+    format!("{location}{list_modal}")
+}
+
+fn key_debug_name(state: &ConsoleState, key: crossterm::event::KeyEvent) -> String {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let has_command_modifier = key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER);
+    let code = match key.code {
+        KeyCode::Char(_) if consumes_letter_input(state) && !has_command_modifier => {
+            "Char(<redacted>)".to_string()
+        }
+        KeyCode::Char(ch) => format!("Char({})", ch.escape_default()),
+        other => format!("{other:?}"),
+    };
+    if key.modifiers.is_empty() {
+        code
+    } else {
+        format!("{:?}+{code}", key.modifiers)
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run_console(
     mut config: AppConfig,
@@ -173,6 +241,7 @@ pub fn run_console(
             let _ = stdout.execute(DisableMouseCapture);
             let _ = stdout.execute(crossterm::terminal::LeaveAlternateScreen);
             let _ = stdout.execute(crossterm::cursor::Show);
+            crate::tui::end_debug_buffering();
         }
     }
 
@@ -180,6 +249,7 @@ pub fn run_console(
     let mut stdout = std::io::stdout();
     enable_raw_mode()?;
     let guard = TerminalGuard;
+    crate::tui::begin_debug_buffering();
     stdout.execute(EnterAlternateScreen)?;
     stdout.execute(EnableMouseCapture)?;
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
@@ -217,6 +287,12 @@ pub fn run_console(
         if event::poll(Duration::from_millis(TICK_MS))? {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    crate::debug_log!(
+                        "tui",
+                        "key={} location={}",
+                        key_debug_name(&state, key),
+                        console_location_debug(&state)
+                    );
                     if let Some(confirm) = state.quit_confirm.as_mut() {
                         use crate::console::widgets::ModalOutcome;
                         match confirm.handle_key(key) {
@@ -292,6 +368,11 @@ pub fn run_console(
                     }
                 }
                 Event::Mouse(mouse) => {
+                    crate::debug_log!(
+                        "tui",
+                        "mouse={mouse:?} location={}",
+                        console_location_debug(&state)
+                    );
                     if let ConsoleStage::Manager(ms) = &mut state.stage {
                         manager::input::handle_mouse(ms, mouse, term_size);
                     }
@@ -322,6 +403,15 @@ mod quit_confirm_tests {
         let cwd = std::env::temp_dir();
         let config = AppConfig::default();
         ConsoleState::new(&config, &cwd).unwrap()
+    }
+
+    fn key(code: crossterm::event::KeyCode) -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent {
+            code,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }
     }
 
     #[test]
@@ -369,38 +459,73 @@ mod quit_confirm_tests {
     }
 
     #[test]
+    fn debug_key_redacts_text_input_characters() {
+        let mut state = fresh_state();
+        let ConsoleStage::Manager(ms) = &mut state.stage;
+        let mut editor = EditorState::new_create();
+        editor.modal = Some(Modal::TextInput {
+            target: TextInputTarget::EnvValue {
+                scope: SecretsScopeTag::Workspace,
+                key: "TOKEN".into(),
+            },
+            state: TextInputState::new("Value", ""),
+        });
+        ms.stage = ManagerStage::Editor(editor);
+
+        assert_eq!(
+            key_debug_name(&state, key(crossterm::event::KeyCode::Char('s'))),
+            "Char(<redacted>)"
+        );
+        assert_eq!(
+            key_debug_name(&state, key(crossterm::event::KeyCode::Enter)),
+            "Enter"
+        );
+    }
+
+    #[test]
+    fn debug_location_includes_stage_and_modal_without_values() {
+        let mut state = fresh_state();
+        let ConsoleStage::Manager(ms) = &mut state.stage;
+        let mut editor = EditorState::new_create();
+        editor.modal = Some(Modal::TextInput {
+            target: TextInputTarget::EnvValue {
+                scope: SecretsScopeTag::Workspace,
+                key: "TOKEN".into(),
+            },
+            state: TextInputState::new("Value", ""),
+        });
+        ms.stage = ManagerStage::Editor(editor);
+
+        let location = console_location_debug(&state);
+        assert!(location.contains("editor"), "{location}");
+        assert!(location.contains("modal=TextInput"), "{location}");
+        assert!(!location.contains("TOKEN"), "{location}");
+    }
+
+    #[test]
     fn quit_confirm_handle_key_y_commits_exit() {
         let mut s = ConfirmState::new("Exit jackin'?");
-        let key = crossterm::event::KeyEvent {
-            code: crossterm::event::KeyCode::Char('y'),
-            modifiers: crossterm::event::KeyModifiers::NONE,
-            kind: crossterm::event::KeyEventKind::Press,
-            state: crossterm::event::KeyEventState::NONE,
-        };
-        assert!(matches!(s.handle_key(key), ModalOutcome::Commit(true)));
+        assert!(matches!(
+            s.handle_key(key(crossterm::event::KeyCode::Char('y'))),
+            ModalOutcome::Commit(true)
+        ));
     }
 
     #[test]
     fn quit_confirm_handle_key_n_returns_commit_false() {
         let mut s = ConfirmState::new("Exit jackin'?");
-        let key = crossterm::event::KeyEvent {
-            code: crossterm::event::KeyCode::Char('n'),
-            modifiers: crossterm::event::KeyModifiers::NONE,
-            kind: crossterm::event::KeyEventKind::Press,
-            state: crossterm::event::KeyEventState::NONE,
-        };
-        assert!(matches!(s.handle_key(key), ModalOutcome::Commit(false)));
+        assert!(matches!(
+            s.handle_key(key(crossterm::event::KeyCode::Char('n'))),
+            ModalOutcome::Commit(false)
+        ));
     }
 
     #[test]
     fn quit_confirm_handle_key_esc_cancels() {
         let mut s = ConfirmState::new("Exit jackin'?");
-        let key = crossterm::event::KeyEvent {
-            code: crossterm::event::KeyCode::Esc,
-            modifiers: crossterm::event::KeyModifiers::NONE,
-            kind: crossterm::event::KeyEventKind::Press,
-            state: crossterm::event::KeyEventState::NONE,
-        };
-        assert!(matches!(s.handle_key(key), ModalOutcome::Cancel));
+        assert!(matches!(
+            s.handle_key(key(crossterm::event::KeyCode::Esc)),
+            ModalOutcome::Cancel
+        ));
     }
 }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -198,6 +198,10 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
     format!("{location}{list_modal}")
 }
 
+/// Render a key event for the `--debug` log. Redacts the literal
+/// character when the focused widget is consuming text input — without
+/// the redaction the operator's typed values (workspace names, env
+/// values, paths) would land in `--debug` output verbatim.
 fn key_debug_name(state: &ConsoleState, key: crossterm::event::KeyEvent) -> String {
     use crossterm::event::{KeyCode, KeyModifiers};
     let has_command_modifier = key

--- a/src/console/widgets/confirm.rs
+++ b/src/console/widgets/confirm.rs
@@ -18,6 +18,14 @@ pub enum ConfirmFocus {
 pub struct ConfirmState {
     pub prompt: String,
     pub focus: ConfirmFocus,
+    pub title: String,
+    pub presentation: ConfirmPresentation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfirmPresentation {
+    Default,
+    RoleTrust,
 }
 
 impl ConfirmState {
@@ -27,6 +35,17 @@ impl ConfirmState {
         Self {
             prompt: prompt.into(),
             focus: ConfirmFocus::No,
+            title: "Confirm".into(),
+            presentation: ConfirmPresentation::Default,
+        }
+    }
+
+    pub fn role_trust(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            focus: ConfirmFocus::No,
+            title: "Trust role source".into(),
+            presentation: ConfirmPresentation::RoleTrust,
         }
     }
 
@@ -60,16 +79,29 @@ use ratatui::{
 
 const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
 const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
+const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 const WHITE: Color = Color::Rgb(255, 255, 255);
+const WARNING_YELLOW: Color = Color::Rgb(255, 216, 94);
 
 /// Height (rows) this Confirm modal wants, given its current prompt text.
 /// Layout is: N prompt lines + 1 spacer + 1 buttons + 1 spacer + 1 hint.
 /// Callers use this to size the surrounding modal rect.
 #[must_use]
 pub fn required_height(state: &ConfirmState) -> u16 {
+    if matches!(state.presentation, ConfirmPresentation::RoleTrust) {
+        return 12;
+    }
     let prompt_lines = state.prompt.lines().count().max(1) as u16;
     // Fixed chrome: top/bottom border (2) + spacer + buttons + spacer + hint (4).
     prompt_lines + 6
+}
+
+#[must_use]
+pub const fn width_pct(state: &ConfirmState) -> u16 {
+    match state.presentation {
+        ConfirmPresentation::Default => 60,
+        ConfirmPresentation::RoleTrust => 70,
+    }
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
@@ -78,12 +110,17 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(PHOSPHOR_DARK))
         .title(Span::styled(
-            " Confirm ",
+            format!(" {} ", state.title),
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
+
+    if matches!(state.presentation, ConfirmPresentation::RoleTrust) {
+        render_role_trust(frame, inner, state);
+        return;
+    }
 
     // Vertical layout inside the inner rect. The prompt area grows with the
     // number of lines in `state.prompt` so multi-line confirmations (e.g.
@@ -164,6 +201,148 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(hint, chunks[4]);
+}
+
+fn render_role_trust(frame: &mut Frame, inner: Rect, state: &ConfirmState) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let (role, repository) = parse_role_trust_prompt(&state.prompt);
+    let key = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let value = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
+    let note = Style::default().fg(PHOSPHOR_DIM);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "Trust this role source?",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        )))
+        .alignment(Alignment::Left),
+        inset(rows[0], 3),
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Role: ", key),
+            Span::styled(role, value),
+        ])),
+        inset(rows[2], 3),
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Repository: ", key),
+            Span::styled(repository, value),
+        ])),
+        inset(rows[3], 3),
+    );
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled(
+                    "!",
+                    Style::default()
+                        .fg(WARNING_YELLOW)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled("Dockerfile can run during image builds.", note),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "!",
+                    Style::default()
+                        .fg(WARNING_YELLOW)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled("The role can access mounted workspace files.", note),
+            ]),
+        ]),
+        inset(rows[5], 3),
+    );
+
+    render_buttons(frame, rows[6], state);
+    render_hint(frame, rows[7]);
+}
+
+fn parse_role_trust_prompt(prompt: &str) -> (&str, &str) {
+    let mut lines = prompt.lines();
+    let role = lines.next().unwrap_or_default();
+    let repository = lines.next().unwrap_or_default();
+    (role, repository)
+}
+
+const fn inset(area: Rect, x: u16) -> Rect {
+    Rect {
+        x: area.x.saturating_add(x),
+        y: area.y,
+        width: area.width.saturating_sub(x.saturating_mul(2)),
+        height: area.height,
+    }
+}
+
+fn render_buttons(frame: &mut Frame, area: Rect, state: &ConfirmState) {
+    let yes_focused = matches!(state.focus, ConfirmFocus::Yes);
+    let no_focused = matches!(state.focus, ConfirmFocus::No);
+
+    let focused_style = Style::default()
+        .bg(WHITE)
+        .fg(Color::Black)
+        .add_modifier(Modifier::BOLD);
+    let unfocused_style = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
+
+    let yes_btn_style = if yes_focused {
+        focused_style
+    } else {
+        unfocused_style
+    };
+    let no_btn_style = if no_focused {
+        focused_style
+    } else {
+        unfocused_style
+    };
+
+    let button_line = Line::from(vec![
+        Span::styled("  Yes  ", yes_btn_style),
+        Span::raw("    "),
+        Span::styled("  No  ", no_btn_style),
+    ]);
+    frame.render_widget(
+        Paragraph::new(button_line).alignment(Alignment::Center),
+        area,
+    );
+}
+
+fn render_hint(frame: &mut Frame, area: Rect) {
+    let key = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let text = Style::default().fg(PHOSPHOR_GREEN);
+    let sep = Style::default().fg(PHOSPHOR_DARK);
+    let hint = Paragraph::new(ratatui::text::Line::from(vec![
+        Span::styled("Y", key),
+        Span::styled(" yes", text),
+        Span::styled(" \u{b7} ", sep),
+        Span::styled("N", key),
+        Span::styled(" no", text),
+        Span::styled(" \u{b7} ", sep),
+        Span::styled("Esc", key),
+        Span::styled(" cancel", text),
+    ]))
+    .alignment(Alignment::Center);
+    frame.render_widget(hint, area);
 }
 
 #[cfg(test)]
@@ -266,5 +445,35 @@ mod tests {
             s.handle_key(key(KeyCode::Char('y'))),
             ModalOutcome::Commit(true)
         ));
+    }
+
+    #[test]
+    fn role_trust_prompt_renders_readable_source_details() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        let s = ConfirmState::role_trust(
+            "scentbird/agent-jones\nhttps://github.com/scentbird/jackin-agent-jones.git",
+        );
+        let area = Rect::new(0, 0, 100, required_height(&s));
+        let backend = TestBackend::new(area.width, area.height);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, area, &s)).unwrap();
+
+        let buf = term.backend().buffer();
+        let mut rendered = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                rendered.push_str(buf[(x, y)].symbol());
+            }
+            rendered.push('\n');
+        }
+
+        assert!(rendered.contains("Trust role source"));
+        assert!(rendered.contains("Role: scentbird/agent-jones"));
+        assert!(
+            rendered.contains("Repository: https://github.com/scentbird/jackin-agent-jones.git")
+        );
+        assert!(rendered.contains("Dockerfile can run during image builds."));
+        assert!(rendered.contains("The role can access mounted workspace files."));
     }
 }

--- a/src/console/widgets/confirm.rs
+++ b/src/console/widgets/confirm.rs
@@ -16,9 +16,9 @@ pub enum ConfirmFocus {
 
 #[derive(Debug, Clone)]
 pub struct ConfirmState {
-    pub focus: ConfirmFocus,
-    pub title: String,
-    pub kind: ConfirmKind,
+    pub(crate) focus: ConfirmFocus,
+    pub(crate) title: String,
+    pub(crate) kind: ConfirmKind,
 }
 
 /// Discriminated payload for the Confirm modal.

--- a/src/console/widgets/confirm.rs
+++ b/src/console/widgets/confirm.rs
@@ -16,16 +16,20 @@ pub enum ConfirmFocus {
 
 #[derive(Debug, Clone)]
 pub struct ConfirmState {
-    pub prompt: String,
     pub focus: ConfirmFocus,
     pub title: String,
-    pub presentation: ConfirmPresentation,
+    pub kind: ConfirmKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfirmPresentation {
-    Default,
-    RoleTrust,
+/// Discriminated payload for the Confirm modal.
+///
+/// `Default` carries a free-form prompt string; `RoleTrust` carries the
+/// role key and repository URL as separate fields so the renderer can lay
+/// them out without parsing them back out of a `\n`-delimited blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfirmKind {
+    Default { prompt: String },
+    RoleTrust { role: String, repository: String },
 }
 
 impl ConfirmState {
@@ -33,19 +37,22 @@ impl ConfirmState {
     /// destructive actions — Enter won't accidentally commit Yes).
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
-            prompt: prompt.into(),
             focus: ConfirmFocus::No,
             title: "Confirm".into(),
-            presentation: ConfirmPresentation::Default,
+            kind: ConfirmKind::Default {
+                prompt: prompt.into(),
+            },
         }
     }
 
-    pub fn role_trust(prompt: impl Into<String>) -> Self {
+    pub fn role_trust(role: impl Into<String>, repository: impl Into<String>) -> Self {
         Self {
-            prompt: prompt.into(),
             focus: ConfirmFocus::No,
             title: "Trust role source".into(),
-            presentation: ConfirmPresentation::RoleTrust,
+            kind: ConfirmKind::RoleTrust {
+                role: role.into(),
+                repository: repository.into(),
+            },
         }
     }
 
@@ -83,24 +90,27 @@ const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 const WHITE: Color = Color::Rgb(255, 255, 255);
 const WARNING_YELLOW: Color = Color::Rgb(255, 216, 94);
 
-/// Height (rows) this Confirm modal wants, given its current prompt text.
-/// Layout is: N prompt lines + 1 spacer + 1 buttons + 1 spacer + 1 hint.
-/// Callers use this to size the surrounding modal rect.
+/// Height (rows) this Confirm modal wants, given its current contents.
+///
+/// `Default` kind: N prompt lines + 6 chrome rows (top/bottom border = 2,
+/// spacer, buttons, spacer, hint). `RoleTrust` uses a fixed 12-row layout
+/// matching the structured renderer in `render_role_trust`.
 #[must_use]
 pub fn required_height(state: &ConfirmState) -> u16 {
-    if matches!(state.presentation, ConfirmPresentation::RoleTrust) {
-        return 12;
+    match &state.kind {
+        ConfirmKind::RoleTrust { .. } => 12,
+        ConfirmKind::Default { prompt } => {
+            let prompt_lines = prompt.lines().count().max(1) as u16;
+            prompt_lines + 6
+        }
     }
-    let prompt_lines = state.prompt.lines().count().max(1) as u16;
-    // Fixed chrome: top/bottom border (2) + spacer + buttons + spacer + hint (4).
-    prompt_lines + 6
 }
 
 #[must_use]
 pub const fn width_pct(state: &ConfirmState) -> u16 {
-    match state.presentation {
-        ConfirmPresentation::Default => 60,
-        ConfirmPresentation::RoleTrust => 70,
+    match &state.kind {
+        ConfirmKind::Default { .. } => 60,
+        ConfirmKind::RoleTrust { .. } => 70,
     }
 }
 
@@ -117,15 +127,18 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
-    if matches!(state.presentation, ConfirmPresentation::RoleTrust) {
-        render_role_trust(frame, inner, state);
-        return;
-    }
+    let prompt = match &state.kind {
+        ConfirmKind::RoleTrust { role, repository } => {
+            render_role_trust(frame, inner, state, role, repository);
+            return;
+        }
+        ConfirmKind::Default { prompt } => prompt.as_str(),
+    };
 
     // Vertical layout inside the inner rect. The prompt area grows with the
-    // number of lines in `state.prompt` so multi-line confirmations (e.g.
+    // number of lines in `prompt` so multi-line confirmations (e.g.
     // the mount-collapse prompt) render without clipping.
-    let prompt_lines = state.prompt.lines().count().max(1) as u16;
+    let prompt_lines = prompt.lines().count().max(1) as u16;
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -138,8 +151,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
         .split(inner);
 
     // Prompt — render each line in turn so centering applies per-line.
-    let prompt_lines_vec: Vec<Line> = state
-        .prompt
+    let prompt_lines_vec: Vec<Line> = prompt
         .lines()
         .map(|l| {
             Line::from(Span::styled(
@@ -203,7 +215,13 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
     frame.render_widget(hint, chunks[4]);
 }
 
-fn render_role_trust(frame: &mut Frame, inner: Rect, state: &ConfirmState) {
+fn render_role_trust(
+    frame: &mut Frame,
+    inner: Rect,
+    state: &ConfirmState,
+    role: &str,
+    repository: &str,
+) {
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -218,7 +236,6 @@ fn render_role_trust(frame: &mut Frame, inner: Rect, state: &ConfirmState) {
         ])
         .split(inner);
 
-    let (role, repository) = parse_role_trust_prompt(&state.prompt);
     let key = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
     let value = Style::default()
         .fg(PHOSPHOR_GREEN)
@@ -275,13 +292,6 @@ fn render_role_trust(frame: &mut Frame, inner: Rect, state: &ConfirmState) {
 
     render_buttons(frame, rows[6], state);
     render_hint(frame, rows[7]);
-}
-
-fn parse_role_trust_prompt(prompt: &str) -> (&str, &str) {
-    let mut lines = prompt.lines();
-    let role = lines.next().unwrap_or_default();
-    let repository = lines.next().unwrap_or_default();
-    (role, repository)
 }
 
 const fn inset(area: Rect, x: u16) -> Rect {
@@ -452,7 +462,8 @@ mod tests {
         use ratatui::{Terminal, backend::TestBackend, layout::Rect};
 
         let s = ConfirmState::role_trust(
-            "scentbird/agent-jones\nhttps://github.com/scentbird/jackin-agent-jones.git",
+            "scentbird/agent-jones",
+            "https://github.com/scentbird/jackin-agent-jones.git",
         );
         let area = Rect::new(0, 0, 100, required_height(&s));
         let backend = TestBackend::new(area.width, area.height);

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -26,6 +26,11 @@ const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 pub struct ErrorPopupState {
     pub title: String,
     pub message: String,
+    /// Memoized `(inner_width, rows)` from the last `estimated_message_rows`
+    /// call. The popup is rendered every frame while open and the message
+    /// can be a long anyhow chain — re-walking each line every frame is
+    /// avoidable. `Cell` because `render` only takes `&self`.
+    cached_rows: std::cell::Cell<Option<(u16, u16)>>,
 }
 
 impl ErrorPopupState {
@@ -33,6 +38,7 @@ impl ErrorPopupState {
         Self {
             title: title.into(),
             message: message.into(),
+            cached_rows: std::cell::Cell::new(None),
         }
     }
 
@@ -49,8 +55,17 @@ impl ErrorPopupState {
 
 /// Estimate the number of wrapped rows the message needs for a given
 /// inner width. Used by the modal sizer so tall messages don't clip.
+///
+/// The result is memoized on `state` keyed by `inner_width` so the
+/// per-line `chars().count()` walk only happens on resize, not on every
+/// render frame.
 #[must_use]
 pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 {
+    if let Some((cached_width, rows)) = state.cached_rows.get()
+        && cached_width == inner_width
+    {
+        return rows;
+    }
     let w = usize::from(inner_width.max(1));
     let mut rows: u32 = 0;
     for line in state.message.lines() {
@@ -60,7 +75,9 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
         let r = len.div_ceil(w);
         rows = rows.saturating_add(u32::try_from(r).unwrap_or(u32::MAX));
     }
-    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
+    let result = u16::try_from(rows.max(1)).unwrap_or(u16::MAX);
+    state.cached_rows.set(Some((inner_width, result)));
+    result
 }
 
 /// Total rows the popup wants. Layout: top border + blank + N message

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -68,7 +68,7 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
 #[must_use]
 pub fn required_height(state: &ErrorPopupState, inner_width: u16) -> u16 {
     let body = estimated_message_rows(state, inner_width);
-    body.saturating_add(6).min(15)
+    body.saturating_add(7).min(15)
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ErrorPopupState) {
@@ -207,5 +207,29 @@ mod tests {
         let s = ErrorPopupState::new("t", "abcdefghijklmnop"); // 16 chars
         // width 8 → 2 rows
         assert_eq!(estimated_message_rows(&s, 8), 2);
+    }
+
+    #[test]
+    fn render_single_line_message_is_visible() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        let state = ErrorPopupState::new("Role not found", "repository not found");
+        let area = Rect::new(0, 0, 60, required_height(&state, 56));
+        let backend = TestBackend::new(area.width, area.height);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| render(f, area, &state)).unwrap();
+
+        let buf = term.backend().buffer();
+        let mut rendered = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                rendered.push_str(buf[(x, y)].symbol());
+            }
+            rendered.push('\n');
+        }
+        assert!(
+            rendered.contains("repository not found"),
+            "message should be visible in popup:\n{rendered}"
+        );
     }
 }

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -65,10 +65,16 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
 
 /// Total rows the popup wants. Layout: top border + blank + N message
 /// rows + blank + button + blank + hint + bottom border.
+///
+/// `max_rows` is the upper bound the caller is willing to allocate
+/// (typically terminal height minus its own chrome). Long anyhow chains
+/// — common when role resolution or docker build fails — easily exceed
+/// 15 rows, and a fixed cap silently truncates the bottom of the
+/// message where the root cause usually lives.
 #[must_use]
-pub fn required_height(state: &ErrorPopupState, inner_width: u16) -> u16 {
+pub fn required_height(state: &ErrorPopupState, inner_width: u16, max_rows: u16) -> u16 {
     let body = estimated_message_rows(state, inner_width);
-    body.saturating_add(7).min(15)
+    body.saturating_add(7).min(max_rows.max(7))
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ErrorPopupState) {
@@ -197,9 +203,15 @@ mod tests {
     }
 
     #[test]
-    fn required_height_caps_at_15() {
+    fn required_height_respects_caller_supplied_max() {
+        // Long message wants well above the cap — required_height must
+        // not exceed `max_rows`, and never drop below the chrome floor.
         let s = ErrorPopupState::new("Save failed", "word ".repeat(500));
-        assert!(required_height(&s, 30) <= 15);
+        assert!(required_height(&s, 30, 15) <= 15);
+        assert!(required_height(&s, 30, 40) <= 40);
+        // Floor: caller passing too-small max still yields enough rows
+        // for the chrome (button + hint + spacers).
+        assert!(required_height(&s, 30, 1) >= 7);
     }
 
     #[test]
@@ -214,7 +226,7 @@ mod tests {
         use ratatui::{Terminal, backend::TestBackend, layout::Rect};
 
         let state = ErrorPopupState::new("Role not found", "repository not found");
-        let area = Rect::new(0, 0, 60, required_height(&state, 56));
+        let area = Rect::new(0, 0, 60, required_height(&state, 56, 25));
         let backend = TestBackend::new(area.width, area.height);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| render(f, area, &state)).unwrap();

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -71,10 +71,15 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
 /// — common when role resolution or docker build fails — easily exceed
 /// 15 rows, and a fixed cap silently truncates the bottom of the
 /// message where the root cause usually lives.
+///
+/// The chrome floor is 8 (2 borders + 4 spacer/button/hint rows + 1 message
+/// row). At smaller `max_rows` the renderer would produce a zero-row body
+/// chunk and the message would disappear, which is worse than the popup
+/// overflowing the terminal.
 #[must_use]
 pub fn required_height(state: &ErrorPopupState, inner_width: u16, max_rows: u16) -> u16 {
     let body = estimated_message_rows(state, inner_width);
-    body.saturating_add(7).min(max_rows.max(7))
+    body.saturating_add(7).min(max_rows.max(8))
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ErrorPopupState) {
@@ -209,9 +214,10 @@ mod tests {
         let s = ErrorPopupState::new("Save failed", "word ".repeat(500));
         assert!(required_height(&s, 30, 15) <= 15);
         assert!(required_height(&s, 30, 40) <= 40);
-        // Floor: caller passing too-small max still yields enough rows
-        // for the chrome (button + hint + spacers).
-        assert!(required_height(&s, 30, 1) >= 7);
+        // Floor: caller passing too-small max still yields the 8-row
+        // chrome floor so the renderer's body chunk is never zero rows
+        // (which would make the message vanish).
+        assert!(required_height(&s, 30, 1) >= 8);
     }
 
     #[test]

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -111,7 +111,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ErrorPopupState) {
         .split(inner);
 
     // Message body — WHITE to keep readable against the red border.
-    let paragraph = Paragraph::new(state.message.clone())
+    let paragraph = Paragraph::new(state.message.as_str())
         .style(Style::default().fg(WHITE))
         .alignment(Alignment::Center)
         .wrap(Wrap { trim: false });

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -70,11 +70,13 @@ impl FileBrowserState {
                 self.set_cwd(&path);
                 ModalOutcome::Continue
             }
-            // `o` for "open the repo's web URL in the browser" — best-effort;
-            // silent no-op when `pending_git_url` is `None` (non-GitHub origin
-            // or unresolvable remote) or when the launcher fails. The overlay
-            // drops the `· O open` hint segment in the None case so the
-            // keystroke is only advertised when it actually does something.
+            // `o` for "open the repo's web URL in the browser" — best-effort.
+            // No-op when `pending_git_url` is `None` (non-GitHub origin or
+            // unresolvable remote); launcher failures are logged on the
+            // `--debug` channel since `FileBrowserState` doesn't own the
+            // global toast queue. The overlay drops the `· O open` hint
+            // segment in the None case so the keystroke is only advertised
+            // when it actually does something.
             KeyCode::Char('o' | 'O') => {
                 if let Some(url) = self.pending_git_url.as_deref()
                     && let Err(e) = open::that_detached(url)

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -33,11 +33,15 @@ pub enum GitPromptFocus {
     Cancel,
 }
 
-/// Resolve the origin web URL for a git-repo path via `mount_info::inspect`.
-/// Returns `Some` only for GitHub remotes that expose a resolvable web URL.
+/// Resolve the raw origin remote URL for a git-repo path via
+/// `mount_info::inspect`. Returns `Some` only for GitHub remotes.
 pub(super) fn resolve_git_url(path: &Path) -> Option<String> {
     match crate::console::manager::mount_info::inspect(&path.display().to_string()) {
-        crate::console::manager::mount_info::MountKind::Git { web_url, .. } => web_url,
+        crate::console::manager::mount_info::MountKind::Git {
+            host: crate::console::manager::mount_info::GitHost::Github,
+            remote_url,
+            ..
+        } => remote_url,
         _ => None,
     }
 }
@@ -359,7 +363,7 @@ mod tests {
             .pending_git_url
             .as_deref()
             .expect("GitHub origin must resolve");
-        assert!(url.contains("github.com/jackin-project/jackin"));
+        assert_eq!(url, "git@github.com:jackin-project/jackin.git");
     }
 
     #[test]

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -81,9 +81,6 @@ impl FileBrowserState {
                 if let Some(url) = self.pending_git_url.as_deref()
                     && let Err(e) = open::that_detached(url)
                 {
-                    // FileBrowserState doesn't own the global toast queue, so
-                    // surface the failure on the debug channel where operators
-                    // running with --debug can see why nothing happened.
                     crate::debug_log!("git_prompt", "open::that_detached({url:?}) failed: {e}");
                 }
                 ModalOutcome::Continue

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -33,15 +33,15 @@ pub enum GitPromptFocus {
     Cancel,
 }
 
-/// Resolve the raw origin remote URL for a git-repo path via
-/// `mount_info::inspect`. Returns `Some` only for GitHub remotes.
+/// Resolve the web URL for a git-repo path via `mount_info::inspect`.
+/// Returns `Some` only for GitHub remotes that have a parseable web URL.
 pub(super) fn resolve_git_url(path: &Path) -> Option<String> {
     match crate::console::manager::mount_info::inspect(&path.display().to_string()) {
         crate::console::manager::mount_info::MountKind::Git {
             host: crate::console::manager::mount_info::GitHost::Github,
-            remote_url,
+            web_url,
             ..
-        } => remote_url,
+        } => web_url,
         _ => None,
     }
 }
@@ -363,7 +363,7 @@ mod tests {
             .pending_git_url
             .as_deref()
             .expect("GitHub origin must resolve");
-        assert_eq!(url, "git@github.com:jackin-project/jackin.git");
+        assert_eq!(url, "https://github.com/jackin-project/jackin/tree/main");
     }
 
     #[test]

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -76,8 +76,13 @@ impl FileBrowserState {
             // drops the `· O open` hint segment in the None case so the
             // keystroke is only advertised when it actually does something.
             KeyCode::Char('o' | 'O') => {
-                if let Some(url) = self.pending_git_url.as_deref() {
-                    let _ = open::that_detached(url);
+                if let Some(url) = self.pending_git_url.as_deref()
+                    && let Err(e) = open::that_detached(url)
+                {
+                    // FileBrowserState doesn't own the global toast queue, so
+                    // surface the failure on the debug channel where operators
+                    // running with --debug can see why nothing happened.
+                    crate::debug_log!("git_prompt", "open::that_detached({url:?}) failed: {e}");
                 }
                 ModalOutcome::Continue
             }

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -38,10 +38,9 @@ pub enum GitPromptFocus {
 pub(super) fn resolve_git_url(path: &Path) -> Option<String> {
     match crate::console::manager::mount_info::inspect(&path.display().to_string()) {
         crate::console::manager::mount_info::MountKind::Git {
-            host: crate::console::manager::mount_info::GitHost::Github,
-            web_url,
+            origin: Some(crate::console::manager::mount_info::GitOrigin::Github { web_url, .. }),
             ..
-        } => web_url,
+        } => Some(web_url),
         _ => None,
     }
 }

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -371,6 +371,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_git_url_returns_none_for_non_github_origin() {
+        // Non-github remote (gitlab here) must yield `None` so the
+        // `O open` keystroke is not advertised — the launcher only
+        // speaks github web URLs.
+        let tmp = tempdir().unwrap();
+        let repo = tmp.path().join("gitlab-repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        seed_git_repo_with_origin(&repo, "git@gitlab.com:owner/repo.git");
+        assert!(resolve_git_url(&repo).is_none());
+    }
+
+    #[test]
     fn enter_on_git_repo_without_origin_leaves_url_none() {
         let tmp = tempdir().unwrap();
         let parent = tmp.path().join("parent");

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -205,7 +205,7 @@ mod consistency_tests {
 
     fn render_mount_dst() -> (Buffer, Rect) {
         use super::mount_dst_choice::{MountDstChoiceState, render};
-        let area = Rect::new(0, 0, 80, 9);
+        let area = Rect::new(0, 0, 80, 8);
         let state = MountDstChoiceState::new("/home/user/app");
         let buf = draw(area.width, area.height, |f| render(f, area, &state));
         (buf, area)

--- a/src/console/widgets/mount_dst_choice.rs
+++ b/src/console/widgets/mount_dst_choice.rs
@@ -1,8 +1,9 @@
 //! Three-button choice modal for picking a mount destination.
 //!
 //! Most operator mounts want `dst = src`. This modal offers a fast path
-//! (`Use same path`) for that common case and falls back to the text-input flow via
-//! `Edit destination` when the operator wants a different container path.
+//! (`Mount at same path`) for that common case and falls back to the
+//! text-input flow via `Edit destination` when the operator wants a
+//! different container path.
 
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -46,7 +47,7 @@ impl MountDstChoiceState {
 
     pub const fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<MountDstChoice> {
         match key.code {
-            KeyCode::Char('u' | 'U') => ModalOutcome::Commit(MountDstChoice::Ok),
+            KeyCode::Char('m' | 'M') => ModalOutcome::Commit(MountDstChoice::Ok),
             KeyCode::Char('e' | 'E') => ModalOutcome::Commit(MountDstChoice::Edit),
             KeyCode::Char('c' | 'C') | KeyCode::Esc => ModalOutcome::Cancel,
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l' | 'L') => {
@@ -92,13 +93,13 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
-    // Layout: path | blank | explanation | blank | buttons | blank | hint
+    // Layout mirrors the git-repo prompt:
+    // question | path | blank | buttons | blank | hint
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
+            Constraint::Length(1), // question
             Constraint::Length(1), // src path
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // explanation
             Constraint::Length(1), // spacer
             Constraint::Length(1), // buttons
             Constraint::Length(1), // spacer
@@ -106,25 +107,26 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
         ])
         .split(inner);
 
-    // Host path line — the operator-picked source.
-    let shortened = crate::tui::shorten_home(&state.src);
     frame.render_widget(
         Paragraph::new(Span::styled(
-            shortened,
+            "What would you like to do?",
             Style::default().fg(white).add_modifier(Modifier::BOLD),
         ))
         .alignment(Alignment::Center),
         chunks[0],
     );
 
-    // Explanation line in PHOSPHOR_DIM.
+    // Host path line — the operator-picked source.
+    let shortened = crate::tui::shorten_home(&state.src);
     frame.render_widget(
         Paragraph::new(Span::styled(
-            "Use this same path inside the container, or choose a different destination?",
-            Style::default().fg(phosphor_dim),
+            shortened,
+            Style::default()
+                .fg(phosphor_dim)
+                .add_modifier(Modifier::ITALIC),
         ))
         .alignment(Alignment::Center),
-        chunks[2],
+        chunks[1],
     );
 
     // Buttons — focused choice highlights on white; unfocused stays
@@ -152,7 +154,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     };
 
     let button_line = Line::from(vec![
-        Span::styled("  Use same path  ", ok_style),
+        Span::styled("  Mount at same path  ", ok_style),
         Span::raw("    "),
         Span::styled("  Edit destination  ", edit_style),
         Span::raw("    "),
@@ -160,7 +162,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     ]);
     frame.render_widget(
         Paragraph::new(button_line).alignment(Alignment::Center),
-        chunks[4],
+        chunks[3],
     );
 
     // Footer hint — mirrors save_discard styling (key WHITE+BOLD, label
@@ -170,8 +172,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     let sep_style = Style::default().fg(phosphor_dark);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("U", key_style),
-            Span::styled(" use same path", text_style),
+            Span::styled("M", key_style),
+            Span::styled(" mount", text_style),
             Span::styled(" \u{b7} ", sep_style),
             Span::styled("E", key_style),
             Span::styled(" edit", text_style),
@@ -180,7 +182,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
             Span::styled(" cancel", text_style),
         ]))
         .alignment(Alignment::Center),
-        chunks[6],
+        chunks[5],
     );
 }
 
@@ -263,12 +265,12 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_u_commits_ok() {
+    fn shortcut_m_commits_ok() {
         let mut s = MountDstChoiceState::new("/h");
-        // Rotate focus away first to prove `u` is not focus-dependent.
+        // Rotate focus away first to prove `m` is not focus-dependent.
         s.handle_key(key(KeyCode::Tab)); // focus -> Edit
         assert!(matches!(
-            s.handle_key(key(KeyCode::Char('u'))),
+            s.handle_key(key(KeyCode::Char('m'))),
             ModalOutcome::Commit(MountDstChoice::Ok)
         ));
     }
@@ -306,7 +308,7 @@ mod tests {
         // commit/cancel outcomes.
         let mut s = MountDstChoiceState::new("/h");
         assert!(matches!(
-            s.handle_key(key(KeyCode::Char('U'))),
+            s.handle_key(key(KeyCode::Char('M'))),
             ModalOutcome::Commit(MountDstChoice::Ok)
         ));
         let mut s = MountDstChoiceState::new("/h");

--- a/src/console/widgets/mount_dst_choice.rs
+++ b/src/console/widgets/mount_dst_choice.rs
@@ -16,15 +16,23 @@ use ratatui::{
 
 use super::ModalOutcome;
 
+/// Outcome of the mount-destination modal.
+///
+/// The button label reads "Mount at same path" — the variant name
+/// mirrors that intent so grep'ing for `Ok` doesn't conflate this
+/// modal's choice with `Result::Ok`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MountDstChoice {
-    Ok,
+    /// Use the host source path verbatim as the container destination.
+    SamePath,
+    /// Open the destination text-input so the user can pick a different
+    /// container path.
     Edit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MountDstFocus {
-    Ok,
+    SamePath,
     Edit,
     Cancel,
 }
@@ -36,38 +44,38 @@ pub struct MountDstChoiceState {
 }
 
 impl MountDstChoiceState {
-    /// Default focus = `Ok`: the common case is "same path inside the
-    /// container", so Enter should commit that without extra effort.
+    /// Default focus = `SamePath`: the common case is "same path inside
+    /// the container", so Enter should commit that without extra effort.
     pub fn new(src: impl Into<String>) -> Self {
         Self {
             src: src.into(),
-            focus: MountDstFocus::Ok,
+            focus: MountDstFocus::SamePath,
         }
     }
 
     pub const fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<MountDstChoice> {
         match key.code {
-            KeyCode::Char('m' | 'M') => ModalOutcome::Commit(MountDstChoice::Ok),
+            KeyCode::Char('m' | 'M') => ModalOutcome::Commit(MountDstChoice::SamePath),
             KeyCode::Char('e' | 'E') => ModalOutcome::Commit(MountDstChoice::Edit),
             KeyCode::Char('c' | 'C') | KeyCode::Esc => ModalOutcome::Cancel,
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l' | 'L') => {
                 self.focus = match self.focus {
-                    MountDstFocus::Ok => MountDstFocus::Edit,
+                    MountDstFocus::SamePath => MountDstFocus::Edit,
                     MountDstFocus::Edit => MountDstFocus::Cancel,
-                    MountDstFocus::Cancel => MountDstFocus::Ok,
+                    MountDstFocus::Cancel => MountDstFocus::SamePath,
                 };
                 ModalOutcome::Continue
             }
             KeyCode::Left | KeyCode::Char('h' | 'H') => {
                 self.focus = match self.focus {
-                    MountDstFocus::Ok => MountDstFocus::Cancel,
-                    MountDstFocus::Edit => MountDstFocus::Ok,
+                    MountDstFocus::SamePath => MountDstFocus::Cancel,
+                    MountDstFocus::Edit => MountDstFocus::SamePath,
                     MountDstFocus::Cancel => MountDstFocus::Edit,
                 };
                 ModalOutcome::Continue
             }
             KeyCode::Enter => match self.focus {
-                MountDstFocus::Ok => ModalOutcome::Commit(MountDstChoice::Ok),
+                MountDstFocus::SamePath => ModalOutcome::Commit(MountDstChoice::SamePath),
                 MountDstFocus::Edit => ModalOutcome::Commit(MountDstChoice::Edit),
                 MountDstFocus::Cancel => ModalOutcome::Cancel,
             },
@@ -137,7 +145,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
         .add_modifier(Modifier::BOLD);
     let unfocused_style = Style::default().fg(phosphor).add_modifier(Modifier::BOLD);
 
-    let ok_style = if state.focus == MountDstFocus::Ok {
+    let ok_style = if state.focus == MountDstFocus::SamePath {
         focused_style
     } else {
         unfocused_style
@@ -203,14 +211,14 @@ mod tests {
     #[test]
     fn new_defaults_focus_to_ok() {
         let s = MountDstChoiceState::new("/host/path");
-        assert_eq!(s.focus, MountDstFocus::Ok);
+        assert_eq!(s.focus, MountDstFocus::SamePath);
         assert_eq!(s.src, "/host/path");
     }
 
     #[test]
     fn tab_cycles_ok_edit_cancel_ok() {
         let mut s = MountDstChoiceState::new("/h");
-        assert_eq!(s.focus, MountDstFocus::Ok);
+        assert_eq!(s.focus, MountDstFocus::SamePath);
         assert!(matches!(
             s.handle_key(key(KeyCode::Tab)),
             ModalOutcome::Continue
@@ -219,19 +227,19 @@ mod tests {
         s.handle_key(key(KeyCode::Tab));
         assert_eq!(s.focus, MountDstFocus::Cancel);
         s.handle_key(key(KeyCode::Tab));
-        assert_eq!(s.focus, MountDstFocus::Ok);
+        assert_eq!(s.focus, MountDstFocus::SamePath);
     }
 
     #[test]
     fn left_reverse_cycles() {
         let mut s = MountDstChoiceState::new("/h");
-        assert_eq!(s.focus, MountDstFocus::Ok);
+        assert_eq!(s.focus, MountDstFocus::SamePath);
         s.handle_key(key(KeyCode::Left));
         assert_eq!(s.focus, MountDstFocus::Cancel);
         s.handle_key(key(KeyCode::Left));
         assert_eq!(s.focus, MountDstFocus::Edit);
         s.handle_key(key(KeyCode::Left));
-        assert_eq!(s.focus, MountDstFocus::Ok);
+        assert_eq!(s.focus, MountDstFocus::SamePath);
     }
 
     #[test]
@@ -239,7 +247,7 @@ mod tests {
         let mut s = MountDstChoiceState::new("/h");
         assert!(matches!(
             s.handle_key(key(KeyCode::Enter)),
-            ModalOutcome::Commit(MountDstChoice::Ok)
+            ModalOutcome::Commit(MountDstChoice::SamePath)
         ));
     }
 
@@ -271,7 +279,7 @@ mod tests {
         s.handle_key(key(KeyCode::Tab)); // focus -> Edit
         assert!(matches!(
             s.handle_key(key(KeyCode::Char('m'))),
-            ModalOutcome::Commit(MountDstChoice::Ok)
+            ModalOutcome::Commit(MountDstChoice::SamePath)
         ));
     }
 
@@ -309,7 +317,7 @@ mod tests {
         let mut s = MountDstChoiceState::new("/h");
         assert!(matches!(
             s.handle_key(key(KeyCode::Char('M'))),
-            ModalOutcome::Commit(MountDstChoice::Ok)
+            ModalOutcome::Commit(MountDstChoice::SamePath)
         ));
         let mut s = MountDstChoiceState::new("/h");
         assert!(matches!(

--- a/src/console/widgets/mount_dst_choice.rs
+++ b/src/console/widgets/mount_dst_choice.rs
@@ -1,7 +1,7 @@
 //! Three-button choice modal for picking a mount destination.
 //!
 //! Most operator mounts want `dst = src`. This modal offers a fast path
-//! (`OK`) for that common case and falls back to the text-input flow via
+//! (`Use same path`) for that common case and falls back to the text-input flow via
 //! `Edit destination` when the operator wants a different container path.
 
 use crossterm::event::{KeyCode, KeyEvent};
@@ -46,7 +46,7 @@ impl MountDstChoiceState {
 
     pub const fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<MountDstChoice> {
         match key.code {
-            KeyCode::Char('o' | 'O') => ModalOutcome::Commit(MountDstChoice::Ok),
+            KeyCode::Char('u' | 'U') => ModalOutcome::Commit(MountDstChoice::Ok),
             KeyCode::Char('e' | 'E') => ModalOutcome::Commit(MountDstChoice::Edit),
             KeyCode::Char('c' | 'C') | KeyCode::Esc => ModalOutcome::Cancel,
             KeyCode::Tab | KeyCode::Right | KeyCode::Char('l' | 'L') => {
@@ -120,7 +120,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     // Explanation line in PHOSPHOR_DIM.
     frame.render_widget(
         Paragraph::new(Span::styled(
-            "Mount into the container at the same path, or pick a different destination?",
+            "Use this same path inside the container, or choose a different destination?",
             Style::default().fg(phosphor_dim),
         ))
         .alignment(Alignment::Center),
@@ -152,7 +152,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     };
 
     let button_line = Line::from(vec![
-        Span::styled("  OK  ", ok_style),
+        Span::styled("  Use same path  ", ok_style),
         Span::raw("    "),
         Span::styled("  Edit destination  ", edit_style),
         Span::raw("    "),
@@ -170,8 +170,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &MountDstChoiceState) {
     let sep_style = Style::default().fg(phosphor_dark);
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("O", key_style),
-            Span::styled(" ok", text_style),
+            Span::styled("U", key_style),
+            Span::styled(" use same path", text_style),
             Span::styled(" \u{b7} ", sep_style),
             Span::styled("E", key_style),
             Span::styled(" edit", text_style),
@@ -263,12 +263,12 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_o_commits_ok() {
+    fn shortcut_u_commits_ok() {
         let mut s = MountDstChoiceState::new("/h");
-        // Rotate focus away first to prove `o` is not focus-dependent.
+        // Rotate focus away first to prove `u` is not focus-dependent.
         s.handle_key(key(KeyCode::Tab)); // focus -> Edit
         assert!(matches!(
-            s.handle_key(key(KeyCode::Char('o'))),
+            s.handle_key(key(KeyCode::Char('u'))),
             ModalOutcome::Commit(MountDstChoice::Ok)
         ));
     }
@@ -306,7 +306,7 @@ mod tests {
         // commit/cancel outcomes.
         let mut s = MountDstChoiceState::new("/h");
         assert!(matches!(
-            s.handle_key(key(KeyCode::Char('O'))),
+            s.handle_key(key(KeyCode::Char('U'))),
             ModalOutcome::Commit(MountDstChoice::Ok)
         ));
         let mut s = MountDstChoiceState::new("/h");

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,4 +1,3 @@
-use owo_colors::OwoColorize;
 use std::io::Read;
 use std::path::Path;
 
@@ -50,12 +49,9 @@ impl ShellRunner {
             let redacted = redact_env_args(args);
             let cmd = format!("{} {}", program, redacted.join(" "));
             if let Some(dir) = cwd {
-                eprintln!(
-                    "{}",
-                    format!("[debug] cd {} && {}", dir.display(), cmd).dimmed()
-                );
+                crate::tui::emit_debug_line("cmd", &format!("cd {} && {cmd}", dir.display()));
             } else {
-                eprintln!("{}", format!("[debug] {cmd}").dimmed());
+                crate::tui::emit_debug_line("cmd", &cmd);
             }
         }
     }
@@ -223,7 +219,7 @@ impl CommandRunner for ShellRunner {
         let stdout = String::from_utf8_lossy(&stdout).trim().to_string();
         if self.debug && !stdout.is_empty() {
             let first_line = stdout.lines().next().unwrap_or("");
-            eprintln!("{}", format!("[debug] -> {first_line}").dimmed());
+            crate::tui::emit_debug_line("cmd", &format!("-> {first_line}"));
         }
         Ok(stdout)
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -30,32 +30,72 @@ pub struct ValidatedRoleRepo {
     pub dockerfile: ValidatedDockerfile,
 }
 
-pub fn validate_role_repo(repo_dir: &Path) -> anyhow::Result<ValidatedRoleRepo> {
+/// Specific structural rejections from `validate_role_repo`.
+///
+/// Variants carry the rejected path / label so the editor's friendly
+/// translator can render rich messages without parsing free-form
+/// strings; downstream `RepoError::InvalidRoleRepo` is matched against
+/// the inner variant rather than substring-stripped.
+///
+/// Add a variant per new rejection rule; reach for `Other(anyhow::Error)`
+/// only when the failure is a non-structural pass-through (manifest TOML
+/// parse, IO error from the underlying filesystem, etc.).
+#[derive(Debug, thiserror::Error)]
+pub enum RoleRepoValidationError {
+    #[error("missing {}", _0.display())]
+    Missing(PathBuf),
+    #[error("{label} path must be relative")]
+    PathMustBeRelative { label: &'static str },
+    #[error("{label} path must stay inside the repo")]
+    PathOutsideRepo { label: &'static str },
+    #[error("{label} path must not be a symlink")]
+    PathIsSymlink { label: &'static str },
+    #[error("{label} path escapes the repo boundary")]
+    PathEscapesBoundary { label: &'static str },
+    #[error("pre_launch hook is empty: {}", _0.display())]
+    EmptyPreLaunchHook(PathBuf),
+    #[error("unable to parse Dockerfile: {0}")]
+    DockerfileParse(String),
+    #[error("Dockerfile must contain at least one FROM instruction")]
+    DockerfileMissingFrom,
+    #[error("final Dockerfile stage must use literal FROM {expected}")]
+    DockerfileNonConstruct { expected: &'static str },
+    /// Catch-all for non-structural failures (TOML parse, IO, manifest
+    /// semantic validation). The friendly translator renders these as
+    /// the generic "not a valid Jackin role" message.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<std::io::Error> for RoleRepoValidationError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+pub fn validate_role_repo(
+    repo_dir: &Path,
+) -> Result<ValidatedRoleRepo, RoleRepoValidationError> {
     let manifest_path = repo_dir.join("jackin.role.toml");
 
     if !manifest_path.is_file() {
-        anyhow::bail!("invalid role repo: missing {}", manifest_path.display());
+        return Err(RoleRepoValidationError::Missing(manifest_path));
     }
 
     let manifest = RoleManifest::load(repo_dir)?;
-    let dockerfile_path = resolve_manifest_dockerfile_path(repo_dir, &manifest)?;
+    let dockerfile_path = validate_relative_path(repo_dir, &manifest.dockerfile, "dockerfile")?;
     let dockerfile = validate_agent_dockerfile(&dockerfile_path)?;
 
-    // Validate pre-launch hook path if declared
     if let Some(ref hooks) = manifest.hooks
         && let Some(ref pre_launch) = hooks.pre_launch
     {
         let hook_path = validate_relative_path(repo_dir, pre_launch, "pre_launch hook")?;
         let contents = std::fs::read_to_string(&hook_path)?;
         if contents.is_empty() {
-            anyhow::bail!(
-                "invalid role repo: pre_launch hook is empty: {}",
-                hook_path.display()
-            );
+            return Err(RoleRepoValidationError::EmptyPreLaunchHook(hook_path));
         }
     }
 
-    // Validate env var declarations
     let warnings = manifest.validate()?;
     for warning in &warnings {
         eprintln!("warning: {}", warning.message);
@@ -67,11 +107,15 @@ pub fn validate_role_repo(repo_dir: &Path) -> anyhow::Result<ValidatedRoleRepo> 
     })
 }
 
-fn validate_relative_path(repo_dir: &Path, path_str: &str, label: &str) -> anyhow::Result<PathBuf> {
+fn validate_relative_path(
+    repo_dir: &Path,
+    path_str: &str,
+    label: &'static str,
+) -> Result<PathBuf, RoleRepoValidationError> {
     let path = Path::new(path_str);
 
     if path.is_absolute() {
-        anyhow::bail!("invalid role repo: {label} path must be relative");
+        return Err(RoleRepoValidationError::PathMustBeRelative { label });
     }
 
     for component in path.components() {
@@ -79,35 +123,28 @@ fn validate_relative_path(repo_dir: &Path, path_str: &str, label: &str) -> anyho
             component,
             Component::ParentDir | Component::RootDir | Component::Prefix(_)
         ) {
-            anyhow::bail!("invalid role repo: {label} path must stay inside the repo");
+            return Err(RoleRepoValidationError::PathOutsideRepo { label });
         }
     }
 
     let resolved = repo_dir.join(path);
     if !resolved.is_file() {
-        anyhow::bail!("invalid role repo: missing {}", resolved.display());
+        return Err(RoleRepoValidationError::Missing(resolved));
     }
     if std::fs::symlink_metadata(&resolved)?
         .file_type()
         .is_symlink()
     {
-        anyhow::bail!("invalid role repo: {label} path must not be a symlink");
+        return Err(RoleRepoValidationError::PathIsSymlink { label });
     }
 
     let canonical_repo = repo_dir.canonicalize()?;
     let canonical_resolved = resolved.canonicalize()?;
     if !canonical_resolved.starts_with(&canonical_repo) {
-        anyhow::bail!("invalid role repo: {label} path escapes the repo boundary");
+        return Err(RoleRepoValidationError::PathEscapesBoundary { label });
     }
 
     Ok(canonical_resolved)
-}
-
-fn resolve_manifest_dockerfile_path(
-    repo_dir: &Path,
-    manifest: &RoleManifest,
-) -> anyhow::Result<PathBuf> {
-    validate_relative_path(repo_dir, &manifest.dockerfile, "dockerfile")
 }
 
 #[cfg(test)]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -73,9 +73,7 @@ impl From<std::io::Error> for RoleRepoValidationError {
     }
 }
 
-pub fn validate_role_repo(
-    repo_dir: &Path,
-) -> Result<ValidatedRoleRepo, RoleRepoValidationError> {
+pub fn validate_role_repo(repo_dir: &Path) -> Result<ValidatedRoleRepo, RoleRepoValidationError> {
     let manifest_path = repo_dir.join("jackin.role.toml");
 
     if !manifest_path.is_file() {

--- a/src/repo_contract.rs
+++ b/src/repo_contract.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 
 use dockerfile_parser_rs::{Dockerfile, Instruction};
 
+use crate::repo::RoleRepoValidationError;
+
 pub const CONSTRUCT_IMAGE: &str = "projectjackin/construct:trixie";
 
 #[derive(Debug, Clone)]
@@ -13,11 +15,12 @@ pub struct ValidatedDockerfile {
     pub final_stage_alias: Option<String>,
 }
 
-pub fn validate_agent_dockerfile(dockerfile_path: &Path) -> anyhow::Result<ValidatedDockerfile> {
+pub fn validate_agent_dockerfile(
+    dockerfile_path: &Path,
+) -> Result<ValidatedDockerfile, RoleRepoValidationError> {
     let dockerfile_contents = std::fs::read_to_string(dockerfile_path)?;
-    let dockerfile = Dockerfile::from_str(&dockerfile_contents).map_err(|error| {
-        anyhow::anyhow!("invalid role repo: unable to parse Dockerfile: {error}")
-    })?;
+    let dockerfile = Dockerfile::from_str(&dockerfile_contents)
+        .map_err(|error| RoleRepoValidationError::DockerfileParse(error.to_string()))?;
 
     let Some((platform, image, alias)) =
         dockerfile
@@ -37,13 +40,14 @@ pub fn validate_agent_dockerfile(dockerfile_path: &Path) -> anyhow::Result<Valid
                 Some((platform, image, alias))
             })
     else {
-        anyhow::bail!("invalid role repo: Dockerfile must contain at least one FROM instruction")
+        return Err(RoleRepoValidationError::DockerfileMissingFrom);
     };
 
-    anyhow::ensure!(
-        platform.is_none() && image == CONSTRUCT_IMAGE,
-        "invalid role repo: final Dockerfile stage must use literal FROM {CONSTRUCT_IMAGE}"
-    );
+    if platform.is_some() || image != CONSTRUCT_IMAGE {
+        return Err(RoleRepoValidationError::DockerfileNonConstruct {
+            expected: CONSTRUCT_IMAGE,
+        });
+    }
 
     Ok(ValidatedDockerfile {
         dockerfile_path: dockerfile_path.to_path_buf(),

--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -70,9 +70,14 @@ pub(super) fn build_agent_image(
     // the original pre-bust layer, causing the installed agent version to
     // ping-pong between old and new on alternate launches.
     let cache_bust_value = if rebuild {
+        // System clock before UNIX_EPOCH is essentially impossible, but if it
+        // happens we must not silently fall back to 0 — that collapses to the
+        // Dockerfile's `JACKIN_CACHE_BUST=0` default and defeats the operator's
+        // explicit `--rebuild` request.
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs())
+            .map_err(|e| anyhow::anyhow!("system clock is before UNIX epoch: {e}"))?
+            .as_secs()
             .to_string();
         version_check::store_cache_bust(paths, &image, &ts);
         ts

--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -44,13 +44,14 @@ pub(super) fn build_agent_image(
     drop(repo_lock);
 
     if debug {
+        let dockerfile_body = std::fs::read_to_string(&build.dockerfile_path)
+            .unwrap_or_else(|e| format!("<read failed: {e}>"));
         eprintln!(
             "{}",
             format!(
                 r"[debug] DerivedDockerfile ({}):
-{}",
+{dockerfile_body}",
                 build.dockerfile_path.display(),
-                std::fs::read_to_string(&build.dockerfile_path).unwrap_or_default()
             )
             .dimmed()
         );

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,16 +24,20 @@ pub use self::discovery::{
 pub use self::launch::{LoadOptions, load_role};
 pub use self::naming::matching_family;
 
-pub(crate) fn resolve_agent_repo(
+pub(crate) fn register_agent_repo(
     paths: &crate::paths::JackinPaths,
     selector: &crate::selector::RoleSelector,
     git_url: &str,
     runner: &mut impl crate::docker::CommandRunner,
     debug: bool,
-) -> anyhow::Result<(
-    crate::repo::CachedRepo,
-    crate::repo::ValidatedRoleRepo,
-    std::fs::File,
-)> {
-    self::repo_cache::resolve_agent_repo(paths, selector, git_url, runner, debug)
+    persist_registration: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<(crate::repo::CachedRepo, crate::repo::ValidatedRoleRepo)> {
+    self::repo_cache::register_agent_repo(
+        paths,
+        selector,
+        git_url,
+        runner,
+        debug,
+        persist_registration,
+    )
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,3 +23,17 @@ pub use self::discovery::{
 };
 pub use self::launch::{LoadOptions, load_role};
 pub use self::naming::matching_family;
+
+pub(crate) fn resolve_agent_repo(
+    paths: &crate::paths::JackinPaths,
+    selector: &crate::selector::RoleSelector,
+    git_url: &str,
+    runner: &mut impl crate::docker::CommandRunner,
+    debug: bool,
+) -> anyhow::Result<(
+    crate::repo::CachedRepo,
+    crate::repo::ValidatedRoleRepo,
+    std::fs::File,
+)> {
+    self::repo_cache::resolve_agent_repo(paths, selector, git_url, runner, debug)
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,6 +23,7 @@ pub use self::discovery::{
 };
 pub use self::launch::{LoadOptions, load_role};
 pub use self::naming::matching_family;
+pub(crate) use self::repo_cache::RepoError;
 
 pub(crate) fn register_agent_repo(
     paths: &crate::paths::JackinPaths,

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -9,25 +9,6 @@ use std::io::IsTerminal;
 
 use super::identity::try_capture;
 
-/// Map an anyhow error from `validate_role_repo` into a typed
-/// `RepoError::InvalidRoleRepo` when any link in the chain uses the
-/// validator's `invalid role repo: ` prefix; pass anything else through
-/// unchanged.
-///
-/// The validator currently emits anyhow strings; this function is the
-/// single substring match left over after the typed-error refactor and
-/// lives here so it's co-located with the variant it produces.
-fn map_validate_error(err: anyhow::Error) -> anyhow::Error {
-    for cause in err.chain() {
-        if let Some(detail) = cause.to_string().strip_prefix("invalid role repo: ") {
-            return anyhow::Error::new(RepoError::InvalidRoleRepo {
-                detail: detail.to_string(),
-            });
-        }
-    }
-    err
-}
-
 /// Typed errors raised by role-repo resolution.
 ///
 /// Surfaced through `anyhow::Error` chains so the editor can downcast and
@@ -47,10 +28,11 @@ pub enum RepoError {
     #[error("cached role repo remote mismatch — aborting")]
     RemoteMismatch,
 
-    /// `validate_role_repo` rejected the cloned repo. `detail` is the
-    /// validator's message with the `invalid role repo: ` prefix stripped.
-    #[error("invalid role repo: {detail}")]
-    InvalidRoleRepo { detail: String },
+    /// `validate_role_repo` rejected the cloned repo. The inner typed
+    /// error carries the structural reason; `friendly_role_resolution_error`
+    /// matches on its variants for richer messages.
+    #[error("invalid role repo: {0}")]
+    InvalidRoleRepo(#[from] crate::repo::RoleRepoValidationError),
 }
 
 /// Extract `owner/repo` from a git remote URL.
@@ -213,7 +195,7 @@ pub(super) fn register_agent_repo(
         )
         .map_err(RepoError::CloneFailed)?;
 
-    let validated_repo = validate_role_repo(&temp_repo).map_err(map_validate_error)?;
+    let validated_repo = validate_role_repo(&temp_repo).map_err(RepoError::InvalidRoleRepo)?;
     // Install the repo into the cache before persisting registration: if
     // rename fails the role stays unregistered and the user can retry from a
     // clean state. Persisting first would leave config.toml referencing a
@@ -296,7 +278,7 @@ pub(super) fn resolve_agent_repo_with(
                     .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
                     .map_err(RepoError::CloneFailed)?;
                 let validated_repo =
-                    validate_role_repo(&cached_repo.repo_dir).map_err(map_validate_error)?;
+                    validate_role_repo(&cached_repo.repo_dir).map_err(RepoError::InvalidRoleRepo)?;
                 return Ok((cached_repo, validated_repo, lock_file));
             }
 
@@ -348,7 +330,7 @@ pub(super) fn resolve_agent_repo_with(
             .map_err(RepoError::CloneFailed)?;
     }
 
-    let validated_repo = validate_role_repo(&cached_repo.repo_dir).map_err(map_validate_error)?;
+    let validated_repo = validate_role_repo(&cached_repo.repo_dir).map_err(RepoError::InvalidRoleRepo)?;
 
     // Return the repo lock so the caller can hold it until the build
     // context (a snapshot copy of the repo) is created.  This prevents
@@ -784,7 +766,7 @@ plugins = []
 
         assert!(
             err.downcast_ref::<RepoError>()
-                .is_some_and(|e| matches!(e, RepoError::InvalidRoleRepo { .. })),
+                .is_some_and(|e| matches!(e, RepoError::InvalidRoleRepo(_))),
             "expected RepoError::InvalidRoleRepo, got {err:?}"
         );
         assert!(

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -18,11 +18,12 @@ use super::identity::try_capture;
 /// here so it's co-located with the variant it produces.
 fn map_validate_error(err: anyhow::Error) -> anyhow::Error {
     let msg = err.to_string();
-    msg.strip_prefix("invalid role repo: ").map_or(err, |detail| {
-        anyhow::Error::new(RepoError::InvalidRoleRepo {
-            detail: detail.to_string(),
+    msg.strip_prefix("invalid role repo: ")
+        .map_or(err, |detail| {
+            anyhow::Error::new(RepoError::InvalidRoleRepo {
+                detail: detail.to_string(),
+            })
         })
-    })
 }
 
 /// Typed errors raised by role-repo resolution.

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -805,10 +805,10 @@ plugins = []
 
     #[test]
     fn register_agent_repo_aborts_when_persist_registration_fails() {
-        // Persist runs *after* rename (the Phase 2 ordering fix), so a
-        // persist failure leaves the cache populated but registration
-        // un-persisted. Verify the error surfaces with the diagnostic
-        // context that points the operator at the inconsistency.
+        // Persist runs after rename, so a persist failure leaves the
+        // cache populated but registration un-persisted. Verify the
+        // error surfaces with the diagnostic context that points the
+        // operator at the inconsistency.
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
@@ -847,8 +847,7 @@ plugins = []
     fn register_agent_repo_rejects_stale_non_git_directory() {
         // A pre-existing directory at the cache slot that is *not* a
         // git repo must bail rather than overwrite or skip — the
-        // operator likely has unsynced work there. Pre-fix this branch
-        // had no regression coverage.
+        // operator likely has unsynced work there.
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -696,4 +696,176 @@ plugins = []
             runner.run_recorded
         );
     }
+
+    /// Materialise a valid role repo at `repo_dir` — `.git`, `Dockerfile`,
+    /// and `jackin.role.toml` are all required by `validate_role_repo`.
+    fn seed_valid_role_repo(repo_dir: &std::path::Path) {
+        std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+    }
+
+    /// Find the `repo` subdir under the first `role-resolve-*` temp dir
+    /// `register_agent_repo` creates inside `data_dir`. Used inside
+    /// `git clone` side-effect callbacks where the path isn't known
+    /// until the function runs.
+    fn first_temp_role_repo(data_dir: &std::path::Path) -> std::path::PathBuf {
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.is_dir()
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.starts_with("role-resolve-"))
+            })
+            .expect("role registration temp dir should exist before git clone side-effect")
+            .join("repo")
+    }
+
+    #[test]
+    fn register_agent_repo_cleans_up_temp_dir_on_validate_failure() {
+        // When validation rejects the cloned repo (here: no Dockerfile,
+        // no jackin.role.toml — just a `.git` dir), `register_agent_repo`
+        // must NOT rename the temp dir into the cache and must NOT call
+        // `persist_registration`. The temp dir is cleaned up by tempfile's
+        // Drop, so the only assertion is that the cache slot is empty.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let selector = RoleSelector::new(None, "agent-broken");
+        let cached_dir = paths.roles_dir.join("agent-broken");
+
+        let data_dir = paths.data_dir.clone();
+        let mut runner = FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            // Materialise a `.git` dir but skip the manifest files so
+            // `validate_role_repo` rejects the clone.
+            Box::new(move || {
+                let temp_repo = first_temp_role_repo(&data_dir);
+                std::fs::create_dir_all(temp_repo.join(".git")).unwrap();
+            }),
+        ));
+
+        let persist_called = std::cell::Cell::new(false);
+        let err = register_agent_repo(
+            &paths,
+            &selector,
+            "https://github.com/example/agent-broken.git",
+            &mut runner,
+            false,
+            || {
+                persist_called.set(true);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            err.downcast_ref::<RepoError>()
+                .is_some_and(|e| matches!(e, RepoError::InvalidRoleRepo { .. })),
+            "expected RepoError::InvalidRoleRepo, got {err:?}"
+        );
+        assert!(
+            !persist_called.get(),
+            "persist must not run on validate failure"
+        );
+        assert!(
+            !cached_dir.exists(),
+            "cache slot must remain empty when validate fails: {}",
+            cached_dir.display()
+        );
+    }
+
+    #[test]
+    fn register_agent_repo_aborts_when_persist_registration_fails() {
+        // Persist runs *after* rename (the Phase 2 ordering fix), so a
+        // persist failure leaves the cache populated but registration
+        // un-persisted. Verify the error surfaces with the diagnostic
+        // context that points the operator at the inconsistency.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let selector = RoleSelector::new(None, "agent-persist-fail");
+        let cached_dir = paths.roles_dir.join("agent-persist-fail");
+
+        let data_dir = paths.data_dir.clone();
+        let mut runner = FakeRunner::default();
+        runner.side_effects.push((
+            "git clone".to_string(),
+            Box::new(move || seed_valid_role_repo(&first_temp_role_repo(&data_dir))),
+        ));
+
+        let err = register_agent_repo(
+            &paths,
+            &selector,
+            "https://github.com/example/agent-persist-fail.git",
+            &mut runner,
+            false,
+            || anyhow::bail!("simulated config write failure"),
+        )
+        .unwrap_err();
+
+        let chain = format!("{err:?}");
+        assert!(
+            chain.contains("registration could not be persisted"),
+            "error chain must surface persist failure: {chain}"
+        );
+        assert!(
+            cached_dir.join(".git").is_dir(),
+            "cache must be populated before persist runs (rename-then-persist invariant)",
+        );
+    }
+
+    #[test]
+    fn register_agent_repo_rejects_stale_non_git_directory() {
+        // A pre-existing directory at the cache slot that is *not* a
+        // git repo must bail rather than overwrite or skip — the
+        // operator likely has unsynced work there. Pre-fix this branch
+        // had no regression coverage.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        let selector = RoleSelector::new(None, "agent-stale");
+        let cached_dir = paths.roles_dir.join("agent-stale");
+        std::fs::create_dir_all(&cached_dir).unwrap();
+        std::fs::write(cached_dir.join("README"), "operator's lost work\n").unwrap();
+
+        let mut runner = FakeRunner::default();
+        let err = register_agent_repo(
+            &paths,
+            &selector,
+            "https://github.com/example/agent-stale.git",
+            &mut runner,
+            false,
+            || Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("cached role path exists but is not a git repository"),
+            "expected stale-non-git bail, got: {err}"
+        );
+        // Operator's file remains untouched.
+        assert_eq!(
+            std::fs::read_to_string(cached_dir.join("README")).unwrap(),
+            "operator's lost work\n"
+        );
+    }
 }

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -14,23 +14,18 @@ use super::identity::try_capture;
 /// validator's `invalid role repo: ` prefix; pass anything else through
 /// unchanged.
 ///
-/// Walking the whole chain (rather than only `err.to_string()` at the
-/// root) lets a future caller wrap the validator error with
-/// `with_context` without silently dropping the typed classification.
 /// The validator currently emits anyhow strings; this function is the
 /// single substring match left over after the typed-error refactor and
 /// lives here so it's co-located with the variant it produces.
 fn map_validate_error(err: anyhow::Error) -> anyhow::Error {
-    err.chain()
-        .find_map(|cause| {
-            cause
-                .to_string()
-                .strip_prefix("invalid role repo: ")
-                .map(str::to_string)
-        })
-        .map_or(err, |detail| {
-            anyhow::Error::new(RepoError::InvalidRoleRepo { detail })
-        })
+    for cause in err.chain() {
+        if let Some(detail) = cause.to_string().strip_prefix("invalid role repo: ") {
+            return anyhow::Error::new(RepoError::InvalidRoleRepo {
+                detail: detail.to_string(),
+            });
+        }
+    }
+    err
 }
 
 /// Typed errors raised by role-repo resolution.

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -277,8 +277,8 @@ pub(super) fn resolve_agent_repo_with(
                 runner
                     .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
                     .map_err(RepoError::CloneFailed)?;
-                let validated_repo =
-                    validate_role_repo(&cached_repo.repo_dir).map_err(RepoError::InvalidRoleRepo)?;
+                let validated_repo = validate_role_repo(&cached_repo.repo_dir)
+                    .map_err(RepoError::InvalidRoleRepo)?;
                 return Ok((cached_repo, validated_repo, lock_file));
             }
 
@@ -330,7 +330,8 @@ pub(super) fn resolve_agent_repo_with(
             .map_err(RepoError::CloneFailed)?;
     }
 
-    let validated_repo = validate_role_repo(&cached_repo.repo_dir).map_err(RepoError::InvalidRoleRepo)?;
+    let validated_repo =
+        validate_role_repo(&cached_repo.repo_dir).map_err(RepoError::InvalidRoleRepo)?;
 
     // Return the repo lock so the caller can hold it until the build
     // context (a snapshot copy of the repo) is created.  This prevents

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -3,6 +3,7 @@ use crate::instance::primary_container_name;
 use crate::paths::JackinPaths;
 use crate::repo::{CachedRepo, validate_role_repo};
 use crate::selector::RoleSelector;
+use anyhow::Context;
 use fs2::FileExt;
 use owo_colors::OwoColorize;
 use std::io::IsTerminal;
@@ -95,6 +96,76 @@ pub(super) fn resolve_agent_repo(
         debug,
         confirm_repo_removal_interactive,
     )
+}
+
+pub(super) fn register_agent_repo(
+    paths: &JackinPaths,
+    selector: &RoleSelector,
+    git_url: &str,
+    runner: &mut impl CommandRunner,
+    debug: bool,
+    persist_registration: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedRoleRepo)> {
+    let cached_repo = CachedRepo::new(paths, selector);
+    if cached_repo.repo_dir.join(".git").is_dir() {
+        let (cached_repo, validated_repo, _lock_file) =
+            resolve_agent_repo_with(paths, selector, git_url, runner, debug, || Ok(false))?;
+        persist_registration()?;
+        return Ok((cached_repo, validated_repo));
+    }
+
+    let repo_parent = cached_repo.repo_dir.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "role repo path has no parent: {}",
+            cached_repo.repo_dir.display()
+        )
+    })?;
+    std::fs::create_dir_all(repo_parent)?;
+    std::fs::create_dir_all(&paths.data_dir)?;
+
+    if cached_repo.repo_dir.exists() {
+        anyhow::bail!(
+            "cached role path exists but is not a git repository: {}",
+            cached_repo.repo_dir.display()
+        );
+    }
+
+    let lock_path = paths
+        .data_dir
+        .join(format!("{}.repo.lock", primary_container_name(selector)));
+    let lock_file = std::fs::File::create(&lock_path)?;
+    lock_file
+        .lock_exclusive()
+        .map_err(|e| anyhow::anyhow!("failed to acquire repo lock for {}: {e}", selector.key()))?;
+
+    let temp_dir = tempfile::Builder::new()
+        .prefix("role-resolve-")
+        .tempdir_in(&paths.data_dir)?;
+    let temp_repo = temp_dir.path().join("repo");
+    let temp_repo_path = temp_repo.display().to_string();
+    let git_run_opts = RunOptions {
+        quiet: !debug,
+        ..RunOptions::default()
+    };
+    runner
+        .run(
+            "git",
+            &["clone", git_url, &temp_repo_path],
+            None,
+            &git_run_opts,
+        )
+        .with_context(|| "repository is not available or cannot be accessed")?;
+
+    let validated_repo = validate_role_repo(&temp_repo)?;
+    persist_registration()?;
+    std::fs::rename(&temp_repo, &cached_repo.repo_dir).with_context(|| {
+        format!(
+            "failed to install role repository at {}",
+            cached_repo.repo_dir.display()
+        )
+    })?;
+
+    Ok((cached_repo, validated_repo))
 }
 
 pub(super) fn resolve_agent_repo_with(

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -144,7 +144,7 @@ pub(super) fn register_agent_repo(
     let temp_repo = temp_dir.path().join("repo");
     let temp_repo_path = temp_repo.display().to_string();
     let git_run_opts = RunOptions {
-        quiet: true,
+        quiet: !debug,
         ..RunOptions::default()
     };
     runner
@@ -157,10 +157,20 @@ pub(super) fn register_agent_repo(
         .with_context(|| "repository is not available or cannot be accessed")?;
 
     let validated_repo = validate_role_repo(&temp_repo)?;
-    persist_registration()?;
+    // Install the repo into the cache before persisting registration: if
+    // rename fails the role stays unregistered and the user can retry from a
+    // clean state. Persisting first would leave config.toml referencing a
+    // role that has no on-disk repo, surfacing as "failed to install" once
+    // and then silently registered every load thereafter.
     std::fs::rename(&temp_repo, &cached_repo.repo_dir).with_context(|| {
         format!(
             "failed to install role repository at {}",
+            cached_repo.repo_dir.display()
+        )
+    })?;
+    persist_registration().with_context(|| {
+        format!(
+            "role repo installed at {} but registration could not be persisted",
             cached_repo.repo_dir.display()
         )
     })?;
@@ -255,8 +265,12 @@ pub(super) fn resolve_agent_repo_with(
         // Fetch + merge instead of pull to avoid "Cannot fast-forward to
         // multiple branches" errors that occur with `git pull` when the
         // remote has multiple branches.
-        let branch =
-            git_branch(&cached_repo.repo_dir, runner).unwrap_or_else(|| "main".to_string());
+        let branch = git_branch(&cached_repo.repo_dir, runner).ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not determine current branch of cached role repo at {}",
+                cached_repo.repo_dir.display()
+            )
+        })?;
         runner.run(
             "git",
             &["-C", &repo_path, "fetch", "origin", &branch],

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -5,10 +5,50 @@ use crate::repo::{CachedRepo, validate_role_repo};
 use crate::selector::RoleSelector;
 use anyhow::Context;
 use fs2::FileExt;
-use owo_colors::OwoColorize;
 use std::io::IsTerminal;
 
 use super::identity::try_capture;
+
+/// Map an anyhow error from `validate_role_repo` into a typed
+/// `RepoError::InvalidRoleRepo` when the message uses the validator's
+/// `invalid role repo: ` prefix; pass anything else through unchanged.
+///
+/// The validator currently uses anyhow strings; this is the single
+/// substring match left over after the typed-error refactor and lives
+/// here so it's co-located with the variant it produces.
+fn map_validate_error(err: anyhow::Error) -> anyhow::Error {
+    let msg = err.to_string();
+    msg.strip_prefix("invalid role repo: ").map_or(err, |detail| {
+        anyhow::Error::new(RepoError::InvalidRoleRepo {
+            detail: detail.to_string(),
+        })
+    })
+}
+
+/// Typed errors raised by role-repo resolution.
+///
+/// Surfaced through `anyhow::Error` chains so the editor can downcast and
+/// pick a friendly translation without substring-matching free text. Add
+/// new variants here together with their `friendly_role_resolution_error`
+/// arm in `console::manager::input::editor`.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoError {
+    /// `git clone` failed for any reason — host unreachable, auth required,
+    /// repo missing, server-side error. The original anyhow chain is kept
+    /// as the `#[source]` so `--debug` still surfaces it.
+    #[error("repository is not available or cannot be accessed")]
+    CloneFailed(#[source] anyhow::Error),
+
+    /// Cached repo's `origin` remote points at a different URL than the
+    /// configured source and the operator declined removal.
+    #[error("cached role repo remote mismatch — aborting")]
+    RemoteMismatch,
+
+    /// `validate_role_repo` rejected the cloned repo. `detail` is the
+    /// validator's message with the `invalid role repo: ` prefix stripped.
+    #[error("invalid role repo: {detail}")]
+    InvalidRoleRepo { detail: String },
+}
 
 /// Extract `owner/repo` from a git remote URL.
 pub(super) fn parse_repo_name(url: &str) -> Option<String> {
@@ -154,9 +194,9 @@ pub(super) fn register_agent_repo(
             None,
             &git_run_opts,
         )
-        .with_context(|| "repository is not available or cannot be accessed")?;
+        .map_err(RepoError::CloneFailed)?;
 
-    let validated_repo = validate_role_repo(&temp_repo)?;
+    let validated_repo = validate_role_repo(&temp_repo).map_err(map_validate_error)?;
     // Install the repo into the cache before persisting registration: if
     // rename fails the role stays unregistered and the user can retry from a
     // clean state. Persisting first would leave config.toml referencing a
@@ -222,26 +262,26 @@ pub(super) fn resolve_agent_repo_with(
             None,
         )?;
         if !repo_matches(git_url, &remote_url) {
-            let repo_display = cached_repo.repo_dir.display();
-            eprintln!(
-                "{} cached role repo remote does not match configured source",
-                "error:".red().bold()
+            // Route diagnostics through the buffered debug channel rather
+            // than `eprintln!` — the latter corrupts the alt-screen render
+            // when called from inside the TUI session. Operators with
+            // `--debug` still get the full expected/found/path trio.
+            crate::debug_log!(
+                "repo_cache",
+                "cached role repo remote mismatch: expected={git_url:?} \
+                 found={remote_url:?} path={}",
+                cached_repo.repo_dir.display()
             );
-            eprintln!("  expected: {}", git_url.green());
-            eprintln!("  found:    {}", remote_url.yellow());
-            eprintln!();
-            eprintln!("To fix this, remove the cached repo and try again:");
-            eprintln!("  rm -rf {repo_display}");
-            eprintln!();
 
             if confirm_removal()? {
                 std::fs::remove_dir_all(&cached_repo.repo_dir)?;
                 runner.run("git", &["clone", git_url, &repo_path], None, &git_run_opts)?;
-                let validated_repo = validate_role_repo(&cached_repo.repo_dir)?;
+                let validated_repo =
+                    validate_role_repo(&cached_repo.repo_dir).map_err(map_validate_error)?;
                 return Ok((cached_repo, validated_repo, lock_file));
             }
 
-            anyhow::bail!("cached role repo remote mismatch — aborting");
+            return Err(anyhow::Error::new(RepoError::RemoteMismatch));
         }
 
         let status = runner.capture(

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -139,6 +139,20 @@ pub(super) fn resolve_agent_repo(
     )
 }
 
+/// Resolve a role repo into the cache, registering it on success.
+///
+/// Two paths:
+/// 1. Cache hit (`.git` already exists): delegate to
+///    `resolve_agent_repo_with` which fetch+merges, then run
+///    `persist_registration` if validation passes.
+/// 2. Cache miss: clone into a temp dir under `data_dir`, validate,
+///    `rename` into the cache, then run `persist_registration`. Rename
+///    happens before persist so a failed rename leaves the role
+///    *un-registered* (clean state) rather than registered without an
+///    on-disk repo (broken state).
+///
+/// `persist_registration` is the single commit point — it must be
+/// idempotent so retries after a transient failure are safe.
 pub(super) fn register_agent_repo(
     paths: &JackinPaths,
     selector: &RoleSelector,

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -144,7 +144,7 @@ pub(super) fn register_agent_repo(
     let temp_repo = temp_dir.path().join("repo");
     let temp_repo_path = temp_repo.display().to_string();
     let git_run_opts = RunOptions {
-        quiet: !debug,
+        quiet: true,
         ..RunOptions::default()
     };
     runner

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -10,19 +10,26 @@ use std::io::IsTerminal;
 use super::identity::try_capture;
 
 /// Map an anyhow error from `validate_role_repo` into a typed
-/// `RepoError::InvalidRoleRepo` when the message uses the validator's
-/// `invalid role repo: ` prefix; pass anything else through unchanged.
+/// `RepoError::InvalidRoleRepo` when any link in the chain uses the
+/// validator's `invalid role repo: ` prefix; pass anything else through
+/// unchanged.
 ///
-/// The validator currently uses anyhow strings; this is the single
-/// substring match left over after the typed-error refactor and lives
-/// here so it's co-located with the variant it produces.
+/// Walking the whole chain (rather than only `err.to_string()` at the
+/// root) lets a future caller wrap the validator error with
+/// `with_context` without silently dropping the typed classification.
+/// The validator currently emits anyhow strings; this function is the
+/// single substring match left over after the typed-error refactor and
+/// lives here so it's co-located with the variant it produces.
 fn map_validate_error(err: anyhow::Error) -> anyhow::Error {
-    let msg = err.to_string();
-    msg.strip_prefix("invalid role repo: ")
+    err.chain()
+        .find_map(|cause| {
+            cause
+                .to_string()
+                .strip_prefix("invalid role repo: ")
+                .map(str::to_string)
+        })
         .map_or(err, |detail| {
-            anyhow::Error::new(RepoError::InvalidRoleRepo {
-                detail: detail.to_string(),
-            })
+            anyhow::Error::new(RepoError::InvalidRoleRepo { detail })
         })
 }
 
@@ -290,7 +297,9 @@ pub(super) fn resolve_agent_repo_with(
 
             if confirm_removal()? {
                 std::fs::remove_dir_all(&cached_repo.repo_dir)?;
-                runner.run("git", &["clone", git_url, &repo_path], None, &git_run_opts)?;
+                runner
+                    .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
+                    .map_err(RepoError::CloneFailed)?;
                 let validated_repo =
                     validate_role_repo(&cached_repo.repo_dir).map_err(map_validate_error)?;
                 return Ok((cached_repo, validated_repo, lock_file));
@@ -339,10 +348,12 @@ pub(super) fn resolve_agent_repo_with(
             &git_run_opts,
         )?;
     } else {
-        runner.run("git", &["clone", git_url, &repo_path], None, &git_run_opts)?;
+        runner
+            .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
+            .map_err(RepoError::CloneFailed)?;
     }
 
-    let validated_repo = validate_role_repo(&cached_repo.repo_dir)?;
+    let validated_repo = validate_role_repo(&cached_repo.repo_dir).map_err(map_validate_error)?;
 
     // Return the repo lock so the caller can hold it until the build
     // context (a snapshot copy of the repo) is created.  This prevents

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,11 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
+static DEBUG_BUFFER_ACTIVE: AtomicBool = AtomicBool::new(false);
+static DEBUG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
 pub fn set_debug_mode(enabled: bool) {
     DEBUG_MODE.store(enabled, Ordering::Relaxed);
@@ -19,6 +24,40 @@ pub fn format_debug_line(category: &str, message: &str) -> String {
     format!("[jackin debug {category}] {message}")
 }
 
+fn debug_buffer() -> &'static Mutex<Vec<String>> {
+    DEBUG_BUFFER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn drain_debug_buffer() -> Vec<String> {
+    let mut guard = debug_buffer()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    std::mem::take(&mut *guard)
+}
+
+pub(crate) fn begin_debug_buffering() {
+    DEBUG_BUFFER_ACTIVE.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn end_debug_buffering() {
+    DEBUG_BUFFER_ACTIVE.store(false, Ordering::Relaxed);
+    for line in drain_debug_buffer() {
+        eprintln!("{line}");
+    }
+}
+
+pub fn emit_debug_line(category: &str, message: &str) {
+    let line = format_debug_line(category, message);
+    if DEBUG_BUFFER_ACTIVE.load(Ordering::Relaxed) {
+        let mut guard = debug_buffer()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.push(line);
+    } else {
+        eprintln!("{line}");
+    }
+}
+
 /// Verbose-trace helper for `--debug` runs. No-op when the flag is off
 /// — formatting is deferred behind the gate so disabled call sites cost
 /// only an atomic load.
@@ -33,7 +72,7 @@ pub fn format_debug_line(category: &str, message: &str) -> String {
 macro_rules! debug_log {
     ($category:expr, $($arg:tt)*) => {
         if $crate::tui::is_debug_mode() {
-            eprintln!("{}", $crate::tui::format_debug_line($category, &format!($($arg)*)));
+            $crate::tui::emit_debug_line($category, &format!($($arg)*));
         }
     };
 }
@@ -65,6 +104,9 @@ pub use prompt::{prompt_choice, require_interactive_stdin, spin_wait};
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static DEBUG_BUFFER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn format_debug_line_matches_wire_format() {
@@ -89,5 +131,22 @@ mod tests {
         // assert the snapshot is a bool. Toggle/observe is exercised in
         // the binary-level integration test.
         let _: bool = is_debug_mode();
+    }
+
+    #[test]
+    fn debug_lines_buffer_while_tui_is_active() {
+        let _lock = DEBUG_BUFFER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        DEBUG_BUFFER_ACTIVE.store(false, Ordering::Relaxed);
+        let _ = drain_debug_buffer();
+
+        begin_debug_buffering();
+        emit_debug_line("role", "resolving test role");
+        assert_eq!(
+            drain_debug_buffer(),
+            vec!["[jackin debug role] resolving test role".to_string()]
+        );
+        end_debug_buffering();
     }
 }

--- a/src/workspace/planner.rs
+++ b/src/workspace/planner.rs
@@ -44,7 +44,7 @@ pub struct WorkspaceEditPlan {
 ///
 /// Collapses redundancies among the supplied mount list. Callers must
 /// pass every mount explicitly — the planner does not auto-mount the
-/// workdir (see `DEPRECATED.md` for the `--no-workdir-mount` history).
+/// workdir.
 pub fn plan_create(mounts: &[MountConfig]) -> Result<WorkspaceCreatePlan, CollapseError> {
     let all_indexes: Vec<usize> = (0..mounts.len()).collect();
     let plan = plan_collapse(mounts, &all_indexes)?;

--- a/src/workspace/planner.rs
+++ b/src/workspace/planner.rs
@@ -16,7 +16,8 @@ use crate::workspace::mounts::covers;
 
 /// Plan for `jackin workspace create`.
 pub struct WorkspaceCreatePlan {
-    /// The final, collapsed mount list the caller should persist.
+    /// The final mount list the caller should persist after collapsing
+    /// redundancies among explicitly supplied mounts.
     pub final_mounts: Vec<MountConfig>,
     /// Mounts subsumed during the collapse. All are edit-driven for create.
     pub collapsed: Vec<Removal>,
@@ -41,31 +42,16 @@ pub struct WorkspaceEditPlan {
 
 /// Plan a `workspace create`.
 ///
-/// Auto-inserts a workdir-mount at position 0 unless `no_workdir_mount` is
-/// set or the workdir destination is already mounted. Then runs the collapse
-/// with every mount marked as new (since everything is "new" for a create).
+/// Runs collapse with every supplied mount marked as new (since everything is
+/// "new" for a create). The workdir is not auto-mounted; callers must provide
+/// the mount set explicitly.
 pub fn plan_create(
-    workdir: &str,
-    mounts: Vec<MountConfig>,
-    no_workdir_mount: bool,
+    _workdir: &str,
+    mounts: &[MountConfig],
+    _no_workdir_mount: bool,
 ) -> Result<WorkspaceCreatePlan, CollapseError> {
-    let mut all_mounts = mounts;
-    if !no_workdir_mount {
-        let already_mounted = all_mounts.iter().any(|m| m.dst == workdir);
-        if !already_mounted {
-            all_mounts.insert(
-                0,
-                MountConfig {
-                    src: workdir.to_string(),
-                    dst: workdir.to_string(),
-                    readonly: false,
-                    isolation: crate::isolation::MountIsolation::Shared,
-                },
-            );
-        }
-    }
-    let all_indexes: Vec<usize> = (0..all_mounts.len()).collect();
-    let plan = plan_collapse(&all_mounts, &all_indexes)?;
+    let all_indexes: Vec<usize> = (0..mounts.len()).collect();
+    let plan = plan_collapse(mounts, &all_indexes)?;
     Ok(WorkspaceCreatePlan {
         final_mounts: plan.kept,
         collapsed: plan.removed,
@@ -279,19 +265,17 @@ mod tests {
     }
 
     #[test]
-    fn plan_create_inserts_workdir_auto_mount_at_front() {
-        let plan = plan_create("/work", vec![mount("/data", "/data")], false).unwrap();
+    fn plan_create_does_not_insert_workdir_auto_mount() {
+        let plan = plan_create("/work", &[mount("/data", "/data")], false).unwrap();
 
-        assert_eq!(plan.final_mounts.len(), 2);
-        assert_eq!(plan.final_mounts[0].dst, "/work");
-        assert_eq!(plan.final_mounts[0].src, "/work");
-        assert_eq!(plan.final_mounts[1].dst, "/data");
+        assert_eq!(plan.final_mounts.len(), 1);
+        assert_eq!(plan.final_mounts[0].dst, "/data");
         assert!(plan.collapsed.is_empty());
     }
 
     #[test]
     fn plan_create_skips_auto_mount_when_workdir_already_mounted() {
-        let plan = plan_create("/work", vec![mount("/custom-src", "/work")], false).unwrap();
+        let plan = plan_create("/work", &[mount("/custom-src", "/work")], false).unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].src, "/custom-src");
@@ -300,8 +284,8 @@ mod tests {
     }
 
     #[test]
-    fn plan_create_no_workdir_mount_suppresses_auto_mount() {
-        let plan = plan_create("/work", vec![mount("/data", "/data")], true).unwrap();
+    fn plan_create_no_workdir_mount_flag_is_noop_for_compatibility() {
+        let plan = plan_create("/work", &[mount("/data", "/data")], true).unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].dst, "/data");
@@ -310,8 +294,12 @@ mod tests {
 
     #[test]
     fn plan_create_collapses_redundant_children_under_parent() {
-        // /work auto-inserts, then /work/sub is a child of /work — gets collapsed.
-        let plan = plan_create("/work", vec![mount("/work/sub", "/work/sub")], false).unwrap();
+        let plan = plan_create(
+            "/work",
+            &[mount("/work", "/work"), mount("/work/sub", "/work/sub")],
+            false,
+        )
+        .unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].dst, "/work");

--- a/src/workspace/planner.rs
+++ b/src/workspace/planner.rs
@@ -16,10 +16,10 @@ use crate::workspace::mounts::covers;
 
 /// Plan for `jackin workspace create`.
 pub struct WorkspaceCreatePlan {
-    /// The final mount list the caller should persist after collapsing
-    /// redundancies among explicitly supplied mounts.
+    /// The final mount list the caller should persist.
     pub final_mounts: Vec<MountConfig>,
-    /// Mounts subsumed during the collapse. All are edit-driven for create.
+    /// Mounts subsumed during the collapse — i.e. each `Removal`'s child
+    /// was redundant against its parent in the supplied mount list.
     pub collapsed: Vec<Removal>,
 }
 
@@ -42,14 +42,10 @@ pub struct WorkspaceEditPlan {
 
 /// Plan a `workspace create`.
 ///
-/// Runs collapse with every supplied mount marked as new (since everything is
-/// "new" for a create). The workdir is not auto-mounted; callers must provide
-/// the mount set explicitly.
-pub fn plan_create(
-    _workdir: &str,
-    mounts: &[MountConfig],
-    _no_workdir_mount: bool,
-) -> Result<WorkspaceCreatePlan, CollapseError> {
+/// Collapses redundancies among the supplied mount list. Callers must
+/// pass every mount explicitly — the planner does not auto-mount the
+/// workdir (see `DEPRECATED.md` for the `--no-workdir-mount` history).
+pub fn plan_create(mounts: &[MountConfig]) -> Result<WorkspaceCreatePlan, CollapseError> {
     let all_indexes: Vec<usize> = (0..mounts.len()).collect();
     let plan = plan_collapse(mounts, &all_indexes)?;
     Ok(WorkspaceCreatePlan {
@@ -266,7 +262,7 @@ mod tests {
 
     #[test]
     fn plan_create_does_not_insert_workdir_auto_mount() {
-        let plan = plan_create("/work", &[mount("/data", "/data")], false).unwrap();
+        let plan = plan_create(&[mount("/data", "/data")]).unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].dst, "/data");
@@ -274,8 +270,8 @@ mod tests {
     }
 
     #[test]
-    fn plan_create_skips_auto_mount_when_workdir_already_mounted() {
-        let plan = plan_create("/work", &[mount("/custom-src", "/work")], false).unwrap();
+    fn plan_create_preserves_explicit_workdir_mount() {
+        let plan = plan_create(&[mount("/custom-src", "/work")]).unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].src, "/custom-src");
@@ -284,22 +280,9 @@ mod tests {
     }
 
     #[test]
-    fn plan_create_no_workdir_mount_flag_is_noop_for_compatibility() {
-        let plan = plan_create("/work", &[mount("/data", "/data")], true).unwrap();
-
-        assert_eq!(plan.final_mounts.len(), 1);
-        assert_eq!(plan.final_mounts[0].dst, "/data");
-        assert!(plan.collapsed.is_empty());
-    }
-
-    #[test]
     fn plan_create_collapses_redundant_children_under_parent() {
-        let plan = plan_create(
-            "/work",
-            &[mount("/work", "/work"), mount("/work/sub", "/work/sub")],
-            false,
-        )
-        .unwrap();
+        let plan =
+            plan_create(&[mount("/work", "/work"), mount("/work/sub", "/work/sub")]).unwrap();
 
         assert_eq!(plan.final_mounts.len(), 1);
         assert_eq!(plan.final_mounts[0].dst, "/work");

--- a/tests/cli_env.rs
+++ b/tests/cli_env.rs
@@ -48,7 +48,15 @@ fn seed_agent(env: &Env, name: &str) {
 fn seed_workspace(env: &Env, name: &str, workdir: &str) {
     fs::create_dir_all(workdir).unwrap();
     jackin(env)
-        .args(["workspace", "create", name, "--workdir", workdir])
+        .args([
+            "workspace",
+            "create",
+            name,
+            "--workdir",
+            workdir,
+            "--mount",
+            workdir,
+        ])
         .assert()
         .success();
 }

--- a/tests/workspace_config_crud.rs
+++ b/tests/workspace_config_crud.rs
@@ -128,7 +128,7 @@ fn workspace_create_requires_explicit_mount() {
         .create_workspace(
             "my-app",
             WorkspaceConfig {
-                workdir: expanded_workdir.clone(),
+                workdir: expanded_workdir,
                 mounts: vec![],
                 ..Default::default()
             },

--- a/tests/workspace_config_crud.rs
+++ b/tests/workspace_config_crud.rs
@@ -110,10 +110,11 @@ fn workspace_create_resolves_dot_workdir_and_dotdot_mount() {
     assert!(mount.src.ends_with("/jackin-agent-smith"));
 }
 
-/// Simulates `jackin workspace create my-app --workdir /tmp/app` (default behavior).
-/// The workdir must be auto-mounted as the first mount.
+/// Simulates `jackin workspace create my-app --workdir /tmp/app` without
+/// `--mount`. Workdir is only the start path now, so at least one explicit
+/// mount is required.
 #[test]
-fn workspace_create_auto_mounts_workdir_by_default() {
+fn workspace_create_requires_explicit_mount() {
     let (_temp_home, paths) = bootstrap_paths();
 
     let temp = tempfile::tempdir().unwrap();
@@ -122,48 +123,28 @@ fn workspace_create_auto_mounts_workdir_by_default() {
 
     let expanded_workdir = workdir_dir.display().to_string();
 
-    // Simulate default behavior: no_workdir_mount = false
-    let no_workdir_mount = false;
-    let mut all_mounts: Vec<workspace::MountConfig> = vec![];
-    if !no_workdir_mount {
-        let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
-        if !already_mounted {
-            all_mounts.insert(
-                0,
-                workspace::MountConfig {
-                    src: expanded_workdir.clone(),
-                    dst: expanded_workdir.clone(),
-                    readonly: false,
-                    isolation: jackin::isolation::MountIsolation::Shared,
-                },
-            );
-        }
-    }
-
     let mut editor = ConfigEditor::open(&paths).unwrap();
-    editor
+    let err = editor
         .create_workspace(
             "my-app",
             WorkspaceConfig {
                 workdir: expanded_workdir.clone(),
-                mounts: all_mounts,
+                mounts: vec![],
                 ..Default::default()
             },
         )
-        .unwrap();
+        .unwrap_err();
 
-    let config = editor.save().unwrap();
-    let ws = config.workspaces.get("my-app").unwrap();
-    assert_eq!(ws.mounts.len(), 1);
-    assert_eq!(ws.mounts[0].src, expanded_workdir);
-    assert_eq!(ws.mounts[0].dst, expanded_workdir);
-    assert!(!ws.mounts[0].readonly);
+    assert!(
+        err.to_string().contains("must define at least one mount"),
+        "expected missing mount validation, got: {err}"
+    );
 }
 
-/// Simulates `jackin workspace create monorepo --workdir /workspace --no-workdir-mount
-/// --mount /tmp/src:/workspace`. The workdir must NOT be auto-mounted.
+/// Simulates `jackin workspace create monorepo --workdir /workspace
+/// --mount /tmp/src:/workspace`. The workdir must not add any implicit mount.
 #[test]
-fn workspace_create_no_workdir_mount_skips_auto_mount() {
+fn workspace_create_uses_only_explicit_mounts() {
     let (_temp_home, paths) = bootstrap_paths();
 
     let temp = tempfile::tempdir().unwrap();
@@ -172,26 +153,12 @@ fn workspace_create_no_workdir_mount_skips_auto_mount() {
 
     let src_path = src_dir.display().to_string();
 
-    // Simulate --no-workdir-mount with explicit mount
-    let no_workdir_mount = true;
-    let mut all_mounts = vec![workspace::MountConfig {
+    let all_mounts = vec![workspace::MountConfig {
         src: src_path.clone(),
         dst: "/workspace".to_string(),
         readonly: false,
         isolation: jackin::isolation::MountIsolation::Shared,
     }];
-    if !no_workdir_mount {
-        // This block should NOT execute
-        all_mounts.insert(
-            0,
-            workspace::MountConfig {
-                src: "/workspace".to_string(),
-                dst: "/workspace".to_string(),
-                readonly: false,
-                isolation: jackin::isolation::MountIsolation::Shared,
-            },
-        );
-    }
 
     let mut editor = ConfigEditor::open(&paths).unwrap();
     editor
@@ -212,10 +179,9 @@ fn workspace_create_no_workdir_mount_skips_auto_mount() {
     assert_eq!(ws.mounts[0].dst, "/workspace");
 }
 
-/// When the workdir is already covered by an explicit --mount, the auto-mount
-/// should be skipped even without --no-workdir-mount.
+/// An explicit workdir mount should be preserved exactly as supplied.
 #[test]
-fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
+fn workspace_create_preserves_explicit_workdir_mount() {
     let (_temp_home, paths) = bootstrap_paths();
 
     let temp = tempfile::tempdir().unwrap();
@@ -224,28 +190,12 @@ fn workspace_create_skips_auto_mount_when_workdir_already_mounted() {
 
     let expanded_workdir = workdir_dir.display().to_string();
 
-    // Simulate: user explicitly mounts workdir via --mount
-    let no_workdir_mount = false;
-    let mut all_mounts = vec![workspace::MountConfig {
+    let all_mounts = vec![workspace::MountConfig {
         src: expanded_workdir.clone(),
         dst: expanded_workdir.clone(),
         readonly: true, // user chose read-only
         isolation: jackin::isolation::MountIsolation::Shared,
     }];
-    if !no_workdir_mount {
-        let already_mounted = all_mounts.iter().any(|m| m.dst == expanded_workdir);
-        if !already_mounted {
-            all_mounts.insert(
-                0,
-                workspace::MountConfig {
-                    src: expanded_workdir.clone(),
-                    dst: expanded_workdir.clone(),
-                    readonly: false,
-                    isolation: jackin::isolation::MountIsolation::Shared,
-                },
-            );
-        }
-    }
 
     let mut editor = ConfigEditor::open(&paths).unwrap();
     editor

--- a/tests/workspace_mount_collapse.rs
+++ b/tests/workspace_mount_collapse.rs
@@ -120,7 +120,6 @@ fn workspace_create_rejects_duplicate_destination() {
             "test",
             "--workdir",
             env.proj_alpha.to_str().unwrap(),
-            "--no-workdir-mount",
             "--mount",
             &format!("{}:/work", env.sub_a.to_str().unwrap()),
             "--mount",
@@ -145,7 +144,6 @@ fn workspace_create_accepts_src_colon_dst_spec() {
             "test",
             "--workdir",
             "/code",
-            "--no-workdir-mount",
             "--mount",
             &format!("{}:/code", env.sub_a.to_str().unwrap()),
         ])
@@ -172,7 +170,6 @@ fn workspace_create_rejects_duplicate_name() {
             "test",
             "--workdir",
             env.sub_a.to_str().unwrap(),
-            "--no-workdir-mount",
             "--mount",
             env.sub_a.to_str().unwrap(),
         ])
@@ -186,7 +183,6 @@ fn workspace_create_rejects_duplicate_name() {
             "test",
             "--workdir",
             env.sub_b.to_str().unwrap(),
-            "--no-workdir-mount",
             "--mount",
             env.sub_b.to_str().unwrap(),
         ])

--- a/tests/workspace_mount_collapse.rs
+++ b/tests/workspace_mount_collapse.rs
@@ -108,6 +108,94 @@ fn workspace_create_workdir_parent_does_not_collapse_child_mount() {
 }
 
 #[test]
+fn workspace_create_rejects_duplicate_destination() {
+    // Two `--mount` entries with the same explicit `dst` must fail loudly
+    // at the validator (`workspace::mounts.rs`'s "duplicate mount
+    // destination" bail) rather than silently collapsing one of them.
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "workspace",
+            "create",
+            "test",
+            "--workdir",
+            env.proj_alpha.to_str().unwrap(),
+            "--no-workdir-mount",
+            "--mount",
+            &format!("{}:/work", env.sub_a.to_str().unwrap()),
+            "--mount",
+            &format!("{}:/work", env.sub_b.to_str().unwrap()),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("duplicate mount destination"));
+}
+
+#[test]
+fn workspace_create_accepts_src_colon_dst_spec() {
+    // `--mount src:/dst` should parse and persist the explicit container
+    // path. Pre-existing tests only exercise the `src` and `src:ro`
+    // shapes — this pins the third documented form. `--workdir` matches
+    // the explicit dst so the workdir-vs-dst validator is satisfied.
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "workspace",
+            "create",
+            "test",
+            "--workdir",
+            "/code",
+            "--no-workdir-mount",
+            "--mount",
+            &format!("{}:/code", env.sub_a.to_str().unwrap()),
+        ])
+        .assert()
+        .success();
+
+    jackin(&env)
+        .args(["workspace", "show", "test"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("/code"));
+}
+
+#[test]
+fn workspace_create_rejects_duplicate_name() {
+    // Creating a workspace with a name that already exists must fail
+    // loudly — silently overwriting the existing config would lose the
+    // operator's prior mount/env/workdir setup.
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "workspace",
+            "create",
+            "test",
+            "--workdir",
+            env.sub_a.to_str().unwrap(),
+            "--no-workdir-mount",
+            "--mount",
+            env.sub_a.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    jackin(&env)
+        .args([
+            "workspace",
+            "create",
+            "test",
+            "--workdir",
+            env.sub_b.to_str().unwrap(),
+            "--no-workdir-mount",
+            "--mount",
+            env.sub_b.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
 fn workspace_create_rejects_readonly_mismatch() {
     let env = setup_env();
     jackin(&env)

--- a/tests/workspace_mount_collapse.rs
+++ b/tests/workspace_mount_collapse.rs
@@ -69,6 +69,8 @@ fn workspace_create_auto_collapses_and_prints_summary() {
             "--workdir",
             env.proj_alpha.to_str().unwrap(),
             "--mount",
+            env.proj_alpha.to_str().unwrap(),
+            "--mount",
             env.sub_a.to_str().unwrap(),
             "--mount",
             env.sub_b.to_str().unwrap(),
@@ -78,6 +80,31 @@ fn workspace_create_auto_collapses_and_prints_summary() {
         .stderr(predicate::str::contains("collapsed"))
         .stderr(predicate::str::contains("sub-a"))
         .stderr(predicate::str::contains("sub-b"));
+}
+
+#[test]
+fn workspace_create_workdir_parent_does_not_collapse_child_mount() {
+    let env = setup_env();
+    jackin(&env)
+        .args([
+            "workspace",
+            "create",
+            "test",
+            "--workdir",
+            env.proj_alpha.to_str().unwrap(),
+            "--mount",
+            env.sub_a.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("collapsed").not());
+
+    jackin(&env)
+        .args(["workspace", "show", "test"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sub-a"))
+        .stdout(predicate::str::contains("proj-alpha"));
 }
 
 #[test]

--- a/tests/workspace_mount_collapse.rs
+++ b/tests/workspace_mount_collapse.rs
@@ -48,7 +48,6 @@ fn create_workspace_with_children(env: &Env, name: &str) {
             name,
             "--workdir",
             env.sub_a.to_str().unwrap(),
-            "--no-workdir-mount",
             "--mount",
             env.sub_a.to_str().unwrap(),
             "--mount",
@@ -250,7 +249,6 @@ fn workspace_edit_fails_on_readonly_mismatch_with_clear_error() {
             "test",
             "--workdir",
             env.sub_a.to_str().unwrap(),
-            "--no-workdir-mount",
             "--mount",
             &format!("{}:ro", env.sub_a.to_str().unwrap()),
         ])


### PR DESCRIPTION
Rewrite of the `jackin workspace create` mount flow plus the
surrounding TUI editor / role-input / role-repo plumbing it
exposes. Pre-existing operator commits at the base of the branch
are the original scope; subsequent commits land review fixes from
three review rounds (initial, post-fix, simplify+polish).

## Scope

- Workspace create requires explicit `--mount` arguments; workdir is
  no longer auto-mounted.
- `MountDstChoice` in the create prelude renamed `Ok` → `SamePath`
  to match the button label.
- `MountKind::Git` collapsed into `{ branch, origin: Option<GitOrigin> }`
  so callers can't construct illegal `(host, remote_url, web_url)`
  triples.
- `ConfirmKind::RoleTrust { role, repository }` carries the role
  trust prompt's payload structurally instead of `\n`-delimiting two
  fields into a `prompt: String`.
- Role-repo resolution now classifies failures via typed
  `RepoError` (`CloneFailed` / `RemoteMismatch` / `InvalidRoleRepo`)
  and the inner `RoleRepoValidationError` enum, replacing the
  pre-PR substring matching against free-form anyhow strings.
- `register_agent_repo` install ordering: clone → validate → rename →
  persist registration, so a rename or persist failure leaves the
  cache in a consistent state.
- `error_popup::required_height` accepts the caller's `max_rows` so
  long anyhow chains aren't silently truncated; floor 8 prevents a
  zero-row body chunk on tiny terminals.
- 9 new tests cover mount-validation CLI failures, save error-flow
  routing in Create mode, role-input edges, `register_agent_repo`
  failure injection, and `resolve_git_url` non-github classification.

## Breaking changes

- `jackin workspace create --no-workdir-mount` is removed (no
  deprecation window — POC). `workspace edit --no-workdir-mount` is
  unaffected.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run` (1413 / 1413 pass)
- [ ] Smoke-test `jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --debug`
- [ ] Smoke-test the role-input flow (`r` to add role, GitHub URL,
      Trust confirm) end-to-end with `--debug`
- [ ] Verify the role-repo install cleans up its temp dir on
      validate failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)