### PR TITLE
fix(isolation): adopt stale scratch branch instead of failing materialization

### DIFF
--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -291,26 +291,50 @@ pub fn ensure_worktree_config_enabled(
     Ok(true)
 }
 
-/// Look up the tip SHA of `refs/heads/<branch>` in the host repo at
-/// `repo` via a filesystem probe (loose ref then `packed-refs`).
-/// `None` means the branch is absent; `Some(sha)` lets the caller
-/// skip a follow-up `git rev-parse` subprocess on the adopt path.
-///
-/// Filesystem probe rather than `git show-ref` keeps the
-/// `CommandRunner` capture queue stable across tests: every existing
-/// test would otherwise have to script another runner interaction
-/// just to declare "no scratch branch yet". Ref storage is
-/// files-backed in the configurations jackin supports.
+/// Filesystem probe (loose ref then `packed-refs`) rather than `git
+/// show-ref` to keep the test `CommandRunner` capture queue stable.
 fn find_local_branch_tip(repo: &str, branch: &str) -> Option<String> {
     let git_dir = std::path::Path::new(repo).join(".git");
     let mut loose = git_dir.join("refs").join("heads");
     for segment in branch.split('/') {
         loose = loose.join(segment);
     }
-    if let Ok(contents) = std::fs::read_to_string(&loose) {
-        let sha = contents.trim();
-        if !sha.is_empty() {
-            return Some(sha.to_string());
+    match std::fs::read_to_string(&loose) {
+        Ok(contents) => {
+            let sha = contents.trim();
+            // Symref content (`ref: refs/heads/foo`) and a 0-byte
+            // ref file are pathological local states that would
+            // otherwise be returned verbatim and poison the
+            // `IsolationRecord.base_commit` SHA field. Fall through
+            // to packed-refs and (failing that) `None` so the caller
+            // takes the fresh `-b` path; git will surface its own
+            // error if the branch genuinely does exist somewhere
+            // unreadable.
+            if sha.is_empty() {
+                debug_log!(
+                    "isolation",
+                    "find_local_branch_tip: loose ref {loose} present but empty — treating as missing",
+                    loose = loose.display(),
+                );
+            } else if sha.starts_with("ref:") {
+                debug_log!(
+                    "isolation",
+                    "find_local_branch_tip: loose ref {loose} is a symref ({sha}) — treating as missing",
+                    loose = loose.display(),
+                );
+            } else {
+                return Some(sha.to_string());
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            // Permission / EIO / non-UTF-8: surface so --debug
+            // correlates with the later worktree-add failure.
+            debug_log!(
+                "isolation",
+                "find_local_branch_tip: read {loose} failed: {e}",
+                loose = loose.display(),
+            );
         }
     }
     let packed = git_dir.join("packed-refs");
@@ -318,10 +342,6 @@ fn find_local_branch_tip(repo: &str, branch: &str) -> Option<String> {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
         Err(e) => {
-            // Surface non-ENOENT errors (permission, EIO) so an
-            // operator running with `--debug` sees why the probe
-            // returned `None` and can correlate with the
-            // subsequent `git worktree add` failure.
             debug_log!(
                 "isolation",
                 "find_local_branch_tip: read {packed} failed: {e}",
@@ -335,7 +355,7 @@ fn find_local_branch_tip(repo: &str, branch: &str) -> Option<String> {
         if line.starts_with('#') || line.starts_with('^') {
             continue;
         }
-        let Some((sha, refname)) = line.split_once(' ') else {
+        let Some((sha, refname)) = line.split_once(char::is_whitespace) else {
             continue;
         };
         if refname.trim() == want {
@@ -656,12 +676,13 @@ fn materialize_one(
             .with_context(|| format!("create parent dir for worktree at {}", parent.display()))?;
     }
 
-    // Adopt path: when the scratch branch already exists but there is
-    // no isolation record, a prior run created the branch and crashed
-    // before persisting state. `worktree add -b` would refuse the
-    // duplicate name; reuse the branch (no `-b`) and record its tip
-    // as `base_commit` so finalize's "tip == base_commit ⇒ Safe"
-    // classifier still holds for an unmodified adopted worktree.
+    // `worktree add -b` rejects an existing branch; reuse it. Record
+    // `base_commit = host_head`, NOT branch tip: if a prior session
+    // committed work onto the scratch branch and the operator wiped
+    // the state dir, branch tip != host HEAD, and finalize routes
+    // through the upstream/[gone]/detached arms (fail-safe to
+    // PreservedUnpushed) instead of the `tip == base_commit ⇒ Safe`
+    // arm that would silently delete the work.
     let base_commit = if let Some(branch_tip) = find_local_branch_tip(&mount.src, &scratch_branch) {
         debug_log!(
             "isolation",
@@ -685,20 +706,29 @@ fn materialize_one(
             branch = scratch_branch,
             wt = worktree_path.display(),
         );
-        runner.run(
-            "git",
-            &[
-                "-C",
-                &mount.src,
-                "worktree",
-                "add",
-                &worktree_path.to_string_lossy(),
-                &scratch_branch,
-            ],
-            None,
-            &crate::docker::RunOptions::default(),
-        )?;
-        branch_tip
+        runner
+            .run(
+                "git",
+                &[
+                    "-C",
+                    &mount.src,
+                    "worktree",
+                    "add",
+                    &worktree_path.to_string_lossy(),
+                    &scratch_branch,
+                ],
+                None,
+                &crate::docker::RunOptions::default(),
+            )
+            .with_context(|| {
+                format!(
+                    "isolated mount `{}`: adopt of existing scratch branch `{}` failed; \
+                     if the branch is checked out in another worktree, \
+                     `git -C {} worktree list --porcelain` will show where",
+                    mount.dst, scratch_branch, mount.src,
+                )
+            })?;
+        host_head.clone()
     } else {
         debug_log!(
             "isolation",
@@ -1332,16 +1362,17 @@ mod tests {
     // logic in materialize is gone; coverage moves to
     // `workspace::tests::isolation_layout_rejects_two_worktree_mounts_on_same_repo`.
 
-    /// Write a loose ref under `<repo>/.git/refs/heads/<branch>` to
-    /// simulate a host repo that already has the scratch branch from
-    /// a prior interrupted materialization attempt.
-    fn write_loose_branch(repo: &std::path::Path, branch: &str, sha: &str) {
+    fn write_loose_branch(repo: &std::path::Path, branch: &str, content: &str) {
         let mut p = repo.join(".git").join("refs").join("heads");
         for seg in branch.split('/') {
             p = p.join(seg);
         }
         std::fs::create_dir_all(p.parent().unwrap()).unwrap();
-        std::fs::write(&p, format!("{sha}\n")).unwrap();
+        std::fs::write(&p, content).unwrap();
+    }
+
+    fn write_packed_refs(repo: &std::path::Path, contents: &str) {
+        std::fs::write(repo.join(".git").join("packed-refs"), contents).unwrap();
     }
 
     #[test]
@@ -1349,25 +1380,23 @@ mod tests {
         let repo = make_repo_root();
         let path = repo.path().to_string_lossy();
         assert_eq!(find_local_branch_tip(&path, "jackin/scratch/x"), None);
-        write_loose_branch(repo.path(), "jackin/scratch/x", "deadbeefcafe");
+        write_loose_branch(repo.path(), "jackin/scratch/x", "deadbeefcafe\n");
         assert_eq!(
             find_local_branch_tip(&path, "jackin/scratch/x"),
             Some("deadbeefcafe".into()),
-            "loose ref SHA should be returned without trailing newline",
         );
     }
 
     #[test]
     fn find_local_branch_tip_reads_packed_refs_sha() {
         let repo = make_repo_root();
-        std::fs::write(
-            repo.path().join(".git").join("packed-refs"),
+        write_packed_refs(
+            repo.path(),
             "# pack-refs with: peeled fully-peeled sorted\n\
              1111111111111111111111111111111111111111 refs/heads/main\n\
              2222222222222222222222222222222222222222 refs/heads/jackin/scratch/x\n\
              ^abcd1234abcd1234abcd1234abcd1234abcd1234\n",
-        )
-        .unwrap();
+        );
         let path = repo.path().to_string_lossy();
         assert_eq!(
             find_local_branch_tip(&path, "jackin/scratch/x"),
@@ -1376,10 +1405,72 @@ mod tests {
         assert_eq!(find_local_branch_tip(&path, "jackin/scratch/missing"), None);
     }
 
-    /// Recovery path: a prior run created the scratch branch but
-    /// never persisted the isolation record. The next materialization
-    /// must adopt the existing branch (no `-b`) instead of failing
-    /// with "a branch named '<scratch>' already exists".
+    #[test]
+    fn find_local_branch_tip_loose_ref_wins_over_packed_refs() {
+        // git semantics: loose refs override packed-refs entries.
+        // Critical because base_commit feeds finalize's safety
+        // classifier, and a wrong SHA there can authorize deletion
+        // of operator work.
+        let repo = make_repo_root();
+        write_loose_branch(repo.path(), "jackin/scratch/x", "1010101010101010\n");
+        write_packed_refs(
+            repo.path(),
+            "9999999999999999999999999999999999999999 refs/heads/jackin/scratch/x\n",
+        );
+        assert_eq!(
+            find_local_branch_tip(&repo.path().to_string_lossy(), "jackin/scratch/x"),
+            Some("1010101010101010".into()),
+        );
+    }
+
+    #[test]
+    fn find_local_branch_tip_rejects_symref_loose_content() {
+        // `git symbolic-ref refs/heads/<x> refs/heads/main` writes
+        // `ref: refs/heads/main\n`. Returning that verbatim as the
+        // SHA poisons IsolationRecord.base_commit.
+        let repo = make_repo_root();
+        write_loose_branch(repo.path(), "jackin/scratch/x", "ref: refs/heads/main\n");
+        assert_eq!(
+            find_local_branch_tip(&repo.path().to_string_lossy(), "jackin/scratch/x"),
+            None,
+        );
+    }
+
+    #[test]
+    fn find_local_branch_tip_empty_loose_falls_through_to_packed() {
+        // A 0-byte ref file (interrupted git op, third-party
+        // tooling) must not yield Some("") and must not block the
+        // packed-refs lookup.
+        let repo = make_repo_root();
+        write_loose_branch(repo.path(), "jackin/scratch/x", "");
+        write_packed_refs(
+            repo.path(),
+            "abcdef1234567890abcdef1234567890abcdef12 refs/heads/jackin/scratch/x\n",
+        );
+        assert_eq!(
+            find_local_branch_tip(&repo.path().to_string_lossy(), "jackin/scratch/x"),
+            Some("abcdef1234567890abcdef1234567890abcdef12".into()),
+        );
+    }
+
+    #[test]
+    fn find_local_branch_tip_skips_malformed_packed_refs_lines() {
+        let repo = make_repo_root();
+        write_packed_refs(
+            repo.path(),
+            "# header only\n\
+             ^abcd\n\
+             noseparator\n\
+             1111111111111111111111111111111111111111\trefs/heads/jackin/scratch/x\n",
+        );
+        // Tab-separated row also resolves (split_once now matches
+        // any ASCII whitespace, defensive against non-stock writers).
+        assert_eq!(
+            find_local_branch_tip(&repo.path().to_string_lossy(), "jackin/scratch/x"),
+            Some("1111111111111111111111111111111111111111".into()),
+        );
+    }
+
     #[test]
     fn stale_scratch_branch_is_adopted_when_record_absent() {
         let repo = make_repo_root();
@@ -1387,25 +1478,17 @@ mod tests {
         let container_dir = data.path().join("jackin-the-architect");
         std::fs::create_dir_all(&container_dir).unwrap();
 
-        // Simulate the leftover state: branch present in the host
-        // repo, no record file, no container worktree dir.
         write_loose_branch(
             repo.path(),
             "jackin/scratch/jackin-the-architect",
-            "feedbeefcafebabefeedbeefcafebabefeedbeef",
+            "feedbeefcafebabefeedbeefcafebabefeedbeef\n",
         );
 
         let resolved = resolved_with_one_isolated(repo.path(), "/workspace/jackin");
-        // Capture queue order — fake_with_outputs is positional; if you
-        // change this you must mirror the order materialize_workspace
-        // calls runner.capture():
-        //   preflight: rev-parse --show-toplevel
-        //   preflight: status --porcelain (clean)
-        //   ensure_worktree_config: extensions.worktreeConfig --get
-        //     ("true\n" → already enabled, format-version probe skipped)
-        //   rev-parse HEAD                             (host head)
-        // The adopted branch tip is read straight from the loose ref
-        // by find_local_branch_tip — no runner capture for it.
+        // fake_with_outputs is positional: order must match
+        // materialize_workspace's runner.capture() sequence.
+        // Adopted branch tip is read directly from the loose ref —
+        // no runner.capture() entry is consumed for it.
         let mut runner = fake_with_outputs(&[
             &repo.path().to_string_lossy(),
             "",
@@ -1430,40 +1513,40 @@ mod tests {
 
         assert_eq!(mat.mounts.len(), 1);
 
-        // `worktree prune` ran before the add (clears any orphan admin
-        // entries left by the interrupted prior run).
-        assert!(
-            runner
-                .run_recorded
-                .iter()
-                .any(|c| c.contains("worktree prune")),
-            "expected worktree prune in run_recorded; got {:?}",
-            runner.run_recorded,
-        );
-        // `worktree add` ran without `-b` (adopt mode) and named the
-        // existing branch as the last positional argument.
-        let add = runner
+        let prune_idx = runner
             .run_recorded
             .iter()
-            .find(|c| c.contains("worktree add"))
-            .expect("worktree add should have been invoked");
+            .position(|c| c.contains("worktree prune"))
+            .expect("worktree prune should be invoked on adopt");
+        let add_idx = runner
+            .run_recorded
+            .iter()
+            .position(|c| c.contains("worktree add"))
+            .expect("worktree add should be invoked");
         assert!(
-            !add.contains(" -b "),
-            "adopt path must not pass -b; got {add}",
+            prune_idx < add_idx,
+            "prune must run before add; got prune@{prune_idx} add@{add_idx}: {:?}",
+            runner.run_recorded,
+        );
+        let add = &runner.run_recorded[add_idx];
+        assert!(
+            !add.split_whitespace().any(|t| t == "-b" || t == "--branch"),
+            "adopt path must not pass -b/--branch; got {add}",
         );
         assert!(
-            add.contains("jackin/scratch/jackin-the-architect"),
-            "adopt add must reference the existing branch; got {add}",
+            add.ends_with(" jackin/scratch/jackin-the-architect"),
+            "adopt add must end with the existing branch as the last positional arg; got {add}",
         );
 
-        // Record persisted; base_commit is the adopted branch tip
-        // (matches finalize's "branch tip == base_commit ⇒ safe"
-        // policy when the operator never touched the worktree).
         let recs = read_records(&container_dir).unwrap();
         assert_eq!(recs.len(), 1);
+        // base_commit is host_head, NOT branch tip — see the comment
+        // above the adopt arm in materialize_one. Asserting the
+        // branch-tip value here would silently re-introduce the
+        // data-loss regression flagged in PR #219 review.
         assert_eq!(
-            recs[0].base_commit, "feedbeefcafebabefeedbeefcafebabefeedbeef",
-            "base_commit should be the adopted branch tip, not host HEAD",
+            recs[0].base_commit,
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
         );
         assert_eq!(
             recs[0].scratch_branch,
@@ -1471,11 +1554,54 @@ mod tests {
         );
     }
 
-    /// Mirror of the adopt test for the absent-branch case: when no
-    /// scratch branch exists in the host repo, materialization must
-    /// fall through the original `worktree add -b <branch> <path>
-    /// <host-head>` path. Guards against accidental regression of the
-    /// happy path while reworking the recovery branch above.
+    #[test]
+    fn adopt_aborts_when_worktree_prune_fails() {
+        // Prune failure must short-circuit before `worktree add`,
+        // otherwise the add proceeds against an inconsistent admin
+        // index and risks corrupting state.
+        let repo = make_repo_root();
+        let data = tempfile::TempDir::new().unwrap();
+        let container_dir = data.path().join("jackin-x");
+        std::fs::create_dir_all(&container_dir).unwrap();
+        write_loose_branch(repo.path(), "jackin/scratch/jackin-x", "abc123\n");
+        let resolved = resolved_with_one_isolated(repo.path(), "/workspace/jackin");
+        let mut runner = fake_with_outputs(&[
+            &repo.path().to_string_lossy(),
+            "",
+            "true\n",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
+        ]);
+        runner.fail_on.push("worktree prune".into());
+
+        let err = materialize_workspace(
+            &resolved,
+            &container_dir,
+            "x",
+            "jackin-x",
+            "jackin",
+            &PreflightContext {
+                workspace_name: "jackin".into(),
+                force: false,
+                interactive: false,
+            },
+            &mut runner,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("worktree prune"));
+        assert!(
+            !runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("worktree add")),
+            "worktree add must not run when prune fails; got {:?}",
+            runner.run_recorded,
+        );
+        assert!(
+            read_records(&container_dir).unwrap().is_empty(),
+            "no record on prune failure",
+        );
+    }
+
     #[test]
     fn fresh_materialization_uses_dash_b_when_branch_absent() {
         let repo = make_repo_root();
@@ -1508,18 +1634,20 @@ mod tests {
             .iter()
             .find(|c| c.contains("worktree add"))
             .expect("worktree add should have been invoked");
-        assert!(add.contains(" -b "), "fresh path must use -b; got {add}");
+        assert!(
+            add.split_whitespace().any(|t| t == "-b"),
+            "fresh path must use -b; got {add}",
+        );
         assert!(
             !runner
                 .run_recorded
                 .iter()
                 .any(|c| c.contains("worktree prune")),
-            "fresh path must not run worktree prune (host repo side effect)",
         );
         let recs = read_records(&container_dir).unwrap();
         assert_eq!(
             recs[0].base_commit,
-            "cafef00dcafef00dcafef00dcafef00dcafef00d"
+            "cafef00dcafef00dcafef00dcafef00dcafef00d",
         );
     }
 

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -291,54 +291,58 @@ pub fn ensure_worktree_config_enabled(
     Ok(true)
 }
 
-/// Probe whether `branch` exists in the host repo at `repo`. Used to
-/// decide whether `git worktree add` should create a fresh branch
-/// (`-b`) or adopt an existing one (no `-b`).
+/// Look up the tip SHA of `refs/heads/<branch>` in the host repo at
+/// `repo` via a filesystem probe (loose ref then `packed-refs`).
+/// `None` means the branch is absent; `Some(sha)` lets the caller
+/// skip a follow-up `git rev-parse` subprocess on the adopt path.
 ///
-/// Filesystem probe rather than `git show-ref`: walks
-/// `<repo>/.git/refs/heads/<branch>` (loose ref) and falls back to
-/// `<repo>/.git/packed-refs`. Pure fs reads are cheap, side-effect
-/// free, and don't add a `CommandRunner` capture/run interaction that
-/// every existing test would have to script. jackin enables
-/// `extensions.worktreeConfig` on host repos (see
-/// `ensure_worktree_config_enabled`), but ref storage stays
-/// files-backed in the default git build, so this probe matches
-/// reality for the configurations jackin operates on.
-///
-/// Returns `false` on any read error — the subsequent `git worktree
-/// add` attempt will surface a clearer message if the repo is
-/// genuinely broken.
-fn branch_exists_in(repo: &str, branch: &str) -> bool {
+/// Filesystem probe rather than `git show-ref` keeps the
+/// `CommandRunner` capture queue stable across tests: every existing
+/// test would otherwise have to script another runner interaction
+/// just to declare "no scratch branch yet". Ref storage is
+/// files-backed in the configurations jackin supports.
+fn find_local_branch_tip(repo: &str, branch: &str) -> Option<String> {
     let git_dir = std::path::Path::new(repo).join(".git");
-    if !git_dir.exists() {
-        return false;
-    }
     let mut loose = git_dir.join("refs").join("heads");
     for segment in branch.split('/') {
         loose = loose.join(segment);
     }
-    if loose.is_file() {
-        return true;
+    if let Ok(contents) = std::fs::read_to_string(&loose) {
+        let sha = contents.trim();
+        if !sha.is_empty() {
+            return Some(sha.to_string());
+        }
     }
     let packed = git_dir.join("packed-refs");
-    let Ok(contents) = std::fs::read_to_string(&packed) else {
-        return false;
+    let contents = match std::fs::read_to_string(&packed) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            // Surface non-ENOENT errors (permission, EIO) so an
+            // operator running with `--debug` sees why the probe
+            // returned `None` and can correlate with the
+            // subsequent `git worktree add` failure.
+            debug_log!(
+                "isolation",
+                "find_local_branch_tip: read {packed} failed: {e}",
+                packed = packed.display(),
+            );
+            return None;
+        }
     };
     let want = format!("refs/heads/{branch}");
     for line in contents.lines() {
-        // `# pack-refs with: ...` headers and `^<sha>` peel lines never
-        // carry a refname — skip them. Other lines have the form
-        // `<sha> <refname>`; the refname is whitespace-separated.
         if line.starts_with('#') || line.starts_with('^') {
             continue;
         }
-        if let Some((_, refname)) = line.split_once(' ')
-            && refname.trim() == want
-        {
-            return true;
+        let Some((sha, refname)) = line.split_once(' ') else {
+            continue;
+        };
+        if refname.trim() == want {
+            return Some(sha.trim().to_string());
         }
     }
-    false
+    None
 }
 
 use crate::workspace::MountConfig;
@@ -652,30 +656,20 @@ fn materialize_one(
             .with_context(|| format!("create parent dir for worktree at {}", parent.display()))?;
     }
 
-    // Recovery path: when no isolation record exists but the scratch
-    // branch is already present in the host repo, a prior run of this
-    // container partially materialized — created the branch, then
-    // crashed before persisting the record (or had its state directory
-    // wiped manually). `git worktree add -b` would refuse with "a
-    // branch named '<scratch>' already exists" and leave the operator
-    // unable to launch the role at all. Adopt the existing branch
-    // instead: prune any orphan admin entries left behind, then run
-    // `worktree add` without `-b` so git checks out the existing branch
-    // into the fresh container worktree path. The branch tip becomes
-    // the lifecycle base_commit (matches finalize's "started here"
-    // invariant), preserving any work that may live on the branch.
-    let base_commit = if branch_exists_in(&mount.src, &scratch_branch) {
+    // Adopt path: when the scratch branch already exists but there is
+    // no isolation record, a prior run created the branch and crashed
+    // before persisting state. `worktree add -b` would refuse the
+    // duplicate name; reuse the branch (no `-b`) and record its tip
+    // as `base_commit` so finalize's "tip == base_commit ⇒ Safe"
+    // classifier still holds for an unmodified adopted worktree.
+    let base_commit = if let Some(branch_tip) = find_local_branch_tip(&mount.src, &scratch_branch) {
         debug_log!(
             "isolation",
-            "mount {dst}: scratch branch {branch} already exists in host repo (no isolation record); adopting (likely interrupted prior run)",
+            "mount {dst}: adopting existing scratch branch {branch} at tip {tip} (host HEAD {host}); pruning orphan admin entries first",
             dst = mount.dst,
             branch = scratch_branch,
-        );
-        debug_log!(
-            "isolation",
-            "mount {dst}: git -C {src} worktree prune",
-            dst = mount.dst,
-            src = mount.src,
+            tip = branch_tip,
+            host = host_head,
         );
         runner.run(
             "git",
@@ -683,26 +677,6 @@ fn materialize_one(
             None,
             &crate::docker::RunOptions::default(),
         )?;
-        let branch_tip = runner
-            .capture(
-                "git",
-                &[
-                    "-C",
-                    &mount.src,
-                    "rev-parse",
-                    &format!("refs/heads/{scratch_branch}"),
-                ],
-                None,
-            )?
-            .trim()
-            .to_string();
-        debug_log!(
-            "isolation",
-            "mount {dst}: adopted branch tip {tip} (host HEAD is {host})",
-            dst = mount.dst,
-            tip = branch_tip,
-            host = host_head,
-        );
         debug_log!(
             "isolation",
             "mount {dst}: git -C {src} worktree add {wt} {branch}",
@@ -1371,39 +1345,35 @@ mod tests {
     }
 
     #[test]
-    fn branch_exists_in_detects_loose_ref() {
+    fn find_local_branch_tip_reads_loose_ref_sha() {
         let repo = make_repo_root();
-        assert!(!branch_exists_in(
-            &repo.path().to_string_lossy(),
-            "jackin/scratch/x",
-        ));
-        write_loose_branch(repo.path(), "jackin/scratch/x", "deadbeef");
-        assert!(branch_exists_in(
-            &repo.path().to_string_lossy(),
-            "jackin/scratch/x",
-        ));
+        let path = repo.path().to_string_lossy();
+        assert_eq!(find_local_branch_tip(&path, "jackin/scratch/x"), None);
+        write_loose_branch(repo.path(), "jackin/scratch/x", "deadbeefcafe");
+        assert_eq!(
+            find_local_branch_tip(&path, "jackin/scratch/x"),
+            Some("deadbeefcafe".into()),
+            "loose ref SHA should be returned without trailing newline",
+        );
     }
 
     #[test]
-    fn branch_exists_in_detects_packed_ref() {
+    fn find_local_branch_tip_reads_packed_refs_sha() {
         let repo = make_repo_root();
-        let packed = repo.path().join(".git").join("packed-refs");
         std::fs::write(
-            &packed,
+            repo.path().join(".git").join("packed-refs"),
             "# pack-refs with: peeled fully-peeled sorted\n\
              1111111111111111111111111111111111111111 refs/heads/main\n\
              2222222222222222222222222222222222222222 refs/heads/jackin/scratch/x\n\
              ^abcd1234abcd1234abcd1234abcd1234abcd1234\n",
         )
         .unwrap();
-        assert!(branch_exists_in(
-            &repo.path().to_string_lossy(),
-            "jackin/scratch/x",
-        ));
-        assert!(!branch_exists_in(
-            &repo.path().to_string_lossy(),
-            "jackin/scratch/missing",
-        ));
+        let path = repo.path().to_string_lossy();
+        assert_eq!(
+            find_local_branch_tip(&path, "jackin/scratch/x"),
+            Some("2222222222222222222222222222222222222222".into()),
+        );
+        assert_eq!(find_local_branch_tip(&path, "jackin/scratch/missing"), None);
     }
 
     /// Recovery path: a prior run created the scratch branch but
@@ -1426,19 +1396,21 @@ mod tests {
         );
 
         let resolved = resolved_with_one_isolated(repo.path(), "/workspace/jackin");
-        // Capture queue in `materialize_workspace` order:
+        // Capture queue order — fake_with_outputs is positional; if you
+        // change this you must mirror the order materialize_workspace
+        // calls runner.capture():
         //   preflight: rev-parse --show-toplevel
         //   preflight: status --porcelain (clean)
         //   ensure_worktree_config: extensions.worktreeConfig --get
-        //     ("true\n" → already enabled, format-version probe is skipped)
+        //     ("true\n" → already enabled, format-version probe skipped)
         //   rev-parse HEAD                             (host head)
-        //   rev-parse refs/heads/<scratch>             (adopted branch tip)
+        // The adopted branch tip is read straight from the loose ref
+        // by find_local_branch_tip — no runner capture for it.
         let mut runner = fake_with_outputs(&[
             &repo.path().to_string_lossy(),
             "",
             "true\n",
             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
-            "feedbeefcafebabefeedbeefcafebabefeedbeef\n",
         ]);
 
         let mat = materialize_workspace(

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -291,6 +291,56 @@ pub fn ensure_worktree_config_enabled(
     Ok(true)
 }
 
+/// Probe whether `branch` exists in the host repo at `repo`. Used to
+/// decide whether `git worktree add` should create a fresh branch
+/// (`-b`) or adopt an existing one (no `-b`).
+///
+/// Filesystem probe rather than `git show-ref`: walks
+/// `<repo>/.git/refs/heads/<branch>` (loose ref) and falls back to
+/// `<repo>/.git/packed-refs`. Pure fs reads are cheap, side-effect
+/// free, and don't add a `CommandRunner` capture/run interaction that
+/// every existing test would have to script. jackin enables
+/// `extensions.worktreeConfig` on host repos (see
+/// `ensure_worktree_config_enabled`), but ref storage stays
+/// files-backed in the default git build, so this probe matches
+/// reality for the configurations jackin operates on.
+///
+/// Returns `false` on any read error — the subsequent `git worktree
+/// add` attempt will surface a clearer message if the repo is
+/// genuinely broken.
+fn branch_exists_in(repo: &str, branch: &str) -> bool {
+    let git_dir = std::path::Path::new(repo).join(".git");
+    if !git_dir.exists() {
+        return false;
+    }
+    let mut loose = git_dir.join("refs").join("heads");
+    for segment in branch.split('/') {
+        loose = loose.join(segment);
+    }
+    if loose.is_file() {
+        return true;
+    }
+    let packed = git_dir.join("packed-refs");
+    let Ok(contents) = std::fs::read_to_string(&packed) else {
+        return false;
+    };
+    let want = format!("refs/heads/{branch}");
+    for line in contents.lines() {
+        // `# pack-refs with: ...` headers and `^<sha>` peel lines never
+        // carry a refname — skip them. Other lines have the form
+        // `<sha> <refname>`; the refname is whitespace-separated.
+        if line.starts_with('#') || line.starts_with('^') {
+            continue;
+        }
+        if let Some((_, refname)) = line.split_once(' ')
+            && refname.trim() == want
+        {
+            return true;
+        }
+    }
+    false
+}
+
 use crate::workspace::MountConfig;
 
 #[derive(Debug, Clone)]
@@ -567,15 +617,15 @@ fn materialize_one(
 
     let _ = ensure_worktree_config_enabled(std::path::Path::new(&mount.src), runner)?;
 
-    let base_commit = runner
+    let host_head = runner
         .capture("git", &["-C", &mount.src, "rev-parse", "HEAD"], None)?
         .trim()
         .to_string();
     debug_log!(
         "isolation",
-        "mount {dst}: base commit {commit} from host HEAD",
+        "mount {dst}: host HEAD {commit}",
         dst = mount.dst,
-        commit = base_commit,
+        commit = host_head,
     );
 
     // No per-mount branch suffix in V1: workspace validation rejects
@@ -602,30 +652,106 @@ fn materialize_one(
             .with_context(|| format!("create parent dir for worktree at {}", parent.display()))?;
     }
 
-    debug_log!(
-        "isolation",
-        "mount {dst}: git -C {src} worktree add -b {branch} {wt} {base}",
-        dst = mount.dst,
-        src = mount.src,
-        branch = scratch_branch,
-        wt = worktree_path.display(),
-        base = base_commit,
-    );
-    runner.run(
-        "git",
-        &[
-            "-C",
-            &mount.src,
-            "worktree",
-            "add",
-            "-b",
-            &scratch_branch,
-            &worktree_path.to_string_lossy(),
-            &base_commit,
-        ],
-        None,
-        &crate::docker::RunOptions::default(),
-    )?;
+    // Recovery path: when no isolation record exists but the scratch
+    // branch is already present in the host repo, a prior run of this
+    // container partially materialized — created the branch, then
+    // crashed before persisting the record (or had its state directory
+    // wiped manually). `git worktree add -b` would refuse with "a
+    // branch named '<scratch>' already exists" and leave the operator
+    // unable to launch the role at all. Adopt the existing branch
+    // instead: prune any orphan admin entries left behind, then run
+    // `worktree add` without `-b` so git checks out the existing branch
+    // into the fresh container worktree path. The branch tip becomes
+    // the lifecycle base_commit (matches finalize's "started here"
+    // invariant), preserving any work that may live on the branch.
+    let base_commit = if branch_exists_in(&mount.src, &scratch_branch) {
+        debug_log!(
+            "isolation",
+            "mount {dst}: scratch branch {branch} already exists in host repo (no isolation record); adopting (likely interrupted prior run)",
+            dst = mount.dst,
+            branch = scratch_branch,
+        );
+        debug_log!(
+            "isolation",
+            "mount {dst}: git -C {src} worktree prune",
+            dst = mount.dst,
+            src = mount.src,
+        );
+        runner.run(
+            "git",
+            &["-C", &mount.src, "worktree", "prune"],
+            None,
+            &crate::docker::RunOptions::default(),
+        )?;
+        let branch_tip = runner
+            .capture(
+                "git",
+                &[
+                    "-C",
+                    &mount.src,
+                    "rev-parse",
+                    &format!("refs/heads/{scratch_branch}"),
+                ],
+                None,
+            )?
+            .trim()
+            .to_string();
+        debug_log!(
+            "isolation",
+            "mount {dst}: adopted branch tip {tip} (host HEAD is {host})",
+            dst = mount.dst,
+            tip = branch_tip,
+            host = host_head,
+        );
+        debug_log!(
+            "isolation",
+            "mount {dst}: git -C {src} worktree add {wt} {branch}",
+            dst = mount.dst,
+            src = mount.src,
+            branch = scratch_branch,
+            wt = worktree_path.display(),
+        );
+        runner.run(
+            "git",
+            &[
+                "-C",
+                &mount.src,
+                "worktree",
+                "add",
+                &worktree_path.to_string_lossy(),
+                &scratch_branch,
+            ],
+            None,
+            &crate::docker::RunOptions::default(),
+        )?;
+        branch_tip
+    } else {
+        debug_log!(
+            "isolation",
+            "mount {dst}: git -C {src} worktree add -b {branch} {wt} {base}",
+            dst = mount.dst,
+            src = mount.src,
+            branch = scratch_branch,
+            wt = worktree_path.display(),
+            base = host_head,
+        );
+        runner.run(
+            "git",
+            &[
+                "-C",
+                &mount.src,
+                "worktree",
+                "add",
+                "-b",
+                &scratch_branch,
+                &worktree_path.to_string_lossy(),
+                &host_head,
+            ],
+            None,
+            &crate::docker::RunOptions::default(),
+        )?;
+        host_head
+    };
 
     upsert_record(
         container_state_dir,
@@ -1231,6 +1357,199 @@ mod tests {
     // (`validate_isolation_layout` rule 2). The corresponding suffix
     // logic in materialize is gone; coverage moves to
     // `workspace::tests::isolation_layout_rejects_two_worktree_mounts_on_same_repo`.
+
+    /// Write a loose ref under `<repo>/.git/refs/heads/<branch>` to
+    /// simulate a host repo that already has the scratch branch from
+    /// a prior interrupted materialization attempt.
+    fn write_loose_branch(repo: &std::path::Path, branch: &str, sha: &str) {
+        let mut p = repo.join(".git").join("refs").join("heads");
+        for seg in branch.split('/') {
+            p = p.join(seg);
+        }
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, format!("{sha}\n")).unwrap();
+    }
+
+    #[test]
+    fn branch_exists_in_detects_loose_ref() {
+        let repo = make_repo_root();
+        assert!(!branch_exists_in(
+            &repo.path().to_string_lossy(),
+            "jackin/scratch/x",
+        ));
+        write_loose_branch(repo.path(), "jackin/scratch/x", "deadbeef");
+        assert!(branch_exists_in(
+            &repo.path().to_string_lossy(),
+            "jackin/scratch/x",
+        ));
+    }
+
+    #[test]
+    fn branch_exists_in_detects_packed_ref() {
+        let repo = make_repo_root();
+        let packed = repo.path().join(".git").join("packed-refs");
+        std::fs::write(
+            &packed,
+            "# pack-refs with: peeled fully-peeled sorted\n\
+             1111111111111111111111111111111111111111 refs/heads/main\n\
+             2222222222222222222222222222222222222222 refs/heads/jackin/scratch/x\n\
+             ^abcd1234abcd1234abcd1234abcd1234abcd1234\n",
+        )
+        .unwrap();
+        assert!(branch_exists_in(
+            &repo.path().to_string_lossy(),
+            "jackin/scratch/x",
+        ));
+        assert!(!branch_exists_in(
+            &repo.path().to_string_lossy(),
+            "jackin/scratch/missing",
+        ));
+    }
+
+    /// Recovery path: a prior run created the scratch branch but
+    /// never persisted the isolation record. The next materialization
+    /// must adopt the existing branch (no `-b`) instead of failing
+    /// with "a branch named '<scratch>' already exists".
+    #[test]
+    fn stale_scratch_branch_is_adopted_when_record_absent() {
+        let repo = make_repo_root();
+        let data = tempfile::TempDir::new().unwrap();
+        let container_dir = data.path().join("jackin-the-architect");
+        std::fs::create_dir_all(&container_dir).unwrap();
+
+        // Simulate the leftover state: branch present in the host
+        // repo, no record file, no container worktree dir.
+        write_loose_branch(
+            repo.path(),
+            "jackin/scratch/jackin-the-architect",
+            "feedbeefcafebabefeedbeefcafebabefeedbeef",
+        );
+
+        let resolved = resolved_with_one_isolated(repo.path(), "/workspace/jackin");
+        // Capture queue in `materialize_workspace` order:
+        //   preflight: rev-parse --show-toplevel
+        //   preflight: status --porcelain (clean)
+        //   ensure_worktree_config: extensions.worktreeConfig --get
+        //     ("true\n" → already enabled, format-version probe is skipped)
+        //   rev-parse HEAD                             (host head)
+        //   rev-parse refs/heads/<scratch>             (adopted branch tip)
+        let mut runner = fake_with_outputs(&[
+            &repo.path().to_string_lossy(),
+            "",
+            "true\n",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n",
+            "feedbeefcafebabefeedbeefcafebabefeedbeef\n",
+        ]);
+
+        let mat = materialize_workspace(
+            &resolved,
+            &container_dir,
+            "the-architect",
+            "jackin-the-architect",
+            "jackin",
+            &PreflightContext {
+                workspace_name: "jackin".into(),
+                force: false,
+                interactive: false,
+            },
+            &mut runner,
+        )
+        .unwrap();
+
+        assert_eq!(mat.mounts.len(), 1);
+
+        // `worktree prune` ran before the add (clears any orphan admin
+        // entries left by the interrupted prior run).
+        assert!(
+            runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("worktree prune")),
+            "expected worktree prune in run_recorded; got {:?}",
+            runner.run_recorded,
+        );
+        // `worktree add` ran without `-b` (adopt mode) and named the
+        // existing branch as the last positional argument.
+        let add = runner
+            .run_recorded
+            .iter()
+            .find(|c| c.contains("worktree add"))
+            .expect("worktree add should have been invoked");
+        assert!(
+            !add.contains(" -b "),
+            "adopt path must not pass -b; got {add}",
+        );
+        assert!(
+            add.contains("jackin/scratch/jackin-the-architect"),
+            "adopt add must reference the existing branch; got {add}",
+        );
+
+        // Record persisted; base_commit is the adopted branch tip
+        // (matches finalize's "branch tip == base_commit ⇒ safe"
+        // policy when the operator never touched the worktree).
+        let recs = read_records(&container_dir).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(
+            recs[0].base_commit, "feedbeefcafebabefeedbeefcafebabefeedbeef",
+            "base_commit should be the adopted branch tip, not host HEAD",
+        );
+        assert_eq!(
+            recs[0].scratch_branch,
+            "jackin/scratch/jackin-the-architect",
+        );
+    }
+
+    /// Mirror of the adopt test for the absent-branch case: when no
+    /// scratch branch exists in the host repo, materialization must
+    /// fall through the original `worktree add -b <branch> <path>
+    /// <host-head>` path. Guards against accidental regression of the
+    /// happy path while reworking the recovery branch above.
+    #[test]
+    fn fresh_materialization_uses_dash_b_when_branch_absent() {
+        let repo = make_repo_root();
+        let data = tempfile::TempDir::new().unwrap();
+        let container_dir = data.path().join("jackin-x");
+        std::fs::create_dir_all(&container_dir).unwrap();
+        let resolved = resolved_with_one_isolated(repo.path(), "/workspace/jackin");
+        let mut runner = fake_with_outputs(&[
+            &repo.path().to_string_lossy(),
+            "",
+            "true\n",
+            "cafef00dcafef00dcafef00dcafef00dcafef00d\n",
+        ]);
+        materialize_workspace(
+            &resolved,
+            &container_dir,
+            "x",
+            "jackin-x",
+            "jackin",
+            &PreflightContext {
+                workspace_name: "jackin".into(),
+                force: false,
+                interactive: false,
+            },
+            &mut runner,
+        )
+        .unwrap();
+        let add = runner
+            .run_recorded
+            .iter()
+            .find(|c| c.contains("worktree add"))
+            .expect("worktree add should have been invoked");
+        assert!(add.contains(" -b "), "fresh path must use -b; got {add}");
+        assert!(
+            !runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("worktree prune")),
+            "fresh path must not run worktree prune (host repo side effect)",
+        );
+        let recs = read_records(&container_dir).unwrap();
+        assert_eq!(
+            recs[0].base_commit,
+            "cafef00dcafef00dcafef00dcafef00dcafef00d"
+        );
+    }
 
     #[test]
     fn docker_mount_order_is_length_ascending() {


### PR DESCRIPTION
## Summary

- `jackin load` failed with `fatal: a branch named 'jackin/scratch/<container>' already exists` whenever a prior run created the scratch branch in the host repo but crashed before persisting the per-container `IsolationRecord` (or had its state directory wiped). `materialize_one` always invoked `git worktree add -b`, which refuses an already-present branch — recovery required hand-deleting the stale ref.
- New recovery arm: filesystem probe of `<host>/.git/refs/heads/<branch>` (with a `packed-refs` fallback) decides whether the branch already exists. When present: run `git worktree prune` to clear orphan admin entries from the same interrupted run, then `git worktree add <wt> <branch>` (no `-b`) so git checks out the existing branch into the fresh container worktree path.
- **`base_commit` recorded on adopt = host HEAD**, NOT the adopted branch tip. The branch-tip choice would feed finalize's `tip == base_commit ⇒ Safe` classifier and silently authorize deletion of any commits the operator made onto the scratch branch before a state-dir wipe. Recording host HEAD instead routes a divergent branch through the upstream / `[gone]` / detached arms — fail-safe to `PreservedUnpushed` whenever tip differs from host HEAD.
- Fresh-create path (`-b <branch>`) is unchanged; only the branch-already-present arm diverges.
- The filesystem probe rejects pathological loose-ref content (empty file, symref `ref: refs/heads/foo`, non-ENOENT read errors) that would otherwise be returned verbatim and poison the recorded SHA. Each rejection emits a `--debug` line so an operator running with `--debug` can correlate a probe miss with a downstream `worktree add` failure. `packed-refs` row split uses `char::is_whitespace` so tab-separated rows from non-stock writers also resolve.
- Adopt-mode `worktree add` is wrapped in `with_context` naming the recovery scenario and pointing at `git worktree list --porcelain` — the most likely residual failure (branch already checked out elsewhere) gets a useful error trail instead of bare git stderr.

## Repro (from the bug report)

```
[jackin debug isolation] mount /Users/.../jackin-the-architect: git -C ... worktree add -b jackin/scratch/jackin-the-architect-clone-1 ...
fatal: a branch named 'jackin/scratch/jackin-the-architect-clone-1' already exists

  error: command failed: git -C /Users/.../jackin-the-architect worktree add -b jackin/scratch/jackin-the-architect-clone-1 ...
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test` — 1311 passed (8 new tests in `src/isolation/materialize.rs`):
  - `find_local_branch_tip_reads_loose_ref_sha`
  - `find_local_branch_tip_reads_packed_refs_sha`
  - `find_local_branch_tip_loose_ref_wins_over_packed_refs` — pins the git semantic that loose refs override packed entries
  - `find_local_branch_tip_rejects_symref_loose_content`
  - `find_local_branch_tip_empty_loose_falls_through_to_packed`
  - `find_local_branch_tip_skips_malformed_packed_refs_lines` — also covers tab-separated packed rows
  - `stale_scratch_branch_is_adopted_when_record_absent` — end-to-end via `materialize_workspace`: asserts `prune_idx < add_idx`, no `-b`/`--branch` token in the add invocation, persisted `base_commit == host_head`
  - `adopt_aborts_when_worktree_prune_fails` — pins prune-must-precede-add ordering
  - `fresh_materialization_uses_dash_b_when_branch_absent` — happy-path regression guard
- [x] `cargo test --test per_mount_isolation_e2e` — 1 passed (existing `materialize_then_clean_exit_removes_record_and_branch`, unaffected by the adopt-arm change)
- [ ] Smoke from the original repro: with the branch already present in `/Users/.../jackin-the-architect/.git/refs/heads/jackin/scratch/jackin-the-architect-clone-1` and no `IsolationRecord` for the container, `jackin --debug` proceeds past materialization; debug log shows `adopting existing scratch branch ... pruning orphan admin entries first`, `worktree prune`, then `worktree add <wt> <branch>` (no `-b`).

## Commit-by-commit walkthrough

1. `fix(isolation): adopt stale scratch branch instead of failing materialization` — initial fix: probe + adopt arm (with `base_commit = branch_tip`).
2. `refactor(isolation): lift branch tip out of probe and trim adopt-path noise` — return `Option<String>` from the probe so the adopt arm reuses the loose-ref SHA instead of spawning a follow-up `git rev-parse` subprocess.
3. `fix(isolation): apply PR #219 review — fail-safe base_commit + probe hardening` — review-fix commit. Switches `base_commit` on adopt to host HEAD (data-loss prevention), rejects symref/empty/error-read loose-ref content, adds `with_context` for the residual failure, and adds the 5 coverage tests above. Comments trimmed per project comment policy.

## Heads-up — pre-existing on `main`

`cargo clippy -- -D warnings` (the CI command) currently fails on `src/derived_image.rs:298` with the new-in-rust-1.95 `clippy::double_ended_iterator_last` lint (`.last()` → `.next_back()`). Untouched by this PR but will likely show on the CI run; worth a separate one-line fix.