### PR TITLE
fix(agent): harden Codex CLI install — root user, pipefail, atomic write

### DIFF
--- a/src/agent/profile.rs
+++ b/src/agent/profile.rs
@@ -30,7 +30,7 @@ RUN claude --version
 ";
 
 const CODEX_INSTALL_BLOCK: &str = "\
-USER agent
+USER root
 ARG JACKIN_CACHE_BUST=0
 ARG TARGETARCH
 RUN set -eux; \\
@@ -51,9 +51,10 @@ RUN set -eux; \\
       v[0-9]*|rust-v[0-9]*) ;; \\
       *) echo \"unexpected codex release tag format: ${TAG}\"; exit 1 ;; \\
     esac; \\
-    curl -fsSL \"https://github.com/openai/codex/releases/download/${TAG}/codex-${ARCH}.tar.gz\" \\
-      | tar -xz -C /usr/local/bin; \\
-    chmod +x /usr/local/bin/codex; \\
+    ASSET=\"codex-${ARCH}\"; \\
+    curl -fsSL \"https://github.com/openai/codex/releases/download/${TAG}/${ASSET}.tar.gz\" \\
+      | tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex; \\
+    chmod 0755 /usr/local/bin/codex; \\
     mkdir -p /etc/jackin && codex --version > /etc/jackin/codex.version
 ";
 
@@ -87,5 +88,17 @@ mod tests {
         assert_eq!(p.required_env, vec!["OPENAI_API_KEY"]);
         assert!(p.install_block.contains("openai/codex/releases"));
         assert!(p.install_block.contains("TARGETARCH"));
+    }
+
+    #[test]
+    fn codex_profile_installs_cli_as_root_with_current_archive_layout() {
+        let p = profile(Agent::Codex);
+        assert!(p.install_block.starts_with("USER root\n"));
+        assert!(p.install_block.contains("ASSET=\"codex-${ARCH}\""));
+        assert!(
+            p.install_block
+                .contains("tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex")
+        );
+        assert!(p.install_block.contains("/etc/jackin/codex.version"));
     }
 }

--- a/src/agent/profile.rs
+++ b/src/agent/profile.rs
@@ -33,7 +33,7 @@ const CODEX_INSTALL_BLOCK: &str = "\
 USER root
 ARG JACKIN_CACHE_BUST=0
 ARG TARGETARCH
-RUN set -eux; \\
+RUN set -euxo pipefail; \\
     : \"${JACKIN_CACHE_BUST}\"; \\
     case \"${TARGETARCH:-amd64}\" in \\
       amd64) ARCH=x86_64-unknown-linux-musl ;; \\
@@ -53,8 +53,9 @@ RUN set -eux; \\
     esac; \\
     ASSET=\"codex-${ARCH}\"; \\
     curl -fsSL \"https://github.com/openai/codex/releases/download/${TAG}/${ASSET}.tar.gz\" \\
-      | tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex; \\
-    chmod 0755 /usr/local/bin/codex; \\
+      | tar -xzf - -O \"${ASSET}\" > /tmp/codex.bin; \\
+    chmod 0755 /tmp/codex.bin; \\
+    mv /tmp/codex.bin /usr/local/bin/codex; \\
     mkdir -p /etc/jackin && codex --version > /etc/jackin/codex.version
 ";
 
@@ -94,10 +95,19 @@ mod tests {
     fn codex_profile_installs_cli_as_root_with_current_archive_layout() {
         let p = profile(Agent::Codex);
         assert!(p.install_block.starts_with("USER root\n"));
+        assert!(p.install_block.contains("set -euxo pipefail"));
+        assert!(p.install_block.contains("${TARGETARCH:-amd64}"));
+        assert!(p.install_block.contains("x86_64-unknown-linux-musl"));
+        assert!(p.install_block.contains("aarch64-unknown-linux-musl"));
         assert!(p.install_block.contains("ASSET=\"codex-${ARCH}\""));
         assert!(
             p.install_block
-                .contains("tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex")
+                .contains("tar -xzf - -O \"${ASSET}\" > /tmp/codex.bin")
+        );
+        assert!(p.install_block.contains("chmod 0755 /tmp/codex.bin"));
+        assert!(
+            p.install_block
+                .contains("mv /tmp/codex.bin /usr/local/bin/codex")
         );
         assert!(p.install_block.contains("/etc/jackin/codex.version"));
     }

--- a/src/agent/profile.rs
+++ b/src/agent/profile.rs
@@ -33,29 +33,29 @@ const CODEX_INSTALL_BLOCK: &str = "\
 USER root
 ARG JACKIN_CACHE_BUST=0
 ARG TARGETARCH
-RUN set -euxo pipefail; \\
-    : \"${JACKIN_CACHE_BUST}\"; \\
+RUN set -euxo pipefail && \\
+    : \"${JACKIN_CACHE_BUST}\" && \\
     case \"${TARGETARCH:-amd64}\" in \\
       amd64) ARCH=x86_64-unknown-linux-musl ;; \\
       arm64) ARCH=aarch64-unknown-linux-musl ;; \\
       *) echo \"unsupported arch ${TARGETARCH}\"; exit 1 ;; \\
-    esac; \\
+    esac && \\
     TAG=$(curl -sfIL -o /dev/null -w '%{url_effective}' \\
             https://github.com/openai/codex/releases/latest \\
-          | sed 's|.*/tag/||'); \\
+          | sed 's|.*/tag/||') && \\
     if [ -z \"${TAG}\" ]; then \\
-      echo \"failed to resolve codex release tag — GitHub redirect format may have changed\"; \\
+      echo \"failed to resolve codex release tag — GitHub redirect format may have changed\" && \\
       exit 1; \\
-    fi; \\
+    fi && \\
     case \"${TAG}\" in \\
       v[0-9]*|rust-v[0-9]*) ;; \\
       *) echo \"unexpected codex release tag format: ${TAG}\"; exit 1 ;; \\
-    esac; \\
-    ASSET=\"codex-${ARCH}\"; \\
+    esac && \\
+    ASSET=\"codex-${ARCH}\" && \\
     curl -fsSL \"https://github.com/openai/codex/releases/download/${TAG}/${ASSET}.tar.gz\" \\
-      | tar -xzf - -O \"${ASSET}\" > /tmp/codex.bin; \\
-    chmod 0755 /tmp/codex.bin; \\
-    mv /tmp/codex.bin /usr/local/bin/codex; \\
+      | tar -xzf - -O \"${ASSET}\" > /tmp/codex.bin && \\
+    chmod 0755 /tmp/codex.bin && \\
+    mv /tmp/codex.bin /usr/local/bin/codex && \\
     mkdir -p /etc/jackin && codex --version > /etc/jackin/codex.version
 ";
 

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -263,7 +263,7 @@ mod tests {
 
         assert!(dockerfile.contains("https://claude.ai/install.sh"));
         assert!(dockerfile.contains("openai/codex/releases"));
-        // Claude block precedes Codex (cache-bust ordering).
+        // Claude block precedes Codex: stable ordering for deterministic Dockerfile output.
         let claude_pos = dockerfile.find("claude.ai/install.sh").unwrap();
         let codex_pos = dockerfile.find("openai/codex/releases").unwrap();
         assert!(claude_pos < codex_pos);
@@ -278,10 +278,29 @@ mod tests {
         );
 
         let codex_block_pos = dockerfile.find("ASSET=\"codex-${ARCH}\"").unwrap();
+        // rfind finds the most recent USER directive before the Codex install
+        // block — must be root, not agent.
         let root_pos = dockerfile[..codex_block_pos].rfind("USER root\n").unwrap();
         assert!(root_pos < codex_block_pos);
-        assert!(dockerfile.contains("tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex"));
+        assert!(dockerfile.contains("set -euxo pipefail"));
+        assert!(dockerfile.contains("tar -xzf - -O \"${ASSET}\" > /tmp/codex.bin"));
+        assert!(dockerfile.contains("mv /tmp/codex.bin /usr/local/bin/codex"));
         assert!(!dockerfile.contains("tar -xz -C /usr/local/bin"));
+    }
+
+    #[test]
+    fn renders_codex_only_dockerfile_final_user_is_agent() {
+        let dockerfile = render_derived_dockerfile(
+            "FROM projectjackin/construct:trixie\n",
+            None,
+            &[Agent::Codex],
+        );
+        let last_user = dockerfile
+            .lines()
+            .filter(|l| l.starts_with("USER "))
+            .last()
+            .unwrap();
+        assert_eq!(last_user, "USER agent");
     }
 
     #[test]

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -270,6 +270,21 @@ mod tests {
     }
 
     #[test]
+    fn renders_codex_install_as_root_without_extracting_directly_to_bin() {
+        let dockerfile = render_derived_dockerfile(
+            "FROM projectjackin/construct:trixie\n",
+            None,
+            &[Agent::Codex],
+        );
+
+        let codex_block_pos = dockerfile.find("ASSET=\"codex-${ARCH}\"").unwrap();
+        let root_pos = dockerfile[..codex_block_pos].rfind("USER root\n").unwrap();
+        assert!(root_pos < codex_block_pos);
+        assert!(dockerfile.contains("tar -xzf - -O \"${ASSET}\" > /usr/local/bin/codex"));
+        assert!(!dockerfile.contains("tar -xz -C /usr/local/bin"));
+    }
+
+    #[test]
     fn renders_codex_only_dockerfile_without_claude_install() {
         let dockerfile = render_derived_dockerfile(
             "FROM projectjackin/construct:trixie\n",


### PR DESCRIPTION
## Summary

- Fix permission bug: switch Codex install block from \`USER agent\` to \`USER root\` so writes to \`/usr/local/bin\` and \`/etc/jackin/codex.version\` succeed
- Fix archive layout bug: Codex release tarballs contain \`codex-<arch>\` (e.g. \`codex-aarch64-unknown-linux-musl\`), not a bare \`codex\` member; extract by name via \`tar -O\`
- Harden with \`set -euxo pipefail\` so a failed \`curl\` in the pipe is no longer invisible to \`errexit\`
- Atomic write: stage binary to \`/tmp/codex.bin\` then \`mv\` to final path so a partial-write on failure never lands at \`/usr/local/bin/codex\`
- Switch command separators from \`; \\\` to \`&& \\\` throughout the install block
- Expand test coverage: pipefail, TARGETARCH default, both arch target triples, atomic write path, \`chmod\`, \`mv\`, and a new test verifying the final \`USER\` directive is always \`agent\` in a Codex-only Dockerfile
- Fix misleading test comment: "cache-bust ordering" → "stable ordering for deterministic Dockerfile output"

## Root Cause

The derived Dockerfile switched to \`USER agent\` before the Codex install step, then attempted to extract directly into \`/usr/local/bin\` and write \`/etc/jackin/codex.version\`. Current Codex release archives contain an architecture-named binary (\`codex-aarch64-unknown-linux-musl\`), not a member named \`codex\`. Additionally, \`set -eux\` without \`pipefail\` allowed a failed \`curl\` to go undetected, and writing directly to the final binary path risked leaving a partial file on failure.

## Verification

Confirmed: both \`codex-aarch64-unknown-linux-musl.tar.gz\` and \`codex-x86_64-unknown-linux-musl.tar.gz\` from the latest release contain exactly one member matching \`codex-\${ARCH}\` — the \`ASSET\` name and \`tar -O\` invocation are correct.

- \`git diff --check\`
- \`cargo fmt -- --check\`
- \`cargo clippy -- -D warnings\`
- \`cargo nextest run\` — 1285 tests pass (outside sandbox because caffeinate tests execute ps)