### PR TITLE
fix(agent): Claude auto-update must refresh agent layer, not full rebuild

### DIFF
--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -19,6 +19,7 @@ pub(super) fn build_agent_image(
     host: &HostIdentity,
     agent: crate::agent::Agent,
     rebuild: bool,
+    agent_update: bool,
     debug: bool,
     runner: &mut impl CommandRunner,
     repo_lock: std::fs::File,
@@ -70,7 +71,7 @@ pub(super) fn build_agent_image(
     // Docker resolves the Dockerfile default `JACKIN_CACHE_BUST=0` and hits
     // the original pre-bust layer, causing the installed agent version to
     // ping-pong between old and new on alternate launches.
-    let cache_bust_value = if rebuild {
+    let cache_bust_value = if rebuild || agent_update {
         // System clock before UNIX_EPOCH is essentially impossible, but if it
         // happens we must not silently fall back to 0 — that collapses to the
         // Dockerfile's `JACKIN_CACHE_BUST=0` default and defeats the operator's

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -996,12 +996,13 @@ fn load_role_with(
 
     let load_result = (|| -> anyhow::Result<String> {
         // Step 2: Build Docker image
-        let rebuild = opts.rebuild || {
+        let rebuild = opts.rebuild;
+        let agent_update = !rebuild && {
             let img = image_name(selector);
             let needs_update = agent == crate::agent::Agent::Claude
                 && version_check::needs_claude_update(paths, &img, runner);
             if needs_update {
-                eprintln!("        Claude update available — rebuilding image");
+                eprintln!("        Claude update available — refreshing agent layer");
             }
             needs_update
         };
@@ -1014,6 +1015,7 @@ fn load_role_with(
             &host,
             agent,
             rebuild,
+            agent_update,
             opts.debug,
             runner,
             repo_lock,


### PR DESCRIPTION
## Summary

- `needs_claude_update()` previously set `rebuild = true`, which disabled `use_prebuilt` mode — Docker rebuilt the entire image from the workspace Dockerfile, blowing away the cached heavy layers (apt installs, Rust toolchain, etc.)
- Split `rebuild` (explicit `--rebuild` flag only) from `agent_update` (auto-detected Claude version change)
- Auto-update now keeps `use_prebuilt = true`; only busts `JACKIN_CACHE_BUST` to reinstall the agent layer on top of the prebuilt image
- Full rebuild from scratch only happens when operator explicitly passes `--rebuild`
- Updated status message: "refreshing agent layer" (was "rebuilding image")

## Test plan

- [ ] All 1440 existing tests pass (`cargo nextest run`)
- [ ] Launch without `--rebuild` when Claude version is stale → Docker build uses prebuilt image as base, only agent install layer runs
- [ ] Launch with `--rebuild` → full rebuild from workspace Dockerfile as before
- [ ] Launch when Claude version is current → no rebuild at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)