### PR TITLE
feat(image): pre-built role image fast path via published_image

### DIFF
--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -77,6 +77,9 @@ ENTRYPOINT [\"/home/agent/entrypoint.sh\"]
 pub fn create_derived_build_context(
     repo_dir: &Path,
     validated: &ValidatedRoleRepo,
+    // When Some, the DerivedDockerfile starts with `FROM <image>` rather than
+    // the workspace Dockerfile contents (pre-built image fast path).
+    base_image_override: Option<&str>,
 ) -> anyhow::Result<DerivedBuildContext> {
     let temp_dir = tempfile::tempdir()?;
     let context_dir = temp_dir.path().join("context");
@@ -92,15 +95,16 @@ pub fn create_derived_build_context(
         .as_ref()
         .and_then(|h| h.pre_launch.as_deref());
 
+    let base_dockerfile = base_image_override.map_or_else(
+        || validated.dockerfile.dockerfile_contents.clone(),
+        |image| format!("FROM {image}\n"),
+    );
+
     let supported = validated.manifest.supported_agents();
     let dockerfile_path = context_dir.join(".jackin-runtime/DerivedDockerfile");
     std::fs::write(
         &dockerfile_path,
-        render_derived_dockerfile(
-            &validated.dockerfile.dockerfile_contents,
-            pre_launch_hook,
-            &supported,
-        ),
+        render_derived_dockerfile(&base_dockerfile, pre_launch_hook, &supported),
     )?;
     ensure_runtime_assets_are_included(&context_dir, pre_launch_hook)?;
 
@@ -375,7 +379,7 @@ plugins = []
         .unwrap();
 
         let validated = crate::repo::validate_role_repo(repo.path()).unwrap();
-        let build = create_derived_build_context(repo.path(), &validated).unwrap();
+        let build = create_derived_build_context(repo.path(), &validated, None).unwrap();
 
         assert!(build.context_dir.join("Dockerfile").is_file());
         assert!(
@@ -413,13 +417,44 @@ plugins = []
         .unwrap();
 
         let validated = crate::repo::validate_role_repo(repo.path()).unwrap();
-        let build = create_derived_build_context(repo.path(), &validated).unwrap();
+        let build = create_derived_build_context(repo.path(), &validated, None).unwrap();
         let dockerignore =
             std::fs::read_to_string(build.context_dir.join(".dockerignore")).unwrap();
 
         assert!(dockerignore.contains("!.jackin-runtime/"));
         assert!(dockerignore.contains("!.jackin-runtime/entrypoint.sh"));
         assert!(dockerignore.contains("!.jackin-runtime/DerivedDockerfile"));
+    }
+
+    #[test]
+    fn uses_base_image_override_instead_of_workspace_dockerfile() {
+        let repo = tempdir().unwrap();
+        std::fs::write(
+            repo.path().join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.path().join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let validated = crate::repo::validate_role_repo(repo.path()).unwrap();
+        let build = create_derived_build_context(
+            repo.path(),
+            &validated,
+            Some("docker.io/myorg/my-role:latest"),
+        )
+        .unwrap();
+
+        let contents = std::fs::read_to_string(&build.dockerfile_path).unwrap();
+        assert!(contents.starts_with("FROM docker.io/myorg/my-role:latest\n"));
+        assert!(!contents.contains("projectjackin/construct:trixie"));
     }
 
     #[cfg(unix)]
@@ -448,7 +483,7 @@ plugins = []
         .unwrap();
 
         let validated = crate::repo::validate_role_repo(repo.path()).unwrap();
-        let error = create_derived_build_context(repo.path(), &validated)
+        let error = create_derived_build_context(repo.path(), &validated, None)
             .expect_err("symlinks should be rejected");
 
         assert!(error.to_string().contains("symlink"));

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -9,6 +9,12 @@ pub mod validate;
 #[serde(deny_unknown_fields)]
 pub struct RoleManifest {
     pub dockerfile: String,
+    /// Pre-built Docker image published to a registry. When set, `jackin
+    /// console` pulls this image and layers only the agent install on top,
+    /// skipping the full workspace Dockerfile build. Pass `--rebuild` to
+    /// force a local rebuild from the Dockerfile instead.
+    #[serde(default)]
+    pub published_image: Option<String>,
     #[serde(default)]
     pub identity: Option<IdentityConfig>,
     /// Top-level list of supported agents. `None` means the field
@@ -375,6 +381,46 @@ plugins = []
         let manifest = RoleManifest::load(temp.path()).unwrap();
 
         assert_eq!(manifest.display_name("agent-smith"), "agent-smith");
+    }
+
+    #[test]
+    fn loads_manifest_with_published_image() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+published_image = "docker.io/myorg/my-role:latest"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let manifest = RoleManifest::load(temp.path()).unwrap();
+
+        assert_eq!(
+            manifest.published_image.as_deref(),
+            Some("docker.io/myorg/my-role:latest")
+        );
+    }
+
+    #[test]
+    fn loads_manifest_without_published_image() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let manifest = RoleManifest::load(temp.path()).unwrap();
+
+        assert!(manifest.published_image.is_none());
     }
 
     #[test]

--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -23,10 +23,24 @@ pub(super) fn build_agent_image(
     runner: &mut impl CommandRunner,
     repo_lock: std::fs::File,
 ) -> anyhow::Result<String> {
+    // Decide the build mode up front.
+    //
+    // Pre-built mode: the manifest declares a `published_image` and the
+    // caller has not passed `--rebuild`. The heavy workspace layers (apt
+    // installs, Rust toolchain, etc.) are already baked into that image; we
+    // only need to layer the agent install on top.
+    //
+    // Workspace mode: either `--rebuild` was requested or no `published_image`
+    // is declared. We build from the workspace Dockerfile from scratch.
+    let published_image = validated_repo.manifest.published_image.as_deref();
+    let use_prebuilt = published_image.is_some() && !rebuild;
+    let base_image_override = use_prebuilt.then(|| published_image.unwrap());
+
     // create_derived_build_context copies the repo into a temp directory,
     // creating an immutable snapshot.  After this point the shared cached
     // repo can be safely modified by a parallel load.
-    let build = create_derived_build_context(&cached_repo.repo_dir, validated_repo)?;
+    let build =
+        create_derived_build_context(&cached_repo.repo_dir, validated_repo, base_image_override)?;
     drop(repo_lock);
 
     if debug {
@@ -48,13 +62,13 @@ pub(super) fn build_agent_image(
     // Always pass the cache-bust arg so Docker matches the correct layer.
     //
     // When rebuilding (update available / --rebuild), generate a fresh
-    // timestamp to invalidate the cached Claude Code install layer, and
-    // persist it so subsequent non-rebuild builds reuse the same layer.
+    // timestamp to invalidate the cached agent install layer, and persist it
+    // so subsequent non-rebuild builds reuse the same layer.
     //
     // When NOT rebuilding, replay the stored bust value.  Without this,
-    // Docker resolves the Dockerfile default `JACKIN_CACHE_BUST=0` and
-    // hits the original pre-bust layer, causing the installed Claude
-    // version to ping-pong between old and new on alternate launches.
+    // Docker resolves the Dockerfile default `JACKIN_CACHE_BUST=0` and hits
+    // the original pre-bust layer, causing the installed agent version to
+    // ping-pong between old and new on alternate launches.
     let cache_bust_value = if rebuild {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -69,17 +83,30 @@ pub(super) fn build_agent_image(
     let dockerfile_path = build.dockerfile_path.display().to_string();
     let context_dir = build.context_dir.display().to_string();
 
-    let mut build_args: Vec<&str> = vec![
-        "build",
-        "--pull",
-        "--build-arg",
-        &build_arg_uid,
-        "--build-arg",
-        &build_arg_gid,
-        "--build-arg",
-        &cache_bust,
-    ];
+    let mut build_args: Vec<&str> = vec!["build"];
+
+    // --pull semantics:
+    //
+    // Pre-built mode: pass --pull so Docker always checks the registry for an
+    // updated published image. A pull with an unchanged digest is a fast
+    // no-op, so this adds negligible overhead while ensuring the local daemon
+    // picks up any newly pushed workspace image.
+    //
+    // Workspace mode with --rebuild: pass --pull to refresh the upstream
+    // construct base before rebuilding from the workspace Dockerfile.
+    //
+    // Workspace mode without --rebuild (no published_image): omit --pull so
+    // Docker's layer cache is respected across invocations. The base image is
+    // not re-evaluated and heavy apt / toolchain layers stay cached.
+    if use_prebuilt || rebuild {
+        build_args.push("--pull");
+    }
+
+    build_args.extend(["--build-arg", &build_arg_uid]);
+    build_args.extend(["--build-arg", &build_arg_gid]);
+    build_args.extend(["--build-arg", &cache_bust]);
     build_args.extend(["-t", &image, "-f", &dockerfile_path, &context_dir]);
+
     runner.run(
         "docker",
         &build_args,

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -2274,7 +2274,8 @@ model = "gpt-5"
             .iter()
             .find(|call| call.contains("docker build "))
             .unwrap();
-        assert!(build_cmd.contains("--pull"));
+        // No published_image and no --rebuild → workspace mode without --pull
+        assert!(!build_cmd.contains("--pull"));
 
         let run_cmd = runner
             .recorded
@@ -2490,6 +2491,198 @@ plugins = []
                 .run_recorded
                 .iter()
                 .any(|call| call.contains("docker build "))
+        );
+    }
+
+    #[test]
+    fn load_agent_omits_pull_flag_in_normal_workspace_build() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([String::new()]);
+
+        let repo_dir = paths.roles_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        load_role(
+            &paths,
+            &mut config,
+            &selector,
+            &repo_workspace(&repo_dir),
+            &mut runner,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+
+        let build_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker build "))
+            .unwrap();
+        assert!(
+            !build_cmd.contains("--pull"),
+            "workspace mode without --rebuild must not pass --pull"
+        );
+    }
+
+    #[test]
+    fn load_agent_passes_pull_flag_when_rebuild() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([String::new()]);
+
+        let repo_dir = paths.roles_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        load_role(
+            &paths,
+            &mut config,
+            &selector,
+            &repo_workspace(&repo_dir),
+            &mut runner,
+            &LoadOptions {
+                rebuild: true,
+                ..LoadOptions::default()
+            },
+        )
+        .unwrap();
+
+        let build_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker build "))
+            .unwrap();
+        assert!(
+            build_cmd.contains("--pull"),
+            "--rebuild must pass --pull to refresh the base image"
+        );
+    }
+
+    #[test]
+    fn load_agent_passes_pull_flag_with_published_image() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([String::new()]);
+
+        let repo_dir = paths.roles_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+published_image = "docker.io/myorg/my-role:latest"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        load_role(
+            &paths,
+            &mut config,
+            &selector,
+            &repo_workspace(&repo_dir),
+            &mut runner,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+
+        let build_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker build "))
+            .unwrap();
+        assert!(
+            build_cmd.contains("--pull"),
+            "pre-built image mode must pass --pull to check for registry updates"
+        );
+        // DerivedDockerfile must use the published image, not the workspace FROM
+        assert!(!build_cmd.contains("projectjackin/construct:trixie"));
+    }
+
+    #[test]
+    fn load_agent_ignores_published_image_when_rebuild() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([String::new()]);
+
+        let repo_dir = paths.roles_dir.join("agent-smith");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+published_image = "docker.io/myorg/my-role:latest"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        load_role(
+            &paths,
+            &mut config,
+            &selector,
+            &repo_workspace(&repo_dir),
+            &mut runner,
+            &LoadOptions {
+                rebuild: true,
+                ..LoadOptions::default()
+            },
+        )
+        .unwrap();
+
+        // With --rebuild the workspace Dockerfile is used even when published_image is set.
+        // The DerivedDockerfile must contain the workspace FROM, not the published image.
+        let recorded = runner.recorded.join("\n");
+        assert!(
+            !recorded.contains("docker.io/myorg/my-role:latest"),
+            "--rebuild must bypass published_image and build from the workspace Dockerfile"
         );
     }
 

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -91,7 +91,8 @@ model = "gpt-5"
     )
     .unwrap();
     let validated = jackin::repo::validate_role_repo(&repo_dir).unwrap();
-    let build = jackin::derived_image::create_derived_build_context(&repo_dir, &validated).unwrap();
+    let build =
+        jackin::derived_image::create_derived_build_context(&repo_dir, &validated, None).unwrap();
     let dockerfile = std::fs::read_to_string(&build.dockerfile_path).unwrap();
     assert!(dockerfile.contains("claude.ai/install.sh"));
     assert!(dockerfile.contains("openai/codex/releases"));
@@ -127,7 +128,8 @@ model = "gpt-5"
         .iter()
         .find(|call| call.contains("docker build "))
         .expect("docker build should run");
-    assert!(build_cmd.contains("--pull"), "{build_cmd}");
+    // No published_image and no --rebuild → workspace mode; --pull is omitted
+    assert!(!build_cmd.contains("--pull"), "{build_cmd}");
 
     let run_cmd = runner
         .recorded


### PR DESCRIPTION
## Summary

- Adds optional \`published_image\` field to \`jackin.role.toml\`; when set, \`jackin console\` pulls the pre-built image and layers only the agent install on top — skipping the full workspace Dockerfile rebuild (apt packages, Rust toolchain, etc.)
- Fixes the unconditional \`--pull\` flag on every \`docker build\`: \`--pull\` is now only passed in pre-built image mode (to check the registry for updates) or on explicit \`--rebuild\` (to refresh the base construct image), so Docker's layer cache is respected on normal launches

## How it works

**Normal launch (\`jackin console\`):**
1. If \`published_image\` is set: builds a minimal DerivedDockerfile starting with \`FROM <published_image>\`, passes \`--pull\` so Docker checks for registry updates — heavy workspace layers never run locally
2. If no \`published_image\`: builds from the workspace Dockerfile without \`--pull\` so apt/toolchain layers stay cached across runs

**\`jackin console --rebuild\`:**
- Always builds from the workspace Dockerfile with \`--pull\` to refresh the base, regardless of \`published_image\`

**Claude/Codex version updates:**
- Handled as before via \`JACKIN_CACHE_BUST\` — only the agent install layer is invalidated, no full workspace rebuild

## Test plan

- [x] 1294 unit + integration tests pass (\`cargo test\`)
- [x] New tests: \`published_image\` manifest parsing, \`base_image_override\` in DerivedDockerfile, \`--pull\` present/absent under each build mode, \`--rebuild\` bypassing \`published_image\`