### PR TITLE
perf(construct): switch tirith to prebuilt binary, cache mounts for shellfirm

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,14 @@ Markers without a corresponding TODO.md entry are allowed for transient in-fligh
 - **Last verified:** 2026-05-01 — latest `lycheeverse/lychee-action` tag is still `v2.8.0`; `faea714` remains current `master` HEAD; pin introduced in [#176](https://github.com/jackin-project/jackin/pull/176). `LYCHEE_VERSION` independently bumped to `v0.24.2` ([release notes](https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.2)) — tarball layout unchanged from v0.24.1 (PR [#2165](https://github.com/lycheeverse/lychee/pull/2165) is binstall-metadata only), so the post-v2.8.0 master SHA is still required.
 - **Done when:** a tag at or after `faea714` ships. Replace the SHA in `docs.yml` with that tag's commit SHA, update the inline comment from "post-v2.8.0 master" to the tag name, and re-confirm `LYCHEE_VERSION` matches whatever the new release defaults to (or keep the explicit pin if newer).
 
+#### `shellfirm-aarch64-linux-binary` — switch to prebuilt download once upstream ships aarch64-linux artifact
+
+- **What:** in [`docker/construct/Dockerfile`](docker/construct/Dockerfile), drop the `cargo install shellfirm` step (and the multi-stage `rust:1.95.0-trixie` `security-tools` builder it lives in) in favor of downloading a prebuilt `shellfirm-vX.Y.Z-aarch64-linux.tar.xz` artifact, mirroring the tirith install pattern already in place.
+- **Why:** the construct image is built multi-arch (`linux/amd64` + `linux/arm64`). shellfirm currently only ships `x86_64-linux` (and macOS/Windows) prebuilt binaries, so the arm64 variant must compile shellfirm and its full dependency graph from source on every layer-cache miss, dominating the arm64 build time. tirith already moved to prebuilt download because its upstream publishes both Linux arches; shellfirm is the last blocker preventing us from removing the rust toolchain stage from the construct image entirely.
+- **Tracking:** <https://github.com/kaplanelad/shellfirm/issues/179> — upstream issue requesting that the existing-but-commented-out `aarch64-linux` matrix entry in [`release.yml`](https://github.com/kaplanelad/shellfirm/blob/main/.github/workflows/release.yml) be re-enabled.
+- **Last verified:** 2026-05-04 — checked v0.3.5 through v0.3.9 release assets; only `x86_64-linux.tar.xz` ships for Linux. Filed upstream issue #179 same day.
+- **Done when:** a shellfirm release at or after the fix publishes `shellfirm-v<ver>-aarch64-linux.tar.xz` (or equivalently named) alongside the existing x86_64 tarball. Replace the cargo install step with a TARGETARCH-aware curl + `tar -xJ` block (mirroring the tirith pattern), drop the `security-tools` stage and the `FROM rust:...` line, remove the `COPY --from=security-tools` for shellfirm, and remove the `TODO(shellfirm-aarch64-linux-binary)` marker in the Dockerfile.
+
 ### Internal cleanups
 
 #### `lychee-no-files-warn` — investigate "No files found for this input source" in deploy link check

--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -1,14 +1,20 @@
 FROM rust:1.95.0-trixie@sha256:a9cfb755b33f5bb872610cbdb25da61f527416b28fc9c052bbce4bef93e7799a AS security-tools
 
-ARG TIRITH_VERSION
 ARG SHELLFIRM_VERSION
 
-RUN cargo install tirith --version "${TIRITH_VERSION}" --locked && \
+# TODO(shellfirm-aarch64-linux-binary): replace with prebuilt binary download
+# once kaplanelad/shellfirm publishes aarch64-linux release artifacts —
+# see TODO.md "External dependencies" → "shellfirm-aarch64-linux-binary".
+# Cache mounts persist the crates.io registry index and downloaded source
+# crates across builds inside a builder, so cargo does not re-download the
+# entire dependency graph on layer-cache miss (eg. SHELLFIRM_VERSION bump
+# or fresh GHA cache scope). The compile itself still runs on miss.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     cargo install shellfirm --version "${SHELLFIRM_VERSION}" --locked
 
 FROM debian:trixie-20260421@sha256:35b8ff74ead4880f22090b617372daff0ccae742eb5674455d542bef71ef1999
 
-COPY --from=security-tools /usr/local/cargo/bin/tirith /usr/local/bin/tirith
 COPY --from=security-tools /usr/local/cargo/bin/shellfirm /usr/local/bin/shellfirm
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -41,6 +47,30 @@ RUN apt-get update && \
 
 # Configure git-lfs
 RUN git lfs install
+
+# Install tirith from prebuilt release binary (sheeki03/tirith ships
+# x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu tarballs plus a
+# checksums.txt). Download path uses TARGETARCH so the buildx multi-arch
+# build picks the matching artifact natively without cross-compilation.
+ARG TIRITH_VERSION
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) tirith_arch=x86_64-unknown-linux-gnu ;; \
+      arm64) tirith_arch=aarch64-unknown-linux-gnu ;; \
+      *) printf 'unsupported TARGETARCH for tirith: %s\n' "${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    base="https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}"; \
+    workdir="$(mktemp -d)"; \
+    cd "${workdir}"; \
+    curl -fsSLO "${base}/tirith-${tirith_arch}.tar.gz"; \
+    curl -fsSLO "${base}/checksums.txt"; \
+    grep "  tirith-${tirith_arch}.tar.gz$" checksums.txt > checksums-tirith.txt; \
+    sha256sum -c checksums-tirith.txt; \
+    tar -xzf "tirith-${tirith_arch}.tar.gz" -C /usr/local/bin tirith; \
+    chmod 0755 /usr/local/bin/tirith; \
+    cd /; \
+    rm -rf "${workdir}"
 
 # Install mise (version pinned via versions.env -> MISE_VERSION ARG; mise apt
 # repo only ships the latest release in `stable`, so this pin must be bumped

--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -2,13 +2,8 @@ FROM rust:1.95.0-trixie@sha256:a9cfb755b33f5bb872610cbdb25da61f527416b28fc9c052b
 
 ARG SHELLFIRM_VERSION
 
-# TODO(shellfirm-aarch64-linux-binary): replace with prebuilt binary download
-# once kaplanelad/shellfirm publishes aarch64-linux release artifacts —
-# see TODO.md "External dependencies" → "shellfirm-aarch64-linux-binary".
-# Cache mounts persist the crates.io registry index and downloaded source
-# crates across builds inside a builder, so cargo does not re-download the
-# entire dependency graph on layer-cache miss (eg. SHELLFIRM_VERSION bump
-# or fresh GHA cache scope). The compile itself still runs on miss.
+# Install shellfirm
+# TODO(shellfirm-aarch64-linux-binary): switch to prebuilt download — see TODO.md.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     cargo install shellfirm --version "${SHELLFIRM_VERSION}" --locked
@@ -48,10 +43,7 @@ RUN apt-get update && \
 # Configure git-lfs
 RUN git lfs install
 
-# Install tirith from prebuilt release binary (sheeki03/tirith ships
-# x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu tarballs plus a
-# checksums.txt). Download path uses TARGETARCH so the buildx multi-arch
-# build picks the matching artifact natively without cross-compilation.
+# Install tirith
 ARG TIRITH_VERSION
 ARG TARGETARCH
 RUN set -eux; \

--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -46,22 +46,21 @@ RUN git lfs install
 # Install tirith
 ARG TIRITH_VERSION
 ARG TARGETARCH
-RUN set -eux; \
-    case "${TARGETARCH}" in \
+RUN case "${TARGETARCH}" in \
       amd64) tirith_arch=x86_64-unknown-linux-gnu ;; \
       arm64) tirith_arch=aarch64-unknown-linux-gnu ;; \
-      *) printf 'unsupported TARGETARCH for tirith: %s\n' "${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    base="https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}"; \
-    workdir="$(mktemp -d)"; \
-    cd "${workdir}"; \
-    curl -fsSLO "${base}/tirith-${tirith_arch}.tar.gz"; \
-    curl -fsSLO "${base}/checksums.txt"; \
-    grep "  tirith-${tirith_arch}.tar.gz$" checksums.txt > checksums-tirith.txt; \
-    sha256sum -c checksums-tirith.txt; \
-    tar -xzf "tirith-${tirith_arch}.tar.gz" -C /usr/local/bin tirith; \
-    chmod 0755 /usr/local/bin/tirith; \
-    cd /; \
+      *) printf 'unsupported TARGETARCH for tirith: %s\n' "${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    base="https://github.com/sheeki03/tirith/releases/download/v${TIRITH_VERSION}" && \
+    workdir="$(mktemp -d)" && \
+    cd "${workdir}" && \
+    curl -fsSLO "${base}/tirith-${tirith_arch}.tar.gz" && \
+    curl -fsSLO "${base}/checksums.txt" && \
+    grep "  tirith-${tirith_arch}.tar.gz$" checksums.txt > checksums-tirith.txt && \
+    sha256sum -c checksums-tirith.txt && \
+    tar -xzf "tirith-${tirith_arch}.tar.gz" -C /usr/local/bin tirith && \
+    chmod 0755 /usr/local/bin/tirith && \
+    cd / && \
     rm -rf "${workdir}"
 
 # Install mise (version pinned via versions.env -> MISE_VERSION ARG; mise apt


### PR DESCRIPTION
## Summary

- Drop `cargo install tirith` in favor of a TARGETARCH-aware curl download of `sheeki03/tirith` release tarball with `sha256sum -c` against the upstream `checksums.txt`. Binary lands in `/usr/local/bin/tirith` directly in stage 2.
- Keep `cargo install shellfirm` in the `security-tools` stage (upstream gap — see below) but add BuildKit cache mounts for `/usr/local/cargo/registry` and `/usr/local/cargo/git` so cold-cache rebuilds skip the crates.io re-fetch.
- Add TODO.md entry `shellfirm-aarch64-linux-binary` under External dependencies tracking <https://github.com/kaplanelad/shellfirm/issues/179> for the eventual full migration.

## Why

The `security-tools` stage was running `cargo install` for both tools. Each layer-cache miss re-compiled tirith + shellfirm + their full transitive dependency graphs from source — dominating arm64 build time on cold caches. tirith publishes prebuilt Linux binaries for both x86_64 and aarch64; shellfirm only publishes x86_64-linux (issue [#179](https://github.com/kaplanelad/shellfirm/issues/179) filed upstream to re-enable the commented-out `aarch64-linux` matrix entry in their `release.yml`).

## Net effect

- **amd64 builds**: tirith install drops from full cargo compile (~30s+ on cold cache) to curl + extract (~2s). shellfirm unchanged.
- **arm64 builds**: tirith same gain; shellfirm cargo install retains cargo cache mounts across builds in the same builder, so cold-cache rebuilds skip the crates.io re-fetch (compile still runs).

When upstream shellfirm ships an aarch64-linux artifact, follow-up PR per the TODO entry can drop the entire `security-tools` stage and the `rust:1.95.0-trixie` base image dependency.

## Caveats

- The `--mount=type=cache` mounts are builder-local; with `type=gha,mode=max` cache exporter they do not persist across separate workflow runs by default. Across-run persistence would need `reproducible-containers/buildkit-cache-dance` or similar — left out for now since pinned `SHELLFIRM_VERSION` should mostly hit the layer cache anyway, and cache mounts already help within a single multi-arch run.
- Stage 2 now uses `TARGETARCH` (auto-provided by `docker buildx`); single-arch `docker build` invocations would need to pass `--build-arg TARGETARCH=amd64|arm64` explicitly. Consistent with existing `linux/$(uname -m)` handling in the local build flow.

## Test plan

- [ ] Construct workflow on this PR builds amd64 + arm64 successfully with tirith downloaded (verify by `docker run --rm ...:trixie-<sha> tirith --version` reporting `0.2.12`).
- [ ] Confirm `shellfirm --version` still works in the resulting image (cargo path unchanged).
- [ ] Compare arm64 stage-1 timing in the Actions run vs. the previous PR (#214) baseline to confirm cache mounts kick in on the second run after merge.
- [ ] After merge, monitor [shellfirm#179](https://github.com/kaplanelad/shellfirm/issues/179) — when resolved, follow-up PR drops `security-tools` stage entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)