### PR TITLE
feat(auth): layered auth config + Environments-style Auth tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased]
-
-### Changed
-
-- **BREAKING.** Auth-forward configuration moved out of `[roles.<role>.claude]` and into per-agent blocks at three layers (`[claude]` global, `[workspaces.<ws>.claude]`, `[workspaces.<ws>.roles.<role>.claude]`). The same shape now exists for `[codex]`. Stale configs that still set `[roles.<role>.claude]` fail to parse with the standard "unknown field" error. No migration shim — see AGENTS.md "Project status: pre-release".
-- New `api_key` mode for both Claude and Codex (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the env layer).
-- `Token` mode renamed to `oauth_token`. The deprecated `"copy"` alias is removed.
-- The `jackin config auth set --role` flag is removed; the new layered overrides are configured via the TUI Auth panel (or hand-edited TOML).
-
-### Added
-
-- Auth panel in the workspace-manager TUI, peer to the Secrets tab. Lets operators set the mode per (workspace × role × agent) with 1Password integration and form-level validation that prevents saving a mode without a resolved credential.
-- Structured `LaunchError::AuthCredentialMissing` with full mode-resolution and env-layer-state arrays for clear diagnostic output when a launch fails because the required credential isn't set.
-- 1Password picker integration in the auth form: picking a reference triggers `op read` validation before commit; broken references never reach disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased]
+
+### Changed
+
+- **BREAKING.** Auth-forward configuration moved out of `[roles.<role>.claude]` and into per-agent blocks at three layers (`[claude]` global, `[workspaces.<ws>.claude]`, `[workspaces.<ws>.roles.<role>.claude]`). The same shape now exists for `[codex]`. Stale configs that still set `[roles.<role>.claude]` fail to parse with the standard "unknown field" error. No migration shim — see AGENTS.md "Project status: pre-release".
+- New `api_key` mode for both Claude and Codex (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the env layer).
+- `Token` mode renamed to `oauth_token`. The deprecated `"copy"` alias is removed.
+- The `jackin config auth set --role` flag is removed; the new layered overrides are configured via the TUI Auth panel (or hand-edited TOML).
+
+### Added
+
+- Auth panel in the workspace-manager TUI, peer to the Secrets tab. Lets operators set the mode per (workspace × role × agent) with 1Password integration and form-level validation that prevents saving a mode without a resolved credential.
+- Structured `LaunchError::AuthCredentialMissing` with full mode-resolution and env-layer-state arrays for clear diagnostic output when a launch fails because the required credential isn't set.
+- 1Password picker integration in the auth form: picking a reference triggers `op read` validation before commit; broken references never reach disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Auth tab UX (breaking)** — the workspace-manager Auth tab now mirrors
+  the Environments tab: per-role overrides render only when set, with a
+  3-step Role → Agent → form add flow under `+ Add per-role override`.
+  Collapsing/expanding a role uses `←` / `→`; `D` on a role header
+  prompts for confirmation before clearing both agents' overrides.
 - **BREAKING.** Auth-forward configuration moved out of `[roles.<role>.claude]` and into per-agent blocks at three layers (`[claude]` global, `[workspaces.<ws>.claude]`, `[workspaces.<ws>.roles.<role>.claude]`). The same shape now exists for `[codex]`. Stale configs that still set `[roles.<role>.claude]` fail to parse with the standard "unknown field" error. No migration shim — see AGENTS.md "Project status: pre-release".
 - New `api_key` mode for both Claude and Codex (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the env layer).
 - `Token` mode renamed to `oauth_token`. The deprecated `"copy"` alias is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **Auth tab UX (breaking)** — the workspace-manager Auth tab now mirrors
-  the Environments tab: per-role overrides render only when set, with a
-  3-step Role → Agent → form add flow under `+ Add per-role override`.
-  Collapsing/expanding a role uses `←` / `→`; `D` on a role header
-  prompts for confirmation before clearing both agents' overrides.
 - **BREAKING.** Auth-forward configuration moved out of `[roles.<role>.claude]` and into per-agent blocks at three layers (`[claude]` global, `[workspaces.<ws>.claude]`, `[workspaces.<ws>.roles.<role>.claude]`). The same shape now exists for `[codex]`. Stale configs that still set `[roles.<role>.claude]` fail to parse with the standard "unknown field" error. No migration shim — see AGENTS.md "Project status: pre-release".
 - New `api_key` mode for both Claude and Codex (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the env layer).
 - `Token` mode renamed to `oauth_token`. The deprecated `"copy"` alias is removed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,12 @@ clap_mangen = "0.3"
 assert_cmd = "2.0"
 predicates = "3.1"
 
+[features]
+# `e2e` gates real-docker smoke tests (tests/e2e_auth_modes.rs).
+# Default `cargo nextest run` skips them; enable with `--features e2e`
+# on a host with a reachable docker daemon.
+e2e = []
+
 [lints.rust]
 unsafe_code = "forbid"
 

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -76,50 +76,44 @@ jackin config mount remove secrets --scope "chainargos/*"
 
 ## `config auth`
 
-Manage Claude Code authentication forwarding from the host machine into agent containers. See the [Authentication Forwarding](/guides/authentication) guide for full details.
+Manage the **global** Claude auth-forwarding mode. See the
+[Authentication Forwarding](/guides/authentication) guide for the full
+layered model. Workspace and per (workspace × role × agent) overrides
+are configured through the **Auth** tab in the `jackin console`
+workspace editor (or by hand-editing TOML).
 
 ### `config auth set`
 
 ```bash
-jackin config auth set <MODE> [OPTIONS]
+jackin config auth set <MODE>
 ```
 
-Set the authentication forwarding mode.
+Set the global Claude auth-forwarding mode (`[claude].auth_forward`).
 
 | Mode | Description |
 |---|---|
-| `copy` | Copy host auth on first container creation (default) |
-| `sync` | Overwrite from host on each launch when host auth exists; preserve container auth when absent |
+| `sync` | Overwrite from host on each launch when host auth exists; preserve container auth when absent (default) |
+| `api_key` | Inject `ANTHROPIC_API_KEY` from the operator-env layer |
+| `oauth_token` | Inject `CLAUDE_CODE_OAUTH_TOKEN` from the operator-env layer |
 | `ignore` | Never forward; revoke any previously forwarded credentials |
 
-| Option | Description |
-|---|---|
-| `--role <SELECTOR>` | Apply to a specific role instead of globally |
-
 ```bash
-# Set global default
-jackin config auth set copy
-
-# Override for a specific role
-jackin config auth set ignore --role agent-smith
-jackin config auth set sync --role chainargos/the-architect
+jackin config auth set sync
+jackin config auth set ignore
+jackin config auth set oauth_token
+jackin config auth set api_key
 ```
 
 ### `config auth show`
 
 ```bash
-jackin config auth show [OPTIONS]
+jackin config auth show
 ```
 
-Show the current authentication forwarding mode.
-
-| Option | Description |
-|---|---|
-| `--role <SELECTOR>` | Show effective mode for a specific role (includes per-role override) |
+Show the current global Claude auth-forwarding mode.
 
 ```bash
 jackin config auth show
-jackin config auth show --role agent-smith
 ```
 
 ## `config env`
@@ -128,7 +122,7 @@ Manage operator env vars at global and per-role scope.
 
 Values are stored verbatim — whatever you type is what goes into the TOML. No editor-side validation of key names or value shape. jackin' resolves values at launch time through the operator-env layer, so `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work.
 
-Without `--role`, writes and reads target the global `[env]` table. With `--role <SELECTOR>`, they target `[roles.<SELECTOR>.env]`. The role selector is not pre-validated — the table path is written even if the role is not registered, matching how `config auth set --role` behaves.
+Without `--role`, writes and reads target the global `[env]` table. With `--role <SELECTOR>`, they target `[roles.<SELECTOR>.env]`. The role selector is not pre-validated — the table path is written even if the role is not registered.
 
 ### `config env set`
 

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -5,46 +5,96 @@ description: Forward or provide agent credentials for agent containers
 import { Aside } from '@astrojs/starlight/components'
 
 
-By default, jackin' forwards your host machine's Claude Code authentication into new agent containers. This means agents start pre-authenticated with your account — no manual `/login` inside the container.
+jackin' provisions agent containers with credentials drawn from the host
+or from the operator-env layer, so agents start pre-authenticated
+without an interactive `/login` step inside the container.
+
+The shape of that provisioning is described by an `auth_forward` mode,
+configured per agent (`claude`, `codex`) at three layers: a global
+default, a per-workspace override, and a per (workspace × role × agent)
+override.
 
 ## How it works
 
-Claude Code stores its credentials differently depending on the platform:
+Each agent has its own credential model:
 
-| Platform | Credential storage |
+| Agent | Credential storage on the host |
 |---|---|
-| macOS | System Keychain ("Claude Code-credentials") |
-| Linux | `~/.claude/.credentials.json` |
+| Claude (macOS) | System Keychain ("Claude Code-credentials") + `~/.claude.json` |
+| Claude (Linux) | `~/.claude/.credentials.json` + `~/.claude.json` |
+| Codex | `~/.codex/auth.json` (written by `codex login`) |
 
-When jackin' creates or launches an agent container, it reads the host credentials and writes them into the agent's persisted state directory at `~/.jackin/data/<container-name>/.claude/.credentials.json`. The host's `~/.claude.json` (account metadata and preferences) is also copied.
+When jackin' creates or launches an agent container, it consults the
+resolved `auth_forward` mode for that (workspace × role × agent) and
+either:
 
-Since the `.claude/` directory and `.claude.json` file are bind-mounted into the container, Claude Code inside the container picks up the credentials immediately.
+- copies the host credential file into the role-state directory
+  (`sync`), or
+- injects an env var resolved from the operator-env layer
+  (`api_key`, `oauth_token`), or
+- provisions an empty state and lets the agent authenticate inside the
+  container (`ignore`).
 
-## Auth forwarding modes
+The role-state directory at `~/.jackin/data/<container-name>/` is
+bind-mounted into the container, so the agent picks up forwarded
+credentials immediately.
 
-jackin' supports three modes, configurable globally or per-agent:
+## Modes
+
+jackin' supports four modes:
 
 | Mode | Behavior |
 |---|---|
-| `sync` (default) | When host auth exists, overwrite container auth on each launch. When host auth is absent, preserve existing container auth. |
-| `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself via `/login`. |
-| `token` | Provision the agent with an empty state and inject `CLAUDE_CODE_OAUTH_TOKEN` (from the resolved operator env) into the container. Claude Code uses the token directly — no `/login` session state is bind-mounted. Recommended for long-lived or concurrent sessions. |
+| `sync` (default) | When host auth exists, copy it into the container's role-state on each launch. When host auth is absent, preserve any existing container auth. |
+| `api_key` | Inject the agent's API-key env var (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex), resolved from the operator-env layer. No credential files are written. |
+| `oauth_token` | **Claude only.** Inject `CLAUDE_CODE_OAUTH_TOKEN` from the operator-env layer. Codex rejects this mode at config-parse time. |
+| `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself inside the container. |
 
 ### sync
 
-The `sync` mode is the default. It re-copies host credentials on every launch. Use this when you want agents to always reflect the host's current account — for example, if you rotate credentials frequently or switch between organizations.
+`sync` re-copies host credentials on every launch. Use this when you
+want agents to always reflect the host's current account — for example,
+if you rotate credentials frequently or switch between organizations.
 
-When the host's `~/.claude.json` or credentials are missing (e.g. you logged out), `sync` preserves the container's existing auth rather than wiping it. This prevents accidental de-authentication from a missing file.
+When the host's credentials are missing (e.g. you logged out), `sync`
+preserves the container's existing auth rather than wiping it. This
+prevents accidental de-authentication from a missing file.
 
-### ignore
+### api_key
 
-The `ignore` mode is the legacy behavior — the container starts with an empty `{}` config and no credentials. The agent must authenticate itself inside the container (Claude Code's device-flow login via browser).
+`api_key` provisions the agent with an empty state and exports the
+agent's API key into the container's process env. Claude Code reads
+`ANTHROPIC_API_KEY`; Codex CLI reads `OPENAI_API_KEY`. No file-based
+credentials are written into the role-state.
 
-Switching an agent from `copy` or `sync` to `ignore` actively revokes any previously forwarded credentials by resetting `.claude.json` to `{}` and deleting `.credentials.json`.
+Setup:
 
-### token
+1. Add the API-key entry to any of the four operator-env layers.
+   For example, in the workspace's `[env]` block referencing 1Password:
 
-The `token` mode is designed for long-lived and concurrent jackin' sessions. Instead of bind-mounting a copy of your host's `/login` session state, jackin' injects a long-lived OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) into the container's process env. Claude Code inside the container reads the token directly, bypassing the file-based credential store entirely.
+   ```toml
+   [workspaces.my-app.env]
+   ANTHROPIC_API_KEY = "op://Personal/Anthropic/key"
+   ```
+
+   Or forwarding from the host shell:
+
+   ```toml
+   [env]
+   OPENAI_API_KEY = "$OPENAI_API_KEY"
+   ```
+
+2. Set the `auth_forward` mode at the layer that should pick this up
+   (see [Layered configuration](#layered-configuration) below).
+
+### oauth_token (Claude only)
+
+`oauth_token` is designed for long-lived and concurrent jackin' sessions
+on Claude. Instead of bind-mounting a copy of the host's `/login`
+session state, jackin' injects a long-lived OAuth token
+(`CLAUDE_CODE_OAUTH_TOKEN`) into the container's process env. Claude
+Code inside the container reads the token directly, bypassing the
+file-based credential store.
 
 Setup:
 
@@ -54,161 +104,256 @@ Setup:
    claude setup-token
    ```
 
-2. Tell jackin' where to find it by adding a line to the `[env]` section of the workspace manifest. Either reference a 1Password secret:
+2. Tell jackin' where to find it by adding a line to one of the
+   operator-env layers. For example, referencing 1Password:
 
    ```toml
-   [env]
+   [claude.env]
    CLAUDE_CODE_OAUTH_TOKEN = "op://Personal/Claude/token"
    ```
 
-   or forward from the host shell:
+   or forwarding from the host shell:
 
    ```toml
    [env]
    CLAUDE_CODE_OAUTH_TOKEN = "$CLAUDE_CODE_OAUTH_TOKEN"
    ```
 
-3. Enable token mode:
+3. Set `auth_forward = "oauth_token"` for `[claude]` at the appropriate
+   layer.
 
-   ```bash
-   jackin config auth set token
-   ```
+If `CLAUDE_CODE_OAUTH_TOKEN` is not present in the resolved env when
+`oauth_token` mode is active, jackin' aborts the launch with a
+structured error (see [Launch-time validation](#launch-time-validation)).
 
-On launch, jackin' prints a one-line diagnostic confirming the active mode and where the token came from:
+<Aside type="caution">
+Codex has no OAuth-token analog of Claude's `CLAUDE_CODE_OAUTH_TOKEN`.
+Setting `auth_forward = "oauth_token"` under any `[codex]` block is
+rejected at config-parse time with an "unknown variant" error. Use
+`api_key` (with `OPENAI_API_KEY`) or `sync` for Codex.
+</Aside>
 
-```
-claude auth: OAuth token (CLAUDE_CODE_OAUTH_TOKEN ← op://Personal/Claude/token)
-```
+### ignore
 
-If `CLAUDE_CODE_OAUTH_TOKEN` is not present in the resolved env when `token` mode is active, jackin' aborts with an actionable error listing both remediation paths above.
+`ignore` provisions the container with an empty state — no
+credential file is written, and any previously forwarded credentials
+in the role-state are deleted. The agent must authenticate itself
+inside the container the next time it runs.
 
-The agent's state directory is provisioned with the same empty shape as `ignore` mode — no `.credentials.json` is written — so switching between `token`, `sync`, and `ignore` is safe.
+Switching an agent from `sync`, `api_key`, or `oauth_token` to `ignore`
+actively revokes any previously forwarded credentials.
 
-### `copy` (deprecated)
+## Layered configuration
 
-The `copy` mode — "copy host auth on first container creation only; never overwrite afterwards" — was jackin's previous default. It caused subtle auth drift when OAuth refresh tokens rotated across concurrent Claude Code sessions on the host and in containers, surfacing as intermittent `API Error: 401` inside agents.
+`auth_forward` is configured per agent (`claude`, `codex`) at three
+layers, with most-specific wins:
 
-It was removed in favor of `sync`. On the first launch after upgrading, jackin automatically rewrites any `auth_forward = "copy"` entries in your config to `"sync"` and prints a one-line deprecation notice:
+1. **Global default** — `[claude].auth_forward` and
+   `[codex].auth_forward` in `~/.config/jackin/config.toml`.
+2. **Per workspace** — `[workspaces.<ws>.claude].auth_forward` and
+   `[workspaces.<ws>.codex].auth_forward`.
+3. **Per (workspace × role)** — `[workspaces.<ws>.roles.<role>.claude].auth_forward`
+   and `[workspaces.<ws>.roles.<role>.codex].auth_forward`.
 
-```
-warning: migrated auth_forward "copy" → "sync" in ~/.config/jackin/config.toml (copy is deprecated)
-```
+Resolution order: **per-(workspace × role) > per-workspace > global > `sync`**.
 
-Scripts or invocations that still pass `copy` to `jackin config auth set` continue to work — the value is accepted as a deprecated alias and saved as `sync`.
-
-## Configuration
-
-### Set the global default
-
-```bash
-jackin config auth set sync     # default — overwrite from host on each launch
-jackin config auth set ignore   # never forward
-```
-
-### Override per role
-
-```bash
-jackin config auth set ignore --role agent-smith
-jackin config auth set sync --role chainargos/the-architect
-```
-
-### Show the current mode
-
-```bash
-# Global default
-jackin config auth show
-
-# Effective mode for a specific role (includes per-role override)
-jackin config auth show --role agent-smith
-```
-
-### config.toml format
+Example `config.toml`:
 
 ```toml
-# Global default
+# Layer 1 — global defaults
 [claude]
 auth_forward = "sync"
 
-# Per-role override
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-trusted = true
+[codex]
+auth_forward = "sync"
 
-[roles.agent-smith.claude]
-auth_forward = "token"
+# Layer 2 — workspace-wide overrides
+[workspaces.my-app.claude]
+auth_forward = "oauth_token"
+
+# Layer 3 — most-specific override for one (workspace, role) cell
+[workspaces.my-app.roles.agent-smith.claude]
+auth_forward = "ignore"
+
+[workspaces.my-app.roles.agent-smith.codex]
+auth_forward = "api_key"
 ```
 
-Resolution order: **per-agent override > global default > `sync`**.
+Credentials referenced by `api_key` and `oauth_token` modes live in
+ordinary `[*.env]` blocks under the well-known names
+(`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`) and
+follow the same four-layer env merge as every other variable. See
+[Environment Variables](/guides/environment-variables) for the layer
+order.
 
 <Aside type="note">
-Auth forwarding is an operator-level setting. Agent manifests (`jackin.role.toml`) cannot set or override this — it is always the operator's decision.
+Auth forwarding is an operator-level setting. Agent manifests
+(`jackin.role.toml`) cannot set or override this — it is always the
+operator's decision.
 </Aside>
 
-## Codex authentication
+## Auth tab in the operator console
 
-Codex supports three auth paths in jackin:
+The `jackin console` workspace editor exposes auth forwarding through a
+dedicated **Auth** tab, peer to the existing **Secrets** tab. To open
+it:
 
-1. **API key (non-interactive).** Set `OPENAI_API_KEY` through the same operator env system used for other secrets:
+1. Run `jackin console` (or `jackin` on an interactive terminal).
+2. Select the workspace.
+3. In the workspace editor, switch to the **Auth** tab.
 
-   ```toml
-   [env]
-   OPENAI_API_KEY = "$OPENAI_API_KEY"
-   ```
+The Auth tab shows three sections, mirroring the three configuration
+layers:
 
-   or:
+| Section | Layer it edits |
+|---|---|
+| **Global** | `[claude]` / `[codex]` in `~/.config/jackin/config.toml` |
+| **This workspace** | `[workspaces.<ws>.claude]` / `[workspaces.<ws>.codex]` |
+| **Per role × agent** | `[workspaces.<ws>.roles.<role>.claude]` / `[workspaces.<ws>.roles.<role>.codex]` for each role allowed in this workspace |
 
-   ```toml
-   [env]
-   OPENAI_API_KEY = "op://Work/OpenAI/default"
-   ```
+Each row shows the configured mode at that layer and which mode is
+**effective** at the most-specific cell after layered resolution.
 
-   When set, jackin forwards the value into the container as a `-e OPENAI_API_KEY=…` env var. Codex CLI prefers this path when both an API key and a synced `auth.json` are present (verified against the Codex CLI source as of 2026-05).
+### The edit form
 
-2. **Synced ChatGPT login (`auth_forward = "sync"`, default).** When the host has `~/.codex/auth.json` (written by `codex login` on the host), jackin copies it into the role-state directory `~/.jackin/data/<container>/codex/auth.json` with `0600` permissions and bind-mounts that file at `/home/agent/.codex/auth.json`. The container reuses the host's ChatGPT session without prompting, and any in-container token refresh writes back to the host file through the bind mount.
+Selecting a cell opens an edit form with three blocks:
 
-   When the host has no `~/.codex/auth.json` (and no `OPENAI_API_KEY` is set), jackin still starts the container — Codex CLI prompts for ChatGPT login on first invocation. jackin emits a `codex auth: none — Codex CLI will prompt for ChatGPT login` notice at launch so the fallback is explicit, not silent. The login that happens inside the container writes to the container's writable layer (no bind mount exists yet), so it is **not** preserved across `docker rm` / `jackin purge`. To get persistence, run `codex login` on the host first so jackin can sync the resulting `~/.codex/auth.json` on the next launch.
+1. **Mode picker.** `sync`, `api_key`, `oauth_token` (Claude only),
+   `ignore`. Codex cells omit `oauth_token`.
+2. **Credential block** (only shown for modes that need a credential —
+   `api_key` and `oauth_token`). Pick the credential source: a
+   1Password reference (`op://...`), a host-env passthrough
+   (`$VAR` / `${VAR}`), or a literal value.
+3. **Save / Cancel / Reset.** Save commits the change to disk; Cancel
+   reverts the form; Reset clears the override at this layer (so the
+   cell falls through to the next layer up).
 
-3. **Ignore (`auth_forward = "ignore"`).** Any role-state `auth.json` is deleted at launch; the operator must re-login from inside the container every time.
+#### Save invariant
 
-`auth_forward = "token"` is a no-op for Codex (no OAuth-token analog of Claude's `CLAUDE_CODE_OAUTH_TOKEN` — the API key in env is the token). jackin leaves any existing role-state `auth.json` untouched and reports `codex auth: none (token mode is a no-op for Codex — set OPENAI_API_KEY or auth_forward = "sync")`.
+The **Save** button stays disabled until both:
 
-## What gets forwarded
+- a mode is selected, and
+- if the mode requires a credential (`api_key` or `oauth_token`),
+  the credential block has a committed value.
 
-Two pieces of data are forwarded from the host:
+This makes it impossible to leave the workspace in a state where
+`auth_forward` says "use a credential" but no credential resolves.
+
+#### 1Password picker integration
+
+When the credential source is set to a 1Password reference, the form
+opens the standard 1Password picker (the same component used by the
+Secrets tab). Picking a reference triggers an `op read` validation
+**before** the value is committed to the form — broken or
+unauthorized references never reach the form, and never reach disk.
+
+## Launch-time validation
+
+When jackin' resolves `auth_forward` for a launch, it verifies that
+modes requiring a credential have one set in the operator-env layer.
+If the credential is missing, the launch fails with a structured
+`LaunchError::AuthCredentialMissing` error containing:
+
+- The fully-resolved mode trace (which layer chose which mode for
+  Claude and Codex).
+- The state of the relevant env var across all four env layers, so the
+  operator can see exactly which layer was supposed to provide the
+  value.
+
+A typical message looks like:
+
+```
+error: auth credential missing for claude (mode = oauth_token)
+  required env var: CLAUDE_CODE_OAUTH_TOKEN
+  mode resolved at: workspaces.my-app.claude
+  env layer state:
+    [env]                                     : (unset)
+    [claude.env]                              : (unset)
+    [workspaces.my-app.env]                   : (unset)
+    [workspaces.my-app.roles.smith.env]       : (unset)
+  fix: set CLAUDE_CODE_OAUTH_TOKEN in any of the four env layers above,
+       or change auth_forward to "sync" / "ignore".
+```
+
+## What gets forwarded under `sync`
+
+For Claude, two pieces of data are forwarded from the host:
 
 | File | Contents |
 |---|---|
 | `.claude.json` | Account metadata, preferences (email, org, billing type, startup config) |
 | `.claude/.credentials.json` | OAuth tokens (access token, refresh token, scopes, subscription type) |
 
-Both files are written with `0600` permissions (owner-only read/write). If an older agent state directory has a pre-existing `.claude.json` with permissive permissions (e.g. `0644`), the permissions are tightened on the next write.
+Both files are written with `0600` permissions (owner-only read/write).
+If an older agent state directory has a pre-existing `.claude.json`
+with permissive permissions (e.g. `0644`), the permissions are
+tightened on the next write.
+
+For Codex, the host's `~/.codex/auth.json` is copied into
+`~/.jackin/data/<container>/codex/auth.json` with `0600` permissions
+and bind-mounted at `/home/agent/.codex/auth.json`. Token refreshes
+inside the container write back to the host file through the bind
+mount.
+
+When the host has no Codex auth.json (and `OPENAI_API_KEY` is not set
+via `api_key` mode), jackin' still starts the container — Codex CLI
+prompts for ChatGPT login on first invocation. jackin' emits a
+`codex auth: none — Codex CLI will prompt for ChatGPT login` notice at
+launch so the fallback is explicit, not silent.
 
 ## Security considerations
 
-- Forwarded credentials give the agent the same Claude Code access as your host account (same model tier, same organization, same billing).
-- Credentials are stored on disk in the agent's state directory (`~/.jackin/data/<container-name>/`). Use `jackin purge <agent>` to delete all persisted state including credentials.
-- Switching to `ignore` mode actively revokes forwarded credentials — it does not just stop future forwarding.
-- The agent manifest cannot control auth forwarding. An untrusted agent cannot force `sync` or `ignore` against the operator's wishes.
+- Forwarded credentials give the agent the same agent access as your
+  host account (same model tier, same organization, same billing).
+- Under `sync`, credentials are stored on disk in the agent's
+  state directory (`~/.jackin/data/<container-name>/`). Use
+  `jackin purge <agent>` to delete all persisted state including
+  credentials.
+- Switching to `ignore` mode actively revokes forwarded credentials —
+  it does not just stop future forwarding.
+- The agent manifest cannot control auth forwarding. An untrusted
+  agent cannot force any mode against the operator's wishes.
+- `api_key` and `oauth_token` modes never write the credential to disk
+  in the role-state — the value is exported into the container's
+  process env at launch only.
 
 <Aside type="caution">
-Auth forwarding copies OAuth tokens to the container's filesystem. While the files are permission-locked to `0600`, any process running as the container user can read them. This is equivalent to the existing risk when authenticating manually inside the container — the difference is that forwarding happens automatically.
+Under `sync`, OAuth tokens are copied to the container's filesystem.
+While the files are permission-locked to `0600`, any process running
+as the container user can read them. This is equivalent to the
+existing risk when authenticating manually inside the container — the
+difference is that forwarding happens automatically.
 </Aside>
+
 ## Troubleshooting
 
 ### Agent shows "Not logged in" after forwarding
 
-If the agent shows "Not logged in" or falls back to a different model tier (e.g. Sonnet instead of Opus), the credentials may not have been forwarded. Check:
+If the agent shows "Not logged in" or falls back to a different model
+tier (e.g. Sonnet instead of Opus), the credentials may not have been
+forwarded. Check:
 
-1. **Is auth forwarding enabled?** Run `jackin config auth show` — the default is `sync`.
-2. **Does the host have credentials?** On macOS, check `security find-generic-password -s "Claude Code-credentials" -w`. On Linux, check `~/.claude/.credentials.json`.
-3. **Is this a pre-existing container?** In `sync` mode, host credentials are forwarded on every launch — but if the host has no credentials, the container's existing auth is preserved. If the container has stale auth and the host has fresh auth, restart the container (`jackin eject <agent> && jackin load <agent>`) or purge state (`jackin purge <agent>`) to force a fresh sync.
+1. **What mode is effective?** Open the **Auth** tab in
+   `jackin console` for that workspace, and look at the effective mode
+   for the (role × agent) cell.
+2. **Does the host have credentials?** For Claude on macOS, check
+   `security find-generic-password -s "Claude Code-credentials" -w`.
+   On Linux, check `~/.claude/.credentials.json`. For Codex, check
+   `~/.codex/auth.json`.
+3. **Is this a pre-existing container?** In `sync` mode, host
+   credentials are forwarded on every launch — but if the host has no
+   credentials, the container's existing auth is preserved. If the
+   container has stale auth and the host has fresh auth, restart the
+   container (`jackin eject <agent> && jackin load <agent>`) or purge
+   state (`jackin purge <agent>`) to force a fresh sync.
 
 ### Revoking forwarded credentials
 
-To stop forwarding and clear existing credentials:
+To stop forwarding and clear existing credentials, set the (workspace
+× role × agent) cell to `ignore` in the **Auth** tab and reload the
+agent:
 
 ```bash
-jackin config auth set ignore --role <role>
 jackin load <role>  # next launch will reset to {}
 ```
 
@@ -220,4 +365,9 @@ jackin purge <agent>
 
 ## See also
 
-- [Environment Variables](/guides/environment-variables) — forward operator-owned secrets (API tokens, host env vars, 1Password items) into the agent container. Complements (but does not replace) Claude Code auth forwarding.
+- [Environment Variables](/guides/environment-variables) — the
+  four-layer operator-env model that supplies credentials for
+  `api_key` and `oauth_token` modes, and forwards arbitrary
+  operator-owned secrets into the agent container.
+- [Configuration File](/reference/configuration) — the full
+  `config.toml` schema, including the layered `auth_forward` shape.

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -198,25 +198,34 @@ The `jackin console` workspace editor exposes auth forwarding through a
 dedicated **Auth** tab, peer to the existing **Secrets** tab. To open
 it:
 
-1. Run `jackin console` (or `jackin` on an interactive terminal).
+1. Run `jackin console`.
 2. Select the workspace.
 3. In the workspace editor, switch to the **Auth** tab.
 
-The Auth tab shows three sections, mirroring the three configuration
-layers:
+The Auth tab presents three sections, top to bottom:
 
-| Section | Layer it edits |
-|---|---|
-| **Global** | `[claude]` / `[codex]` in `~/.config/jackin/config.toml` |
-| **This workspace** | `[workspaces.<ws>.claude]` / `[workspaces.<ws>.codex]` |
-| **Per role × agent** | `[workspaces.<ws>.roles.<role>.claude]` / `[workspaces.<ws>.roles.<role>.codex]` for each role allowed in this workspace |
+1. **Global defaults** (read-only) — what `[claude]` / `[codex]` resolve
+   to at the global layer. These rows reflect `~/.config/jackin/config.toml`
+   and cannot be edited from within a workspace.
+2. **Workspace defaults** — `[workspaces.<ws>.claude]` and
+   `[workspaces.<ws>.codex]` rows. Press `Enter` on a row to open the
+   auth-edit form for that agent.
+3. **Per-role overrides** — collapsible role headers. The list starts
+   empty; press `Enter` on the `+ Add per-role override` entry to step
+   through a three-step flow: choose the **role**, choose the **agent**
+   (`claude` or `codex`), then fill in the **auth-edit form**.
+   Press `→` / `←` to expand or collapse a role header. Press `D` on a
+   role header to open a confirmation dialog that clears both agents'
+   overrides for that role; press `D` on a single agent row to clear
+   only that agent's override.
 
-Each row shows the configured mode at that layer and which mode is
-**effective** at the most-specific cell after layered resolution.
+Footer hints surface the resolved mode and its provenance for whichever
+override row is currently focused.
 
 ### The edit form
 
-Selecting a cell opens an edit form with three blocks:
+Pressing `Enter` on a workspace-defaults row or completing the
+role-add flow opens an edit form with three blocks:
 
 1. **Mode picker.** `sync`, `api_key`, `oauth_token` (Claude only),
    `ignore`. Codex cells omit `oauth_token`.

--- a/docs/src/content/docs/guides/security-model.mdx
+++ b/docs/src/content/docs/guides/security-model.mdx
@@ -168,9 +168,9 @@ Mounted files are live host files. If the agent edits a mounted path, the host f
 
 ### Authentication forwarding
 
-By default, jackin' forwards the host's Claude Code OAuth credentials into new agent containers (`auth_forward = "copy"`). This means agents start pre-authenticated but also means OAuth tokens are stored on disk in the agent state directory with `0600` permissions.
+By default, jackin' forwards the host's Claude Code OAuth credentials into new agent containers (`auth_forward = "sync"`). This means agents start pre-authenticated but also means OAuth tokens are stored on disk in the agent state directory with `0600` permissions.
 
-You can control this behavior globally or per-agent — see [Authentication Forwarding](/guides/authentication). Setting `auth_forward = "ignore"` revokes any previously forwarded credentials and returns to the legacy behavior of manual in-container login.
+You can control this behavior at three layers (global, per workspace, and per workspace × role × agent) — see [Authentication Forwarding](/guides/authentication). Setting `auth_forward = "ignore"` revokes any previously forwarded credentials and returns to the legacy behavior of manual in-container login. The `api_key` and `oauth_token` modes inject the credential into the container's process env at launch only — no credential is written to disk in the role-state directory.
 
 ### Credentials obtained inside the runtime remain inside the runtime
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -16,25 +16,55 @@ import { Aside } from '@astrojs/starlight/components'
 
 The configuration file is TOML format at `~/.config/jackin/config.toml`. It's managed through CLI commands — you generally don't need to edit it by hand.
 
-### Claude Code settings
+### Agent auth-forward settings
+
+`auth_forward` is configured per agent (`claude`, `codex`) at three
+layers, with most-specific wins:
 
 ```toml
+# Layer 1 — global default (per agent)
 [claude]
-auth_forward = "sync"  # "sync" (default), "ignore", or "token"
+auth_forward = "sync"  # "sync" (default), "api_key", "oauth_token", or "ignore"
+
+[codex]
+auth_forward = "sync"  # "sync" (default), "api_key", or "ignore" — Codex rejects "oauth_token"
+
+# Layer 2 — workspace-wide override
+[workspaces.my-app.claude]
+auth_forward = "oauth_token"
+
+[workspaces.my-app.codex]
+auth_forward = "api_key"
+
+# Layer 3 — most-specific (workspace × role × agent) override
+[workspaces.my-app.roles.agent-smith.claude]
+auth_forward = "ignore"
+
+[workspaces.my-app.roles.agent-smith.codex]
+auth_forward = "sync"
 ```
 
 | Field | Description | Default |
 |---|---|---|
-| `auth_forward` | How the host's Claude Code credentials are made available to agent containers. See [Authentication Forwarding](/guides/authentication). | `sync` |
+| `auth_forward` | How the host's agent credentials (or env-supplied keys/tokens) are made available to agent containers. See [Authentication Forwarding](/guides/authentication). | `sync` |
 
-Per-role overrides are set under the role's `[claude]` section:
+Accepted values: `sync` \| `api_key` \| `oauth_token` \| `ignore`.
+`oauth_token` is **Claude only** — setting it under any `[codex]` block
+is rejected at parse time with an "unknown variant" error.
 
-```toml
-[roles.agent-smith.claude]
-auth_forward = "ignore"
-```
+Locations the field may appear at, in resolution order
+(most-specific first):
 
-Resolution order: per-role override > global `[claude]` > `sync`.
+- `[workspaces.<ws>.roles.<role>.claude].auth_forward`
+- `[workspaces.<ws>.roles.<role>.codex].auth_forward`
+- `[workspaces.<ws>.claude].auth_forward`
+- `[workspaces.<ws>.codex].auth_forward`
+- `[claude].auth_forward` (global default)
+- `[codex].auth_forward` (global default)
+
+Credentials referenced by `api_key` and `oauth_token` live in ordinary
+`[*.env]` blocks under the well-known names `ANTHROPIC_API_KEY`,
+`CLAUDE_CODE_OAUTH_TOKEN`, and `OPENAI_API_KEY`.
 
 ### Operator env layers
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -23,6 +23,36 @@ impl Agent {
             Self::Codex => CODEX_INSTALL_BLOCK,
         }
     }
+
+    /// Well-known env var that carries the auth credential for this
+    /// (agent, mode) combination, if any. Returns None for modes that
+    /// don't inject a credential (sync, ignore) or for combinations that
+    /// don't make sense for the agent.
+    pub const fn required_env_var(
+        self,
+        mode: crate::config::AuthForwardMode,
+    ) -> Option<&'static str> {
+        use crate::config::AuthForwardMode as M;
+        match (self, mode) {
+            (Self::Claude, M::ApiKey) => Some("ANTHROPIC_API_KEY"),
+            (Self::Claude, M::OAuthToken) => Some("CLAUDE_CODE_OAUTH_TOKEN"),
+            (Self::Codex, M::ApiKey) => Some("OPENAI_API_KEY"),
+            (Self::Claude, M::Sync | M::Ignore)
+            | (Self::Codex, M::Sync | M::Ignore | M::OAuthToken) => None,
+        }
+    }
+
+    /// Modes this agent supports. UI surfaces should consult this when
+    /// listing options to the user. The TOML parser uses `CodexAuthConfig`
+    /// to reject unsupported modes at parse time — this method is the
+    /// runtime/UI parallel.
+    pub const fn supported_modes(self) -> &'static [crate::config::AuthForwardMode] {
+        use crate::config::AuthForwardMode as M;
+        match self {
+            Self::Claude => &[M::Sync, M::ApiKey, M::OAuthToken, M::Ignore],
+            Self::Codex => &[M::Sync, M::ApiKey, M::Ignore],
+        }
+    }
 }
 
 const CLAUDE_INSTALL_BLOCK: &str = "\
@@ -145,5 +175,64 @@ mod tests {
         assert!(block.starts_with("USER agent\n"));
         assert!(block.contains("claude.ai/install.sh"));
         assert!(block.contains("claude --version"));
+    }
+}
+
+#[cfg(test)]
+mod auth_table_tests {
+    use super::*;
+    use crate::config::AuthForwardMode;
+
+    #[test]
+    fn required_env_var_table() {
+        // Claude
+        assert_eq!(Agent::Claude.required_env_var(AuthForwardMode::Sync), None);
+        assert_eq!(
+            Agent::Claude.required_env_var(AuthForwardMode::ApiKey),
+            Some("ANTHROPIC_API_KEY")
+        );
+        assert_eq!(
+            Agent::Claude.required_env_var(AuthForwardMode::OAuthToken),
+            Some("CLAUDE_CODE_OAUTH_TOKEN")
+        );
+        assert_eq!(
+            Agent::Claude.required_env_var(AuthForwardMode::Ignore),
+            None
+        );
+
+        // Codex
+        assert_eq!(Agent::Codex.required_env_var(AuthForwardMode::Sync), None);
+        assert_eq!(
+            Agent::Codex.required_env_var(AuthForwardMode::ApiKey),
+            Some("OPENAI_API_KEY")
+        );
+        // OAuthToken for Codex is parser-rejected (Task 6); behavior at the
+        // method level is "no env var" (None) for safety.
+        assert_eq!(
+            Agent::Codex.required_env_var(AuthForwardMode::OAuthToken),
+            None
+        );
+        assert_eq!(Agent::Codex.required_env_var(AuthForwardMode::Ignore), None);
+    }
+
+    #[test]
+    fn supported_modes_claude_includes_oauth_token() {
+        let modes = Agent::Claude.supported_modes();
+        assert!(modes.contains(&AuthForwardMode::Sync));
+        assert!(modes.contains(&AuthForwardMode::ApiKey));
+        assert!(modes.contains(&AuthForwardMode::OAuthToken));
+        assert!(modes.contains(&AuthForwardMode::Ignore));
+    }
+
+    #[test]
+    fn supported_modes_codex_excludes_oauth_token() {
+        let modes = Agent::Codex.supported_modes();
+        assert!(modes.contains(&AuthForwardMode::Sync));
+        assert!(modes.contains(&AuthForwardMode::ApiKey));
+        assert!(
+            !modes.contains(&AuthForwardMode::OAuthToken),
+            "codex must not advertise oauth_token"
+        );
+        assert!(modes.contains(&AuthForwardMode::Ignore));
     }
 }

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -457,7 +457,6 @@ mod tests {
             config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -501,7 +500,6 @@ mod tests {
             config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -544,7 +542,6 @@ mod tests {
             config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -587,7 +584,6 @@ mod tests {
             config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -596,7 +592,6 @@ mod tests {
             config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-the-architect.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -477,6 +477,8 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                claude: None,
+                codex: None,
             },
         );
 
@@ -520,6 +522,8 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                claude: None,
+                codex: None,
             },
         );
 
@@ -562,6 +566,8 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                claude: None,
+                codex: None,
             },
         );
 
@@ -612,6 +618,8 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                claude: None,
+                codex: None,
             },
         );
         config

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,14 +26,8 @@ use self::context::{
 };
 
 /// Parse an `auth_forward` mode value as it arrived from the CLI.
-///
-/// Returns the resolved mode and a boolean indicating whether the operator
-/// passed the deprecated `copy` alias — the caller is responsible for
-/// emitting a user-facing warning in that case.
-fn parse_auth_forward_mode_from_cli(raw: &str) -> anyhow::Result<(config::AuthForwardMode, bool)> {
-    let mode: config::AuthForwardMode = raw.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
-    let was_deprecated = raw == "copy";
-    Ok((mode, was_deprecated))
+fn parse_auth_forward_mode_from_cli(raw: &str) -> anyhow::Result<config::AuthForwardMode> {
+    raw.parse().map_err(|e: String| anyhow::anyhow!("{e}"))
 }
 
 #[allow(clippy::too_many_lines)]
@@ -365,12 +359,7 @@ pub fn run(cli: Cli) -> Result<()> {
             },
             cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
                 cli::AuthCommand::Set { mode, role } => {
-                    let (parsed_mode, was_deprecated) = parse_auth_forward_mode_from_cli(&mode)?;
-                    if was_deprecated {
-                        tui::deprecation_warning(
-                            "auth_forward \"copy\" is deprecated; saving as \"sync\"",
-                        );
-                    }
+                    let parsed_mode = parse_auth_forward_mode_from_cli(&mode)?;
                     if let Some(role_selector) = role {
                         let class = RoleSelector::parse(&role_selector)?;
                         config.resolve_role_source(&class)?;
@@ -1165,17 +1154,15 @@ mod auth_set_tests {
     use super::*;
 
     #[test]
-    fn parse_auth_forward_mode_from_cli_accepts_copy_as_deprecated() {
-        let (mode, was_deprecated) = parse_auth_forward_mode_from_cli("copy").unwrap();
-        assert_eq!(mode, crate::config::AuthForwardMode::Sync);
-        assert!(was_deprecated);
+    fn parse_auth_forward_mode_from_cli_rejects_deprecated_copy_alias() {
+        // Pre-release stance: no compatibility shims.
+        assert!(parse_auth_forward_mode_from_cli("copy").is_err());
     }
 
     #[test]
-    fn parse_auth_forward_mode_from_cli_accepts_sync_non_deprecated() {
-        let (mode, was_deprecated) = parse_auth_forward_mode_from_cli("sync").unwrap();
+    fn parse_auth_forward_mode_from_cli_accepts_sync() {
+        let mode = parse_auth_forward_mode_from_cli("sync").unwrap();
         assert_eq!(mode, crate::config::AuthForwardMode::Sync);
-        assert!(!was_deprecated);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -358,12 +358,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
             },
             cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
-                cli::AuthCommand::Set { mode, role } => {
-                    if role.is_some() {
-                        anyhow::bail!(
-                            "per-role auth_forward is not currently supported; set the global mode instead"
-                        );
-                    }
+                cli::AuthCommand::Set { mode } => {
                     let parsed_mode = parse_auth_forward_mode_from_cli(&mode)?;
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     editor.set_global_auth_forward(parsed_mode);
@@ -371,7 +366,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     println!("Set global auth forwarding to {parsed_mode}.");
                     Ok(())
                 }
-                cli::AuthCommand::Show { role: _ } => {
+                cli::AuthCommand::Show => {
                     let mode = config
                         .claude
                         .as_ref()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -367,11 +367,12 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
                 cli::AuthCommand::Show => {
-                    let mode = config
-                        .claude
-                        .as_ref()
-                        .map(|c| c.auth_forward)
-                        .unwrap_or_default();
+                    // Empty workspace + role names fall through to layer 1
+                    // (global), so this prints the global default — same
+                    // user-visible semantics as before, but the resolver
+                    // logic is no longer duplicated in this site.
+                    let mode =
+                        crate::config::resolve_mode(&config, crate::agent::Agent::Claude, "", "");
                     println!("{mode}");
                     Ok(())
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -498,6 +498,8 @@ pub fn run(cli: Cli) -> Result<()> {
                     keep_awake: crate::workspace::KeepAwakeConfig {
                         enabled: keep_awake,
                     },
+                    claude: None,
+                    codex: None,
                 };
                 let mut editor = crate::config::ConfigEditor::open(&paths)?;
                 editor.create_workspace(&name, ws)?;
@@ -1182,6 +1184,8 @@ mod auth_set_tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         };
         let out = render_workspace_show("jackin", &ws);
         assert!(out.contains("Isolation"));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -359,38 +359,25 @@ pub fn run(cli: Cli) -> Result<()> {
             },
             cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
                 cli::AuthCommand::Set { mode, role } => {
-                    let parsed_mode = parse_auth_forward_mode_from_cli(&mode)?;
-                    if let Some(role_selector) = role {
-                        let class = RoleSelector::parse(&role_selector)?;
-                        config.resolve_role_source(&class)?;
-                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                        if let Some(source) = config.roles.get(&class.key()) {
-                            editor.upsert_agent_source(&class.key(), source);
-                        }
-                        editor.set_agent_auth_forward(&class.key(), parsed_mode);
-                        editor.save()?;
-                        println!("Set auth forwarding for {} to {parsed_mode}.", class.key());
-                    } else {
-                        let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                        editor.set_global_auth_forward(parsed_mode);
-                        editor.save()?;
-                        println!("Set global auth forwarding to {parsed_mode}.");
+                    if role.is_some() {
+                        anyhow::bail!(
+                            "per-role auth_forward is not currently supported; set the global mode instead"
+                        );
                     }
+                    let parsed_mode = parse_auth_forward_mode_from_cli(&mode)?;
+                    let mut editor = crate::config::ConfigEditor::open(&paths)?;
+                    editor.set_global_auth_forward(parsed_mode);
+                    editor.save()?;
+                    println!("Set global auth forwarding to {parsed_mode}.");
                     Ok(())
                 }
-                cli::AuthCommand::Show { role } => {
-                    if let Some(role_selector) = role {
-                        let class = RoleSelector::parse(&role_selector)?;
-                        let effective = config.resolve_auth_forward_mode(&class.key());
-                        println!("{effective}");
-                    } else {
-                        let mode = config
-                            .claude
-                            .as_ref()
-                            .map(|c| c.auth_forward)
-                            .unwrap_or_default();
-                        println!("{mode}");
-                    }
+                cli::AuthCommand::Show { role: _ } => {
+                    let mode = config
+                        .claude
+                        .as_ref()
+                        .map(|c| c.auth_forward)
+                        .unwrap_or_default();
+                    println!("{mode}");
                     Ok(())
                 }
             },

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -384,7 +384,12 @@ pub fn run(cli: Cli) -> Result<()> {
                         let effective = config.resolve_auth_forward_mode(&class.key());
                         println!("{effective}");
                     } else {
-                        println!("{}", config.claude.auth_forward);
+                        let mode = config
+                            .claude
+                            .as_ref()
+                            .map(|c| c.auth_forward)
+                            .unwrap_or_default();
+                        println!("{mode}");
                     }
                     Ok(())
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -367,13 +367,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
                 cli::AuthCommand::Show => {
-                    // Empty workspace + role names fall through to layer 1
-                    // (global), so this prints the global default — same
-                    // user-visible semantics as before, but the resolver
-                    // logic is no longer duplicated in this site.
-                    let mode =
-                        crate::config::resolve_mode(&config, crate::agent::Agent::Claude, "", "");
-                    println!("{mode}");
+                    print!("{}", render_auth_show(&config));
                     Ok(())
                 }
             },
@@ -1060,6 +1054,21 @@ fn remove_data_dir_if_exists(path: &Path) -> Result<()> {
     }
 }
 
+/// Render the `config auth show` output as a string. Empty workspace + role
+/// names fall through to layer 1 (global), so this prints the global default
+/// for each agent. Printing both Claude and Codex avoids privileging either
+/// agent in the no-context output — until/unless an `--agent` flag is added,
+/// both-agents output is the honest bridge.
+fn render_auth_show(config: &AppConfig) -> String {
+    use std::fmt::Write as _;
+    let claude_mode = crate::config::resolve_mode(config, crate::agent::Agent::Claude, "", "");
+    let codex_mode = crate::config::resolve_mode(config, crate::agent::Agent::Codex, "", "");
+    let mut out = String::new();
+    let _ = writeln!(out, "claude: {claude_mode}");
+    let _ = writeln!(out, "codex:  {codex_mode}");
+    out
+}
+
 /// Render the `workspace show <name>` output as a string. Includes the info
 /// table (name/workdir/allowed/default-role), and, when there are mounts, a
 /// trailing mounts table with one row per mount. The mounts table renders the
@@ -1158,6 +1167,18 @@ mod auth_set_tests {
     #[test]
     fn parse_auth_forward_mode_from_cli_rejects_bogus() {
         assert!(parse_auth_forward_mode_from_cli("bogus").is_err());
+    }
+
+    #[test]
+    fn auth_show_prints_both_agents() {
+        // No global override means each agent falls through to its
+        // default-mode (Sync). The point of this test is the output shape:
+        // both agents are surfaced, so a Codex-primary operator running
+        // `jackin config auth show` is not silently shown only Claude.
+        let config = AppConfig::default();
+        let out = render_auth_show(&config);
+        assert!(out.contains("claude:"), "missing claude line: {out}");
+        assert!(out.contains("codex:"), "missing codex line: {out}");
     }
 
     #[test]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -86,14 +86,16 @@ Examples:
 pub enum AuthCommand {
     /// Set the authentication forwarding mode
     ///
-    /// Controls how the host's Claude Code authentication is made available
+    /// Controls how the host's agent authentication is made available
     /// to role containers.
     /// Modes: sync (default — overwrite container auth from host on each
     /// launch when host auth exists; preserve container auth when host auth
-    /// is absent), ignore (revoke and never forward), token (use a long-lived
-    /// `CLAUDE_CODE_OAUTH_TOKEN` resolved from the operator env — the token
-    /// itself is never written to disk; see `jackin` docs on auth forwarding
-    /// for setup).
+    /// is absent), ignore (revoke and never forward), `oauth_token` (use a
+    /// long-lived `CLAUDE_CODE_OAUTH_TOKEN` resolved from the operator env),
+    /// `api_key` (use a short-lived API key — e.g. `ANTHROPIC_API_KEY` /
+    /// `OPENAI_API_KEY` — resolved from the operator env). Tokens and keys
+    /// are never written to disk; see `jackin` docs on auth forwarding for
+    /// setup.
     #[command(
         before_help = BANNER,
         styles = HELP_STYLES,
@@ -101,12 +103,13 @@ pub enum AuthCommand {
 Examples:
   jackin config auth set sync
   jackin config auth set ignore
-  jackin config auth set token
+  jackin config auth set oauth_token
+  jackin config auth set api_key
   jackin config auth set sync --role agent-smith
-  jackin config auth set token --role chainargos/the-architect"
+  jackin config auth set oauth_token --role chainargos/the-architect"
     )]
     Set {
-        /// Authentication forwarding mode: sync, ignore, or token
+        /// Authentication forwarding mode: sync, ignore, `api_key`, or `oauth_token`
         mode: String,
         /// Apply to a specific role instead of globally
         #[arg(long)]
@@ -372,20 +375,24 @@ mod tests {
         let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
         assert!(help.contains("Examples:"));
         assert!(help.contains("jackin config auth set sync"));
-        assert!(help.contains("jackin config auth set token"));
+        assert!(help.contains("jackin config auth set oauth_token"));
+        assert!(help.contains("jackin config auth set api_key"));
         assert!(help.contains("--role"));
     }
 
     #[test]
     fn config_auth_set_help_lists_token_as_accepted_mode() {
         let help = help_text(&["jackin", "config", "auth", "set", "--help"]);
-        // Modes are listed in the subcommand doc comment. After this
-        // PR the accepted modes are sync, ignore, and token.
+        // Modes are listed in the subcommand doc comment.
         assert!(help.contains("sync"));
         assert!(help.contains("ignore"));
         assert!(
-            help.contains("token"),
-            "help text must advertise the token mode; got:\n{help}"
+            help.contains("oauth_token"),
+            "help text must advertise the oauth_token mode; got:\n{help}"
+        );
+        assert!(
+            help.contains("api_key"),
+            "help text must advertise the api_key mode; got:\n{help}"
         );
     }
 
@@ -409,14 +416,14 @@ mod tests {
     }
 
     #[test]
-    fn parses_config_auth_set_token_global() {
-        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "token"]).unwrap();
+    fn parses_config_auth_set_oauth_token_global() {
+        let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "oauth_token"]).unwrap();
         assert!(matches!(
             cli.command,
             Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
                         role: None,
-                    }))) if mode == "token"
+                    }))) if mode == "oauth_token"
         ));
     }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -104,16 +104,11 @@ Examples:
   jackin config auth set sync
   jackin config auth set ignore
   jackin config auth set oauth_token
-  jackin config auth set api_key
-  jackin config auth set sync --role agent-smith
-  jackin config auth set oauth_token --role chainargos/the-architect"
+  jackin config auth set api_key"
     )]
     Set {
         /// Authentication forwarding mode: sync, ignore, `api_key`, or `oauth_token`
         mode: String,
-        /// Apply to a specific role instead of globally
-        #[arg(long)]
-        role: Option<String>,
     },
     /// Show the current authentication forwarding mode
     #[command(
@@ -121,14 +116,9 @@ Examples:
         styles = HELP_STYLES,
         after_long_help = "\
 Examples:
-  jackin config auth show
-  jackin config auth show --role agent-smith"
+  jackin config auth show"
     )]
-    Show {
-        /// Show mode for a specific role (including inheritance)
-        #[arg(long)]
-        role: Option<String>,
-    },
+    Show,
 }
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]
@@ -377,7 +367,6 @@ mod tests {
         assert!(help.contains("jackin config auth set sync"));
         assert!(help.contains("jackin config auth set oauth_token"));
         assert!(help.contains("jackin config auth set api_key"));
-        assert!(help.contains("--role"));
     }
 
     #[test]
@@ -410,7 +399,6 @@ mod tests {
             cli.command,
             Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
-                        role: None,
                     }))) if mode == "sync"
         ));
     }
@@ -422,29 +410,7 @@ mod tests {
             cli.command,
             Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
                         ref mode,
-                        role: None,
                     }))) if mode == "oauth_token"
-        ));
-    }
-
-    #[test]
-    fn parses_config_auth_set_per_agent() {
-        let cli = Cli::try_parse_from([
-            "jackin",
-            "config",
-            "auth",
-            "set",
-            "sync",
-            "--role",
-            "agent-smith",
-        ])
-        .unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
-                        ref mode,
-                        role: Some(ref role),
-                    }))) if mode == "sync" && role == "agent-smith"
         ));
     }
 
@@ -453,9 +419,7 @@ mod tests {
         let cli = Cli::try_parse_from(["jackin", "config", "auth", "show"]).unwrap();
         assert!(matches!(
             cli.command,
-            Some(Command::Config(ConfigCommand::Auth(AuthCommand::Show {
-                role: None
-            })))
+            Some(Command::Config(ConfigCommand::Auth(AuthCommand::Show)))
         ));
     }
 }

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -313,37 +313,6 @@ impl ConfigEditor {
         }
     }
 
-    /// Rewrite any `auth_forward = "copy"` to `"sync"` at the two paths
-    /// `contains_deprecated_copy_auth_forward` checks:
-    ///   [claude].`auth_forward`
-    ///   [roles.*.claude].`auth_forward`
-    ///
-    /// Does not touch any other structure. Used by `load_or_init` when the
-    /// on-disk config still contains the deprecated literal.
-    pub fn normalize_deprecated_copy(&mut self) {
-        // Global [claude]
-        if let Some(claude) = self.doc.get_mut("claude").and_then(|i| i.as_table_mut())
-            && claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy")
-        {
-            claude.insert("auth_forward", toml_edit::value("sync"));
-        }
-        // Per-role [roles.X.claude]
-        if let Some(roles) = self.doc.get_mut("roles").and_then(|i| i.as_table_mut()) {
-            for (_, agent_item) in roles.iter_mut() {
-                let Some(agent_table) = agent_item.as_table_mut() else {
-                    continue;
-                };
-                let Some(claude) = agent_table.get_mut("claude").and_then(|i| i.as_table_mut())
-                else {
-                    continue;
-                };
-                if claude.get("auth_forward").and_then(|i| i.as_str()) == Some("copy") {
-                    claude.insert("auth_forward", toml_edit::value("sync"));
-                }
-            }
-        }
-    }
-
     pub fn remove_env_var(&mut self, scope: &EnvScope, key: &str) -> bool {
         let path = env_scope_path(scope);
         // Walk without creating: return false if any segment is missing.
@@ -486,7 +455,10 @@ const fn auth_forward_str(mode: crate::config::AuthForwardMode) -> &'static str 
     match mode {
         crate::config::AuthForwardMode::Ignore => "ignore",
         crate::config::AuthForwardMode::Sync => "sync",
-        crate::config::AuthForwardMode::Token => "token",
+        // Tasks 10/11 will split per-mode behavior; today both env-driven
+        // modes serialize to their canonical snake_case names.
+        crate::config::AuthForwardMode::ApiKey => "api_key",
+        crate::config::AuthForwardMode::OAuthToken => "oauth_token",
     }
 }
 
@@ -1272,12 +1244,12 @@ git = "x"
         .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_agent_auth_forward("my-role", crate::config::AuthForwardMode::Token);
+        editor.set_agent_auth_forward("my-role", crate::config::AuthForwardMode::OAuthToken);
         editor.save().unwrap();
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains("[roles.my-role.claude]"), "{out}");
-        assert!(out.contains(r#"auth_forward = "token""#), "{out}");
+        assert!(out.contains(r#"auth_forward = "oauth_token""#), "{out}");
     }
 
     #[test]
@@ -1327,7 +1299,7 @@ git = "OLD-URL"
 trusted = false
 
 [roles.agent-smith.claude]
-auth_forward = "token"
+auth_forward = "oauth_token"
 "#,
         )
         .unwrap();
@@ -1346,7 +1318,7 @@ auth_forward = "token"
         );
         assert!(out.contains("trusted = true"), "{out}");
         assert!(
-            out.contains(r#"auth_forward = "token""#),
+            out.contains(r#"auth_forward = "oauth_token""#),
             "claude override wiped: {out}"
         );
     }
@@ -1461,37 +1433,6 @@ MY_VAR = "preserved"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains(r#"git = "NEW""#), "{out}");
         assert!(out.contains(r#"MY_VAR = "preserved""#), "{out}");
-    }
-
-    #[test]
-    fn normalize_deprecated_copy_rewrites_global_and_agent_paths() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-        std::fs::write(
-            &paths.config_file,
-            r#"[claude]
-auth_forward = "copy"
-
-[roles.foo]
-git = "x"
-
-[roles.foo.claude]
-auth_forward = "copy"
-
-[roles.bar]
-git = "y"
-"#,
-        )
-        .unwrap();
-
-        let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.normalize_deprecated_copy();
-        editor.save().unwrap();
-
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(!out.contains(r#""copy""#), "{out}");
-        assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
     }
 
     #[test]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -237,44 +237,27 @@ impl ConfigEditor {
         }
     }
 
-    pub fn set_agent_auth_forward(
-        &mut self,
-        agent_key: &str,
-        mode: crate::config::AuthForwardMode,
-    ) {
-        let claude_table = table_path_mut(
-            &mut self.doc,
-            &[
-                "roles".to_string(),
-                agent_key.to_string(),
-                "claude".to_string(),
-            ],
-        );
-        claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
-    }
-
     pub fn set_global_auth_forward(&mut self, mode: crate::config::AuthForwardMode) {
         let claude_table = table_path_mut(&mut self.doc, &["claude".to_string()]);
         claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
     }
 
     pub fn upsert_builtin_agent(&mut self, agent_key: &str, git_url: &str) {
-        // Touch only git + trusted. Leave [roles.X.claude] and
-        // [roles.X.env] alone — those are operator-owned.
+        // Touch only git + trusted. Leave [roles.X.env] alone —
+        // operator-owned.
         let table = table_path_mut(&mut self.doc, &["roles".to_string(), agent_key.to_string()]);
         table.insert("git", toml_edit::value(git_url));
         table.insert("trusted", toml_edit::value(true));
     }
 
     /// Writes `git` and `trusted` from the given `RoleSource` into
-    /// `[roles.<agent_key>]`, and if the doc has no `[roles.<agent_key>.claude]`
-    /// table yet but the source carries a `claude` override, writes that too.
-    /// Does NOT touch `[roles.<agent_key>.env]` — operator-owned.
+    /// `[roles.<agent_key>]`. Does NOT touch `[roles.<agent_key>.env]` —
+    /// operator-owned.
     ///
     /// Used by call sites that first invoke `resolve_role_source` (which may
     /// insert a new role into the in-memory `AppConfig`) and need the editor
-    /// to persist that insert alongside whatever trust / `auth_forward` change
-    /// they're about to make.
+    /// to persist that insert alongside whatever trust change they're about
+    /// to make.
     pub fn upsert_agent_source(&mut self, agent_key: &str, source: &crate::config::RoleSource) {
         let table = table_path_mut(&mut self.doc, &["roles".to_string(), agent_key.to_string()]);
         table.insert("git", toml_edit::value(source.git.clone()));
@@ -282,34 +265,6 @@ impl ConfigEditor {
             table.insert("trusted", toml_edit::value(true));
         } else {
             table.remove("trusted");
-        }
-        // If the source carries a claude override and the doc doesn't have
-        // one, serialize it in. If the doc already has one, leave it alone —
-        // operator-owned.
-        if let Some(claude) = &source.claude {
-            let existing_claude = self
-                .doc
-                .get("roles")
-                .and_then(|i| i.as_table())
-                .and_then(|t| t.get(agent_key))
-                .and_then(|i| i.as_table())
-                .and_then(|t| t.get("claude"));
-            if existing_claude.is_none()
-                && let Ok(rendered) = toml::to_string(claude)
-                && let Ok(parsed) = rendered.parse::<DocumentMut>()
-            {
-                let claude_table = table_path_mut(
-                    &mut self.doc,
-                    &[
-                        "roles".to_string(),
-                        agent_key.to_string(),
-                        "claude".to_string(),
-                    ],
-                );
-                for (k, v) in parsed.as_table() {
-                    claude_table.insert(k, v.clone());
-                }
-            }
         }
     }
 
@@ -1231,28 +1186,6 @@ trusted = true
     }
 
     #[test]
-    fn set_agent_auth_forward_writes_claude_subtable() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-        std::fs::write(
-            &paths.config_file,
-            r#"[roles.my-role]
-git = "x"
-"#,
-        )
-        .unwrap();
-
-        let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_agent_auth_forward("my-role", crate::config::AuthForwardMode::OAuthToken);
-        editor.save().unwrap();
-
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[roles.my-role.claude]"), "{out}");
-        assert!(out.contains(r#"auth_forward = "oauth_token""#), "{out}");
-    }
-
-    #[test]
     fn set_global_auth_forward_writes_root_claude_table() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
@@ -1285,42 +1218,6 @@ git = "x"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains("[roles.agent-smith]"), "{out}");
         assert!(out.contains("trusted = true"), "{out}");
-    }
-
-    #[test]
-    fn upsert_builtin_agent_preserves_existing_claude_override() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-        std::fs::write(
-            &paths.config_file,
-            r#"[roles.agent-smith]
-git = "OLD-URL"
-trusted = false
-
-[roles.agent-smith.claude]
-auth_forward = "oauth_token"
-"#,
-        )
-        .unwrap();
-
-        let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.upsert_builtin_agent(
-            "agent-smith",
-            "https://github.com/jackin-project/jackin-agent-smith.git",
-        );
-        editor.save().unwrap();
-
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(
-            out.contains(r#"git = "https://github.com/jackin-project/jackin-agent-smith.git""#),
-            "{out}"
-        );
-        assert!(out.contains("trusted = true"), "{out}");
-        assert!(
-            out.contains(r#"auth_forward = "oauth_token""#),
-            "claude override wiped: {out}"
-        );
     }
 
     #[test]
@@ -1423,7 +1320,6 @@ MY_VAR = "preserved"
         let source = crate::config::RoleSource {
             git: "NEW".to_string(),
             trusted: true,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         };
         let mut editor = ConfigEditor::open(&paths).unwrap();

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -242,6 +242,68 @@ impl ConfigEditor {
         claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
     }
 
+    /// Write or clear `[workspaces.<workspace>.<agent>].auth_forward`.
+    ///
+    /// `mode = Some(m)` writes the named mode; `mode = None` removes the
+    /// `auth_forward` field (and the agent block if it becomes empty),
+    /// dropping that layer of the resolver back to the workspace's
+    /// inheritance from the global default.
+    ///
+    /// The agent block is keyed by `agent.slug()` (`"claude"` /
+    /// `"codex"`), keeping the on-disk shape parallel to
+    /// `set_global_auth_forward`.
+    pub fn set_workspace_auth_forward(
+        &mut self,
+        workspace: &str,
+        agent: crate::agent::Agent,
+        mode: Option<crate::config::AuthForwardMode>,
+    ) {
+        let agent_path = vec![
+            "workspaces".to_string(),
+            workspace.to_string(),
+            agent.slug().to_string(),
+        ];
+        match mode {
+            Some(m) => {
+                let table = table_path_mut(&mut self.doc, &agent_path);
+                table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
+            }
+            None => {
+                clear_auth_forward_field(&mut self.doc, &agent_path);
+            }
+        }
+    }
+
+    /// Write or clear `[workspaces.<workspace>.roles.<role>.<agent>].auth_forward`.
+    ///
+    /// Mirrors [`Self::set_workspace_auth_forward`] one layer deeper.
+    /// Used by the workspace-manager's Auth tab when the operator commits
+    /// the auth-edit form on a (role × agent) row.
+    pub fn set_workspace_role_auth_forward(
+        &mut self,
+        workspace: &str,
+        role: &str,
+        agent: crate::agent::Agent,
+        mode: Option<crate::config::AuthForwardMode>,
+    ) {
+        let agent_path = vec![
+            "workspaces".to_string(),
+            workspace.to_string(),
+            "roles".to_string(),
+            role.to_string(),
+            agent.slug().to_string(),
+        ];
+        match mode {
+            Some(m) => {
+                let table = table_path_mut(&mut self.doc, &agent_path);
+                table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
+            }
+            None => {
+                clear_auth_forward_field(&mut self.doc, &agent_path);
+            }
+        }
+    }
+
     pub fn upsert_builtin_agent(&mut self, agent_key: &str, git_url: &str) {
         // Touch only git + trusted. Leave [roles.X.env] alone —
         // operator-owned.
@@ -441,6 +503,37 @@ fn validate_candidate(contents: &str) -> anyhow::Result<AppConfig> {
     let config: AppConfig = toml::from_str(contents).context("deserializing candidate config")?;
     crate::operator_env::validate_reserved_names(&config)?;
     Ok(config)
+}
+
+/// Remove the `auth_forward` field at `agent_path`. If the agent block
+/// is left empty afterwards, removes the agent block too. Walks without
+/// creating, so a reset on a layer that was already empty is a no-op.
+fn clear_auth_forward_field(doc: &mut DocumentMut, agent_path: &[String]) {
+    let mut current: &mut Item = doc.as_item_mut();
+    for segment in agent_path {
+        match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
+            Some(next) => current = next,
+            None => return,
+        }
+    }
+    if let Some(table) = current.as_table_mut() {
+        table.remove("auth_forward");
+        if table.is_empty()
+            && let Some((last, parent_path)) = agent_path.split_last()
+        {
+            // Walk to the parent and remove the now-empty agent block.
+            let mut walker: &mut Item = doc.as_item_mut();
+            for segment in parent_path {
+                match walker.as_table_mut().and_then(|t| t.get_mut(segment)) {
+                    Some(next) => walker = next,
+                    None => return,
+                }
+            }
+            if let Some(parent_table) = walker.as_table_mut() {
+                parent_table.remove(last.as_str());
+            }
+        }
+    }
 }
 
 fn table_path_mut<'a>(doc: &'a mut DocumentMut, path: &[String]) -> &'a mut Table {
@@ -1199,6 +1292,121 @@ trusted = true
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(out.contains("[claude]"), "{out}");
         assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+    }
+
+    #[test]
+    fn set_workspace_auth_forward_writes_workspace_agent_block() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"
+[workspaces.proj]
+workdir = "/tmp/proj"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_workspace_auth_forward(
+            "proj",
+            crate::agent::Agent::Claude,
+            Some(crate::config::AuthForwardMode::ApiKey),
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[workspaces.proj.claude]"), "{out}");
+        assert!(out.contains(r#"auth_forward = "api_key""#), "{out}");
+    }
+
+    #[test]
+    fn set_workspace_auth_forward_clears_when_mode_none() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"
+[workspaces.proj]
+workdir = "/tmp/proj"
+
+[workspaces.proj.claude]
+auth_forward = "api_key"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_workspace_auth_forward("proj", crate::agent::Agent::Claude, None);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            !out.contains("[workspaces.proj.claude]"),
+            "agent block must be removed when mode = None; {out}"
+        );
+        assert!(
+            !out.contains("auth_forward"),
+            "auth_forward field must be cleared; {out}"
+        );
+    }
+
+    #[test]
+    fn set_workspace_role_auth_forward_writes_role_agent_block() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"
+[workspaces.proj]
+workdir = "/tmp/proj"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_workspace_role_auth_forward(
+            "proj",
+            "smith",
+            crate::agent::Agent::Codex,
+            Some(crate::config::AuthForwardMode::ApiKey),
+        );
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(out.contains("[workspaces.proj.roles.smith.codex]"), "{out}");
+        assert!(out.contains(r#"auth_forward = "api_key""#), "{out}");
+    }
+
+    #[test]
+    fn set_workspace_role_auth_forward_clears_when_mode_none() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"
+[workspaces.proj]
+workdir = "/tmp/proj"
+
+[workspaces.proj.roles.smith.claude]
+auth_forward = "oauth_token"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.set_workspace_role_auth_forward("proj", "smith", crate::agent::Agent::Claude, None);
+        editor.save().unwrap();
+
+        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(
+            !out.contains("[workspaces.proj.roles.smith.claude]"),
+            "{out}"
+        );
     }
 
     #[test]

--- a/src/config/fixtures/config.round_trip.toml
+++ b/src/config/fixtures/config.round_trip.toml
@@ -1,7 +1,11 @@
 # Jackin config — top-of-file note
 # keep this across saves
 
+# Layer 1: global agent auth defaults
 [claude]
+auth_forward = "sync"
+
+[codex]
 auth_forward = "sync"
 
 # Our two builtin roles
@@ -21,7 +25,15 @@ trusted = true
 # Production workspace — the big one
 [workspaces.prod]
 workdir = "/workspace/prod"
+allowed_roles = ["agent-smith"]
 default_agent = "codex"
+
+# Layer 2: workspace-level agent auth
+[workspaces.prod.claude]
+auth_forward = "api_key"
+
+[workspaces.prod.codex]
+auth_forward = "api_key"
 
 [workspaces.prod.env]
 # Rotate quarterly (last: 2026-Q1)
@@ -30,8 +42,18 @@ API_TOKEN = "op://Personal/api/token"
 # Passes through from host
 GITHUB_TOKEN = "$GITHUB_TOKEN"
 
+# Layer 3: per-(workspace × role × agent) most-specific overrides
+[workspaces.prod.roles.agent-smith.claude]
+auth_forward = "oauth_token"
+
+[workspaces.prod.roles.agent-smith.codex]
+auth_forward = "ignore"
+
 [workspaces.prod.roles.agent-smith.env]
-OPENAI_API_KEY = "op://Work/OpenAI/default"
+# 1Password OpRef shape
+ANTHROPIC_API_KEY = { op = "op://Work/Anthropic/api-key", path = "Work/Anthropic/api-key" }
+# Literal $-expansion shape
+OPENAI_API_KEY = "$OPENAI_API_KEY"
 
 # Playground workspace — disposable
 [workspaces.playground]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -92,20 +92,12 @@ pub struct AgentAuthConfig {
     pub auth_forward: AuthForwardMode,
 }
 
-/// Per-role Claude Code configuration override.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ClaudeRoleConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auth_forward: Option<AuthForwardMode>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RoleSource {
     pub git: String,
     #[serde(default, skip_serializing_if = "is_false")]
     pub trusted: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub claude: Option<ClaudeRoleConfig>,
     /// Role-layer operator env map. Merged on top of the global
     /// `[env]` map when the role is launched. Values use the
     /// `operator_env` dispatch syntax.
@@ -329,20 +321,6 @@ dst = "/workspace/src"
 
         let err = AppConfig::load_or_init(&paths).unwrap_err();
         assert!(err.to_string().contains("workspace \"broken\" workdir must be equal to, inside, or a parent of one of the workspace mount destinations"));
-    }
-
-    #[test]
-    fn set_agent_auth_forward_creates_claude_section() {
-        let toml_str = r#"
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-"#;
-        let mut config: AppConfig = toml::from_str(toml_str).unwrap();
-        config.set_agent_auth_forward("agent-smith", AuthForwardMode::Sync);
-        assert_eq!(
-            config.resolve_auth_forward_mode("agent-smith"),
-            AuthForwardMode::Sync
-        );
     }
 
     #[test]
@@ -805,6 +783,24 @@ auth_forward = "api_key"
         assert!(
             msg.contains("unknown field `bogus`") || msg.contains("unknown field \"bogus\""),
             "expected unknown-field error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_legacy_role_claude_block() {
+        let toml = r#"
+[roles.smith]
+git = "git@example.com:smith.git"
+trusted = true
+
+[roles.smith.claude]
+auth_forward = "ignore"
+"#;
+        let err = toml::from_str::<AppConfig>(toml).expect_err("must reject legacy block");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown field `claude`") || msg.contains("unknown field \"claude\""),
+            "expected unknown-field error for legacy [roles.X.claude] block, got: {msg}"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -746,6 +746,34 @@ auth_forward = "oauth_token"
     }
 
     #[test]
+    fn agent_auth_config_serializes_canonical_names() {
+        for (mode, expected) in [
+            (AuthForwardMode::Sync, "sync"),
+            (AuthForwardMode::ApiKey, "api_key"),
+            (AuthForwardMode::OAuthToken, "oauth_token"),
+            (AuthForwardMode::Ignore, "ignore"),
+        ] {
+            let cfg = AgentAuthConfig { auth_forward: mode };
+            let s = toml::to_string(&cfg).expect("serialize must succeed");
+            assert!(
+                s.contains(&format!("auth_forward = \"{expected}\"")),
+                "mode {mode:?} must serialize as auth_forward = \"{expected}\", got: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_auth_config_rejects_unknown_field() {
+        let toml = "auth_forward = \"sync\"\nbogus = true";
+        let err = toml::from_str::<AgentAuthConfig>(toml).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown field `bogus`") || msg.contains("unknown field \"bogus\""),
+            "expected unknown-field error, got: {msg}"
+        );
+    }
+
+    #[test]
     fn deserializes_global_env_map() {
         let toml_str = r#"
 [env]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,12 +8,13 @@ pub use crate::workspace::WorkspaceRoleOverride;
 pub mod editor;
 mod mounts;
 mod persist;
-mod roles;
+pub mod roles;
 mod workspaces;
 
 pub use editor::{ConfigEditor, EnvScope};
 pub use mounts::DockerMounts;
 pub(crate) use mounts::MountEntry;
+pub use roles::resolve_mode;
 pub use workspaces::{DriftDetection, detect_workspace_edit_drift};
 
 /// Serde helper: `skip_serializing_if` requires `fn(&T) -> bool`.
@@ -368,7 +369,12 @@ trusted = true
             "absent [claude] block must deserialize to None"
         );
         assert_eq!(
-            config.resolve_auth_forward_mode("agent-smith"),
+            crate::config::roles::resolve_mode(
+                &config,
+                crate::agent::Agent::Claude,
+                "",
+                "agent-smith",
+            ),
             AuthForwardMode::Sync
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -92,6 +92,38 @@ pub struct AgentAuthConfig {
     pub auth_forward: AuthForwardMode,
 }
 
+/// Newtype around `AgentAuthConfig` that rejects `oauth_token` at parse time.
+///
+/// Codex does not support `AuthForwardMode::OAuthToken` (the CLI uses a
+/// refresh-token flow rather than a static OAuth token); rejecting it at
+/// deserialization time keeps the type system honest so downstream code
+/// never has to handle the impossible combination.
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct CodexAuthConfig(pub AgentAuthConfig);
+
+impl<'de> serde::Deserialize<'de> for CodexAuthConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let cfg = AgentAuthConfig::deserialize(deserializer)?;
+        if cfg.auth_forward == AuthForwardMode::OAuthToken {
+            return Err(serde::de::Error::custom(
+                "auth_forward 'oauth_token' is not supported for codex; \
+                 supported modes: sync, api_key, ignore",
+            ));
+        }
+        Ok(Self(cfg))
+    }
+}
+
+impl std::ops::Deref for CodexAuthConfig {
+    type Target = AgentAuthConfig;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RoleSource {
@@ -116,7 +148,7 @@ pub struct AppConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude: Option<AgentAuthConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub codex: Option<AgentAuthConfig>,
+    pub codex: Option<CodexAuthConfig>,
     /// Global operator env map — the bottom layer. Merged under
     /// per-role, per-workspace, and per-(workspace × role) layers.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -399,6 +431,20 @@ auth_forward = "api_key"
         assert!(
             cfg.codex.is_none(),
             "codex must be None when [codex] absent"
+        );
+    }
+
+    #[test]
+    fn reject_codex_oauth_token_global() {
+        let toml = r#"
+[codex]
+auth_forward = "oauth_token"
+"#;
+        let err = toml::from_str::<AppConfig>(toml).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not supported for codex"),
+            "expected codex-rejection message, got: {msg}"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@ pub use crate::workspace::WorkspaceRoleOverride;
 pub mod editor;
 mod mounts;
 mod persist;
-pub mod roles;
+mod roles;
 mod workspaces;
 
 pub use editor::{ConfigEditor, EnvScope};
@@ -369,12 +369,7 @@ trusted = true
             "absent [claude] block must deserialize to None"
         );
         assert_eq!(
-            crate::config::roles::resolve_mode(
-                &config,
-                crate::agent::Agent::Claude,
-                "",
-                "agent-smith",
-            ),
+            crate::config::resolve_mode(&config, crate::agent::Agent::Claude, "", "agent-smith",),
             AuthForwardMode::Sync
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -92,13 +92,6 @@ pub struct AgentAuthConfig {
     pub auth_forward: AuthForwardMode,
 }
 
-/// Global Claude Code configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ClaudeConfig {
-    #[serde(default)]
-    pub auth_forward: AuthForwardMode,
-}
-
 /// Per-role Claude Code configuration override.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClaudeRoleConfig {
@@ -128,8 +121,10 @@ pub struct DockerConfig {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
-    #[serde(default)]
-    pub claude: ClaudeConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<AgentAuthConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex: Option<AgentAuthConfig>,
     /// Global operator env map — the bottom layer. Merged under
     /// per-role, per-workspace, and per-(workspace × role) layers.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -358,7 +353,10 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
 trusted = true
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+        assert!(
+            config.claude.is_none(),
+            "absent [claude] block must deserialize to None"
+        );
         assert_eq!(
             config.resolve_auth_forward_mode("agent-smith"),
             AuthForwardMode::Sync
@@ -386,7 +384,44 @@ trusted = true
 auth_forward = "oauth_token"
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::OAuthToken);
+        assert_eq!(
+            config.claude.as_ref().unwrap().auth_forward,
+            AuthForwardMode::OAuthToken
+        );
+    }
+
+    #[test]
+    fn parse_app_config_claude_and_codex() {
+        let toml = r#"
+[claude]
+auth_forward = "sync"
+
+[codex]
+auth_forward = "api_key"
+"#;
+        let cfg: AppConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            cfg.claude.as_ref().unwrap().auth_forward,
+            AuthForwardMode::Sync
+        );
+        assert_eq!(
+            cfg.codex.as_ref().unwrap().auth_forward,
+            AuthForwardMode::ApiKey
+        );
+    }
+
+    #[test]
+    fn parse_app_config_no_agent_blocks() {
+        let toml = "";
+        let cfg: AppConfig = toml::from_str(toml).unwrap();
+        assert!(
+            cfg.claude.is_none(),
+            "claude must be None when [claude] absent"
+        );
+        assert!(
+            cfg.codex.is_none(),
+            "codex must be None when [codex] absent"
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,29 +22,43 @@ const fn is_false(v: &bool) -> bool {
     !*v
 }
 
-/// Controls how the host's `~/.claude.json` is forwarded into role containers.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
+/// Controls how the host's agent credentials are forwarded into role containers.
+///
+/// Wire format (TOML / JSON) uses explicit per-variant `rename` so the names
+/// the operator types match what `serde` reads. Without `rename`, the default
+/// `snake_case` rule turns `OAuthToken` into `o_auth_token`, which is not
+/// what we want.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuthForwardMode {
-    /// Revoke any forwarded auth and never copy — container starts with `{}`.
-    Ignore,
     /// Overwrite container auth from host on each launch when host auth
     /// exists; preserve container auth when host auth is absent.
     #[default]
+    #[serde(rename = "sync")]
     Sync,
-    /// Use a long-lived OAuth token from the operator-resolved env
-    /// (`CLAUDE_CODE_OAUTH_TOKEN`). The role state directory is
-    /// provisioned empty (same shape as `Ignore`); Claude Code inside
-    /// the container picks up the token from its process environment.
-    Token,
+    /// Use a short-lived API key sourced from the operator-resolved env
+    /// (e.g. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`). The role state
+    /// directory is provisioned empty; the agent inside the container
+    /// reads the key from its process environment.
+    #[serde(rename = "api_key")]
+    ApiKey,
+    /// Use a long-lived OAuth token sourced from the operator-resolved env
+    /// (e.g. `CLAUDE_CODE_OAUTH_TOKEN`). The role state directory is
+    /// provisioned empty; the agent inside the container reads the token
+    /// from its process environment.
+    #[serde(rename = "oauth_token")]
+    OAuthToken,
+    /// Revoke any forwarded auth and never copy — container starts with `{}`.
+    #[serde(rename = "ignore")]
+    Ignore,
 }
 
 impl std::fmt::Display for AuthForwardMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ignore => write!(f, "ignore"),
             Self::Sync => write!(f, "sync"),
-            Self::Token => write!(f, "token"),
+            Self::ApiKey => write!(f, "api_key"),
+            Self::OAuthToken => write!(f, "oauth_token"),
+            Self::Ignore => write!(f, "ignore"),
         }
     }
 }
@@ -53,35 +67,29 @@ impl std::str::FromStr for AuthForwardMode {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // `"copy"` is kept as a separate arm (rather than merged with `"sync"`)
-        // so callers can pattern-match the literal when emitting a deprecation
-        // warning before calling `parse()`.
-        #[allow(clippy::match_same_arms)]
         match s {
-            "ignore" => Ok(Self::Ignore),
             "sync" => Ok(Self::Sync),
-            "token" => Ok(Self::Token),
-            // Deprecated alias — accepted to avoid breaking scripts and
-            // configs from before the default flipped to `sync`. Callers
-            // that want to surface the deprecation should check for the
-            // literal `"copy"` themselves before calling `parse()`.
-            "copy" => Ok(Self::Sync),
+            "api_key" => Ok(Self::ApiKey),
+            "oauth_token" => Ok(Self::OAuthToken),
+            "ignore" => Ok(Self::Ignore),
             other => Err(format!(
-                "invalid auth_forward mode {other:?}; expected one of: sync, ignore, token"
+                "invalid auth_forward mode {other:?}; expected one of: sync, api_key, oauth_token, ignore"
             )),
         }
     }
 }
 
-impl<'de> serde::Deserialize<'de> for AuthForwardMode {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error;
-        let raw = String::deserialize(deserializer)?;
-        raw.parse().map_err(D::Error::custom)
-    }
+/// Per-agent auth configuration wrapper.
+///
+/// Used at every layer (global, per-role, per-workspace, per-(workspace × role))
+/// to carry the auth-forwarding mode for a particular agent. Future fields
+/// (e.g. credential-env overrides) live under this struct so each agent's
+/// auth knobs are namespaced together.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentAuthConfig {
+    #[serde(default)]
+    pub auth_forward: AuthForwardMode,
 }
 
 /// Global Claude Code configuration.
@@ -358,36 +366,36 @@ trusted = true
     }
 
     #[test]
-    fn auth_forward_mode_from_str_accepts_token() {
+    fn auth_forward_mode_from_str_accepts_oauth_token() {
         use std::str::FromStr;
         assert_eq!(
-            AuthForwardMode::from_str("token").unwrap(),
-            AuthForwardMode::Token
+            AuthForwardMode::from_str("oauth_token").unwrap(),
+            AuthForwardMode::OAuthToken
         );
     }
 
     #[test]
-    fn auth_forward_mode_display_emits_token() {
-        assert_eq!(AuthForwardMode::Token.to_string(), "token");
+    fn auth_forward_mode_display_emits_oauth_token() {
+        assert_eq!(AuthForwardMode::OAuthToken.to_string(), "oauth_token");
     }
 
     #[test]
-    fn auth_forward_mode_deserializes_token() {
+    fn auth_forward_mode_deserializes_oauth_token() {
         let toml_str = r#"
 [claude]
-auth_forward = "token"
+auth_forward = "oauth_token"
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Token);
+        assert_eq!(config.claude.auth_forward, AuthForwardMode::OAuthToken);
     }
 
     #[test]
-    fn auth_forward_mode_from_str_error_lists_token() {
+    fn auth_forward_mode_from_str_error_lists_oauth_token() {
         use std::str::FromStr;
         let err = AuthForwardMode::from_str("nope").unwrap_err();
         assert!(
-            err.contains("token"),
-            "error message should advertise the token mode; got: {err}"
+            err.contains("oauth_token"),
+            "error message should advertise the oauth_token mode; got: {err}"
         );
     }
 
@@ -674,11 +682,11 @@ auth_forward = "token"
     }
 
     #[test]
-    fn auth_forward_mode_from_str_accepts_copy_as_deprecated_alias() {
+    fn auth_forward_mode_from_str_rejects_deprecated_copy_alias() {
         use std::str::FromStr;
-        assert_eq!(
-            AuthForwardMode::from_str("copy").unwrap(),
-            AuthForwardMode::Sync
+        assert!(
+            AuthForwardMode::from_str("copy").is_err(),
+            "the deprecated `copy` alias must no longer parse"
         );
     }
 
@@ -702,19 +710,39 @@ auth_forward = "token"
     }
 
     #[test]
-    fn auth_forward_mode_deserializes_copy_to_sync() {
-        let toml_str = r#"
-[claude]
-auth_forward = "copy"
-"#;
-        let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+    fn auth_forward_mode_display_emits_canonical_names() {
+        assert_eq!(AuthForwardMode::Sync.to_string(), "sync");
+        assert_eq!(AuthForwardMode::Ignore.to_string(), "ignore");
+        assert_eq!(AuthForwardMode::ApiKey.to_string(), "api_key");
+        assert_eq!(AuthForwardMode::OAuthToken.to_string(), "oauth_token");
     }
 
     #[test]
-    fn auth_forward_mode_display_does_not_emit_copy() {
-        assert_eq!(AuthForwardMode::Sync.to_string(), "sync");
-        assert_eq!(AuthForwardMode::Ignore.to_string(), "ignore");
+    fn parse_agent_auth_config_sync() {
+        let toml = r#"auth_forward = "sync""#;
+        let cfg: AgentAuthConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.auth_forward, AuthForwardMode::Sync);
+    }
+
+    #[test]
+    fn parse_agent_auth_config_api_key() {
+        let toml = r#"auth_forward = "api_key""#;
+        let cfg: AgentAuthConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.auth_forward, AuthForwardMode::ApiKey);
+    }
+
+    #[test]
+    fn parse_agent_auth_config_oauth_token() {
+        let toml = r#"auth_forward = "oauth_token""#;
+        let cfg: AgentAuthConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.auth_forward, AuthForwardMode::OAuthToken);
+    }
+
+    #[test]
+    fn parse_agent_auth_config_ignore() {
+        let toml = r#"auth_forward = "ignore""#;
+        let cfg: AgentAuthConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.auth_forward, AuthForwardMode::Ignore);
     }
 
     #[test]

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -11,11 +11,6 @@ impl AppConfig {
             Err(e) => return Err(e.into()),
         };
 
-        let deprecated_copy_seen = match &contents_opt {
-            Some(c) => contains_deprecated_copy_auth_forward(c)?,
-            None => false,
-        };
-
         let mut config: Self = match contents_opt {
             Some(c) => toml::from_str(&c)?,
             None => Self::default(),
@@ -32,21 +27,13 @@ impl AppConfig {
 
         let builtins_changed = config.sync_builtin_agents();
 
-        if deprecated_copy_seen {
-            crate::tui::deprecation_warning(&format!(
-                "migrated auth_forward \"copy\" → \"sync\" in {} (copy is deprecated)",
-                paths.config_file.display()
-            ));
-        }
-
-        if builtins_changed || deprecated_copy_seen {
+        if builtins_changed {
             // Bootstrap only when the file doesn't exist yet. Without this
             // gate, ConfigEditor::open would call load_or_init for the
             // missing file and recurse. When the file DOES exist (the
-            // builtins-drifted or deprecated-copy upgrade path), we must
-            // NOT rewrite it through the lossy serde path first — that
-            // would destroy every user comment before the editor could
-            // preserve them, defeating the whole point of this migration.
+            // builtins-drifted upgrade path), we must NOT rewrite it
+            // through the lossy serde path first — that would destroy
+            // every user comment before the editor could preserve them.
             if !paths.config_file.exists() {
                 // Inline of the removed AppConfig::save. Atomic write:
                 // serialize → .tmp (0o600 on unix, fsync) → rename.
@@ -73,13 +60,8 @@ impl AppConfig {
                 std::fs::rename(&tmp, &paths.config_file)?;
             }
             let mut editor = crate::config::ConfigEditor::open(paths)?;
-            if builtins_changed {
-                for &(name, git) in crate::config::roles::BUILTIN_ROLES {
-                    editor.upsert_builtin_agent(name, git);
-                }
-            }
-            if deprecated_copy_seen {
-                editor.normalize_deprecated_copy();
+            for &(name, git) in crate::config::roles::BUILTIN_ROLES {
+                editor.upsert_builtin_agent(name, git);
             }
             // editor.save() returns an AppConfig parsed from the on-disk file,
             // which has [roles.X.env] preserved (upsert_builtin_agent doesn't
@@ -96,43 +78,6 @@ impl AppConfig {
         config.validate_workspaces()?;
         Ok(config)
     }
-}
-
-/// Detect the literal deprecated `auth_forward = "copy"` at either of the
-/// two known config paths: the global `[claude]` table or any
-/// `[roles.*.claude]` table. Returns `true` if any occurrence is found.
-///
-/// Uses `toml::Value` (cheap — we parse the same string into `AppConfig`
-/// right after) instead of a regex, so quoted keys with odd whitespace
-/// are handled correctly.
-fn contains_deprecated_copy_auth_forward(raw: &str) -> anyhow::Result<bool> {
-    let value: toml::Value = toml::from_str(raw)?;
-
-    // Global [claude] auth_forward
-    if let Some(s) = value
-        .get("claude")
-        .and_then(|c| c.get("auth_forward"))
-        .and_then(|v| v.as_str())
-        && s == "copy"
-    {
-        return Ok(true);
-    }
-
-    // Per-role [roles.<name>.claude] auth_forward
-    if let Some(roles) = value.get("roles").and_then(|a| a.as_table()) {
-        for role in roles.values() {
-            if let Some(s) = role
-                .get("claude")
-                .and_then(|c| c.get("auth_forward"))
-                .and_then(|v| v.as_str())
-                && s == "copy"
-            {
-                return Ok(true);
-            }
-        }
-    }
-
-    Ok(false)
 }
 
 #[cfg(test)]
@@ -167,7 +112,9 @@ mod tests {
     }
 
     #[test]
-    fn load_migrates_global_copy_to_sync_and_rewrites_config() {
+    fn load_rejects_deprecated_copy_alias() {
+        // Pre-release stance: no compatibility shims. `auth_forward = "copy"`
+        // must hard-fail at load instead of being silently migrated.
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
@@ -183,95 +130,12 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
         )
         .unwrap();
 
-        let config = AppConfig::load_or_init(&paths).unwrap();
-
-        // In memory, Copy normalized to Sync
-        assert_eq!(
-            config.claude.auth_forward,
-            crate::config::AuthForwardMode::Sync
-        );
-
-        // On disk, "copy" no longer present
-        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
+        let err = AppConfig::load_or_init(&paths).unwrap_err();
+        let msg = err.to_string();
         assert!(
-            !persisted.contains("auth_forward = \"copy\""),
-            "expected on-disk config to be migrated; got:\n{persisted}"
+            msg.contains("unknown variant `copy`") || msg.contains("invalid auth_forward mode"),
+            "expected parse error rejecting `copy`, got: {msg}"
         );
-        assert!(
-            persisted.contains("auth_forward = \"sync\""),
-            "expected migrated config to contain sync; got:\n{persisted}"
-        );
-    }
-
-    #[test]
-    fn load_migrates_per_agent_copy_to_sync() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-
-        std::fs::write(
-            &paths.config_file,
-            r#"[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-
-[roles.agent-smith.claude]
-auth_forward = "copy"
-"#,
-        )
-        .unwrap();
-
-        let config = AppConfig::load_or_init(&paths).unwrap();
-
-        assert_eq!(
-            config.resolve_auth_forward_mode("agent-smith"),
-            crate::config::AuthForwardMode::Sync
-        );
-
-        let persisted = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(!persisted.contains("auth_forward = \"copy\""));
-    }
-
-    #[test]
-    fn load_migration_preserves_user_comments() {
-        // Regression test for the persist.rs migration path: the copy→sync
-        // and builtin-sync branches must NOT pre-flush through the lossy
-        // serde writer, or every user comment gets destroyed before the
-        // editor can preserve them.
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-
-        let original = r#"# Top-of-file note — keep this
-[claude]
-auth_forward = "copy"
-
-# Builtin role, operator-configured
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-
-# Keep this comment too — it explains why we trust
-[roles.agent-smith.claude]
-auth_forward = "copy"
-"#;
-        std::fs::write(&paths.config_file, original).unwrap();
-
-        let _config = AppConfig::load_or_init(&paths).unwrap();
-
-        let after = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(
-            after.contains("# Top-of-file note — keep this"),
-            "top-of-file comment lost: {after}"
-        );
-        assert!(
-            after.contains("# Builtin role, operator-configured"),
-            "role-section comment lost: {after}"
-        );
-        assert!(
-            after.contains("# Keep this comment too — it explains why we trust"),
-            "claude-section comment lost: {after}"
-        );
-        assert!(!after.contains("\"copy\""), "copy not migrated: {after}");
-        assert!(after.contains("auth_forward = \"sync\""), "{after}");
     }
 
     #[test]
@@ -298,7 +162,7 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
     }
 
     #[test]
-    fn load_does_not_rewrite_when_no_copy_present() {
+    fn load_is_idempotent_when_builtins_already_synced() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
 
@@ -311,7 +175,7 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        // Second load with no "copy" anywhere — must not rewrite.
+        // Second load on a stable file must not rewrite.
         AppConfig::load_or_init(&paths).unwrap();
         let mtime_after = std::fs::metadata(&paths.config_file)
             .unwrap()

--- a/src/config/roles.rs
+++ b/src/config/roles.rs
@@ -52,7 +52,12 @@ impl AppConfig {
             .get(agent_key)
             .and_then(|a| a.claude.as_ref())
             .and_then(|c| c.auth_forward)
-            .unwrap_or(self.claude.auth_forward)
+            .unwrap_or_else(|| {
+                self.claude
+                    .as_ref()
+                    .map(|c| c.auth_forward)
+                    .unwrap_or_default()
+            })
     }
 
     /// Set the per-role auth forward mode override.
@@ -357,7 +362,15 @@ git = "https://github.com/jackin-project/jackin-the-architect.git"
     #[test]
     fn auth_forward_defaults_to_sync() {
         let config = AppConfig::default();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+        assert!(
+            config.claude.is_none(),
+            "default AppConfig must have no [claude] block"
+        );
+        assert_eq!(
+            config.resolve_auth_forward_mode("any"),
+            AuthForwardMode::Sync,
+            "absent [claude] resolves to Sync via default"
+        );
     }
 
     #[test]
@@ -370,7 +383,10 @@ auth_forward = "sync"
 git = "https://github.com/jackin-project/jackin-agent-smith.git"
 "#;
         let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.claude.auth_forward, AuthForwardMode::Sync);
+        assert_eq!(
+            config.claude.as_ref().unwrap().auth_forward,
+            AuthForwardMode::Sync
+        );
     }
 
     #[test]
@@ -449,7 +465,10 @@ auth_forward = "ignore"
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         let serialized = toml::to_string_pretty(&config).unwrap();
         let reloaded: AppConfig = toml::from_str(&serialized).unwrap();
-        assert_eq!(reloaded.claude.auth_forward, AuthForwardMode::Sync);
+        assert_eq!(
+            reloaded.claude.as_ref().unwrap().auth_forward,
+            AuthForwardMode::Sync
+        );
         assert_eq!(
             reloaded.resolve_auth_forward_mode("agent-smith"),
             AuthForwardMode::Ignore

--- a/src/config/roles.rs
+++ b/src/config/roles.rs
@@ -1,5 +1,51 @@
 use super::{AppConfig, AuthForwardMode, RoleSource};
+use crate::agent::Agent;
 use crate::selector::RoleSelector;
+
+/// Resolve the effective auth-forward mode for an agent in a (workspace, role) scope.
+///
+/// Walks three layers, most-specific wins:
+///
+/// 1. `workspaces[ws].roles[role].<agent>.auth_forward`
+/// 2. `workspaces[ws].<agent>.auth_forward`
+/// 3. `<agent>.auth_forward` (global)
+///
+/// Returns [`AuthForwardMode::Sync`] if no layer is set. The `<agent>`
+/// selector picks the `claude` vs `codex` field at each layer.
+///
+/// Passing `workspace = ""` (or any name not present in the config)
+/// naturally falls through to the global layer; this is the supported
+/// way for non-workspace-scoped callers (e.g. `jackin config auth show`)
+/// to read the global default through the same code path.
+pub fn resolve_mode(cfg: &AppConfig, agent: Agent, workspace: &str, role: &str) -> AuthForwardMode {
+    // Layer 3 (most specific): workspace × role × agent
+    if let Some(m) = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.roles.get(role))
+        .and_then(|ro| match agent {
+            Agent::Claude => ro.claude.as_ref().map(|c| c.auth_forward),
+            Agent::Codex => ro.codex.as_ref().map(|c| c.auth_forward),
+        })
+    {
+        return m;
+    }
+
+    // Layer 2: workspace × agent
+    if let Some(m) = cfg.workspaces.get(workspace).and_then(|ws| match agent {
+        Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
+        Agent::Codex => ws.codex.as_ref().map(|c| c.auth_forward),
+    }) {
+        return m;
+    }
+
+    // Layer 1: global agent
+    match agent {
+        Agent::Claude => cfg.claude.as_ref().map(|c| c.auth_forward),
+        Agent::Codex => cfg.codex.as_ref().map(|c| c.auth_forward),
+    }
+    .unwrap_or_default()
+}
 
 pub const BUILTIN_ROLES: &[(&str, &str)] = &[
     (
@@ -41,19 +87,6 @@ impl AppConfig {
         };
         self.roles.insert(selector.key(), source.clone());
         Ok((source, true))
-    }
-
-    /// Resolve the effective `AuthForwardMode` for a given role.
-    ///
-    /// Reads only the global `[claude]` block. The workspace and
-    /// per-(workspace × role) layers added in subsequent tasks
-    /// will rebuild this into a layered resolver; the deleted
-    /// per-role-global slot has no replacement until then.
-    pub fn resolve_auth_forward_mode(&self, _agent_key: &str) -> AuthForwardMode {
-        self.claude
-            .as_ref()
-            .map(|c| c.auth_forward)
-            .unwrap_or_default()
     }
 
     /// Mark an role source as trusted.  Returns `true` when the flag changed.
@@ -344,20 +377,6 @@ git = "https://github.com/jackin-project/jackin-the-architect.git"
     // ── Auth forwarding config tests ────────────────────────────────────
 
     #[test]
-    fn auth_forward_defaults_to_sync() {
-        let config = AppConfig::default();
-        assert!(
-            config.claude.is_none(),
-            "default AppConfig must have no [claude] block"
-        );
-        assert_eq!(
-            config.resolve_auth_forward_mode("any"),
-            AuthForwardMode::Sync,
-            "absent [claude] resolves to Sync via default"
-        );
-    }
-
-    #[test]
     fn deserializes_global_claude_auth_forward() {
         let toml_str = r#"
 [claude]
@@ -372,29 +391,151 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
             AuthForwardMode::Sync
         );
     }
+}
+
+#[cfg(test)]
+mod resolve_mode_tests {
+    use super::*;
+    use crate::agent::Agent;
+    use crate::config::{AgentAuthConfig, AppConfig, AuthForwardMode, CodexAuthConfig};
+    use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+
+    /// Build an `AppConfig` with optionally-set Claude modes at each of
+    /// the 3 layers: global, workspace, workspace × role.
+    fn cfg_claude(
+        global: Option<AuthForwardMode>,
+        ws: Option<AuthForwardMode>,
+        ws_role: Option<AuthForwardMode>,
+    ) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        if let Some(m) = global {
+            cfg.claude = Some(AgentAuthConfig { auth_forward: m });
+        }
+        let mut ws_cfg = WorkspaceConfig::default();
+        if let Some(m) = ws {
+            ws_cfg.claude = Some(AgentAuthConfig { auth_forward: m });
+        }
+        if let Some(m) = ws_role {
+            let over = WorkspaceRoleOverride {
+                claude: Some(AgentAuthConfig { auth_forward: m }),
+                ..Default::default()
+            };
+            ws_cfg.roles.insert("smith".to_string(), over);
+        }
+        cfg.workspaces.insert("proj".to_string(), ws_cfg);
+        cfg
+    }
 
     #[test]
-    fn resolve_auth_forward_defaults_to_sync() {
-        let config = AppConfig::default();
+    fn default_is_sync_when_nothing_set() {
+        let cfg = cfg_claude(None, None, None);
         assert_eq!(
-            config.resolve_auth_forward_mode("nonexistent"),
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
             AuthForwardMode::Sync
         );
     }
 
     #[test]
-    fn resolve_auth_forward_uses_global_setting() {
-        let toml_str = r#"
-[claude]
-auth_forward = "sync"
-
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-"#;
-        let config: AppConfig = toml::from_str(toml_str).unwrap();
+    fn global_used_when_others_unset() {
+        let cfg = cfg_claude(Some(AuthForwardMode::ApiKey), None, None);
         assert_eq!(
-            config.resolve_auth_forward_mode("agent-smith"),
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
+            AuthForwardMode::ApiKey
+        );
+    }
+
+    #[test]
+    fn workspace_overrides_global() {
+        let cfg = cfg_claude(
+            Some(AuthForwardMode::ApiKey),
+            Some(AuthForwardMode::OAuthToken),
+            None,
+        );
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
+            AuthForwardMode::OAuthToken
+        );
+    }
+
+    #[test]
+    fn role_override_wins() {
+        let cfg = cfg_claude(
+            Some(AuthForwardMode::ApiKey),
+            Some(AuthForwardMode::OAuthToken),
+            Some(AuthForwardMode::Ignore),
+        );
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
+            AuthForwardMode::Ignore
+        );
+    }
+
+    #[test]
+    fn workspace_only_when_global_unset() {
+        let cfg = cfg_claude(None, Some(AuthForwardMode::ApiKey), None);
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
+            AuthForwardMode::ApiKey
+        );
+    }
+
+    #[test]
+    fn role_only_when_global_and_workspace_unset() {
+        let cfg = cfg_claude(None, None, Some(AuthForwardMode::OAuthToken));
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "proj", "smith"),
+            AuthForwardMode::OAuthToken
+        );
+    }
+
+    #[test]
+    fn unknown_workspace_falls_back_to_global() {
+        let cfg = cfg_claude(Some(AuthForwardMode::ApiKey), None, None);
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "nonexistent", "smith"),
+            AuthForwardMode::ApiKey
+        );
+    }
+
+    #[test]
+    fn unknown_role_falls_back_to_workspace_or_global() {
+        let cfg = cfg_claude(
+            Some(AuthForwardMode::ApiKey),
+            Some(AuthForwardMode::OAuthToken),
+            None,
+        );
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Claude, "proj", "ghost"),
+            AuthForwardMode::OAuthToken
+        );
+    }
+
+    #[test]
+    fn codex_isolated_from_claude_global() {
+        let cfg = AppConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::ApiKey,
+            }),
+            // codex unset
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Codex, "proj", "smith"),
             AuthForwardMode::Sync
+        );
+    }
+
+    #[test]
+    fn codex_uses_codex_layer() {
+        let cfg = AppConfig {
+            codex: Some(CodexAuthConfig(AgentAuthConfig {
+                auth_forward: AuthForwardMode::ApiKey,
+            })),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            resolve_mode(&cfg, Agent::Codex, "proj", "smith"),
+            AuthForwardMode::ApiKey
         );
     }
 }

--- a/src/config/roles.rs
+++ b/src/config/roles.rs
@@ -1,4 +1,4 @@
-use super::{AppConfig, AuthForwardMode, ClaudeRoleConfig, RoleSource};
+use super::{AppConfig, AuthForwardMode, RoleSource};
 use crate::selector::RoleSelector;
 
 pub const BUILTIN_ROLES: &[(&str, &str)] = &[
@@ -37,7 +37,6 @@ impl AppConfig {
                 selector.name
             ),
             trusted: false,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         };
         self.roles.insert(selector.key(), source.clone());
@@ -46,28 +45,15 @@ impl AppConfig {
 
     /// Resolve the effective `AuthForwardMode` for a given role.
     ///
-    /// Resolution order: per-role override → global default → `Sync`.
-    pub fn resolve_auth_forward_mode(&self, agent_key: &str) -> AuthForwardMode {
-        self.roles
-            .get(agent_key)
-            .and_then(|a| a.claude.as_ref())
-            .and_then(|c| c.auth_forward)
-            .unwrap_or_else(|| {
-                self.claude
-                    .as_ref()
-                    .map(|c| c.auth_forward)
-                    .unwrap_or_default()
-            })
-    }
-
-    /// Set the per-role auth forward mode override.
-    // pub(crate): test-only affordance; production callers use ConfigEditor.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn set_agent_auth_forward(&mut self, key: &str, mode: AuthForwardMode) {
-        if let Some(source) = self.roles.get_mut(key) {
-            let claude = source.claude.get_or_insert_with(ClaudeRoleConfig::default);
-            claude.auth_forward = Some(mode);
-        }
+    /// Reads only the global `[claude]` block. The workspace and
+    /// per-(workspace × role) layers added in subsequent tasks
+    /// will rebuild this into a layered resolver; the deleted
+    /// per-role-global slot has no replacement until then.
+    pub fn resolve_auth_forward_mode(&self, _agent_key: &str) -> AuthForwardMode {
+        self.claude
+            .as_ref()
+            .map(|c| c.auth_forward)
+            .unwrap_or_default()
     }
 
     /// Mark an role source as trusted.  Returns `true` when the flag changed.
@@ -109,11 +95,9 @@ impl AppConfig {
     pub(super) fn sync_builtin_agents(&mut self) -> bool {
         let mut changed = false;
         for &(name, git) in BUILTIN_ROLES {
-            let existing_claude = self.roles.get(name).and_then(|a| a.claude.clone());
             let expected = RoleSource {
                 git: git.to_string(),
                 trusted: true,
-                claude: existing_claude,
                 env: std::collections::BTreeMap::new(),
             };
             match self.roles.get(name) {
@@ -390,23 +374,6 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
     }
 
     #[test]
-    fn deserializes_per_agent_claude_auth_forward() {
-        let toml_str = r#"
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-
-[roles.agent-smith.claude]
-auth_forward = "ignore"
-"#;
-        let config: AppConfig = toml::from_str(toml_str).unwrap();
-        let role = config.roles.get("agent-smith").unwrap();
-        assert_eq!(
-            role.claude.as_ref().unwrap().auth_forward,
-            Some(AuthForwardMode::Ignore)
-        );
-    }
-
-    #[test]
     fn resolve_auth_forward_defaults_to_sync() {
         let config = AppConfig::default();
         assert_eq!(
@@ -428,50 +395,6 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
         assert_eq!(
             config.resolve_auth_forward_mode("agent-smith"),
             AuthForwardMode::Sync
-        );
-    }
-
-    #[test]
-    fn resolve_auth_forward_per_agent_overrides_global() {
-        let toml_str = r#"
-[claude]
-auth_forward = "sync"
-
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-
-[roles.agent-smith.claude]
-auth_forward = "ignore"
-"#;
-        let config: AppConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            config.resolve_auth_forward_mode("agent-smith"),
-            AuthForwardMode::Ignore
-        );
-    }
-
-    #[test]
-    fn auth_forward_round_trips_through_toml() {
-        let toml_str = r#"
-[claude]
-auth_forward = "sync"
-
-[roles.agent-smith]
-git = "https://github.com/jackin-project/jackin-agent-smith.git"
-
-[roles.agent-smith.claude]
-auth_forward = "ignore"
-"#;
-        let config: AppConfig = toml::from_str(toml_str).unwrap();
-        let serialized = toml::to_string_pretty(&config).unwrap();
-        let reloaded: AppConfig = toml::from_str(&serialized).unwrap();
-        assert_eq!(
-            reloaded.claude.as_ref().unwrap().auth_forward,
-            AuthForwardMode::Sync
-        );
-        assert_eq!(
-            reloaded.resolve_auth_forward_mode("agent-smith"),
-            AuthForwardMode::Ignore
         );
     }
 }

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -266,6 +266,8 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         };
         config
             .create_workspace("big-monorepo", original.clone())

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -104,9 +104,13 @@ pub(super) fn handle_auth_form_key(
         return false;
     };
 
-    // Esc cancels at every focus.
+    // Esc cancels at every focus. Drain the auth-form return stash too so
+    // a stale OpPicker round-trip can't be re-applied to a future modal —
+    // every other exit path (Save / Cancel / Reset commit, OpPicker
+    // commit/cancel) drains it explicitly; Esc must too.
     if key.code == KeyCode::Esc {
         editor.modal = None;
+        editor.pending_auth_form_return = None;
         return true;
     }
 
@@ -857,5 +861,111 @@ mod tests {
             "failed vault read must surface an error popup"
         );
         assert!(editor.pending_auth_form_return.is_none());
+    }
+
+    /// Esc on an open auth form must drain `pending_auth_form_return`
+    /// alongside dismissing the modal — leaving it set would let a
+    /// later `OpPicker` open from the Secrets tab silently inherit a
+    /// stale auth-form context. Defensive cleanup against future
+    /// picker flows.
+    #[test]
+    fn auth_form_esc_clears_pending_auth_form_return() {
+        use crate::console::manager::state::AuthFormReturnPath;
+
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        // Stash a return path manually as if a picker handoff was in
+        // flight. (Reaching this state via the public API is hard
+        // because the picker swap takes the modal — the defensive
+        // cleanup is for reentrancy / partial-flow bugs we don't want
+        // to leak through Esc.)
+        editor.pending_auth_form_return = Some(AuthFormReturnPath {
+            target: AuthFormTarget::Workspace {
+                agent: Agent::Claude,
+            },
+            state: Box::new(AuthForm::new(Agent::Claude)),
+            focus: AuthFormFocus::Mode,
+            literal_buffer: String::new(),
+        });
+        // Open the auth form modal so handle_auth_form_key can be
+        // entered.
+        open_auth_form_modal(editor);
+        assert!(matches!(editor.modal, Some(Modal::AuthForm { .. })));
+
+        let closed = drive_key(editor, key(KeyCode::Esc));
+        assert!(closed, "Esc must close the auth form");
+        assert!(editor.modal.is_none(), "modal must be dropped");
+        assert!(
+            editor.pending_auth_form_return.is_none(),
+            "Esc must drain pending_auth_form_return so future picker flows \
+             don't inherit stale stash state"
+        );
+    }
+
+    /// `Enter` on the Save focus when `can_save` is false (e.g. an
+    /// `OpRef` credential with empty `op` and `path`) must NOT dismiss
+    /// the modal NOR mutate `editor.pending`. The Task 18 fixup made
+    /// `can_save` reject empty `OpRef`s; this test pins that the input
+    /// layer honours the guard rather than ignoring it.
+    #[test]
+    fn auth_form_save_disabled_blocks_enter() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        let pending_before = editor.pending.clone();
+        open_auth_form_modal(editor);
+        // Build a form state with mode = ApiKey and credential = empty
+        // OpRef so `can_save` returns false. Cycle Mode (None → Sync →
+        // ApiKey), Enter into the credential block, Space to flip from
+        // Literal to (empty) OpRef, then Down to navigate to OpRefValue.
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Char(' ')));
+
+        // Confirm the form's credential is the empty OpRef and can_save
+        // is false.
+        let Some(Modal::AuthForm { state, .. }) = &editor.modal else {
+            panic!("auth form must still be open");
+        };
+        match &state.credential {
+            CredentialInput::OpRef(r) => {
+                assert!(
+                    r.op.is_empty() && r.path.is_empty(),
+                    "expected empty OpRef as setup; got {r:?}"
+                );
+            }
+            other => panic!("expected OpRef credential after toggle; got {other:?}"),
+        }
+        assert!(
+            !state.can_save(),
+            "form must NOT be save-able with mode set + empty OpRef"
+        );
+
+        // Move focus directly to Save and press Enter. The handler
+        // must short-circuit on `!can_save()` and leave the modal
+        // open + pending untouched.
+        if let Some(Modal::AuthForm { focus, .. }) = editor.modal.as_mut() {
+            *focus = AuthFormFocus::Save;
+        } else {
+            panic!("auth form must still be open");
+        }
+        let closed = drive_key(editor, key(KeyCode::Enter));
+        assert!(
+            !closed,
+            "Enter on Save with !can_save must NOT close the modal"
+        );
+        assert!(
+            matches!(editor.modal, Some(Modal::AuthForm { .. })),
+            "modal must remain on AuthForm; got {:?}",
+            editor.modal
+        );
+        assert_eq!(
+            editor.pending, pending_before,
+            "Enter on Save with !can_save must NOT mutate editor.pending"
+        );
     }
 }

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -1,0 +1,570 @@
+//! Auth-tab input handling: open the form modal, route keystrokes to
+//! the form, and persist commits back to `editor.pending`.
+//!
+//! Mirrors the Secrets tab's pattern of "form mutates `editor.pending`
+//! in memory; the editor's existing save flow (`edit_workspace`)
+//! serializes the whole `WorkspaceConfig` block back to disk on save".
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::super::super::widgets::auth_panel::{AuthForm, CredentialInput};
+use super::super::render::editor::resolve_auth_row_target;
+use super::super::state::{AuthFormFocus, AuthFormTarget, EditorState, FieldFocus, Modal};
+use crate::agent::Agent;
+use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
+use crate::operator_env::EnvValue;
+use crate::workspace::WorkspaceRoleOverride;
+
+/// Open the auth-edit form modal for the row currently under the
+/// cursor on the Auth tab. Pre-populates the form from the row's
+/// effective mode + credential so editing an existing entry shows
+/// what's there.
+pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>) {
+    let FieldFocus::Row(n) = editor.active_field;
+    let Some(target) = resolve_auth_row_target(editor, n) else {
+        return;
+    };
+    let agent = match &target {
+        AuthFormTarget::Workspace { agent } | AuthFormTarget::WorkspaceRole { agent, .. } => *agent,
+    };
+    let (existing_mode, existing_cred) = current_mode_and_credential(editor, &target);
+    let form = existing_mode.map_or_else(
+        || AuthForm::new(agent),
+        |mode| AuthForm::from_existing(agent, mode, existing_cred),
+    );
+    let literal_buffer = if let CredentialInput::Literal(s) = &form.credential {
+        s.clone()
+    } else {
+        String::new()
+    };
+    editor.modal = Some(Modal::AuthForm {
+        target,
+        state: Box::new(form),
+        focus: AuthFormFocus::Mode,
+        literal_buffer,
+    });
+}
+
+/// Read the current mode + credential for the form's target out of
+/// `editor.pending`. Returns `(None, _)` when the layer has no explicit
+/// mode set yet — the form opens with the mode picker unset.
+fn current_mode_and_credential(
+    editor: &EditorState<'_>,
+    target: &AuthFormTarget,
+) -> (Option<AuthForwardMode>, Option<EnvValue>) {
+    match target {
+        AuthFormTarget::Workspace { agent } => {
+            let mode = match agent {
+                Agent::Claude => editor.pending.claude.as_ref().map(|c| c.auth_forward),
+                Agent::Codex => editor.pending.codex.as_ref().map(|c| c.0.auth_forward),
+            };
+            let env_var = mode.and_then(|m| agent.required_env_var(m));
+            let cred = env_var.and_then(|v| editor.pending.env.get(v).cloned());
+            (mode, cred)
+        }
+        AuthFormTarget::WorkspaceRole { role, agent } => {
+            let override_ref = editor.pending.roles.get(role);
+            let mode = override_ref.and_then(|ro| match agent {
+                Agent::Claude => ro.claude.as_ref().map(|c| c.auth_forward),
+                Agent::Codex => ro.codex.as_ref().map(|c| c.0.auth_forward),
+            });
+            let env_var = mode.and_then(|m| agent.required_env_var(m));
+            let cred = env_var.and_then(|v| override_ref.and_then(|ro| ro.env.get(v).cloned()));
+            (mode, cred)
+        }
+    }
+}
+
+/// Drive a single keystroke into an open `Modal::AuthForm`. Returns
+/// `true` when the modal was closed (committed or cancelled).
+pub(super) fn handle_auth_form_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
+    let Some(Modal::AuthForm {
+        state,
+        focus,
+        literal_buffer,
+        ..
+    }) = editor.modal.as_mut()
+    else {
+        return false;
+    };
+
+    // Esc cancels at every focus.
+    if key.code == KeyCode::Esc {
+        editor.modal = None;
+        return true;
+    }
+
+    match *focus {
+        AuthFormFocus::Mode => {
+            handle_mode_key(focus, state.as_mut(), key);
+        }
+        AuthFormFocus::CredentialSource => {
+            handle_credential_source_key(focus, state.as_mut(), literal_buffer.as_str(), key);
+        }
+        AuthFormFocus::LiteralValue => {
+            handle_literal_value_key(focus, state.as_mut(), literal_buffer, key);
+        }
+        AuthFormFocus::OpRefValue => match key.code {
+            KeyCode::Down | KeyCode::Tab => *focus = AuthFormFocus::Save,
+            KeyCode::Up => *focus = AuthFormFocus::CredentialSource,
+            _ => {}
+        },
+        AuthFormFocus::Save => {
+            return handle_save_key(editor, key);
+        }
+        AuthFormFocus::Cancel => {
+            return handle_cancel_key(editor, key);
+        }
+        AuthFormFocus::Reset => {
+            return handle_reset_key(editor, key);
+        }
+    }
+    false
+}
+
+fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent) {
+    match key.code {
+        KeyCode::Tab | KeyCode::Char(' ') => cycle_mode(form),
+        KeyCode::Down | KeyCode::Char('j') => *focus = next_focus_after_mode(form),
+        KeyCode::Enter => {
+            *focus = if form.shows_credential_block() {
+                AuthFormFocus::CredentialSource
+            } else {
+                AuthFormFocus::Save
+            };
+        }
+        _ => {}
+    }
+}
+
+fn handle_credential_source_key(
+    focus: &mut AuthFormFocus,
+    form: &mut AuthForm,
+    literal_buffer: &str,
+    key: KeyEvent,
+) {
+    match key.code {
+        KeyCode::Char(' ') => toggle_credential_source(form, literal_buffer),
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Enter => {
+            *focus = focus_for_credential_value(form);
+        }
+        KeyCode::Up | KeyCode::Char('k') => *focus = AuthFormFocus::Mode,
+        _ => {}
+    }
+}
+
+fn handle_literal_value_key(
+    focus: &mut AuthFormFocus,
+    form: &mut AuthForm,
+    literal_buffer: &mut String,
+    key: KeyEvent,
+) {
+    match key.code {
+        KeyCode::Char(c) => {
+            literal_buffer.push(c);
+            form.set_literal(literal_buffer.clone());
+        }
+        KeyCode::Backspace => {
+            literal_buffer.pop();
+            form.set_literal(literal_buffer.clone());
+        }
+        KeyCode::Down | KeyCode::Tab | KeyCode::Enter => *focus = AuthFormFocus::Save,
+        KeyCode::Up => *focus = AuthFormFocus::CredentialSource,
+        _ => {}
+    }
+}
+
+fn handle_save_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
+    let Some(Modal::AuthForm {
+        target,
+        state,
+        focus,
+        ..
+    }) = editor.modal.as_mut()
+    else {
+        return false;
+    };
+    match key.code {
+        KeyCode::Right | KeyCode::Tab => {
+            *focus = AuthFormFocus::Cancel;
+            false
+        }
+        KeyCode::Up => {
+            *focus = if state.shows_credential_block() {
+                focus_for_credential_value(state.as_ref())
+            } else {
+                AuthFormFocus::Mode
+            };
+            false
+        }
+        KeyCode::Enter => {
+            if !state.can_save() {
+                return false;
+            }
+            let committed_target = target.clone();
+            let agent = state.agent;
+            let form = std::mem::replace(state.as_mut(), AuthForm::new(agent));
+            editor.modal = None;
+            persist_form(editor, &committed_target, &form);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_cancel_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
+    let Some(Modal::AuthForm { focus, .. }) = editor.modal.as_mut() else {
+        return false;
+    };
+    match key.code {
+        KeyCode::Left => {
+            *focus = AuthFormFocus::Save;
+            false
+        }
+        KeyCode::Right | KeyCode::Tab => {
+            *focus = AuthFormFocus::Reset;
+            false
+        }
+        KeyCode::Enter => {
+            editor.modal = None;
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_reset_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
+    let Some(Modal::AuthForm { target, focus, .. }) = editor.modal.as_mut() else {
+        return false;
+    };
+    match key.code {
+        KeyCode::Left => {
+            *focus = AuthFormFocus::Cancel;
+            false
+        }
+        KeyCode::Enter => {
+            let committed_target = target.clone();
+            editor.modal = None;
+            clear_layer(editor, &committed_target);
+            true
+        }
+        _ => false,
+    }
+}
+
+const fn focus_for_credential_value(form: &AuthForm) -> AuthFormFocus {
+    if matches!(form.credential, CredentialInput::OpRef(_)) {
+        AuthFormFocus::OpRefValue
+    } else {
+        AuthFormFocus::LiteralValue
+    }
+}
+
+fn cycle_mode(form: &mut AuthForm) {
+    let modes = form.available_modes();
+    if modes.is_empty() {
+        return;
+    }
+    let next = form.mode.map_or(modes[0], |current| {
+        let idx = modes.iter().position(|m| *m == current).unwrap_or(0);
+        modes[(idx + 1) % modes.len()]
+    });
+    form.set_mode(next);
+}
+
+const fn next_focus_after_mode(form: &AuthForm) -> AuthFormFocus {
+    if form.shows_credential_block() {
+        AuthFormFocus::CredentialSource
+    } else {
+        AuthFormFocus::Save
+    }
+}
+
+fn toggle_credential_source(form: &mut AuthForm, literal_buffer: &str) {
+    use crate::operator_env::OpRef;
+    let next = match &form.credential {
+        CredentialInput::OpRef(_) => CredentialInput::Literal(literal_buffer.to_string()),
+        CredentialInput::None | CredentialInput::Literal(_) => CredentialInput::OpRef(OpRef {
+            op: String::new(),
+            path: String::new(),
+        }),
+    };
+    form.credential = next;
+}
+
+/// Apply a successful form commit to `editor.pending`. Writes both the
+/// agent block (`auth_forward`) AND the credential env var when the
+/// form's outcome includes one.
+fn persist_form(editor: &mut EditorState<'_>, target: &AuthFormTarget, form: &AuthForm) {
+    let Some(outcome) = form.commit() else {
+        return;
+    };
+    match target {
+        AuthFormTarget::Workspace { agent } => {
+            set_workspace_mode(&mut editor.pending, *agent, Some(outcome.mode));
+            if let (Some(name), Some(value)) = (outcome.env_var_name, outcome.env_value.clone()) {
+                editor.pending.env.insert(name.to_string(), value);
+            }
+        }
+        AuthFormTarget::WorkspaceRole { role, agent } => {
+            let entry = editor.pending.roles.entry(role.clone()).or_default();
+            set_role_mode(entry, *agent, Some(outcome.mode));
+            if let (Some(name), Some(value)) = (outcome.env_var_name, outcome.env_value.clone()) {
+                entry.env.insert(name.to_string(), value);
+            }
+        }
+    }
+}
+
+/// Clear the `auth_forward` at the form's target layer. Does NOT touch
+/// the credential env var — operators delete those via the Secrets tab
+/// so the deletion is explicit.
+fn clear_layer(editor: &mut EditorState<'_>, target: &AuthFormTarget) {
+    match target {
+        AuthFormTarget::Workspace { agent } => {
+            set_workspace_mode(&mut editor.pending, *agent, None);
+        }
+        AuthFormTarget::WorkspaceRole { role, agent } => {
+            if let Some(entry) = editor.pending.roles.get_mut(role) {
+                set_role_mode(entry, *agent, None);
+            }
+        }
+    }
+}
+
+fn set_workspace_mode(
+    ws: &mut crate::workspace::WorkspaceConfig,
+    agent: Agent,
+    mode: Option<AuthForwardMode>,
+) {
+    match agent {
+        Agent::Claude => {
+            ws.claude = mode.map(|auth_forward| AgentAuthConfig { auth_forward });
+        }
+        Agent::Codex => {
+            ws.codex = mode.map(|auth_forward| CodexAuthConfig(AgentAuthConfig { auth_forward }));
+        }
+    }
+}
+
+fn set_role_mode(entry: &mut WorkspaceRoleOverride, agent: Agent, mode: Option<AuthForwardMode>) {
+    match agent {
+        Agent::Claude => {
+            entry.claude = mode.map(|auth_forward| AgentAuthConfig { auth_forward });
+        }
+        Agent::Codex => {
+            entry.codex =
+                mode.map(|auth_forward| CodexAuthConfig(AgentAuthConfig { auth_forward }));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::Agent;
+    use crate::config::{AppConfig, AuthForwardMode};
+    use crate::console::manager::state::{
+        AuthFormTarget, EditorState, FieldFocus, ManagerStage, ManagerState,
+    };
+    use crate::workspace::{MountConfig, WorkspaceConfig};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn build_state() -> (AppConfig, ManagerState<'static>) {
+        let mut cfg = AppConfig::default();
+        let mut ws = WorkspaceConfig {
+            workdir: "/code/proj".into(),
+            mounts: vec![MountConfig {
+                src: "/code/proj".into(),
+                dst: "/code/proj".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }],
+            allowed_roles: vec!["smith".into()],
+            ..Default::default()
+        };
+        ws.allowed_roles.sort();
+        cfg.workspaces.insert("proj".into(), ws);
+        cfg.roles.insert(
+            "smith".into(),
+            crate::config::RoleSource {
+                git: "https://example.com/jackin-smith.git".into(),
+                trusted: true,
+                env: std::collections::BTreeMap::default(),
+            },
+        );
+
+        let cwd = std::path::PathBuf::from("/tmp");
+        let mut state = ManagerState::from_config(&cfg, &cwd);
+        let ws = cfg.workspaces.get("proj").unwrap().clone();
+        let mut editor = EditorState::new_edit("proj".into(), ws);
+        editor.active_tab = crate::console::manager::state::EditorTab::Auth;
+        editor.active_field = FieldFocus::Row(0);
+        state.stage = ManagerStage::Editor(editor);
+        (cfg, state)
+    }
+
+    /// Walking from the workspace × Claude row through the form:
+    /// Enter opens form, Space cycles mode to `api_key`, Enter into
+    /// credential, type literal, navigate to Save, Enter saves. The
+    /// in-memory `pending.claude` and `pending.env` reflect the change.
+    #[test]
+    fn auth_form_save_persists_workspace_layer_into_pending() {
+        let (_cfg, mut state) = build_state();
+        // Open form (Enter) on row 0 → workspace × Claude.
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        assert!(matches!(editor.modal, Some(Modal::AuthForm { .. })));
+
+        // Cycle mode: None → first available (sync) → ApiKey is two cycles.
+        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
+        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
+        // Enter to advance to credential block.
+        handle_auth_form_key(editor, key(KeyCode::Enter));
+        // Enter on cred radio → into LiteralValue.
+        handle_auth_form_key(editor, key(KeyCode::Enter));
+        // Type "secret".
+        for c in "secret".chars() {
+            handle_auth_form_key(editor, key(KeyCode::Char(c)));
+        }
+        // Tab to Save.
+        handle_auth_form_key(editor, key(KeyCode::Tab));
+        // Enter → save.
+        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        assert!(closed, "save must close the modal");
+        assert!(editor.modal.is_none(), "modal should be gone");
+
+        // pending.claude reflects ApiKey.
+        let claude_cfg = editor
+            .pending
+            .claude
+            .as_ref()
+            .expect("workspace claude block must be set");
+        assert_eq!(claude_cfg.auth_forward, AuthForwardMode::ApiKey);
+        // pending.env carries the credential.
+        let value = editor
+            .pending
+            .env
+            .get("ANTHROPIC_API_KEY")
+            .expect("credential env var must be set");
+        match value {
+            EnvValue::Plain(s) => assert_eq!(s, "secret"),
+            EnvValue::OpRef(_) => panic!("expected plain literal credential"),
+        }
+    }
+
+    /// Reset action clears the layer's mode without touching any
+    /// credential env var. Confirms that the Reset button on the form
+    /// produces the "drop down to inherited" behavior.
+    #[test]
+    fn auth_form_reset_clears_workspace_layer_mode() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        editor.pending.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        open_auth_form_modal(editor);
+        // Tab through to Reset and Enter.
+        // From Mode → Down → Cred → Down → Literal → Tab → Save → Tab → Cancel → Tab → Reset.
+        handle_auth_form_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
+        handle_auth_form_key(editor, key(KeyCode::Down)); // → LiteralValue
+        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Save
+        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Cancel
+        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Reset
+        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        assert!(closed, "reset must close the modal");
+        assert!(
+            editor.pending.claude.is_none(),
+            "reset must clear workspace claude block"
+        );
+    }
+
+    /// Cancel doesn't persist anything to pending: the workspace layer
+    /// stays untouched.
+    #[test]
+    fn auth_form_cancel_does_not_mutate_pending() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        handle_auth_form_key(editor, key(KeyCode::Char(' '))); // cycle to sync
+        // Esc cancels at any focus.
+        let closed = handle_auth_form_key(editor, key(KeyCode::Esc));
+        assert!(closed);
+        assert!(
+            editor.pending.claude.is_none(),
+            "cancel must not write to pending"
+        );
+    }
+
+    /// Picking the role × agent row mounts the form against the
+    /// override layer. Save persists the mode under
+    /// `pending.roles[role].claude` and the env var under
+    /// `pending.roles[role].env`.
+    #[test]
+    fn auth_form_save_persists_role_layer_into_pending() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        // Row 2 is workspace×role[0]×Claude (rows 0..2 are the workspace
+        // layer × {Claude, Codex}; row 2 is the first role-agent row).
+        editor.active_field = FieldFocus::Row(2);
+        open_auth_form_modal(editor);
+        let Some(Modal::AuthForm { target, .. }) = &editor.modal else {
+            panic!("form must be open");
+        };
+        assert_eq!(
+            target,
+            &AuthFormTarget::WorkspaceRole {
+                role: "smith".into(),
+                agent: Agent::Claude,
+            }
+        );
+
+        // Cycle to api_key, enter cred, type, tab to save, enter.
+        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
+        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
+        handle_auth_form_key(editor, key(KeyCode::Enter));
+        handle_auth_form_key(editor, key(KeyCode::Enter));
+        for c in "abc".chars() {
+            handle_auth_form_key(editor, key(KeyCode::Char(c)));
+        }
+        handle_auth_form_key(editor, key(KeyCode::Tab));
+        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        assert!(closed);
+
+        let role_entry = editor
+            .pending
+            .roles
+            .get("smith")
+            .expect("role override must exist");
+        let cfg = role_entry
+            .claude
+            .as_ref()
+            .expect("role override claude must be set");
+        assert_eq!(cfg.auth_forward, AuthForwardMode::ApiKey);
+        let env_val = role_entry
+            .env
+            .get("ANTHROPIC_API_KEY")
+            .expect("role env credential must be set");
+        match env_val {
+            EnvValue::Plain(s) => assert_eq!(s, "abc"),
+            EnvValue::OpRef(_) => panic!("expected plain literal"),
+        }
+    }
+}

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -8,10 +8,14 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use super::super::super::widgets::auth_panel::{AuthForm, CredentialInput};
+use super::super::super::widgets::op_picker::OpPickerState;
 use super::super::render::editor::resolve_auth_row_target;
-use super::super::state::{AuthFormFocus, AuthFormTarget, EditorState, FieldFocus, Modal};
+use super::super::state::{
+    AuthFormFocus, AuthFormReturnPath, AuthFormTarget, EditorState, FieldFocus, Modal,
+};
 use crate::agent::Agent;
 use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
+use crate::console::op_cache::OpCache;
 use crate::operator_env::EnvValue;
 use crate::workspace::WorkspaceRoleOverride;
 
@@ -76,8 +80,20 @@ fn current_mode_and_credential(
 }
 
 /// Drive a single keystroke into an open `Modal::AuthForm`. Returns
-/// `true` when the modal was closed (committed or cancelled).
-pub(super) fn handle_auth_form_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
+/// `true` when the modal was closed (committed, cancelled, or
+/// transitioned to `Modal::OpPicker` for credential selection).
+///
+/// `op_cache` is consumed when the operator presses Enter at
+/// `AuthFormFocus::OpRefValue` to mount a fresh `OpPicker` modal; the
+/// auth-form's context is stashed in
+/// `editor.pending_auth_form_return` so the picker's commit handler
+/// in `editor.rs` can re-mount the form with the picked `OpRef`
+/// applied (or unchanged on cancel).
+pub(super) fn handle_auth_form_key(
+    editor: &mut EditorState<'_>,
+    key: KeyEvent,
+    op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
+) -> bool {
     let Some(Modal::AuthForm {
         state,
         focus,
@@ -105,6 +121,9 @@ pub(super) fn handle_auth_form_key(editor: &mut EditorState<'_>, key: KeyEvent) 
             handle_literal_value_key(focus, state.as_mut(), literal_buffer, key);
         }
         AuthFormFocus::OpRefValue => match key.code {
+            KeyCode::Enter => {
+                return open_op_picker_from_auth_form(editor, op_cache);
+            }
             KeyCode::Down | KeyCode::Tab => *focus = AuthFormFocus::Save,
             KeyCode::Up => *focus = AuthFormFocus::CredentialSource,
             _ => {}
@@ -120,6 +139,121 @@ pub(super) fn handle_auth_form_key(editor: &mut EditorState<'_>, key: KeyEvent) 
         }
     }
     false
+}
+
+/// Detach the auth-form context into `editor.pending_auth_form_return`
+/// and replace `editor.modal` with a fresh `Modal::OpPicker`. The
+/// picker's commit handler (in `editor.rs`) is responsible for
+/// reading `pending_auth_form_return.take()` and re-mounting the form.
+///
+/// Returns `true` so the caller treats the auth-form modal as closed
+/// (it's been swapped out for the picker).
+fn open_op_picker_from_auth_form(
+    editor: &mut EditorState<'_>,
+    op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
+) -> bool {
+    let Some(Modal::AuthForm {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    }) = editor.modal.take()
+    else {
+        return false;
+    };
+    editor.pending_auth_form_return = Some(AuthFormReturnPath {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    });
+    editor.modal = Some(Modal::OpPicker {
+        state: Box::new(OpPickerState::new_with_cache(op_cache)),
+    });
+    true
+}
+
+/// Re-mount the auth-form modal with a freshly-picked `OpRef` applied
+/// against the production `OpCli` runner. Called from the `OpPicker`'s
+/// commit handler in `editor.rs` when `pending_auth_form_return` was
+/// set (i.e. the picker was opened from the auth form, not from the
+/// Secrets tab).
+///
+/// On `try_commit_op_ref` failure (vault read error), the form is
+/// re-opened with the credential left unchanged and an `ErrorPopup`
+/// modal is layered on top so the operator sees what went wrong. The
+/// `read-then-commit` invariant from Task 18 guarantees a broken
+/// reference never lands in `editor.pending`.
+pub(super) fn apply_op_picker_to_auth_form(
+    editor: &mut EditorState<'_>,
+    op_ref: crate::operator_env::OpRef,
+) {
+    apply_op_picker_to_auth_form_with_runner(editor, op_ref, &crate::operator_env::OpCli::new());
+}
+
+/// Restore the auth-form modal unchanged after the operator cancels
+/// the `OpPicker`. Called from the `OpPicker` cancel branch in
+/// `editor.rs` when `pending_auth_form_return` was set.
+pub(super) fn restore_auth_form_after_op_picker_cancel(editor: &mut EditorState<'_>) {
+    let Some(AuthFormReturnPath {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    }) = editor.pending_auth_form_return.take()
+    else {
+        return;
+    };
+    editor.modal = Some(Modal::AuthForm {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    });
+}
+
+/// Inner helper split out so tests can inject a fake `OpRunner`
+/// without touching the real `op` binary. Mirrors the test pattern
+/// for `try_commit_op_ref` in `form.rs`.
+fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?Sized>(
+    editor: &mut EditorState<'_>,
+    op_ref: crate::operator_env::OpRef,
+    runner: &R,
+) {
+    use crate::console::widgets::error_popup::ErrorPopupState;
+
+    let Some(AuthFormReturnPath {
+        target,
+        mut state,
+        focus,
+        literal_buffer,
+    }) = editor.pending_auth_form_return.take()
+    else {
+        return;
+    };
+    let read_result = state.try_commit_op_ref(runner, op_ref);
+    let new_focus = if read_result.is_ok() {
+        // On success, drop the cursor onto Save so Enter commits.
+        AuthFormFocus::Save
+    } else {
+        // On failure, keep the cursor on OpRefValue so the operator
+        // can retry without navigating.
+        focus
+    };
+    editor.modal = Some(Modal::AuthForm {
+        target,
+        state,
+        focus: new_focus,
+        literal_buffer,
+    });
+    if let Err(e) = read_result {
+        // Layer the error popup on top of the re-mounted auth form.
+        // The popup's commit closes only itself, returning the
+        // operator to the form with the credential field unchanged.
+        editor.modal = Some(Modal::ErrorPopup {
+            state: ErrorPopupState::new("1Password read failed", e.to_string()),
+        });
+    }
 }
 
 fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent) {
@@ -367,6 +501,7 @@ mod tests {
     use crate::console::manager::state::{
         AuthFormTarget, EditorState, FieldFocus, ManagerStage, ManagerState,
     };
+    use crate::operator_env::{OpRef, OpRunner};
     use crate::workspace::{MountConfig, WorkspaceConfig};
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
@@ -377,6 +512,18 @@ mod tests {
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }
+    }
+
+    /// Per-test op-cache (no shared state between test cases).
+    fn fresh_op_cache() -> std::rc::Rc<std::cell::RefCell<OpCache>> {
+        std::rc::Rc::new(std::cell::RefCell::new(OpCache::default()))
+    }
+
+    /// Test wrapper around `handle_auth_form_key` that allocates a
+    /// throwaway op-cache. Most existing tests don't care about
+    /// op-picker plumbing — this keeps their bodies short.
+    fn drive_key(editor: &mut EditorState<'_>, k: KeyEvent) -> bool {
+        handle_auth_form_key(editor, k, fresh_op_cache())
     }
 
     fn build_state() -> (AppConfig, ManagerState<'static>) {
@@ -428,20 +575,20 @@ mod tests {
         assert!(matches!(editor.modal, Some(Modal::AuthForm { .. })));
 
         // Cycle mode: None → first available (sync) → ApiKey is two cycles.
-        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
-        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
         // Enter to advance to credential block.
-        handle_auth_form_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Enter));
         // Enter on cred radio → into LiteralValue.
-        handle_auth_form_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Enter));
         // Type "secret".
         for c in "secret".chars() {
-            handle_auth_form_key(editor, key(KeyCode::Char(c)));
+            drive_key(editor, key(KeyCode::Char(c)));
         }
         // Tab to Save.
-        handle_auth_form_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Tab));
         // Enter → save.
-        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        let closed = drive_key(editor, key(KeyCode::Enter));
         assert!(closed, "save must close the modal");
         assert!(editor.modal.is_none(), "modal should be gone");
 
@@ -479,12 +626,12 @@ mod tests {
         open_auth_form_modal(editor);
         // Tab through to Reset and Enter.
         // From Mode → Down → Cred → Down → Literal → Tab → Save → Tab → Cancel → Tab → Reset.
-        handle_auth_form_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
-        handle_auth_form_key(editor, key(KeyCode::Down)); // → LiteralValue
-        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Save
-        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Cancel
-        handle_auth_form_key(editor, key(KeyCode::Tab)); // → Reset
-        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
+        drive_key(editor, key(KeyCode::Down)); // → LiteralValue
+        drive_key(editor, key(KeyCode::Tab)); // → Save
+        drive_key(editor, key(KeyCode::Tab)); // → Cancel
+        drive_key(editor, key(KeyCode::Tab)); // → Reset
+        let closed = drive_key(editor, key(KeyCode::Enter));
         assert!(closed, "reset must close the modal");
         assert!(
             editor.pending.claude.is_none(),
@@ -501,9 +648,9 @@ mod tests {
             panic!()
         };
         open_auth_form_modal(editor);
-        handle_auth_form_key(editor, key(KeyCode::Char(' '))); // cycle to sync
+        drive_key(editor, key(KeyCode::Char(' '))); // cycle to sync
         // Esc cancels at any focus.
-        let closed = handle_auth_form_key(editor, key(KeyCode::Esc));
+        let closed = drive_key(editor, key(KeyCode::Esc));
         assert!(closed);
         assert!(
             editor.pending.claude.is_none(),
@@ -537,15 +684,15 @@ mod tests {
         );
 
         // Cycle to api_key, enter cred, type, tab to save, enter.
-        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
-        handle_auth_form_key(editor, key(KeyCode::Char(' ')));
-        handle_auth_form_key(editor, key(KeyCode::Enter));
-        handle_auth_form_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Enter));
         for c in "abc".chars() {
-            handle_auth_form_key(editor, key(KeyCode::Char(c)));
+            drive_key(editor, key(KeyCode::Char(c)));
         }
-        handle_auth_form_key(editor, key(KeyCode::Tab));
-        let closed = handle_auth_form_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Tab));
+        let closed = drive_key(editor, key(KeyCode::Enter));
         assert!(closed);
 
         let role_entry = editor
@@ -566,5 +713,149 @@ mod tests {
             EnvValue::Plain(s) => assert_eq!(s, "abc"),
             EnvValue::OpRef(_) => panic!("expected plain literal"),
         }
+    }
+
+    /// Pressing Enter while focused on `OpRefValue` swaps the auth-form
+    /// modal for an `OpPicker` and stashes the form context in
+    /// `pending_auth_form_return`. Confirms the open path of the
+    /// picker round-trip wiring.
+    #[test]
+    fn auth_form_op_ref_picker_invocation_opens_op_picker_modal() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        // Mode → ApiKey (two cycles past `None → sync`).
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        // Enter to advance to the credential block (CredentialSource).
+        drive_key(editor, key(KeyCode::Enter));
+        // Toggle credential source: Literal → OpRef. Now the cred-value
+        // focus resolves to OpRefValue.
+        drive_key(editor, key(KeyCode::Char(' ')));
+        // Down: CredentialSource → OpRefValue (focus_for_credential_value).
+        drive_key(editor, key(KeyCode::Down));
+        // Sanity-check we're on OpRefValue.
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("expected auth form still open before picker invocation")
+        };
+        assert_eq!(*focus, AuthFormFocus::OpRefValue);
+        // Enter on OpRefValue → swaps to OpPicker.
+        let closed = drive_key(editor, key(KeyCode::Enter));
+        assert!(closed, "transitioning to OpPicker must close auth form");
+        assert!(
+            matches!(editor.modal, Some(Modal::OpPicker { .. })),
+            "auth form must hand off to OpPicker on Enter at OpRefValue"
+        );
+        assert!(
+            editor.pending_auth_form_return.is_some(),
+            "auth-form context must be stashed for the picker to return to"
+        );
+    }
+
+    /// Simulating a successful `OpPicker` commit re-mounts the auth
+    /// form with the picked `OpRef` applied. `can_save` flips to true
+    /// because the form now carries a valid OpRef and a committed
+    /// mode. Uses an injected fake `OpRunner` so the test never
+    /// shells out to the real `op` binary.
+    #[test]
+    fn auth_form_op_ref_picker_commit_applies_to_form() {
+        struct StubRunner;
+        impl OpRunner for StubRunner {
+            fn read(&self, _r: &str) -> anyhow::Result<String> {
+                Ok("sk-ant-from-vault".into())
+            }
+        }
+
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        // Open the auth form on workspace × Claude and bring it to
+        // OpRefValue with mode = ApiKey.
+        open_auth_form_modal(editor);
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Down));
+        drive_key(editor, key(KeyCode::Enter));
+        assert!(matches!(editor.modal, Some(Modal::OpPicker { .. })));
+
+        // Simulate the picker committing a valid OpRef. Bypass the
+        // production `OpCli` by calling the runner-injecting helper
+        // directly — same code path the editor.rs handler invokes,
+        // just with a stub runner.
+        let picked = OpRef {
+            op: "op://uuid/anthropic-vault".into(),
+            path: "Work/Anthropic/api-key".into(),
+        };
+        super::apply_op_picker_to_auth_form_with_runner(editor, picked.clone(), &StubRunner);
+
+        // Form is back; the credential carries the picked OpRef and
+        // can_save must be true (mode + non-empty OpRef both set).
+        let Some(Modal::AuthForm { state, focus, .. }) = &editor.modal else {
+            panic!("auth form must be re-mounted after picker commit");
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::Save,
+            "successful picker commit drops cursor onto Save"
+        );
+        match &state.credential {
+            CredentialInput::OpRef(r) => assert_eq!(r, &picked),
+            other => panic!("expected OpRef credential after picker commit; got {other:?}"),
+        }
+        assert!(
+            state.can_save(),
+            "form must be commitable after picker supplies a non-empty OpRef"
+        );
+        assert!(
+            editor.pending_auth_form_return.is_none(),
+            "stash must be drained on commit"
+        );
+    }
+
+    /// A failed vault read (e.g. biometric timeout) must NOT corrupt
+    /// the form's credential — the read-then-commit invariant from
+    /// Task 18 is what stops a broken reference reaching disk. The
+    /// form re-opens with the credential unchanged and an
+    /// `ErrorPopup` layered on top.
+    #[test]
+    fn auth_form_op_ref_picker_failed_read_does_not_apply_op_ref() {
+        struct FailRunner;
+        impl OpRunner for FailRunner {
+            fn read(&self, _r: &str) -> anyhow::Result<String> {
+                Err(anyhow::anyhow!("biometric prompt timed out"))
+            }
+        }
+
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Enter));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Down));
+        drive_key(editor, key(KeyCode::Enter));
+
+        let picked = OpRef {
+            op: "op://uuid/missing".into(),
+            path: "Vault/Missing/field".into(),
+        };
+        super::apply_op_picker_to_auth_form_with_runner(editor, picked, &FailRunner);
+
+        // Top modal must be the ErrorPopup; credential must remain
+        // the empty OpRef (or whatever the toggle seeded), NOT the
+        // attempted reference.
+        assert!(
+            matches!(editor.modal, Some(Modal::ErrorPopup { .. })),
+            "failed vault read must surface an error popup"
+        );
+        assert!(editor.pending_auth_form_return.is_none());
     }
 }

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -14,8 +14,8 @@ use super::super::render::editor::resolve_auth_row_target;
 use super::super::state::{
     AuthFormFocus, AuthFormReturnPath, AuthFormTarget, EditorState, FieldFocus, Modal,
 };
-use crate::config::AppConfig;
 use crate::agent::Agent;
+use crate::config::AppConfig;
 use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
 use crate::console::op_cache::OpCache;
 use crate::operator_env::EnvValue;
@@ -65,7 +65,7 @@ pub(super) fn open_auth_role_picker(editor: &mut EditorState<'_>, config: &AppCo
         .pending
         .roles
         .iter()
-        .filter(|(_, ro)| ro.claude.is_some() || ro.codex.is_some())
+        .filter(|(_, ro)| ro.has_auth_override())
         .map(|(name, _)| name.clone())
         .collect();
     let candidates: Vec<crate::selector::RoleSelector> = eligible
@@ -85,6 +85,41 @@ pub(super) fn open_auth_role_picker(editor: &mut EditorState<'_>, config: &AppCo
 pub(super) fn toggle_role_expand(editor: &mut EditorState<'_>, role: String) {
     if !editor.auth_expanded.remove(&role) {
         editor.auth_expanded.insert(role);
+    }
+}
+
+/// Handle `D`/`d` on the Auth tab.
+///
+/// - `RoleHeader` → open a `Confirm` modal targeting `ClearAuthRoleOverride`.
+/// - `RoleAgentRow` → silently clear that single agent's override (no modal).
+/// - Anything else → no-op.
+pub(super) fn handle_d_on_auth_row(editor: &mut EditorState<'_>) {
+    let FieldFocus::Row(n) = editor.active_field;
+    let rows = super::super::render::editor::auth_flat_rows(editor);
+    match rows.get(n).cloned() {
+        Some(super::super::render::editor::AuthRow::RoleHeader { role, .. }) => {
+            editor.modal = Some(Modal::Confirm {
+                target: crate::console::manager::state::ConfirmTarget::ClearAuthRoleOverride {
+                    role: role.clone(),
+                },
+                state: crate::console::widgets::confirm::ConfirmState::new(format!(
+                    "Clear all auth overrides for '{role}'?"
+                )),
+            });
+        }
+        Some(super::super::render::editor::AuthRow::RoleAgentRow { role, agent }) => {
+            clear_role_agent(editor, &role, agent);
+        }
+        _ => {}
+    }
+}
+
+fn clear_role_agent(editor: &mut EditorState<'_>, role: &str, agent: crate::agent::Agent) {
+    if let Some(ro) = editor.pending.roles.get_mut(role) {
+        match agent {
+            crate::agent::Agent::Claude => ro.claude = None,
+            crate::agent::Agent::Codex => ro.codex = None,
+        }
     }
 }
 

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -51,10 +51,14 @@ pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>) {
     });
 }
 
-/// Open the role-picker modal for the Auth-tab "+ Add per-role override"
-/// sentinel. Filters out roles that already have at least one agent
-/// override configured so only un-overridden roles appear in the picker.
-/// If no eligible candidates remain, the call is a no-op.
+/// Mount the Auth-tab role picker for the "+ Add per-role override"
+/// flow. Filters `eligible_agents_for_override` down to roles that
+/// don't yet carry any agent override — unlike the Secrets tab, where
+/// adding more env keys to an existing override is meaningful, the
+/// Auth tab's per-role block is a 2-row inline-editable surface, so
+/// re-mounting the picker for an already-overridden role would just
+/// duplicate the existing rows. Silent no-op when no candidates remain
+/// (the row is rendered dimmed in that state).
 pub(super) fn open_auth_role_picker(editor: &mut EditorState<'_>, config: &AppConfig) {
     let eligible = super::super::render::editor::eligible_agents_for_override(editor, config);
     let already_overridden: std::collections::BTreeSet<String> = editor

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -9,10 +9,12 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 use super::super::super::widgets::auth_panel::{AuthForm, CredentialInput};
 use super::super::super::widgets::op_picker::OpPickerState;
+use super::super::super::widgets::role_picker::RolePickerState;
 use super::super::render::editor::resolve_auth_row_target;
 use super::super::state::{
     AuthFormFocus, AuthFormReturnPath, AuthFormTarget, EditorState, FieldFocus, Modal,
 };
+use crate::config::AppConfig;
 use crate::agent::Agent;
 use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
 use crate::console::op_cache::OpCache;
@@ -47,6 +49,39 @@ pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>) {
         focus: AuthFormFocus::Mode,
         literal_buffer,
     });
+}
+
+/// Open the role-picker modal for the Auth-tab "+ Add per-role override"
+/// sentinel. Filters out roles that already have at least one agent
+/// override configured so only un-overridden roles appear in the picker.
+/// If no eligible candidates remain, the call is a no-op.
+pub(super) fn open_auth_role_picker(editor: &mut EditorState<'_>, config: &AppConfig) {
+    let eligible = super::super::render::editor::eligible_agents_for_override(editor, config);
+    let already_overridden: std::collections::BTreeSet<String> = editor
+        .pending
+        .roles
+        .iter()
+        .filter(|(_, ro)| ro.claude.is_some() || ro.codex.is_some())
+        .map(|(name, _)| name.clone())
+        .collect();
+    let candidates: Vec<crate::selector::RoleSelector> = eligible
+        .into_iter()
+        .filter(|r| !already_overridden.contains(r))
+        .filter_map(|r| crate::selector::RoleSelector::parse(&r).ok())
+        .collect();
+    if candidates.is_empty() {
+        return;
+    }
+    let state = RolePickerState::new(candidates);
+    editor.modal = Some(Modal::AuthRolePicker { state });
+}
+
+/// Toggle the expanded/collapsed state of a role section on the Auth tab.
+/// If the role is currently expanded, collapse it; otherwise expand it.
+pub(super) fn toggle_role_expand(editor: &mut EditorState<'_>, role: String) {
+    if !editor.auth_expanded.remove(&role) {
+        editor.auth_expanded.insert(role);
+    }
 }
 
 /// Read the current mode + credential for the form's target out of

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -502,6 +502,7 @@ mod tests {
     use super::*;
     use crate::agent::Agent;
     use crate::config::{AppConfig, AuthForwardMode};
+    use crate::console::manager::render::editor::{AuthRow, auth_flat_rows};
     use crate::console::manager::state::{
         AuthFormTarget, EditorState, FieldFocus, ManagerStage, ManagerState,
     };
@@ -528,6 +529,23 @@ mod tests {
     /// op-picker plumbing — this keeps their bodies short.
     fn drive_key(editor: &mut EditorState<'_>, k: KeyEvent) -> bool {
         handle_auth_form_key(editor, k, fresh_op_cache())
+    }
+
+    /// Return the flat-row index for `WorkspaceDefault { Claude }`.
+    /// Panics if the row doesn't exist (which would indicate a broken
+    /// fixture, not a test-under-test failure).
+    fn workspace_claude_row_idx(editor: &EditorState<'_>) -> usize {
+        auth_flat_rows(editor)
+            .iter()
+            .position(|r| {
+                matches!(
+                    r,
+                    AuthRow::WorkspaceDefault {
+                        agent: Agent::Claude,
+                    }
+                )
+            })
+            .expect("WorkspaceDefault × Claude row must exist in auth_flat_rows")
     }
 
     fn build_state() -> (AppConfig, ManagerState<'static>) {
@@ -559,7 +577,8 @@ mod tests {
         let ws = cfg.workspaces.get("proj").unwrap().clone();
         let mut editor = EditorState::new_edit("proj".into(), ws);
         editor.active_tab = crate::console::manager::state::EditorTab::Auth;
-        editor.active_field = FieldFocus::Row(0);
+        let ws_claude_idx = workspace_claude_row_idx(&editor);
+        editor.active_field = FieldFocus::Row(ws_claude_idx);
         state.stage = ManagerStage::Editor(editor);
         (cfg, state)
     }
@@ -672,9 +691,39 @@ mod tests {
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        // Row 2 is workspace×role[0]×Claude (rows 0..2 are the workspace
-        // layer × {Claude, Codex}; row 2 is the first role-agent row).
-        editor.active_field = FieldFocus::Row(2);
+        // Insert an override entry for "smith" so it materialises as a
+        // RoleHeader in auth_flat_rows (the row only appears when
+        // claude.is_some() || codex.is_some()). We seed codex only so
+        // the claude field stays None — the auth form then opens fresh
+        // (None mode) and the two-Space cycle reaches ApiKey as the
+        // test expects.
+        editor.pending.roles.insert(
+            "smith".into(),
+            WorkspaceRoleOverride {
+                codex: Some(crate::config::CodexAuthConfig(
+                    crate::config::AgentAuthConfig {
+                        auth_forward: AuthForwardMode::Sync,
+                    },
+                )),
+                ..Default::default()
+            },
+        );
+        // Expand the role so the RoleAgentRow children are emitted.
+        editor.auth_expanded.insert("smith".into());
+        // Dynamically locate the smith × Claude agent row.
+        let smith_claude_idx = auth_flat_rows(editor)
+            .iter()
+            .position(|r| {
+                matches!(
+                    r,
+                    AuthRow::RoleAgentRow {
+                        role,
+                        agent: Agent::Claude,
+                    } if role == "smith"
+                )
+            })
+            .expect("RoleAgentRow smith × Claude must exist after override insertion");
+        editor.active_field = FieldFocus::Row(smith_claude_idx);
         open_auth_form_modal(editor);
         let Some(Modal::AuthForm { target, .. }) = &editor.modal else {
             panic!("form must be open");

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -959,6 +959,10 @@ pub(super) fn handle_editor_modal(
         Modal::AuthForm { .. } => {
             super::auth::handle_auth_form_key(editor, key, op_cache);
         }
+        #[allow(clippy::unimplemented)]
+        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Tasks 8-10");
+        }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {
                 ModalOutcome::Commit(op_ref) => {
@@ -1475,6 +1479,10 @@ fn apply_editor_confirm(
         // site because it consumes `plan` and routes through
         // `EditorSaveFlow::PendingCommit`. No-op here.
         ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
+        #[allow(clippy::unimplemented)]
+        ConfirmTarget::ClearAuthRoleOverride { .. } => {
+            unimplemented!("wired in Task 12");
+        }
     }
     Ok(())
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -2936,7 +2936,11 @@ plugins = []
         );
         ws.roles.insert(
             "smith".into(),
-            crate::workspace::WorkspaceRoleOverride { env: ag_env },
+            crate::workspace::WorkspaceRoleOverride {
+                env: ag_env,
+                claude: None,
+                codex: None,
+            },
         );
 
         let mut state = ManagerState::from_config(&config, tmp.path());
@@ -3223,7 +3227,11 @@ plugins = []
         ag_env.insert("API_TOKEN".into(), "role-value".into());
         ws.roles.insert(
             "smith".into(),
-            crate::workspace::WorkspaceRoleOverride { env: ag_env },
+            crate::workspace::WorkspaceRoleOverride {
+                env: ag_env,
+                claude: None,
+                codex: None,
+            },
         );
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
@@ -3277,7 +3285,11 @@ plugins = []
         ag_env.insert("LOG_LEVEL".into(), "debug".into());
         ws.roles.insert(
             "agent-smith".into(),
-            crate::workspace::WorkspaceRoleOverride { env: ag_env },
+            crate::workspace::WorkspaceRoleOverride {
+                env: ag_env,
+                claude: None,
+                codex: None,
+            },
         );
 
         let mut state = ManagerState::from_config(&config, tmp.path());

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -251,6 +251,9 @@ pub(super) fn handle_editor_key(
         KeyCode::Char('d' | 'D') if editor.active_tab == EditorTab::Mounts => {
             remove_mount_at_cursor(editor);
         }
+        KeyCode::Char('d' | 'D') if editor.active_tab == EditorTab::Auth => {
+            super::auth::handle_d_on_auth_row(editor);
+        }
         // M toggles per-row masking on the focused Secrets-tab key row.
         // Operator feedback (commit 32): the global mask flag was too
         // blunt — it revealed every value at once when an operator just
@@ -1550,9 +1553,11 @@ fn apply_editor_confirm(
         // site because it consumes `plan` and routes through
         // `EditorSaveFlow::PendingCommit`. No-op here.
         ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
-        #[allow(clippy::unimplemented)]
-        ConfirmTarget::ClearAuthRoleOverride { .. } => {
-            unimplemented!("wired in Task 12");
+        ConfirmTarget::ClearAuthRoleOverride { role } => {
+            if let Some(ro) = editor.pending.roles.get_mut(role) {
+                ro.claude = None;
+                ro.codex = None;
+            }
         }
     }
     Ok(())

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -182,7 +182,23 @@ pub(super) fn handle_editor_key(
                 }
             }
             EditorTab::Auth => {
-                super::auth::open_auth_form_modal(editor);
+                let FieldFocus::Row(n) = editor.active_field;
+                let rows = super::super::render::editor::auth_flat_rows(editor);
+                match rows.get(n) {
+                    Some(super::super::render::editor::AuthRow::AddSentinel { .. }) => {
+                        super::auth::open_auth_role_picker(editor, config);
+                    }
+                    Some(super::super::render::editor::AuthRow::RoleHeader { role, .. }) => {
+                        super::auth::toggle_role_expand(editor, role.clone());
+                    }
+                    Some(
+                        super::super::render::editor::AuthRow::WorkspaceDefault { .. }
+                        | super::super::render::editor::AuthRow::RoleAgentRow { .. },
+                    ) => {
+                        super::auth::open_auth_form_modal(editor);
+                    }
+                    _ => {}
+                }
             }
         },
         KeyCode::Char('a' | 'A') if editor.active_tab == EditorTab::Roles => {
@@ -959,9 +975,21 @@ pub(super) fn handle_editor_modal(
         Modal::AuthForm { .. } => {
             super::auth::handle_auth_form_key(editor, key, op_cache);
         }
+        Modal::AuthRolePicker { state: picker } => match picker.handle_key(key) {
+            ModalOutcome::Commit(role) => {
+                editor.modal = Some(Modal::AuthAgentPicker {
+                    role: role.key(),
+                    state: crate::console::widgets::agent_choice::AgentChoiceState::new(),
+                });
+            }
+            ModalOutcome::Cancel => {
+                editor.modal = None;
+            }
+            ModalOutcome::Continue => {}
+        },
         #[allow(clippy::unimplemented)]
-        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Tasks 8-10");
+        Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Task 9");
         }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1269,7 +1269,6 @@ fn candidate_role_source(
                 selector.name
             ),
             trusted: false,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         }),
         Err(err) => Err(err),

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -957,11 +957,19 @@ pub(super) fn handle_editor_modal(
             }
         }
         Modal::AuthForm { .. } => {
-            super::auth::handle_auth_form_key(editor, key);
+            super::auth::handle_auth_form_key(editor, key, op_cache);
         }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {
                 ModalOutcome::Commit(op_ref) => {
+                    // Auth-form round trip wins over the Secrets-tab
+                    // dispatch: the auth form sets
+                    // `pending_auth_form_return` exactly when it's the
+                    // caller, so the two paths can never collide.
+                    if editor.pending_auth_form_return.is_some() {
+                        super::auth::apply_op_picker_to_auth_form(editor, op_ref);
+                        return;
+                    }
                     // Operator picked a Vault → Item → Field path. The
                     // dispatch depends on whether `P` was pressed on a
                     // key row (write directly) or on an `+ Add` sentinel
@@ -988,6 +996,14 @@ pub(super) fn handle_editor_modal(
                     }
                 }
                 ModalOutcome::Cancel => {
+                    // Auth-form round trip: re-mount the form
+                    // unchanged. Mirrors the Commit branch — the two
+                    // callers (Secrets-tab `P`, auth-form Enter) are
+                    // disambiguated by `pending_auth_form_return`.
+                    if editor.pending_auth_form_return.is_some() {
+                        super::auth::restore_auth_form_after_op_picker_cancel(editor);
+                        return;
+                    }
                     // Clear both scratch fields so a stale path/target
                     // can't carry into a later interaction.
                     editor.modal = None;

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -987,9 +987,28 @@ pub(super) fn handle_editor_modal(
             }
             ModalOutcome::Continue => {}
         },
-        #[allow(clippy::unimplemented)]
-        Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Task 9");
+        Modal::AuthAgentPicker { role, state } => {
+            let outcome = state.handle_key(key);
+            match outcome {
+                ModalOutcome::Commit(agent) => {
+                    let role = role.clone();
+                    let target = crate::console::manager::state::AuthFormTarget::WorkspaceRole {
+                        role,
+                        agent,
+                    };
+                    let form = crate::console::widgets::auth_panel::AuthForm::new(agent);
+                    editor.modal = Some(Modal::AuthForm {
+                        target,
+                        state: Box::new(form),
+                        focus: crate::console::manager::state::AuthFormFocus::Mode,
+                        literal_buffer: String::new(),
+                    });
+                }
+                ModalOutcome::Cancel => {
+                    editor.modal = None;
+                }
+                ModalOutcome::Continue => {}
+            }
         }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -96,6 +96,18 @@ pub(super) fn handle_editor_key(
                     return Ok(InputOutcome::Continue);
                 }
             }
+            if key.code == KeyCode::Right && editor.active_tab == EditorTab::Auth {
+                let FieldFocus::Row(n) = editor.active_field;
+                let rows = super::super::render::editor::auth_flat_rows(editor);
+                if let Some(super::super::render::editor::AuthRow::RoleHeader { role, expanded }) =
+                    rows.get(n).cloned()
+                {
+                    if !expanded {
+                        editor.auth_expanded.insert(role);
+                    }
+                    return Ok(InputOutcome::Continue);
+                }
+            }
             let was_secrets = editor.active_tab == EditorTab::Secrets;
             editor.active_tab = match editor.active_tab {
                 EditorTab::General => EditorTab::Mounts,
@@ -118,6 +130,18 @@ pub(super) fn handle_editor_key(
                 if let Some(SecretsRow::RoleHeader { role, expanded }) = rows.get(n).cloned() {
                     if expanded {
                         editor.secrets_expanded.remove(&role);
+                    }
+                    return Ok(InputOutcome::Continue);
+                }
+            }
+            if editor.active_tab == EditorTab::Auth {
+                let FieldFocus::Row(n) = editor.active_field;
+                let rows = super::super::render::editor::auth_flat_rows(editor);
+                if let Some(super::super::render::editor::AuthRow::RoleHeader { role, expanded }) =
+                    rows.get(n).cloned()
+                {
+                    if expanded {
+                        editor.auth_expanded.remove(&role);
                     }
                     return Ok(InputOutcome::Continue);
                 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -101,7 +101,8 @@ pub(super) fn handle_editor_key(
                 EditorTab::General => EditorTab::Mounts,
                 EditorTab::Mounts => EditorTab::Roles,
                 EditorTab::Roles => EditorTab::Secrets,
-                EditorTab::Secrets => EditorTab::General,
+                EditorTab::Secrets => EditorTab::Auth,
+                EditorTab::Auth => EditorTab::General,
             };
             editor.active_field = FieldFocus::Row(0);
             if was_secrets {
@@ -123,10 +124,11 @@ pub(super) fn handle_editor_key(
             }
             let was_secrets = editor.active_tab == EditorTab::Secrets;
             editor.active_tab = match editor.active_tab {
-                EditorTab::General => EditorTab::Secrets,
+                EditorTab::General => EditorTab::Auth,
                 EditorTab::Mounts => EditorTab::General,
                 EditorTab::Roles => EditorTab::Mounts,
                 EditorTab::Secrets => EditorTab::Roles,
+                EditorTab::Auth => EditorTab::Secrets,
             };
             editor.active_field = FieldFocus::Row(0);
             if was_secrets {
@@ -178,6 +180,9 @@ pub(super) fn handle_editor_key(
                 if n == config.roles.len() {
                     open_role_input(editor, config);
                 }
+            }
+            EditorTab::Auth => {
+                super::auth::open_auth_form_modal(editor);
             }
         },
         KeyCode::Char('a' | 'A') if editor.active_tab == EditorTab::Roles => {
@@ -301,6 +306,9 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
         EditorTab::Secrets => 0,
+        EditorTab::Auth => {
+            super::super::render::editor::auth_editable_row_count(editor).saturating_sub(1)
+        }
     }
 }
 
@@ -947,6 +955,9 @@ pub(super) fn handle_editor_modal(
                 }
                 ModalOutcome::Continue => {}
             }
+        }
+        Modal::AuthForm { .. } => {
+            super::auth::handle_auth_form_key(editor, key);
         }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {
@@ -1936,7 +1947,7 @@ plugins = []
 
     #[test]
     fn editor_left_wraps_to_last_tab_from_first() {
-        // Match Tab's wrap contract: Left from General → Secrets.
+        // Match Tab's wrap contract: Left from General → Auth (last tab).
         let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::General);
         handle_key(
             &mut state,
@@ -1949,13 +1960,13 @@ plugins = []
         let ManagerStage::Editor(e) = &state.stage else {
             panic!("editor stage expected");
         };
-        assert_eq!(e.active_tab, EditorTab::Secrets);
+        assert_eq!(e.active_tab, EditorTab::Auth);
     }
 
     #[test]
     fn editor_right_wraps_to_first_tab_from_last() {
-        // Match Tab's wrap contract: Right from Secrets → General.
-        let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::Secrets);
+        // Match Tab's wrap contract: Right from Auth (last tab) → General.
+        let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::Auth);
         handle_key(
             &mut state,
             &mut config,
@@ -3164,7 +3175,7 @@ plugins = []
             key(KeyCode::Char('m')),
         )
         .unwrap();
-        // Tab to General → leaves Secrets.
+        // Tab to Auth → leaves Secrets.
         handle_key(
             &mut state,
             &mut config,
@@ -3173,32 +3184,18 @@ plugins = []
             key(KeyCode::Tab),
         )
         .unwrap();
-        // Tab around the wheel back to Secrets (General → Mounts → Roles
-        // → Secrets is 3 more presses).
-        handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Tab),
-        )
-        .unwrap();
-        handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Tab),
-        )
-        .unwrap();
-        handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Tab),
-        )
-        .unwrap();
+        // Tab around the wheel back to Secrets (Auth → General → Mounts →
+        // Roles → Secrets is 4 more presses).
+        for _ in 0..4 {
+            handle_key(
+                &mut state,
+                &mut config,
+                &paths,
+                tmp.path(),
+                key(KeyCode::Tab),
+            )
+            .unwrap();
+        }
 
         let ManagerStage::Editor(e) = &state.stage else {
             panic!();

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -2,6 +2,7 @@
 //! if a modal is open, events go to the modal handler; otherwise they
 //! go to the active stage's handler.
 
+pub(super) mod auth;
 pub(super) mod editor;
 pub(super) mod list;
 pub(super) mod mouse;

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1838,6 +1838,8 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         };
         let (tmp, paths, config) = setup_with_workspace(ws_name, ws.clone()).unwrap();
 

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -345,6 +345,14 @@ pub(super) fn commit_editor_save_with_runner(
                 return Ok(());
             }
 
+            // `edit_workspace` re-renders the entire `[workspaces.<name>]`
+            // table from the parsed in-memory config — which preserves
+            // whatever `claude` / `codex` / `roles[*].{claude,codex}` blocks
+            // already lived on disk, NOT what's in `editor.pending`. Apply
+            // the diff against `editor.original` AFTER the table rewrite so
+            // mode changes survive the round-trip.
+            apply_auth_forward_diff(&mut ce, &current_name, &editor.original, &editor.pending);
+
             (rename_to, current_name)
         }
         SaveMode::Create => {
@@ -356,6 +364,9 @@ pub(super) fn commit_editor_save_with_runner(
                 open_save_error_popup(editor, &e.to_string());
                 return Ok(());
             }
+            // `create_workspace` serializes `editor.pending` whole, which
+            // already carries `claude` / `codex` / `roles[*].{claude,codex}`
+            // — no separate diff needed for the create path.
             (None, name)
         }
     };
@@ -781,6 +792,66 @@ fn build_prospective_mounts(
         }
     }
     out
+}
+
+/// Diff `claude` / `codex` and per-role `claude` / `codex` mode fields
+/// between `original` and `pending`, propagating each change to disk via
+/// `ConfigEditor::set_workspace_auth_forward` /
+/// `set_workspace_role_auth_forward`.
+///
+/// `WorkspaceEdit` does not (yet) carry the auth-forward fields, so
+/// `edit_workspace` re-renders the entire workspace table from the parsed
+/// in-memory config — preserving whatever was on disk, NOT what the
+/// auth-form mutated in `editor.pending`. Calling this helper after
+/// `edit_workspace` resolves that drift: the typed auth-forward setters
+/// reach into the freshly-rewritten `[workspaces.<name>.<agent>]` /
+/// `[workspaces.<name>.roles.<role>.<agent>]` blocks and apply the diff.
+///
+/// Roles present only in `original` get their auth blocks cleared. Roles
+/// present only in `pending` get their auth blocks written.
+fn apply_auth_forward_diff(
+    ce: &mut crate::config::ConfigEditor,
+    workspace_name: &str,
+    original: &crate::workspace::WorkspaceConfig,
+    pending: &crate::workspace::WorkspaceConfig,
+) {
+    use crate::agent::Agent;
+    let original_claude = original.claude.as_ref().map(|c| c.auth_forward);
+    let pending_claude = pending.claude.as_ref().map(|c| c.auth_forward);
+    if original_claude != pending_claude {
+        ce.set_workspace_auth_forward(workspace_name, Agent::Claude, pending_claude);
+    }
+    let original_codex = original.codex.as_ref().map(|c| c.0.auth_forward);
+    let pending_codex = pending.codex.as_ref().map(|c| c.0.auth_forward);
+    if original_codex != pending_codex {
+        ce.set_workspace_auth_forward(workspace_name, Agent::Codex, pending_codex);
+    }
+
+    // Union so roles on only one side are caught.
+    let role_keys: std::collections::BTreeSet<&String> =
+        original.roles.keys().chain(pending.roles.keys()).collect();
+    for role in role_keys {
+        let orig_override = original.roles.get(role);
+        let pend_override = pending.roles.get(role);
+        let orig_claude = orig_override
+            .and_then(|o| o.claude.as_ref())
+            .map(|c| c.auth_forward);
+        let pend_claude = pend_override
+            .and_then(|p| p.claude.as_ref())
+            .map(|c| c.auth_forward);
+        if orig_claude != pend_claude {
+            ce.set_workspace_role_auth_forward(workspace_name, role, Agent::Claude, pend_claude);
+        }
+        let orig_codex = orig_override
+            .and_then(|o| o.codex.as_ref())
+            .map(|c| c.0.auth_forward);
+        let pend_codex = pend_override
+            .and_then(|p| p.codex.as_ref())
+            .map(|c| c.0.auth_forward);
+        if orig_codex != pend_codex {
+            ce.set_workspace_role_auth_forward(workspace_name, role, Agent::Codex, pend_codex);
+        }
+    }
 }
 
 /// Roles present only in `original` get all keys removed.

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -601,7 +601,6 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
 /// per frame from `editor.pending` + `editor.auth_expanded`. Rendering
 /// and input both index into the same `Vec<AuthRow>` so cursor row
 /// numbers always agree with what's drawn.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::console::manager) enum AuthRow {
     /// Bold "Global defaults" caption (read-only).
@@ -627,7 +626,6 @@ pub(in crate::console::manager) enum AuthRow {
     Divider,
 }
 
-#[allow(dead_code)]
 pub(in crate::console::manager) fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
     use crate::agent::Agent;
     let mut rows = vec![
@@ -1041,32 +1039,24 @@ pub(in crate::console::manager) fn workspace_name_for_panel(state: &EditorState<
     }
 }
 
-/// Map a flattened editable row index (the cursor) to a concrete
-/// `(scope, agent)` pair the form modal can target. The flattened layout
-/// is `[workspace × Claude, workspace × Codex, role0 × Claude, role0 × Codex, ...]`.
+/// Map a flattened editable row index (the cursor) into the
+/// `AuthFormTarget` the form modal should be opened against. Returns
+/// `None` for non-editable rows (headers, defaults, dividers, sentinel)
+/// so callers can branch on it before opening the form.
 pub(in crate::console::manager) fn resolve_auth_row_target(
     state: &EditorState<'_>,
     row: usize,
 ) -> Option<crate::console::manager::state::AuthFormTarget> {
-    use crate::agent::Agent;
     use crate::console::manager::state::AuthFormTarget;
-    let agents = [Agent::Claude, Agent::Codex];
-    if row < agents.len() {
-        return Some(AuthFormTarget::Workspace { agent: agents[row] });
+    let rows = auth_flat_rows(state);
+    match rows.get(row)? {
+        AuthRow::WorkspaceDefault { agent } => Some(AuthFormTarget::Workspace { agent: *agent }),
+        AuthRow::RoleAgentRow { role, agent } => Some(AuthFormTarget::WorkspaceRole {
+            role: role.clone(),
+            agent: *agent,
+        }),
+        _ => None,
     }
-    let mut idx = agents.len();
-    for role in &state.pending.allowed_roles {
-        for agent in agents {
-            if idx == row {
-                return Some(AuthFormTarget::WorkspaceRole {
-                    role: role.clone(),
-                    agent,
-                });
-            }
-            idx += 1;
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -2489,5 +2479,44 @@ mod auth_flat_rows_tests {
             rows[header_pos + 2],
             AuthRow::RoleAgentRow { ref role, agent: Agent::Codex } if role == "the-architect"
         ));
+    }
+
+    #[test]
+    fn resolve_auth_row_target_picks_workspace_default_for_workspacedefault_row() {
+        use crate::agent::Agent;
+        use crate::console::manager::state::AuthFormTarget;
+        use crate::workspace::WorkspaceConfig;
+
+        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let rows = auth_flat_rows(&editor);
+        let workspace_claude_idx = rows
+            .iter()
+            .position(|r| matches!(r, AuthRow::WorkspaceDefault { agent: Agent::Claude }))
+            .unwrap();
+        assert_eq!(
+            super::resolve_auth_row_target(&editor, workspace_claude_idx),
+            Some(AuthFormTarget::Workspace { agent: Agent::Claude }),
+        );
+    }
+
+    #[test]
+    fn resolve_auth_row_target_returns_none_for_global_or_header_or_sentinel() {
+        use crate::workspace::WorkspaceConfig;
+        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let rows = auth_flat_rows(&editor);
+        for (idx, row) in rows.iter().enumerate() {
+            match row {
+                AuthRow::GlobalHeader
+                | AuthRow::GlobalDefault { .. }
+                | AuthRow::WorkspaceHeader
+                | AuthRow::OverridesHeader { .. }
+                | AuthRow::AddSentinel { .. }
+                | AuthRow::Divider => assert!(
+                    super::resolve_auth_row_target(&editor, idx).is_none(),
+                    "row {idx} ({row:?}) must not resolve to an editable target"
+                ),
+                _ => {}
+            }
+        }
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -291,7 +291,25 @@ fn contextual_row_items(
             if rows == 0 {
                 Vec::new()
             } else {
-                vec![FooterItem::Key("Enter"), FooterItem::Text("edit auth")]
+                let mut items = vec![FooterItem::Key("Enter"), FooterItem::Text("edit auth")];
+                // When the cursor sits on a RoleAgentRow, append a provenance
+                // hint describing the resolved mode and which config layer
+                // supplied it (variant 2B: footer-only, no inline badge).
+                let flat = auth_flat_rows(state);
+                if let Some(AuthRow::RoleAgentRow { role, agent }) = flat.get(cursor) {
+                    let synthesized = synthesize_appconfig_for_auth(state, config);
+                    let ws_name = workspace_name_for_panel(state);
+                    let mode = crate::config::resolve_mode(&synthesized, *agent, &ws_name, role);
+                    let label = provenance_label(&synthesized, &ws_name, role, *agent);
+                    let agent_name = crate::console::widgets::auth_panel::agent_display(*agent);
+                    let hint = format!(
+                        "{role} / {agent_name} \u{b7} {mode} ({label})",
+                        mode = crate::console::widgets::auth_panel::mode_str(mode),
+                    );
+                    items.push(FooterItem::Sep);
+                    items.push(FooterItem::Dyn(hint));
+                }
+                items
             }
         }
     }
@@ -1169,6 +1187,41 @@ pub(in crate::console::manager) fn workspace_name_for_panel(state: &EditorState<
             .pending_name
             .clone()
             .unwrap_or_else(|| "(new workspace)".to_string()),
+    }
+}
+
+/// Return a short human-readable provenance label for the given
+/// (workspace, role, agent) triple.
+///
+/// Checks presence at each config layer and returns the most specific
+/// description: role-level override beats workspace default beats global.
+fn provenance_label(
+    synthesized: &crate::config::AppConfig,
+    workspace_name: &str,
+    role: &str,
+    agent: crate::agent::Agent,
+) -> &'static str {
+    let role_explicit = synthesized
+        .workspaces
+        .get(workspace_name)
+        .and_then(|ws| ws.roles.get(role))
+        .and_then(|ro| match agent {
+            crate::agent::Agent::Claude => ro.claude.as_ref().map(|_| ()),
+            crate::agent::Agent::Codex => ro.codex.as_ref().map(|_| ()),
+        });
+    let ws_explicit = synthesized
+        .workspaces
+        .get(workspace_name)
+        .and_then(|ws| match agent {
+            crate::agent::Agent::Claude => ws.claude.as_ref().map(|_| ()),
+            crate::agent::Agent::Codex => ws.codex.as_ref().map(|_| ()),
+        });
+    if role_explicit.is_some() {
+        "overrides workspace default"
+    } else if ws_explicit.is_some() {
+        "inherits workspace default"
+    } else {
+        "inherits global default"
     }
 }
 
@@ -2638,6 +2691,27 @@ mod auth_flat_rows_tests {
             Some(AuthFormTarget::Workspace {
                 agent: Agent::Claude
             }),
+        );
+    }
+
+    #[test]
+    fn provenance_label_picks_overrides_when_role_explicit() {
+        use crate::agent::Agent;
+        use crate::config::{AgentAuthConfig, AppConfig, AuthForwardMode};
+        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+
+        let mut cfg = AppConfig::default();
+        let mut ws = WorkspaceConfig::default();
+        let mut over = WorkspaceRoleOverride::default();
+        over.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::Ignore,
+        });
+        ws.roles.insert("the-architect".into(), over);
+        cfg.workspaces.insert("ws".into(), ws);
+
+        assert_eq!(
+            super::provenance_label(&cfg, "ws", "the-architect", Agent::Claude),
+            "overrides workspace default",
         );
     }
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -53,6 +53,7 @@ pub fn render_editor(
         EditorTab::Mounts => render_mounts_tab(frame, chunks[2], state),
         EditorTab::Roles => render_roles_tab(frame, chunks[2], state, config),
         EditorTab::Secrets => render_secrets_tab(frame, chunks[2], state, config),
+        EditorTab::Auth => render_auth_tab(frame, chunks[2], state, config),
     }
 
     let mut items: Vec<FooterItem> = Vec::new();
@@ -281,7 +282,26 @@ fn contextual_row_items(
                 Some(SecretsRow::SectionSpacer) | None => vec![],
             }
         }
+        EditorTab::Auth => {
+            // Auth tab rows are editable workspace + workspace × role
+            // entries; the global section is read-only.
+            let rows = auth_editable_row_count(state);
+            if rows == 0 {
+                Vec::new()
+            } else {
+                vec![FooterItem::Key("Enter"), FooterItem::Text("edit auth")]
+            }
+        }
     }
+}
+
+/// Number of rows in the auth panel that the operator can navigate / edit.
+/// Workspace rows (one per agent) plus role × agent rows. The global
+/// section is read-only and not part of the editable count.
+pub(in crate::console::manager) const fn auth_editable_row_count(state: &EditorState<'_>) -> usize {
+    // 2 agents (Claude + Codex) at the workspace layer; another 2 per role.
+    let agents = 2;
+    agents + state.pending.allowed_roles.len() * agents
 }
 
 fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
@@ -290,6 +310,7 @@ fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
         (EditorTab::Mounts, "Mounts"),
         (EditorTab::Roles, "Roles"),
         (EditorTab::Secrets, "Environments"),
+        (EditorTab::Auth, "Auth"),
     ];
     let mut spans = Vec::new();
     for (tab, label) in labels {
@@ -876,6 +897,94 @@ fn render_secrets_key_line(
     };
     spans.push(Span::styled(rendered_value, value_style));
     Line::from(spans)
+}
+
+/// Render the Auth tab.
+///
+/// Materializes a synthetic [`AppConfig`] from the editor's pending workspace
+/// merged with the (mostly read-only) global layer of the live config so the
+/// panel's `AuthPanelState::compute_for` can render with the operator's
+/// in-flight edits reflected immediately.
+fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
+    use crate::console::widgets::auth_panel;
+
+    let synthesized = synthesize_appconfig_for_auth(state, config);
+    let workspace_name = workspace_name_for_panel(state);
+    let panel_state = auth_panel::AuthPanelState::compute_for(&synthesized, &workspace_name);
+
+    let FieldFocus::Row(cursor) = state.active_field;
+    let max_idx = auth_editable_row_count(state).saturating_sub(1);
+    let selected = if cursor > max_idx {
+        Some(max_idx)
+    } else {
+        Some(cursor)
+    };
+
+    auth_panel::render_with_selection(frame, area, &panel_state, selected);
+}
+
+/// Synthesize an `AppConfig` whose `[claude]/[codex]` come from the live
+/// global config and whose `[workspaces.<ws>]` mirrors `editor.pending`.
+/// The Auth panel reads from this so changes the operator makes via the
+/// auth-edit form show up immediately, before save.
+pub(in crate::console::manager) fn synthesize_appconfig_for_auth(
+    state: &EditorState<'_>,
+    config: &AppConfig,
+) -> AppConfig {
+    let mut synthesized = AppConfig {
+        claude: config.claude.clone(),
+        codex: config.codex.clone(),
+        env: config.env.clone(),
+        roles: config.roles.clone(),
+        ..AppConfig::default()
+    };
+    let ws_name = workspace_name_for_panel(state);
+    synthesized
+        .workspaces
+        .insert(ws_name, state.pending.clone());
+    synthesized
+}
+
+/// Resolve the workspace key used by the Auth panel. In Edit mode this is
+/// the existing workspace name; in Create mode we use `pending_name` if set,
+/// otherwise a stable placeholder ("(new workspace)") so the panel can still
+/// render with the pending values populated.
+pub(in crate::console::manager) fn workspace_name_for_panel(state: &EditorState<'_>) -> String {
+    match &state.mode {
+        EditorMode::Edit { name } => state.pending_name.clone().unwrap_or_else(|| name.clone()),
+        EditorMode::Create => state
+            .pending_name
+            .clone()
+            .unwrap_or_else(|| "(new workspace)".to_string()),
+    }
+}
+
+/// Map a flattened editable row index (the cursor) to a concrete
+/// `(scope, agent)` pair the form modal can target. The flattened layout
+/// is `[workspace × Claude, workspace × Codex, role0 × Claude, role0 × Codex, ...]`.
+pub(in crate::console::manager) fn resolve_auth_row_target(
+    state: &EditorState<'_>,
+    row: usize,
+) -> Option<crate::console::manager::state::AuthFormTarget> {
+    use crate::agent::Agent;
+    use crate::console::manager::state::AuthFormTarget;
+    let agents = [Agent::Claude, Agent::Codex];
+    if row < agents.len() {
+        return Some(AuthFormTarget::Workspace { agent: agents[row] });
+    }
+    let mut idx = agents.len();
+    for role in &state.pending.allowed_roles {
+        for agent in agents {
+            if idx == row {
+                return Some(AuthFormTarget::WorkspaceRole {
+                    role: role.clone(),
+                    agent,
+                });
+            }
+            idx += 1;
+        }
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -641,22 +641,38 @@ pub(in crate::console::manager) fn auth_flat_rows(editor: &EditorState<'_>) -> V
         AuthRow::Divider,
     ];
 
-    let override_roles: Vec<&String> = editor
+    let override_roles: Vec<String> = editor
         .pending
         .roles
         .iter()
         .filter(|(_, ro)| ro.claude.is_some() || ro.codex.is_some())
-        .map(|(name, _)| name)
+        .map(|(name, _)| name.clone())
         .collect();
     rows.push(AuthRow::OverridesHeader {
         count: override_roles.len(),
     });
-    let eligible_total = if editor.pending.allowed_roles.is_empty() {
-        0
-    } else {
-        editor.pending.allowed_roles.len()
-    };
-    let eligible_remaining = eligible_total.saturating_sub(override_roles.len());
+    for role in &override_roles {
+        let expanded = editor.auth_expanded.contains(role);
+        rows.push(AuthRow::RoleHeader {
+            role: role.clone(),
+            expanded,
+        });
+        if expanded {
+            rows.push(AuthRow::RoleAgentRow {
+                role: role.clone(),
+                agent: crate::agent::Agent::Claude,
+            });
+            rows.push(AuthRow::RoleAgentRow {
+                role: role.clone(),
+                agent: crate::agent::Agent::Codex,
+            });
+        }
+    }
+    let eligible_remaining = editor
+        .pending
+        .allowed_roles
+        .len()
+        .saturating_sub(override_roles.len());
     rows.push(AuthRow::AddSentinel {
         eligible: eligible_remaining,
     });
@@ -2410,5 +2426,68 @@ mod auth_flat_rows_tests {
                 AuthRow::AddSentinel { eligible: 0 },
             ],
         );
+    }
+
+    #[test]
+    fn role_with_override_renders_collapsed_header_then_sentinel() {
+        use crate::config::{AgentAuthConfig, AuthForwardMode};
+        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+        let mut ws = WorkspaceConfig::default();
+        ws.allowed_roles = vec!["the-architect".into(), "agent-smith".into()];
+        let mut over = WorkspaceRoleOverride::default();
+        over.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::Ignore,
+        });
+        ws.roles.insert("the-architect".into(), over);
+
+        let editor = EditorState::new_edit("ws".into(), ws);
+        let rows = auth_flat_rows(&editor);
+
+        let header_idx = rows
+            .iter()
+            .position(|r| matches!(r, AuthRow::OverridesHeader { count: 1 }))
+            .expect("overrides header with count=1 expected");
+        assert!(matches!(
+            rows[header_idx + 1],
+            AuthRow::RoleHeader { ref role, expanded: false } if role == "the-architect"
+        ));
+        assert!(matches!(
+            rows[header_idx + 2],
+            AuthRow::AddSentinel { eligible: 1 }
+        ));
+    }
+
+    #[test]
+    fn role_with_override_when_expanded_emits_agent_rows() {
+        use crate::agent::Agent;
+        use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
+        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+        let mut ws = WorkspaceConfig::default();
+        ws.allowed_roles = vec!["the-architect".into()];
+        let mut over = WorkspaceRoleOverride::default();
+        over.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::Ignore,
+        });
+        over.codex = Some(CodexAuthConfig(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        }));
+        ws.roles.insert("the-architect".into(), over);
+
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.auth_expanded.insert("the-architect".into());
+        let rows = auth_flat_rows(&editor);
+
+        let header_pos = rows
+            .iter()
+            .position(|r| matches!(r, AuthRow::RoleHeader { expanded: true, .. }))
+            .expect("expanded role header missing");
+        assert!(matches!(
+            rows[header_pos + 1],
+            AuthRow::RoleAgentRow { ref role, agent: Agent::Claude } if role == "the-architect"
+        ));
+        assert!(matches!(
+            rows[header_pos + 2],
+            AuthRow::RoleAgentRow { ref role, agent: Agent::Codex } if role == "the-architect"
+        ));
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -633,12 +633,20 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
     use crate::agent::Agent;
     let mut rows = vec![
         AuthRow::GlobalHeader,
-        AuthRow::GlobalDefault { agent: Agent::Claude },
-        AuthRow::GlobalDefault { agent: Agent::Codex },
+        AuthRow::GlobalDefault {
+            agent: Agent::Claude,
+        },
+        AuthRow::GlobalDefault {
+            agent: Agent::Codex,
+        },
         AuthRow::Divider,
         AuthRow::WorkspaceHeader,
-        AuthRow::WorkspaceDefault { agent: Agent::Claude },
-        AuthRow::WorkspaceDefault { agent: Agent::Codex },
+        AuthRow::WorkspaceDefault {
+            agent: Agent::Claude,
+        },
+        AuthRow::WorkspaceDefault {
+            agent: Agent::Codex,
+        },
         AuthRow::Divider,
     ];
 
@@ -646,7 +654,7 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
         .pending
         .roles
         .iter()
-        .filter(|(_, ro)| ro.claude.is_some() || ro.codex.is_some())
+        .filter(|(_, ro)| ro.has_auth_override())
         .map(|(name, _)| name.clone())
         .collect();
     rows.push(AuthRow::OverridesHeader {
@@ -1123,9 +1131,7 @@ fn badge_span(
     use crate::console::widgets::auth_panel::{CredentialBadge, DANGER_RED, PHOSPHOR_GREEN};
     match badge {
         CredentialBadge::Resolves => Span::styled("OK", Style::default().fg(PHOSPHOR_GREEN)),
-        CredentialBadge::Unset => {
-            Span::styled("! unset", Style::default().fg(DANGER_RED))
-        }
+        CredentialBadge::Unset => Span::styled("! unset", Style::default().fg(DANGER_RED)),
         CredentialBadge::NotApplicable => Span::raw(""),
     }
 }
@@ -2618,11 +2624,20 @@ mod auth_flat_rows_tests {
         let rows = auth_flat_rows(&editor);
         let workspace_claude_idx = rows
             .iter()
-            .position(|r| matches!(r, AuthRow::WorkspaceDefault { agent: Agent::Claude }))
+            .position(|r| {
+                matches!(
+                    r,
+                    AuthRow::WorkspaceDefault {
+                        agent: Agent::Claude
+                    }
+                )
+            })
             .unwrap();
         assert_eq!(
             super::resolve_auth_row_target(&editor, workspace_claude_idx),
-            Some(AuthFormTarget::Workspace { agent: Agent::Claude }),
+            Some(AuthFormTarget::Workspace {
+                agent: Agent::Claude
+            }),
         );
     }
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1247,7 +1247,11 @@ mod secrets_tab_render_tests {
         let mut roles = std::collections::BTreeMap::new();
         roles.insert(
             "agent-smith".into(),
-            WorkspaceRoleOverride { env: role_env },
+            WorkspaceRoleOverride {
+                env: role_env,
+                claude: None,
+                codex: None,
+            },
         );
         let ws = WorkspaceConfig {
             roles,
@@ -1385,11 +1389,20 @@ mod secrets_tab_render_tests {
         role_env.insert("KEY".into(), "v".into());
 
         let mut roles = std::collections::BTreeMap::new();
-        roles.insert("agent-a".into(), WorkspaceRoleOverride { env: role_env });
+        roles.insert(
+            "agent-a".into(),
+            WorkspaceRoleOverride {
+                env: role_env,
+                claude: None,
+                codex: None,
+            },
+        );
         roles.insert(
             "agent-b".into(),
             WorkspaceRoleOverride {
                 env: std::collections::BTreeMap::new(),
+                claude: None,
+                codex: None,
             },
         );
 
@@ -1695,7 +1708,11 @@ mod secrets_tab_render_tests {
         let mut roles = std::collections::BTreeMap::new();
         roles.insert(
             "agent-smith".into(),
-            WorkspaceRoleOverride { env: role_env },
+            WorkspaceRoleOverride {
+                env: role_env,
+                claude: None,
+                codex: None,
+            },
         );
         let ws = WorkspaceConfig {
             env,
@@ -1727,9 +1744,20 @@ mod secrets_tab_render_tests {
         let mut roles = std::collections::BTreeMap::new();
         roles.insert(
             "agent-architect".into(),
-            WorkspaceRoleOverride { env: a_env },
+            WorkspaceRoleOverride {
+                env: a_env,
+                claude: None,
+                codex: None,
+            },
         );
-        roles.insert("agent-smith".into(), WorkspaceRoleOverride { env: b_env });
+        roles.insert(
+            "agent-smith".into(),
+            WorkspaceRoleOverride {
+                env: b_env,
+                claude: None,
+                codex: None,
+            },
+        );
         let ws = WorkspaceConfig {
             roles,
             ..WorkspaceConfig::default()
@@ -2030,7 +2058,14 @@ mod eligible_agents_for_override_tests {
         for a in override_agents {
             let mut env = std::collections::BTreeMap::new();
             env.insert("LOG_LEVEL".into(), "debug".into());
-            roles.insert((*a).into(), WorkspaceRoleOverride { env });
+            roles.insert(
+                (*a).into(),
+                WorkspaceRoleOverride {
+                    env,
+                    claude: None,
+                    codex: None,
+                },
+            );
         }
         WorkspaceConfig {
             allowed_roles: allowed.iter().map(|s| (*s).into()).collect(),

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -985,6 +985,9 @@ fn render_secrets_key_line(
 /// merged with the (mostly read-only) global layer of the live config so
 /// in-flight edits are reflected immediately.
 fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
+    use crate::console::widgets::auth_panel::{PHOSPHOR_DARK, WHITE};
+    use ratatui::style::Modifier;
+    use ratatui::text::Span;
     use ratatui::widgets::{List, ListItem, ListState};
 
     let synthesized = synthesize_appconfig_for_auth(state, config);
@@ -999,7 +1002,14 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
         .iter()
         .map(|r| ListItem::new(render_auth_row(r, &synthesized, &workspace_name)))
         .collect();
-    let block = Block::default().borders(Borders::ALL).title(" Auth ");
+    let title_span = Span::styled(
+        " Auth ",
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(title_span);
     let list = List::new(items).block(block).highlight_symbol("▸ ");
     let mut list_state = ListState::default();
     list_state.select(Some(selected));
@@ -1100,11 +1110,11 @@ fn render_auth_row(
 fn badge_span(
     badge: crate::console::widgets::auth_panel::CredentialBadge,
 ) -> ratatui::text::Span<'static> {
-    use crate::console::widgets::auth_panel::CredentialBadge;
+    use crate::console::widgets::auth_panel::{CredentialBadge, DANGER_RED, PHOSPHOR_GREEN};
     match badge {
         CredentialBadge::Resolves => Span::styled("OK", Style::default().fg(PHOSPHOR_GREEN)),
         CredentialBadge::Unset => {
-            Span::styled("! unset", Style::default().fg(Color::Rgb(255, 94, 122)))
+            Span::styled("! unset", Style::default().fg(DANGER_RED))
         }
         CredentialBadge::NotApplicable => Span::raw(""),
     }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1095,11 +1095,18 @@ fn render_auth_row(
                 badge_span(badge),
             ])
         }
-        AuthRow::AddSentinel { eligible } => ratatui::text::Line::from(vec![
-            Span::styled("  + Add per-role override", phosphor),
-            Span::raw("   "),
-            Span::styled(format!("({eligible} eligible)"), dim_green),
-        ]),
+        AuthRow::AddSentinel { eligible } => {
+            let label_style = if *eligible == 0 { dim_green } else { phosphor };
+            let suffix = if *eligible == 0 {
+                "   (all roles overridden)".to_string()
+            } else {
+                format!("   ({eligible} eligible)")
+            };
+            ratatui::text::Line::from(vec![
+                Span::styled("  + Add per-role override", label_style),
+                Span::styled(suffix, dim_green),
+            ])
+        }
         AuthRow::Divider => ratatui::text::Line::from(Span::styled(
             "  ──────────────────────────────────────────",
             dim_green,

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -597,6 +597,72 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
     rows
 }
 
+/// Row-shape model for the Auth tab. `auth_flat_rows()` rebuilds this
+/// per frame from `editor.pending` + `editor.auth_expanded`. Rendering
+/// and input both index into the same `Vec<AuthRow>` so cursor row
+/// numbers always agree with what's drawn.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::console::manager) enum AuthRow {
+    /// Bold "Global defaults" caption (read-only).
+    GlobalHeader,
+    /// One row per agent under the Global header. Read-only.
+    GlobalDefault { agent: crate::agent::Agent },
+    /// Bold "Workspace defaults" caption.
+    WorkspaceHeader,
+    /// Editable workspace-level row, one per agent.
+    WorkspaceDefault { agent: crate::agent::Agent },
+    /// "Per-role overrides (N)" caption.
+    OverridesHeader { count: usize },
+    /// Collapsible role override block. `expanded` toggles the agent rows.
+    RoleHeader { role: String, expanded: bool },
+    /// Agent row inside an expanded `RoleHeader`. Editable.
+    RoleAgentRow {
+        role: String,
+        agent: crate::agent::Agent,
+    },
+    /// `+ Add per-role override (N eligible)` sentinel — always last.
+    AddSentinel { eligible: usize },
+    /// Visual divider between sections; not focusable.
+    Divider,
+}
+
+#[allow(dead_code)]
+pub(in crate::console::manager) fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
+    use crate::agent::Agent;
+    let mut rows = vec![
+        AuthRow::GlobalHeader,
+        AuthRow::GlobalDefault { agent: Agent::Claude },
+        AuthRow::GlobalDefault { agent: Agent::Codex },
+        AuthRow::Divider,
+        AuthRow::WorkspaceHeader,
+        AuthRow::WorkspaceDefault { agent: Agent::Claude },
+        AuthRow::WorkspaceDefault { agent: Agent::Codex },
+        AuthRow::Divider,
+    ];
+
+    let override_roles: Vec<&String> = editor
+        .pending
+        .roles
+        .iter()
+        .filter(|(_, ro)| ro.claude.is_some() || ro.codex.is_some())
+        .map(|(name, _)| name)
+        .collect();
+    rows.push(AuthRow::OverridesHeader {
+        count: override_roles.len(),
+    });
+    let eligible_total = if editor.pending.allowed_roles.is_empty() {
+        0
+    } else {
+        editor.pending.allowed_roles.len()
+    };
+    let eligible_remaining = eligible_total.saturating_sub(override_roles.len());
+    rows.push(AuthRow::AddSentinel {
+        eligible: eligible_remaining,
+    });
+    rows
+}
+
 /// Mirrors launch-time semantics from
 /// [`crate::app::context::eligible_roles_for_workspace`]. Roles
 /// already carrying an override are NOT filtered — operators may add
@@ -2308,5 +2374,41 @@ mod parse_path_breadcrumb_tests {
     fn parse_path_breadcrumb_invalid_too_many_segments() {
         // 5+ segments is not a valid 1Password breadcrumb.
         assert!(parse_path_breadcrumb("a/b/c/d/e").is_none());
+    }
+}
+
+#[cfg(test)]
+mod auth_flat_rows_tests {
+    use super::{AuthRow, auth_flat_rows};
+    use crate::console::manager::state::EditorState;
+    use crate::workspace::WorkspaceConfig;
+
+    #[test]
+    fn empty_workspace_yields_defaults_overrides_header_and_sentinel() {
+        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let rows = auth_flat_rows(&editor);
+        assert_eq!(
+            rows,
+            vec![
+                AuthRow::GlobalHeader,
+                AuthRow::GlobalDefault {
+                    agent: crate::agent::Agent::Claude,
+                },
+                AuthRow::GlobalDefault {
+                    agent: crate::agent::Agent::Codex,
+                },
+                AuthRow::Divider,
+                AuthRow::WorkspaceHeader,
+                AuthRow::WorkspaceDefault {
+                    agent: crate::agent::Agent::Claude,
+                },
+                AuthRow::WorkspaceDefault {
+                    agent: crate::agent::Agent::Codex,
+                },
+                AuthRow::Divider,
+                AuthRow::OverridesHeader { count: 0 },
+                AuthRow::AddSentinel { eligible: 0 },
+            ],
+        );
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -979,28 +979,135 @@ fn render_secrets_key_line(
     Line::from(spans)
 }
 
-/// Render the Auth tab.
+/// Render the Auth tab directly from [`auth_flat_rows`].
 ///
 /// Materializes a synthetic [`AppConfig`] from the editor's pending workspace
-/// merged with the (mostly read-only) global layer of the live config so the
-/// panel's `AuthPanelState::compute_for` can render with the operator's
-/// in-flight edits reflected immediately.
+/// merged with the (mostly read-only) global layer of the live config so
+/// in-flight edits are reflected immediately.
 fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
-    use crate::console::widgets::auth_panel;
+    use ratatui::widgets::{List, ListItem, ListState};
 
     let synthesized = synthesize_appconfig_for_auth(state, config);
     let workspace_name = workspace_name_for_panel(state);
-    let panel_state = auth_panel::AuthPanelState::compute_for(&synthesized, &workspace_name);
+    let rows = auth_flat_rows(state);
 
     let FieldFocus::Row(cursor) = state.active_field;
-    let max_idx = auth_editable_row_count(state).saturating_sub(1);
-    let selected = if cursor > max_idx {
-        Some(max_idx)
-    } else {
-        Some(cursor)
-    };
+    let max_idx = rows.len().saturating_sub(1);
+    let selected = cursor.min(max_idx);
 
-    auth_panel::render_with_selection(frame, area, &panel_state, selected);
+    let items: Vec<ListItem> = rows
+        .iter()
+        .map(|r| ListItem::new(render_auth_row(r, &synthesized, &workspace_name)))
+        .collect();
+    let block = Block::default().borders(Borders::ALL).title(" Auth ");
+    let list = List::new(items).block(block).highlight_symbol("▸ ");
+    let mut list_state = ListState::default();
+    list_state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_auth_row(
+    row: &AuthRow,
+    synthesized: &AppConfig,
+    workspace_name: &str,
+) -> ratatui::text::Line<'static> {
+    use crate::config::resolve_mode;
+    use crate::console::widgets::auth_panel::{agent_display, badge_for, mode_str};
+
+    let bold_white = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let dim_green = Style::default().fg(PHOSPHOR_DIM);
+    let phosphor = Style::default().fg(PHOSPHOR_GREEN);
+
+    match row {
+        AuthRow::GlobalHeader => {
+            ratatui::text::Line::from(Span::styled("Global defaults", bold_white))
+        }
+        AuthRow::GlobalDefault { agent } => {
+            let mode = match agent {
+                crate::agent::Agent::Claude => synthesized
+                    .claude
+                    .as_ref()
+                    .map(|c| c.auth_forward)
+                    .unwrap_or_default(),
+                crate::agent::Agent::Codex => synthesized
+                    .codex
+                    .as_ref()
+                    .map(|c| c.auth_forward)
+                    .unwrap_or_default(),
+            };
+            ratatui::text::Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
+                Span::styled(mode_str(mode).to_string(), phosphor),
+            ])
+        }
+        AuthRow::WorkspaceHeader => {
+            ratatui::text::Line::from(Span::styled("Workspace defaults", bold_white))
+        }
+        AuthRow::WorkspaceDefault { agent } => {
+            let ws = synthesized.workspaces.get(workspace_name);
+            let explicit = ws.and_then(|ws| match agent {
+                crate::agent::Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
+                crate::agent::Agent::Codex => ws.codex.as_ref().map(|c| c.auth_forward),
+            });
+            let mode =
+                explicit.unwrap_or_else(|| resolve_mode(synthesized, *agent, workspace_name, ""));
+            let badge = badge_for(synthesized, workspace_name, "", *agent, mode);
+            ratatui::text::Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
+                Span::styled(mode_str(mode).to_string(), phosphor),
+                Span::raw("  "),
+                badge_span(badge),
+            ])
+        }
+        AuthRow::OverridesHeader { count } => ratatui::text::Line::from(vec![
+            Span::styled("Per-role overrides ", bold_white),
+            Span::styled(format!("({count})"), dim_green),
+        ]),
+        AuthRow::RoleHeader { role, expanded } => {
+            let glyph = if *expanded { "▾" } else { "▸" };
+            ratatui::text::Line::from(vec![
+                Span::raw("  "),
+                Span::styled(glyph.to_string(), phosphor),
+                Span::raw(" "),
+                Span::styled(role.clone(), bold_white),
+            ])
+        }
+        AuthRow::RoleAgentRow { role, agent } => {
+            let mode = resolve_mode(synthesized, *agent, workspace_name, role);
+            let badge = badge_for(synthesized, workspace_name, role, *agent, mode);
+            ratatui::text::Line::from(vec![
+                Span::raw("      "),
+                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
+                Span::styled(mode_str(mode).to_string(), phosphor),
+                Span::raw("  "),
+                badge_span(badge),
+            ])
+        }
+        AuthRow::AddSentinel { eligible } => ratatui::text::Line::from(vec![
+            Span::styled("  + Add per-role override", phosphor),
+            Span::raw("   "),
+            Span::styled(format!("({eligible} eligible)"), dim_green),
+        ]),
+        AuthRow::Divider => ratatui::text::Line::from(Span::styled(
+            "  ──────────────────────────────────────────",
+            dim_green,
+        )),
+    }
+}
+
+fn badge_span(
+    badge: crate::console::widgets::auth_panel::CredentialBadge,
+) -> ratatui::text::Span<'static> {
+    use crate::console::widgets::auth_panel::CredentialBadge;
+    match badge {
+        CredentialBadge::Resolves => Span::styled("OK", Style::default().fg(PHOSPHOR_GREEN)),
+        CredentialBadge::Unset => {
+            Span::styled("! unset", Style::default().fg(Color::Rgb(255, 94, 122)))
+        }
+        CredentialBadge::NotApplicable => Span::raw(""),
+    }
 }
 
 /// Synthesize an `AppConfig` whose `[claude]/[codex]` come from the live

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1,6 +1,8 @@
-//! Editor-stage rendering: full-screen editor with header, tab bar,
-//! per-tab body renderers (General / Mounts / Roles / Secrets), and the
-//! contextual footer composition that varies with the active tab + cursor.
+//! Editor-stage rendering.
+//!
+//! Full-screen editor with header, tab bar, per-tab body renderers
+//! (General / Mounts / Roles / Secrets), and the contextual footer
+//! composition that varies with the active tab + cursor.
 
 use ratatui::{
     Frame,
@@ -597,12 +599,13 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
     rows
 }
 
-/// Row-shape model for the Auth tab. `auth_flat_rows()` rebuilds this
-/// per frame from `editor.pending` + `editor.auth_expanded`. Rendering
-/// and input both index into the same `Vec<AuthRow>` so cursor row
-/// numbers always agree with what's drawn.
+/// Row-shape model for the Auth tab.
+///
+/// `auth_flat_rows()` rebuilds this per frame from `editor.pending` +
+/// `editor.auth_expanded`. Rendering and input both index into the same
+/// `Vec<AuthRow>` so cursor row numbers always agree with what's drawn.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::console::manager) enum AuthRow {
+pub enum AuthRow {
     /// Bold "Global defaults" caption (read-only).
     GlobalHeader,
     /// One row per agent under the Global header. Read-only.
@@ -626,7 +629,7 @@ pub(in crate::console::manager) enum AuthRow {
     Divider,
 }
 
-pub(in crate::console::manager) fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
+pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
     use crate::agent::Agent;
     let mut rows = vec![
         AuthRow::GlobalHeader,

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -1000,6 +1000,8 @@ mod subpanel_padding_tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         }
     }
 

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use super::state::{ManagerListRow, ManagerStage, ManagerState};
 use crate::config::AppConfig;
 
-pub(super) mod editor;
+pub mod editor;
 pub(super) mod list;
 pub(super) mod modal;
 

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -5,10 +5,10 @@
 use ratatui::{Frame, layout::Rect};
 
 use super::super::super::widgets::{
-    confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice, op_picker,
-    role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
+    auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice,
+    op_picker, role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
 };
-use super::super::state::Modal;
+use super::super::state::{AuthFormTarget, Modal};
 use super::centered_rect_fixed;
 
 // ── Modal dispatcher ────────────────────────────────────────────────
@@ -62,6 +62,7 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
             (50, rows)
         }
         Modal::SourcePicker { .. } | Modal::ScopePicker { .. } => (50, 7),
+        Modal::AuthForm { .. } => (70, 14),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -92,5 +93,13 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
         }
         Modal::SourcePicker { state } => source_picker::render(frame, modal_area, state),
         Modal::ScopePicker { state } => scope_picker::render(frame, modal_area, state),
+        Modal::AuthForm { target, state, .. } => {
+            let (workspace, role) = match target {
+                AuthFormTarget::Workspace { .. } => ("(workspace)", "(workspace-default)"),
+                AuthFormTarget::WorkspaceRole { role, .. } => ("(workspace)", role.as_str()),
+            };
+            let ctx = auth_panel::FormContext { workspace, role };
+            auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx);
+        }
     }
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -5,8 +5,9 @@
 use ratatui::{Frame, layout::Rect};
 
 use super::super::super::widgets::{
-    auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice,
-    op_picker, role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
+    agent_choice, auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker,
+    mount_dst_choice, op_picker, role_picker, save_discard, scope_picker, source_picker,
+    text_input, workdir_pick,
 };
 use super::super::state::{AuthFormTarget, Modal};
 use super::centered_rect_fixed;
@@ -65,10 +66,7 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         }
         Modal::SourcePicker { .. } | Modal::ScopePicker { .. } => (50, 7),
         Modal::AuthForm { .. } => (70, 14),
-        #[allow(clippy::unimplemented)]
-        Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Task 9");
-        }
+        Modal::AuthAgentPicker { .. } => (40, 10),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -109,9 +107,8 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             let ctx = auth_panel::FormContext { workspace, role };
             auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx);
         }
-        #[allow(clippy::unimplemented)]
-        Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Task 9");
+        Modal::AuthAgentPicker { state, .. } => {
+            agent_choice::render(frame, modal_area, state);
         }
     }
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -57,15 +57,17 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
             )
         }
         Modal::OpPicker { .. } => (80, 22),
-        Modal::RolePicker { state } | Modal::RoleOverridePicker { state } => {
+        Modal::RolePicker { state }
+        | Modal::RoleOverridePicker { state }
+        | Modal::AuthRolePicker { state } => {
             let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
             (50, rows)
         }
         Modal::SourcePicker { .. } | Modal::ScopePicker { .. } => (50, 7),
         Modal::AuthForm { .. } => (70, 14),
         #[allow(clippy::unimplemented)]
-        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Tasks 8-10");
+        Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Task 9");
         }
     };
     centered_rect_fixed(outer, pct_w, height_rows)
@@ -92,7 +94,9 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             state.tick();
             op_picker::render::render(frame, modal_area, state);
         }
-        Modal::RolePicker { state } | Modal::RoleOverridePicker { state } => {
+        Modal::RolePicker { state }
+        | Modal::RoleOverridePicker { state }
+        | Modal::AuthRolePicker { state } => {
             role_picker::render(frame, modal_area, state);
         }
         Modal::SourcePicker { state } => source_picker::render(frame, modal_area, state),
@@ -106,8 +110,8 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx);
         }
         #[allow(clippy::unimplemented)]
-        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
-            unimplemented!("wired in Tasks 8-10");
+        Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Task 9");
         }
     }
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -64,9 +64,10 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
             let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
             (50, rows)
         }
-        Modal::SourcePicker { .. } | Modal::ScopePicker { .. } => (50, 7),
+        Modal::SourcePicker { .. } | Modal::ScopePicker { .. } | Modal::AuthAgentPicker { .. } => {
+            (50, 7)
+        }
         Modal::AuthForm { .. } => (70, 14),
-        Modal::AuthAgentPicker { .. } => (40, 10),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -63,6 +63,10 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         }
         Modal::SourcePicker { .. } | Modal::ScopePicker { .. } => (50, 7),
         Modal::AuthForm { .. } => (70, 14),
+        #[allow(clippy::unimplemented)]
+        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Tasks 8-10");
+        }
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -100,6 +104,10 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             };
             let ctx = auth_panel::FormContext { workspace, role };
             auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx);
+        }
+        #[allow(clippy::unimplemented)]
+        Modal::AuthRolePicker { .. } | Modal::AuthAgentPicker { .. } => {
+            unimplemented!("wired in Tasks 8-10");
         }
     }
 }

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -10,8 +10,8 @@ use crate::console::op_cache::OpCache;
 use crate::workspace::WorkspaceConfig;
 
 use crate::console::widgets::{
-    confirm::ConfirmState, confirm_save::ConfirmSaveState, error_popup::ErrorPopupState,
-    file_browser::FileBrowserState, github_picker::GithubPickerState,
+    auth_panel::AuthForm, confirm::ConfirmState, confirm_save::ConfirmSaveState,
+    error_popup::ErrorPopupState, file_browser::FileBrowserState, github_picker::GithubPickerState,
     mount_dst_choice::MountDstChoiceState, op_picker::OpPickerState, role_picker::RolePickerState,
     scope_picker::ScopePickerState, source_picker::SourcePickerState, text_input::TextInputState,
     workdir_pick::WorkdirPickState,
@@ -196,6 +196,10 @@ pub enum EditorTab {
     Mounts,
     Roles,
     Secrets,
+    /// Auth panel: workspace-level + per-(workspace × role) auth-forward
+    /// modes and credentials, with a global-defaults preview at the top.
+    /// Mounts the `auth_panel` widget (Tasks 15-18) inside the editor.
+    Auth,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -263,6 +267,57 @@ pub enum Modal<'a> {
     },
     ScopePicker {
         state: ScopePickerState,
+    },
+    /// Auth-form modal opened from the Auth tab. `target` identifies
+    /// which scope (workspace or workspace × role) and which agent the
+    /// form is editing so commit can write back to the correct slot
+    /// on `editor.pending`.
+    AuthForm {
+        target: AuthFormTarget,
+        state: Box<AuthForm>,
+        /// Active focus inside the form (mode picker / cred radio / cred value / buttons).
+        focus: AuthFormFocus,
+        /// Scratch text-input buffer when the credential value is being
+        /// typed inline in the form. Cleared on Esc; committed to
+        /// `state.set_literal` on Enter.
+        literal_buffer: String,
+    },
+}
+
+/// Where in the auth-edit form the cursor currently sits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthFormFocus {
+    /// Mode picker line — Space/Tab cycles, Enter commits selection.
+    Mode,
+    /// Credential source radio (Literal / 1Password) — Space toggles.
+    CredentialSource,
+    /// Literal value text input — operator types into `literal_buffer`.
+    LiteralValue,
+    /// 1Password value display — Enter opens the `OpPicker`.
+    OpRefValue,
+    /// `[ Save ]` action button.
+    Save,
+    /// `[ Cancel ]` action button.
+    Cancel,
+    /// `[ Reset ]` action button — clears the layer's mode/credential.
+    Reset,
+}
+
+/// Identifies the (scope, agent) pair an open `AuthForm` modal is editing.
+///
+/// Committing the form writes back into the matching slot on
+/// `editor.pending` (workspace `claude/codex` field, or workspace-role
+/// override `claude/codex` field, plus the credential env var).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthFormTarget {
+    /// `[workspaces.<ws>.<agent>].auth_forward` slot, with the credential
+    /// env var landing in `[workspaces.<ws>.env]`.
+    Workspace { agent: crate::agent::Agent },
+    /// `[workspaces.<ws>.roles.<role>.<agent>].auth_forward` slot, with
+    /// the credential env var landing in `[workspaces.<ws>.roles.<role>.env]`.
+    WorkspaceRole {
+        role: String,
+        agent: crate::agent::Agent,
     },
 }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -968,8 +968,14 @@ mod tests {
             "LOG_LEVEL".into(),
             crate::operator_env::EnvValue::Plain("info".into()),
         );
-        ws.roles
-            .insert("agent-x".into(), WorkspaceRoleOverride { env: role_x_env });
+        ws.roles.insert(
+            "agent-x".into(),
+            WorkspaceRoleOverride {
+                env: role_x_env,
+                claude: None,
+                codex: None,
+            },
+        );
         let mut e = EditorState::new_edit("a".into(), ws);
         assert_eq!(e.change_count(), 0);
 
@@ -1016,6 +1022,8 @@ mod tests {
                     m.insert("K".into(), crate::operator_env::EnvValue::Plain("v".into()));
                     m
                 },
+                claude: None,
+                codex: None,
             },
         );
         assert!(e2.is_dirty(), "role env set must make state dirty");

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -117,6 +117,7 @@ pub struct EditorState<'a> {
     /// — they render as a breadcrumb, not a masked value.
     pub unmasked_rows: BTreeSet<(SecretsScopeTag, String)>,
     pub secrets_expanded: BTreeSet<String>,
+    pub auth_expanded: BTreeSet<String>,
     /// Scratch for the two-step add flow: set on `EnvKey` commit,
     /// cleared on `EnvValue` commit/cancel.
     pub pending_env_key: Option<(SecretsScopeTag, String)>,
@@ -591,6 +592,7 @@ impl EditorState<'_> {
             save_flow: EditorSaveFlow::Idle,
             unmasked_rows: BTreeSet::default(),
             secrets_expanded: BTreeSet::default(),
+            auth_expanded: BTreeSet::default(),
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,
@@ -612,6 +614,7 @@ impl EditorState<'_> {
             save_flow: EditorSaveFlow::Idle,
             unmasked_rows: BTreeSet::default(),
             secrets_expanded: BTreeSet::default(),
+            auth_expanded: BTreeSet::default(),
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -129,6 +129,28 @@ pub struct EditorState<'a> {
     /// (wrapped as `EnvValue::OpRef`) until the operator names the key
     /// and the `EnvKey` modal commits both fields at once.
     pub pending_picker_value: Option<crate::operator_env::EnvValue>,
+    /// Stash for the auth-form → `OpPicker` → auth-form round trip.
+    /// Set when the operator presses Enter at `AuthFormFocus::OpRefValue`,
+    /// and consumed when `OpPicker` commits or cancels: on commit we
+    /// reconstruct the `Modal::AuthForm` with the picked `OpRef`
+    /// applied; on cancel we reconstruct it pristine. Threading the
+    /// auth-form context through this field (rather than via a
+    /// payload on `Modal::OpPicker`) keeps the picker variant
+    /// orthogonal to its caller.
+    pub pending_auth_form_return: Option<AuthFormReturnPath>,
+}
+
+/// Captured auth-form context to re-mount the form after the
+/// `OpPicker` commits or cancels.
+///
+/// `state` and `literal_buffer` are stashed so a half-typed literal
+/// isn't lost when the operator detours into the picker.
+#[derive(Debug)]
+pub struct AuthFormReturnPath {
+    pub target: AuthFormTarget,
+    pub state: Box<AuthForm>,
+    pub focus: AuthFormFocus,
+    pub literal_buffer: String,
 }
 
 /// Save cycle state machine.
@@ -572,6 +594,7 @@ impl EditorState<'_> {
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,
+            pending_auth_form_return: None,
         }
     }
 
@@ -592,6 +615,7 @@ impl EditorState<'_> {
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,
+            pending_auth_form_return: None,
         }
     }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -395,7 +395,9 @@ pub enum ConfirmTarget {
     },
     /// `D` on a `RoleHeader` on the Auth tab — clears both agent overrides
     /// for `role` after the operator confirms in the Confirm modal.
-    ClearAuthRoleOverride { role: String },
+    ClearAuthRoleOverride {
+        role: String,
+    },
 }
 
 /// Separate from [`crate::config::editor::EnvScope`].

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -1159,6 +1159,8 @@ mod tests {
             env: BTreeMap::default(),
             roles: BTreeMap::default(),
             keep_awake: KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         };
         let mut e = EditorState::new_edit("ws".into(), ws);
         e.active_tab = EditorTab::Mounts;

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -285,6 +285,19 @@ pub enum Modal<'a> {
     RoleOverridePicker {
         state: RolePickerState,
     },
+    /// Auth-tab role picker — the first step in the 3-step add flow
+    /// (sentinel → role → agent → `AuthForm`). Reuses the existing
+    /// `RolePickerState` widget; commit hands off to `AuthAgentPicker`.
+    AuthRolePicker {
+        state: RolePickerState,
+    },
+    /// Auth-tab agent picker — second step. Carries the role chosen in
+    /// `AuthRolePicker` so commit can build the `AuthFormTarget`
+    /// directly without another round-trip.
+    AuthAgentPicker {
+        role: String,
+        state: crate::console::widgets::agent_choice::AgentChoiceState,
+    },
     SourcePicker {
         state: SourcePickerState,
     },
@@ -380,6 +393,9 @@ pub enum ConfirmTarget {
         exit_on_success: bool,
         affected_containers: Vec<String>,
     },
+    /// `D` on a `RoleHeader` on the Auth tab — clears both agent overrides
+    /// for `role` after the operator confirms in the Confirm modal.
+    ClearAuthRoleOverride { role: String },
 }
 
 /// Separate from [`crate::config::editor::EnvScope`].

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -166,6 +166,7 @@ const fn modal_debug_name(modal: &crate::console::manager::state::Modal<'_>) -> 
         Modal::RoleOverridePicker { .. } => "RoleOverridePicker",
         Modal::SourcePicker { .. } => "SourcePicker",
         Modal::ScopePicker { .. } => "ScopePicker",
+        Modal::AuthForm { .. } => "AuthForm",
     }
 }
 

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -167,6 +167,8 @@ const fn modal_debug_name(modal: &crate::console::manager::state::Modal<'_>) -> 
         Modal::SourcePicker { .. } => "SourcePicker",
         Modal::ScopePicker { .. } => "ScopePicker",
         Modal::AuthForm { .. } => "AuthForm",
+        Modal::AuthRolePicker { .. } => "AuthRolePicker",
+        Modal::AuthAgentPicker { .. } => "AuthAgentPicker",
     }
 }
 

--- a/src/console/state.rs
+++ b/src/console/state.rs
@@ -172,7 +172,6 @@ mod tests {
             crate::config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -213,7 +212,6 @@ mod tests {
         crate::config::RoleSource {
             git: "https://example.invalid/org/repo.git".to_string(),
             trusted: true,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         }
     }

--- a/src/console/state.rs
+++ b/src/console/state.rs
@@ -192,6 +192,8 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: crate::workspace::KeepAwakeConfig::default(),
+                claude: None,
+                codex: None,
             },
         );
 
@@ -227,6 +229,8 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         }
     }
 

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -1,0 +1,122 @@
+//! Two-row picker: Claude or Codex, used in the Auth-tab "+ Add" flow.
+//!
+//! Arrow keys move focus, Enter commits, Esc cancels.
+
+use crate::agent::Agent;
+use crate::console::widgets::ModalOutcome;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+#[derive(Debug, Clone)]
+pub struct AgentChoiceState {
+    pub focused: Agent,
+}
+
+impl AgentChoiceState {
+    pub const fn new() -> Self {
+        Self {
+            focused: Agent::Claude,
+        }
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
+        match key.code {
+            KeyCode::Down | KeyCode::Char('j') => {
+                if matches!(self.focused, Agent::Claude) {
+                    self.focused = Agent::Codex;
+                }
+                ModalOutcome::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if matches!(self.focused, Agent::Codex) {
+                    self.focused = Agent::Claude;
+                }
+                ModalOutcome::Continue
+            }
+            KeyCode::Enter => ModalOutcome::Commit(self.focused),
+            KeyCode::Esc => ModalOutcome::Cancel,
+            _ => ModalOutcome::Continue,
+        }
+    }
+}
+
+impl Default for AgentChoiceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AgentChoiceState) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+    let phosphor = Style::default().fg(ratatui::style::Color::Rgb(0, 255, 65));
+    let make_row = |agent: Agent, label: &str| {
+        let prefix = if state.focused == agent { "▸ " } else { "  " };
+        Line::from(vec![
+            Span::styled(prefix, phosphor),
+            Span::styled(label.to_string(), bold),
+        ])
+    };
+    let lines = vec![
+        make_row(Agent::Claude, "Claude"),
+        make_row(Agent::Codex, "Codex"),
+    ];
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Pick agent ");
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn down_moves_to_codex_then_clamps() {
+        let mut s = AgentChoiceState::new();
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.focused, Agent::Codex);
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.focused, Agent::Codex);
+    }
+
+    #[test]
+    fn up_moves_to_claude_then_clamps() {
+        let mut s = AgentChoiceState::new();
+        s.focused = Agent::Codex;
+        let _ = s.handle_key(key(KeyCode::Up));
+        assert_eq!(s.focused, Agent::Claude);
+        let _ = s.handle_key(key(KeyCode::Up));
+        assert_eq!(s.focused, Agent::Claude);
+    }
+
+    #[test]
+    fn enter_commits_focused_agent() {
+        let mut s = AgentChoiceState::new();
+        s.focused = Agent::Codex;
+        match s.handle_key(key(KeyCode::Enter)) {
+            ModalOutcome::Commit(a) => assert_eq!(a, Agent::Codex),
+            other => panic!("expected commit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn esc_cancels() {
+        let mut s = AgentChoiceState::new();
+        assert!(matches!(s.handle_key(key(KeyCode::Esc)), ModalOutcome::Cancel));
+    }
+}

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -6,10 +6,14 @@ use crate::agent::Agent;
 use crate::console::widgets::ModalOutcome;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
+
+const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
+const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
+const WHITE: Color = Color::Rgb(255, 255, 255);
 
 #[derive(Debug, Clone)]
 pub struct AgentChoiceState {
@@ -23,8 +27,7 @@ impl AgentChoiceState {
         }
     }
 
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
+    pub const fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
         match key.code {
             KeyCode::Down | KeyCode::Char('j') => {
                 if matches!(self.focused, Agent::Claude) {
@@ -53,7 +56,7 @@ impl Default for AgentChoiceState {
 
 pub fn render(frame: &mut Frame, area: Rect, state: &AgentChoiceState) {
     let bold = Style::default().add_modifier(Modifier::BOLD);
-    let phosphor = Style::default().fg(ratatui::style::Color::Rgb(0, 255, 65));
+    let phosphor = Style::default().fg(PHOSPHOR_GREEN);
     let make_row = |agent: Agent, label: &str| {
         let prefix = if state.focused == agent { "▸ " } else { "  " };
         Line::from(vec![
@@ -61,14 +64,46 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AgentChoiceState) {
             Span::styled(label.to_string(), bold),
         ])
     };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            " Pick Agent ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(area);
+    frame.render_widget(ratatui::widgets::Clear, area);
+    frame.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),    // agent list
+            Constraint::Length(1), // spacer
+            Constraint::Length(1), // hint footer
+        ])
+        .split(inner);
+
     let lines = vec![
         make_row(Agent::Claude, "Claude"),
         make_row(Agent::Codex, "Codex"),
     ];
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(" Pick agent ");
-    frame.render_widget(Paragraph::new(lines).block(block), area);
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+
+    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let text_style = Style::default().fg(PHOSPHOR_GREEN);
+    let sep_style = Style::default().fg(PHOSPHOR_DARK);
+    let hint = Paragraph::new(Line::from(vec![
+        Span::styled("Enter", key_style),
+        Span::styled(" commit", text_style),
+        Span::styled(" \u{b7} ", sep_style),
+        Span::styled("Esc", key_style),
+        Span::styled(" cancel", text_style),
+    ]))
+    .alignment(Alignment::Center);
+    frame.render_widget(hint, rows[2]);
 }
 
 #[cfg(test)]

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -152,6 +152,9 @@ mod tests {
     #[test]
     fn esc_cancels() {
         let mut s = AgentChoiceState::new();
-        assert!(matches!(s.handle_key(key(KeyCode::Esc)), ModalOutcome::Cancel));
+        assert!(matches!(
+            s.handle_key(key(KeyCode::Esc)),
+            ModalOutcome::Cancel
+        ));
     }
 }

--- a/src/console/widgets/auth_panel/form.rs
+++ b/src/console/widgets/auth_panel/form.rs
@@ -5,7 +5,7 @@
 
 use crate::agent::Agent;
 use crate::config::AuthForwardMode;
-use crate::operator_env::{EnvValue, OpRef};
+use crate::operator_env::{EnvValue, OpRef, OpRunner};
 
 /// What the user has supplied in the credential block.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +78,20 @@ impl AuthForm {
 
     pub fn set_op_ref(&mut self, r: OpRef) {
         self.credential = CredentialInput::OpRef(r);
+    }
+
+    /// Attempts to commit an [`OpRef`]. Calls `runner.read(&candidate.op)`;
+    /// only persists the reference if the read succeeds. On failure, the
+    /// form's credential state is left unchanged so a broken reference
+    /// never reaches disk.
+    pub fn try_commit_op_ref<R: OpRunner + ?Sized>(
+        &mut self,
+        runner: &R,
+        candidate: OpRef,
+    ) -> anyhow::Result<()> {
+        let _ = runner.read(&candidate.op)?;
+        self.set_op_ref(candidate);
+        Ok(())
     }
 
     pub fn clear_credential(&mut self) {
@@ -276,5 +290,51 @@ mod tests {
         );
         assert_eq!(f.mode, Some(AuthForwardMode::OAuthToken));
         assert_eq!(f.credential, CredentialInput::OpRef(r));
+    }
+
+    struct FailRunner;
+    impl OpRunner for FailRunner {
+        fn read(&self, _r: &str) -> anyhow::Result<String> {
+            Err(anyhow::anyhow!("vault gone"))
+        }
+    }
+
+    struct GoodRunner;
+    impl OpRunner for GoodRunner {
+        fn read(&self, _r: &str) -> anyhow::Result<String> {
+            Ok("sk-ant-real".into())
+        }
+    }
+
+    #[test]
+    fn op_picker_failed_read_blocks_commit() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        let attempted = OpRef {
+            op: "op://uuid/missing".into(),
+            path: "Vault/Missing/field".into(),
+        };
+        let result = f.try_commit_op_ref(&FailRunner, attempted);
+        assert!(result.is_err(), "failed op read must not commit");
+        assert!(
+            !f.can_save(),
+            "form must not be commitable after failed read"
+        );
+        assert_eq!(f.credential, CredentialInput::None);
+    }
+
+    #[test]
+    fn op_picker_successful_read_persists_op_ref() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        let r = OpRef {
+            op: "op://uuid/anthropic".into(),
+            path: "Work/Anthropic/api-key".into(),
+        };
+        let result = f.try_commit_op_ref(&GoodRunner, r.clone());
+        assert!(result.is_ok());
+        assert!(f.can_save());
+        let outcome = f.commit().unwrap();
+        assert!(matches!(outcome.env_value, Some(EnvValue::OpRef(ref got)) if got == &r));
     }
 }

--- a/src/console/widgets/auth_panel/form.rs
+++ b/src/console/widgets/auth_panel/form.rs
@@ -1,0 +1,280 @@
+//! Auth-form state and save invariants.
+//!
+//! State-only — rendering and op-picker integration land in Task 18.
+//! The form is mounted by the workspace-manager TUI in Task 19.
+
+use crate::agent::Agent;
+use crate::config::AuthForwardMode;
+use crate::operator_env::{EnvValue, OpRef};
+
+/// What the user has supplied in the credential block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialInput {
+    None,
+    Literal(String),
+    OpRef(OpRef),
+}
+
+/// The form's mutable state. Mode and credential are independently editable;
+/// only the [`AuthForm::can_save`] invariant decides whether the parent should
+/// allow the Save action.
+#[derive(Debug)]
+pub struct AuthForm {
+    pub agent: Agent,
+    pub mode: Option<AuthForwardMode>,
+    pub credential: CredentialInput,
+}
+
+/// Output of a successful commit. The parent uses these fields to write the
+/// agent block at the chosen layer and the env-var entry under the role's env
+/// block.
+#[derive(Debug, Clone)]
+pub struct AuthFormOutcome {
+    pub mode: AuthForwardMode,
+    pub env_var_name: Option<&'static str>,
+    pub env_value: Option<EnvValue>,
+}
+
+impl AuthForm {
+    pub const fn new(agent: Agent) -> Self {
+        Self {
+            agent,
+            mode: None,
+            credential: CredentialInput::None,
+        }
+    }
+
+    /// Pre-populate the form from an existing row's mode and credential.
+    /// Used when [edit] is pressed on a row that already has values.
+    pub fn from_existing(
+        agent: Agent,
+        mode: AuthForwardMode,
+        credential: Option<EnvValue>,
+    ) -> Self {
+        let credential = match credential {
+            None => CredentialInput::None,
+            Some(EnvValue::Plain(s)) => CredentialInput::Literal(s),
+            Some(EnvValue::OpRef(r)) => CredentialInput::OpRef(r),
+        };
+        Self {
+            agent,
+            mode: Some(mode),
+            credential,
+        }
+    }
+
+    /// Set the mode. If switching to a mode that doesn't need a credential,
+    /// clears the credential field automatically.
+    pub fn set_mode(&mut self, mode: AuthForwardMode) {
+        self.mode = Some(mode);
+        if !mode_requires_credential(self.agent, mode) {
+            self.credential = CredentialInput::None;
+        }
+    }
+
+    pub fn set_literal(&mut self, s: String) {
+        self.credential = CredentialInput::Literal(s);
+    }
+
+    pub fn set_op_ref(&mut self, r: OpRef) {
+        self.credential = CredentialInput::OpRef(r);
+    }
+
+    pub fn clear_credential(&mut self) {
+        self.credential = CredentialInput::None;
+    }
+
+    /// Whether the credential input block should be shown.
+    pub const fn shows_credential_block(&self) -> bool {
+        matches!(self.mode, Some(m) if mode_requires_credential(self.agent, m))
+    }
+
+    /// Modes the user can pick. Codex omits `OAuthToken` (parser-rejected by Task 6).
+    pub const fn available_modes(&self) -> &'static [AuthForwardMode] {
+        self.agent.supported_modes()
+    }
+
+    /// Save invariant: mode is committed AND, if needed, a non-empty credential.
+    pub const fn can_save(&self) -> bool {
+        let Some(mode) = self.mode else { return false };
+        if !mode_requires_credential(self.agent, mode) {
+            return true;
+        }
+        match &self.credential {
+            CredentialInput::None => false,
+            CredentialInput::Literal(s) => !s.is_empty(),
+            CredentialInput::OpRef(_) => true,
+        }
+    }
+
+    /// Build the outcome for the parent to persist. Returns None if `!can_save`.
+    pub fn commit(&self) -> Option<AuthFormOutcome> {
+        if !self.can_save() {
+            return None;
+        }
+        let mode = self.mode?;
+        let env_var_name = self.agent.required_env_var(mode);
+        let env_value = match &self.credential {
+            CredentialInput::None => None,
+            CredentialInput::Literal(s) => Some(EnvValue::Plain(s.clone())),
+            CredentialInput::OpRef(r) => Some(EnvValue::OpRef(r.clone())),
+        };
+        Some(AuthFormOutcome {
+            mode,
+            env_var_name,
+            env_value,
+        })
+    }
+}
+
+const fn mode_requires_credential(agent: Agent, mode: AuthForwardMode) -> bool {
+    agent.required_env_var(mode).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_op_ref() -> OpRef {
+        OpRef {
+            op: "op://uuid/test".into(),
+            path: "Test/api/key".into(),
+        }
+    }
+
+    #[test]
+    fn save_disabled_when_mode_unset() {
+        let f = AuthForm::new(Agent::Claude);
+        assert!(!f.can_save(), "no mode picked");
+    }
+
+    #[test]
+    fn save_enabled_for_sync() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::Sync);
+        assert!(f.can_save(), "sync needs no credential");
+    }
+
+    #[test]
+    fn save_enabled_for_ignore() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::Ignore);
+        assert!(f.can_save());
+    }
+
+    #[test]
+    fn save_disabled_for_api_key_without_credential() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        assert!(!f.can_save(), "api_key requires credential");
+    }
+
+    #[test]
+    fn save_enabled_for_api_key_with_literal() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_literal("sk-ant-test".into());
+        assert!(f.can_save());
+    }
+
+    #[test]
+    fn save_disabled_for_api_key_with_empty_literal() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_literal(String::new());
+        assert!(!f.can_save());
+    }
+
+    #[test]
+    fn save_enabled_for_api_key_with_op_ref() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_op_ref(dummy_op_ref());
+        assert!(f.can_save());
+    }
+
+    #[test]
+    fn mode_switch_to_sync_collapses_credential_block() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_literal("sk-ant-test".into());
+        assert!(f.shows_credential_block());
+        f.set_mode(AuthForwardMode::Sync);
+        assert!(!f.shows_credential_block());
+        // Credential is cleared on mode change-to-no-credential.
+        assert_eq!(f.credential, CredentialInput::None);
+    }
+
+    #[test]
+    fn codex_form_does_not_offer_oauth_token() {
+        let f = AuthForm::new(Agent::Codex);
+        let modes = f.available_modes();
+        assert!(!modes.contains(&AuthForwardMode::OAuthToken));
+    }
+
+    #[test]
+    fn save_emits_correct_env_var_name_for_claude_api_key() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_literal("sk-ant-test".into());
+        let outcome = f.commit().unwrap();
+        assert_eq!(outcome.mode, AuthForwardMode::ApiKey);
+        assert_eq!(outcome.env_var_name, Some("ANTHROPIC_API_KEY"));
+        assert!(matches!(outcome.env_value, Some(EnvValue::Plain(ref s)) if s == "sk-ant-test"));
+    }
+
+    #[test]
+    fn save_emits_correct_env_var_name_for_claude_oauth_token() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::OAuthToken);
+        f.set_op_ref(dummy_op_ref());
+        let outcome = f.commit().unwrap();
+        assert_eq!(outcome.env_var_name, Some("CLAUDE_CODE_OAUTH_TOKEN"));
+    }
+
+    #[test]
+    fn save_emits_correct_env_var_name_for_codex_api_key() {
+        let mut f = AuthForm::new(Agent::Codex);
+        f.set_mode(AuthForwardMode::ApiKey);
+        f.set_literal("sk-test".into());
+        let outcome = f.commit().unwrap();
+        assert_eq!(outcome.env_var_name, Some("OPENAI_API_KEY"));
+    }
+
+    #[test]
+    fn save_returns_none_for_sync_with_no_credential() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::Sync);
+        let outcome = f.commit().unwrap();
+        assert_eq!(outcome.mode, AuthForwardMode::Sync);
+        assert_eq!(outcome.env_var_name, None);
+        assert!(outcome.env_value.is_none());
+    }
+
+    #[test]
+    fn from_existing_pre_populates_literal_credential() {
+        let f = AuthForm::from_existing(
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+            Some(EnvValue::Plain("sk-ant-existing".into())),
+        );
+        assert_eq!(f.mode, Some(AuthForwardMode::ApiKey));
+        assert_eq!(
+            f.credential,
+            CredentialInput::Literal("sk-ant-existing".into())
+        );
+        assert!(f.can_save());
+    }
+
+    #[test]
+    fn from_existing_pre_populates_op_ref_credential() {
+        let r = dummy_op_ref();
+        let f = AuthForm::from_existing(
+            Agent::Claude,
+            AuthForwardMode::OAuthToken,
+            Some(EnvValue::OpRef(r.clone())),
+        );
+        assert_eq!(f.mode, Some(AuthForwardMode::OAuthToken));
+        assert_eq!(f.credential, CredentialInput::OpRef(r));
+    }
+}

--- a/src/console/widgets/auth_panel/form.rs
+++ b/src/console/widgets/auth_panel/form.rs
@@ -117,7 +117,13 @@ impl AuthForm {
         match &self.credential {
             CredentialInput::None => false,
             CredentialInput::Literal(s) => !s.is_empty(),
-            CredentialInput::OpRef(_) => true,
+            // Both fields must be non-empty: the empty `OpRef { op: "",
+            // path: "" }` seeded by the credential-source toggle would
+            // otherwise pass the save gate and write a broken reference
+            // into `[workspaces.X.roles.Y.env]`. The launcher would then
+            // fail with "credential is unset" only after the operator
+            // had already committed the corrupt config to disk.
+            CredentialInput::OpRef(r) => !r.op.is_empty() && !r.path.is_empty(),
         }
     }
 
@@ -205,6 +211,35 @@ mod tests {
         f.set_mode(AuthForwardMode::ApiKey);
         f.set_op_ref(dummy_op_ref());
         assert!(f.can_save());
+    }
+
+    /// Empty `OpRef` (seeded by the credential-source toggle before
+    /// the operator has picked a vault item) must NOT pass the save
+    /// gate. Persisting such a reference into the env block would
+    /// only blow up at launch time with "credential is unset", long
+    /// after the broken config had been written to disk.
+    #[test]
+    fn save_disabled_for_api_key_with_empty_op_ref() {
+        let mut f = AuthForm::new(Agent::Claude);
+        f.set_mode(AuthForwardMode::ApiKey);
+        // Both fields empty (the toggle-radio seed): rejected.
+        f.set_op_ref(OpRef {
+            op: String::new(),
+            path: String::new(),
+        });
+        assert!(!f.can_save());
+        // Empty `op` alone: rejected.
+        f.set_op_ref(OpRef {
+            op: String::new(),
+            path: "Test/api/key".into(),
+        });
+        assert!(!f.can_save());
+        // Empty `path` alone: rejected.
+        f.set_op_ref(OpRef {
+            op: "op://uuid/test".into(),
+            path: String::new(),
+        });
+        assert!(!f.can_save());
     }
 
     #[test]

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -7,8 +7,10 @@
 //!
 //! Mounted as a peer to the Secrets panel by Task 19.
 
+pub mod form;
 pub mod render;
 pub mod state;
 
+pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
 pub use render::{render, render_with_selection};
 pub use state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -12,5 +12,5 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub use render::{render, render_with_selection};
+pub use render::{FormContext, render, render_form, render_with_selection};
 pub use state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -11,5 +11,7 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub use render::{FormContext, agent_display, mode_str, render_form};
-pub use state::{CredentialBadge, ProvenanceTag, badge_for, classify_env_value};
+pub use render::{FormContext, render_form};
+pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, agent_display, mode_str};
+pub use state::{CredentialBadge, ProvenanceTag};
+pub(crate) use state::badge_for;

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,16 +1,15 @@
-//! Auth panel: lists role-agent auth modes for the active workspace.
+//! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
-//! Splits state from rendering for unit-testability:
-//!   - `state.rs`   : pure data types and `AuthPanelState::compute_for`
-//!   - `render.rs`  : ratatui render path (Task 16)
-//!   - `form.rs`    : edit-form state (Task 17)
+//!   - `state.rs`   : `ProvenanceTag`, `CredentialBadge`, `badge_for`, `classify_env_value`
+//!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `agent_display`, `mode_str`
+//!   - `form.rs`    : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
 //!
-//! Mounted as a peer to the Secrets panel by Task 19.
+//! Flat-row Auth tab rendering lives in `src/console/manager/render/editor.rs`.
 
 pub mod form;
 pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub use render::{FormContext, render, render_form, render_with_selection};
-pub use state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};
+pub use render::{FormContext, agent_display, mode_str, render_form};
+pub use state::{CredentialBadge, ProvenanceTag, badge_for, classify_env_value};

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,6 +1,6 @@
 //! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
-//!   - `state.rs`   : `ProvenanceTag`, `CredentialBadge`, `badge_for`, `classify_env_value`
+//!   - `state.rs`   : `CredentialBadge`, `badge_for`, `classify_env_value`
 //!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `agent_display`, `mode_str`
 //!   - `form.rs`    : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
 //!
@@ -11,7 +11,9 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
+pub(crate) use render::{
+    DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, agent_display, mode_str,
+};
 pub use render::{FormContext, render_form};
-pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, agent_display, mode_str};
-pub use state::{CredentialBadge, ProvenanceTag};
+pub use state::CredentialBadge;
 pub(crate) use state::badge_for;

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Splits state from rendering for unit-testability:
 //!   - `state.rs`   : pure data types and `AuthPanelState::compute_for`
+//!   - `render.rs`  : ratatui render path (Task 16)
 //!   - `form.rs`    : edit-form state (Task 17)
-//!   - rendering    : Task 16 will add a render method to `AuthPanel`
 //!
 //! Mounted as a peer to the Secrets panel by Task 19.
 
+pub mod render;
 pub mod state;
 
+pub use render::{render, render_with_selection};
 pub use state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,0 +1,12 @@
+//! Auth panel: lists role-agent auth modes for the active workspace.
+//!
+//! Splits state from rendering for unit-testability:
+//!   - `state.rs`   : pure data types and `AuthPanelState::compute_for`
+//!   - `form.rs`    : edit-form state (Task 17)
+//!   - rendering    : Task 16 will add a render method to `AuthPanel`
+//!
+//! Mounted as a peer to the Secrets panel by Task 19.
+
+pub mod state;
+
+pub use state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -27,6 +27,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
+use super::form::{AuthForm, CredentialInput};
 use super::state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};
 use crate::agent::Agent;
 use crate::config::AuthForwardMode;
@@ -230,6 +231,194 @@ const fn badge_display(b: CredentialBadge) -> (&'static str, Style) {
     }
 }
 
+/// Identification context passed alongside the form's mutable state so the
+/// render can title the modal with the workspace and role being edited.
+pub struct FormContext<'a> {
+    pub workspace: &'a str,
+    pub role: &'a str,
+}
+
+/// Render the auth-edit modal for `form` into `area`.
+///
+/// Lays out, top-to-bottom:
+///   - title block: `Edit auth: workspace 'X' / role 'Y' / Agent`
+///   - mode picker line (current mode + cycle hint)
+///   - credential block (only when [`AuthForm::shows_credential_block`])
+///     - `Literal | 1Password` radio
+///     - text input or op-ref path display
+///     - resolves badge if a literal/op-ref is committed
+///   - action buttons: `Save` (DIM if `!form.can_save`) / `Cancel` / `Reset`
+///
+/// Pure render — no input handling. Task 19 wires the keystroke router.
+pub fn render_form(frame: &mut Frame, area: Rect, form: &AuthForm, ctx: &FormContext) {
+    frame.render_widget(ratatui::widgets::Clear, area);
+    let title = format!(
+        " Edit auth: workspace '{ws}' / role '{role}' / {agent} ",
+        ws = ctx.workspace,
+        role = ctx.role,
+        agent = agent_display(form.agent),
+    );
+    let title_span = Span::styled(
+        title,
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(title_span);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = build_form_lines(form);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn build_form_lines(form: &AuthForm) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Mode picker line.
+    let mode_text = form.mode.map_or("(unset)", mode_str);
+    lines.push(Line::from(vec![
+        Span::styled(
+            "Mode: ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
+        Span::styled(
+            "  (Tab/Space to cycle)".to_string(),
+            Style::default().fg(PHOSPHOR_DIM),
+        ),
+    ]));
+
+    if form.shows_credential_block() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Credential",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(credential_radio_line(&form.credential));
+        lines.push(credential_value_line(&form.credential));
+        lines.push(credential_status_line(&form.credential));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(action_buttons_line(form.can_save()));
+    lines
+}
+
+fn credential_radio_line(cred: &CredentialInput) -> Line<'static> {
+    // Default selection when no credential committed yet is `Literal`.
+    let is_op_ref = matches!(cred, CredentialInput::OpRef(_));
+    let is_literal = !is_op_ref;
+
+    let literal_label = if is_literal {
+        "(*) Literal"
+    } else {
+        "( ) Literal"
+    };
+    let op_label = if is_op_ref {
+        "(*) 1Password"
+    } else {
+        "( ) 1Password"
+    };
+
+    let lit_style = if is_literal {
+        Style::default().fg(PHOSPHOR_GREEN)
+    } else {
+        Style::default().fg(PHOSPHOR_DIM)
+    };
+    let op_style = if is_op_ref {
+        Style::default().fg(PHOSPHOR_GREEN)
+    } else {
+        Style::default().fg(PHOSPHOR_DIM)
+    };
+
+    Line::from(vec![
+        Span::styled(literal_label.to_string(), lit_style),
+        Span::raw("    "),
+        Span::styled(op_label.to_string(), op_style),
+    ])
+}
+
+fn credential_value_line(cred: &CredentialInput) -> Line<'static> {
+    match cred {
+        CredentialInput::None => Line::from(Span::styled(
+            "  (enter a literal value or pick from 1Password)".to_string(),
+            Style::default().fg(PHOSPHOR_DIM),
+        )),
+        CredentialInput::Literal(s) => {
+            // Mask the value for display — still need to show *something*
+            // so the operator knows there is content.
+            let masked = if s.is_empty() {
+                String::from("(empty)")
+            } else {
+                "*".repeat(s.chars().count().min(20))
+            };
+            Line::from(vec![
+                Span::styled(
+                    "  Value: ",
+                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(masked, Style::default().fg(WHITE)),
+            ])
+        }
+        CredentialInput::OpRef(r) => Line::from(vec![
+            Span::styled(
+                "  Path:  ",
+                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(r.path.clone(), Style::default().fg(WHITE)),
+            Span::raw("  "),
+            Span::styled(
+                "[Pick from 1Password]".to_string(),
+                Style::default().fg(PHOSPHOR_GREEN),
+            ),
+        ]),
+    }
+}
+
+fn credential_status_line(cred: &CredentialInput) -> Line<'static> {
+    match cred {
+        CredentialInput::None => Line::from(Span::styled(
+            "  Status: ! unset".to_string(),
+            Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
+        )),
+        CredentialInput::Literal(s) if s.is_empty() => Line::from(Span::styled(
+            "  Status: ! empty".to_string(),
+            Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
+        )),
+        CredentialInput::Literal(_) | CredentialInput::OpRef(_) => Line::from(Span::styled(
+            "  Status: OK resolves".to_string(),
+            Style::default().fg(PHOSPHOR_GREEN),
+        )),
+    }
+}
+
+fn action_buttons_line(can_save: bool) -> Line<'static> {
+    let save_style = if can_save {
+        Style::default()
+            .fg(PHOSPHOR_GREEN)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(PHOSPHOR_DIM)
+            .add_modifier(Modifier::DIM)
+    };
+    Line::from(vec![
+        Span::styled("[ Save ]".to_string(), save_style),
+        Span::raw("  "),
+        Span::styled(
+            "[ Cancel ]".to_string(),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            "[ Reset ]".to_string(),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
 #[cfg(test)]
 mod render_tests {
     use super::*;
@@ -390,6 +579,137 @@ mod render_tests {
         assert!(
             s.contains('\u{25b8}'),
             "selected row must render the triangle cursor; dump:\n{s}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod form_render_tests {
+    use super::*;
+    use crate::operator_env::OpRef;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn dump_form(form: &AuthForm, ctx: &FormContext) -> String {
+        let backend = TestBackend::new(100, 20);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.area();
+            render_form(f, area, form, ctx);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    fn ctx() -> FormContext<'static> {
+        FormContext {
+            workspace: "proj",
+            role: "smith",
+        }
+    }
+
+    #[test]
+    fn form_header_includes_workspace_role_and_agent() {
+        let form = AuthForm::new(Agent::Claude);
+        let s = dump_form(&form, &ctx());
+        assert!(s.contains("Edit auth:"), "missing header; dump:\n{s}");
+        assert!(s.contains("proj"), "missing workspace name; dump:\n{s}");
+        assert!(s.contains("smith"), "missing role name; dump:\n{s}");
+        assert!(s.contains("Claude"), "missing agent name; dump:\n{s}");
+    }
+
+    #[test]
+    fn form_with_unset_mode_hides_credential_block_and_dims_save() {
+        let form = AuthForm::new(Agent::Claude);
+        let s = dump_form(&form, &ctx());
+        assert!(s.contains("Mode:"), "missing mode line; dump:\n{s}");
+        assert!(
+            s.contains("(unset)"),
+            "expected (unset) mode label; dump:\n{s}"
+        );
+        // No credential block when mode is unset.
+        assert!(
+            !s.contains("Credential"),
+            "credential block must be hidden when mode unset; dump:\n{s}"
+        );
+        // Save still appears as a button label even when disabled.
+        assert!(s.contains("Save"), "missing Save button; dump:\n{s}");
+        assert!(s.contains("Cancel"), "missing Cancel button; dump:\n{s}");
+        assert!(s.contains("Reset"), "missing Reset button; dump:\n{s}");
+    }
+
+    #[test]
+    fn form_with_sync_mode_hides_credential_block_and_enables_save() {
+        let mut form = AuthForm::new(Agent::Claude);
+        form.set_mode(AuthForwardMode::Sync);
+        let s = dump_form(&form, &ctx());
+        assert!(s.contains("sync"), "missing sync mode label; dump:\n{s}");
+        // Sync requires no credential.
+        assert!(
+            !s.contains("Credential"),
+            "sync should hide credential block; dump:\n{s}"
+        );
+        assert!(form.can_save());
+    }
+
+    #[test]
+    fn form_with_api_key_literal_shows_credential_block_and_resolves() {
+        let mut form = AuthForm::new(Agent::Claude);
+        form.set_mode(AuthForwardMode::ApiKey);
+        form.set_literal("sk-ant-test".into());
+        let s = dump_form(&form, &ctx());
+        assert!(s.contains("api_key"), "missing api_key mode; dump:\n{s}");
+        assert!(
+            s.contains("Credential"),
+            "credential block must show for api_key; dump:\n{s}"
+        );
+        assert!(s.contains("Literal"), "missing Literal radio; dump:\n{s}");
+        assert!(
+            s.contains("1Password"),
+            "missing 1Password radio; dump:\n{s}"
+        );
+        // Active radio marker on the Literal side.
+        assert!(
+            s.contains("(*) Literal"),
+            "Literal radio not selected; dump:\n{s}"
+        );
+        assert!(
+            s.contains("resolves"),
+            "missing resolves status badge; dump:\n{s}"
+        );
+    }
+
+    #[test]
+    fn form_with_op_ref_credential_shows_path_and_picker_button() {
+        let mut form = AuthForm::new(Agent::Claude);
+        form.set_mode(AuthForwardMode::ApiKey);
+        form.set_op_ref(OpRef {
+            op: "op://uuid/anthropic".into(),
+            path: "Work/Anthropic/api-key".into(),
+        });
+        let s = dump_form(&form, &ctx());
+        assert!(
+            s.contains("(*) 1Password"),
+            "1Password radio not selected; dump:\n{s}"
+        );
+        assert!(
+            s.contains("Work/Anthropic/api-key"),
+            "missing op-ref path display; dump:\n{s}"
+        );
+        assert!(
+            s.contains("Pick from 1Password"),
+            "missing op-picker button; dump:\n{s}"
+        );
+        assert!(
+            s.contains("resolves"),
+            "missing resolves status badge for op-ref; dump:\n{s}"
         );
     }
 }

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -1,23 +1,8 @@
-//! Render path for [`super::AuthPanelState`].
+//! Render helpers for the auth edit form.
 //!
-//! Three sections, top-to-bottom:
-//!
-//!   1. **Global defaults** — read-only, hint links to global-config screen.
-//!   2. **This workspace** — `[edit]` / `[reset]` affordances per row.
-//!   3. **Per role × agent** — `[edit]` affordance per row.
-//!
-//! Each row renders as: `<label>: <mode> (<provenance>)  <badge>` where
-//! `<badge>` is one of `OK resolves`, `! unset`, or `-` (not applicable).
-//! Selection highlight follows the canonical phosphor list-modal style
-//! used by [`crate::console::widgets::op_picker::render`].
-//!
-//! This is a pure render — no input handling, no form mounting (those
-//! land in Task 17/18/19).
-//!
-//! The selection cursor is supplied by the parent panel out-of-band via
-//! the `selected` argument; row indexing is the flattened concatenation
-//! of `workspace_rows` + `role_agent_rows` (the global section is
-//! read-only and not part of the selectable surface).
+//! `render_form` renders the auth-edit modal for a single (workspace, role,
+//! agent) combination. The flat-row Auth tab rendering lives in
+//! `src/console/manager/render/editor.rs`.
 
 use ratatui::{
     Frame,
@@ -28,206 +13,28 @@ use ratatui::{
 };
 
 use super::form::{AuthForm, CredentialInput};
-use super::state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};
 use crate::agent::Agent;
 use crate::config::AuthForwardMode;
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
-const DANGER_RED: Color = Color::Rgb(255, 94, 122);
+pub(crate) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
+pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
+pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
+pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
+pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 
-/// Render `state` into `area` with no row selected (read-only display).
-pub fn render(frame: &mut Frame, area: Rect, state: &AuthPanelState) {
-    render_with_selection(frame, area, state, None);
-}
-
-/// Render `state` into `area` with `selected` highlighted.
-///
-/// `selected` indexes the flattened list of editable rows
-/// (`workspace_rows` followed by `role_agent_rows`). The global section
-/// is read-only and is never highlighted.
-pub fn render_with_selection(
-    frame: &mut Frame,
-    area: Rect,
-    state: &AuthPanelState,
-    selected: Option<usize>,
-) {
-    let title = Span::styled(
-        " Auth ",
-        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-    );
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(title);
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    let lines = build_lines(state, selected);
-    frame.render_widget(Paragraph::new(lines), inner);
-}
-
-/// Build the panel's full set of lines, including section headers,
-/// dividers, rows, and the global-section hint.
-fn build_lines(state: &AuthPanelState, selected: Option<usize>) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    let editable_offset_workspace = 0usize;
-    let editable_offset_role = state.workspace_rows.len();
-
-    // Section 1: Global defaults (read-only).
-    lines.push(section_header("Global defaults"));
-    for row in &state.global_rows {
-        lines.push(format_row_line(row, false, /* show_role = */ false));
-    }
-    lines.push(Line::from(Span::styled(
-        "  (edit on the global-config screen)",
-        Style::default().fg(PHOSPHOR_DIM),
-    )));
-
-    // Divider between sections 1 and 2.
-    lines.push(divider());
-
-    // Section 2: This workspace (editable).
-    lines.push(section_header("This workspace"));
-    for (i, row) in state.workspace_rows.iter().enumerate() {
-        let is_selected = selected == Some(editable_offset_workspace + i);
-        lines.push(format_row_line(
-            row,
-            is_selected,
-            /* show_role = */ false,
-        ));
-    }
-
-    // Divider between sections 2 and 3.
-    lines.push(divider());
-
-    // Section 3: Per role × agent (editable).
-    lines.push(section_header("Per role x agent"));
-    for (i, row) in state.role_agent_rows.iter().enumerate() {
-        let is_selected = selected == Some(editable_offset_role + i);
-        lines.push(format_row_line(
-            row,
-            is_selected,
-            /* show_role = */ true,
-        ));
-    }
-
-    lines
-}
-
-fn section_header(text: &str) -> Line<'static> {
-    Line::from(Span::styled(
-        text.to_string(),
-        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-    ))
-}
-
-fn divider() -> Line<'static> {
-    Line::from(Span::styled(
-        "  ".to_string() + &"-".repeat(48),
-        Style::default().fg(PHOSPHOR_DARK),
-    ))
-}
-
-fn format_row_line(row: &AuthRow, is_selected: bool, show_role: bool) -> Line<'static> {
-    let prefix = if is_selected { "\u{25b8} " } else { "  " };
-    let label = if show_role {
-        format!(
-            "{prefix}{role} / {agent}: {mode}",
-            role = row.role,
-            agent = agent_display(row.agent),
-            mode = mode_str(row.mode),
-        )
-    } else {
-        format!(
-            "{prefix}{agent}: {mode}",
-            agent = agent_display(row.agent),
-            mode = mode_str(row.mode),
-        )
-    };
-    let label_style = if is_selected {
-        Style::default()
-            .fg(PHOSPHOR_GREEN)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(WHITE)
-    };
-
-    let provenance = format!(" ({})", provenance_str(row.provenance));
-    let provenance_style = Style::default().fg(PHOSPHOR_DIM);
-
-    let (badge_text, badge_style) = badge_display(row.credential);
-
-    Line::from(vec![
-        Span::styled(label, label_style),
-        Span::styled(provenance, provenance_style),
-        Span::raw("  "),
-        Span::styled(badge_text, badge_style),
-    ])
-}
-
-const fn agent_display(agent: Agent) -> &'static str {
+pub const fn agent_display(agent: Agent) -> &'static str {
     match agent {
         Agent::Claude => "Claude",
         Agent::Codex => "Codex",
     }
 }
 
-const fn mode_str(m: AuthForwardMode) -> &'static str {
+pub const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
         AuthForwardMode::Sync => "sync",
         AuthForwardMode::ApiKey => "api_key",
         AuthForwardMode::OAuthToken => "oauth_token",
         AuthForwardMode::Ignore => "ignore",
-    }
-}
-
-const fn provenance_str(p: ProvenanceTag) -> &'static str {
-    match p {
-        ProvenanceTag::Global => "global",
-        ProvenanceTag::Workspace => "workspace",
-        ProvenanceTag::MostSpecific => "most-specific",
-        ProvenanceTag::Inherited => "inherited",
-    }
-}
-
-/// Render the credential badge as plain ASCII so terminal-renderer
-/// snapshots stay portable. The check / cross / dash characters in
-/// the design doc map to `OK`, `!`, and `-` respectively.
-const fn badge_display(b: CredentialBadge) -> (&'static str, Style) {
-    match b {
-        CredentialBadge::Resolves => (
-            "OK resolves",
-            Style {
-                fg: Some(PHOSPHOR_GREEN),
-                bg: None,
-                underline_color: None,
-                add_modifier: Modifier::empty(),
-                sub_modifier: Modifier::empty(),
-            },
-        ),
-        CredentialBadge::Unset => (
-            "! unset",
-            Style {
-                fg: Some(DANGER_RED),
-                bg: None,
-                underline_color: None,
-                add_modifier: Modifier::BOLD,
-                sub_modifier: Modifier::empty(),
-            },
-        ),
-        CredentialBadge::NotApplicable => (
-            "-",
-            Style {
-                fg: Some(PHOSPHOR_DIM),
-                bg: None,
-                underline_color: None,
-                add_modifier: Modifier::empty(),
-                sub_modifier: Modifier::empty(),
-            },
-        ),
     }
 }
 
@@ -419,169 +226,6 @@ fn action_buttons_line(can_save: bool) -> Line<'static> {
     ])
 }
 
-#[cfg(test)]
-mod render_tests {
-    use super::*;
-    use crate::config::{AgentAuthConfig, AppConfig};
-    use crate::operator_env::EnvValue;
-    use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
-    use ratatui::{Terminal, backend::TestBackend};
-
-    fn dump(state: &AuthPanelState, selected: Option<usize>) -> String {
-        let backend = TestBackend::new(100, 30);
-        let mut term = Terminal::new(backend).unwrap();
-        term.draw(|f| {
-            let area = f.area();
-            render_with_selection(f, area, state, selected);
-        })
-        .unwrap();
-        let buf = term.backend().buffer();
-        let mut s = String::new();
-        for y in 0..buf.area.height {
-            for x in 0..buf.area.width {
-                s.push_str(buf[(x, y)].symbol());
-            }
-            s.push('\n');
-        }
-        s
-    }
-
-    fn cfg_with_role(role: &str) -> AppConfig {
-        let mut cfg = AppConfig {
-            claude: Some(AgentAuthConfig {
-                auth_forward: AuthForwardMode::Sync,
-            }),
-            ..AppConfig::default()
-        };
-        let ws = WorkspaceConfig {
-            workdir: "/tmp/proj".to_string(),
-            allowed_roles: vec![role.to_string()],
-            ..Default::default()
-        };
-        cfg.workspaces.insert("proj".into(), ws);
-        cfg
-    }
-
-    #[test]
-    fn renders_three_sections_with_dividers() {
-        let cfg = cfg_with_role("smith");
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let s = dump(&state, None);
-
-        assert!(
-            s.contains("Global defaults"),
-            "missing Global defaults header; dump:\n{s}"
-        );
-        assert!(
-            s.contains("This workspace"),
-            "missing This workspace header; dump:\n{s}"
-        );
-        assert!(
-            s.contains("Per role x agent"),
-            "missing Per role x agent header; dump:\n{s}"
-        );
-        // Dividers (long run of '-' characters between sections).
-        assert!(
-            s.contains(&"-".repeat(20)),
-            "missing divider between sections; dump:\n{s}"
-        );
-        // Both agents present in global + workspace sections.
-        assert!(s.contains("Claude"), "missing Claude label; dump:\n{s}");
-        assert!(s.contains("Codex"), "missing Codex label; dump:\n{s}");
-        // Role appears in role × agent section.
-        assert!(
-            s.contains("smith"),
-            "missing role name in role x agent section; dump:\n{s}"
-        );
-        // Hint pointing at global-config screen.
-        assert!(
-            s.contains("global-config screen"),
-            "missing global-config hint; dump:\n{s}"
-        );
-    }
-
-    #[test]
-    fn row_displays_mode_provenance_and_badge() {
-        let mut cfg = cfg_with_role("smith");
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        });
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let s = dump(&state, None);
-
-        // Mode label rendered.
-        assert!(
-            s.contains("api_key"),
-            "missing api_key mode label; dump:\n{s}"
-        );
-        // Provenance tag rendered (workspace overrides global → workspace prov).
-        assert!(
-            s.contains("workspace"),
-            "missing workspace provenance tag; dump:\n{s}"
-        );
-        // Unset badge rendered (ANTHROPIC_API_KEY not set anywhere).
-        assert!(s.contains("unset"), "missing unset badge; dump:\n{s}");
-    }
-
-    #[test]
-    fn resolves_badge_shown_when_env_var_present() {
-        let mut cfg = cfg_with_role("smith");
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        });
-        ws.env.insert(
-            "ANTHROPIC_API_KEY".into(),
-            EnvValue::Plain("sk-ant-test".into()),
-        );
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let s = dump(&state, None);
-
-        assert!(
-            s.contains("resolves"),
-            "missing resolves badge when env var is set; dump:\n{s}"
-        );
-    }
-
-    #[test]
-    fn most_specific_provenance_rendered_for_role_override() {
-        let mut cfg = cfg_with_role("smith");
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.roles.insert(
-            "smith".into(),
-            WorkspaceRoleOverride {
-                claude: Some(AgentAuthConfig {
-                    auth_forward: AuthForwardMode::OAuthToken,
-                }),
-                ..Default::default()
-            },
-        );
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let s = dump(&state, None);
-
-        assert!(
-            s.contains("oauth_token"),
-            "role override mode missing; dump:\n{s}"
-        );
-        assert!(
-            s.contains("most-specific"),
-            "missing most-specific provenance for role override; dump:\n{s}"
-        );
-    }
-
-    #[test]
-    fn selection_marker_appears_on_selected_row() {
-        let cfg = cfg_with_role("smith");
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        // Select the first workspace row (index 0 in the editable surface).
-        let s = dump(&state, Some(0));
-        assert!(
-            s.contains('\u{25b8}'),
-            "selected row must render the triangle cursor; dump:\n{s}"
-        );
-    }
-}
 
 #[cfg(test)]
 mod form_render_tests {

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -226,7 +226,6 @@ fn action_buttons_line(can_save: bool) -> Line<'static> {
     ])
 }
 
-
 #[cfg(test)]
 mod form_render_tests {
     use super::*;

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -22,14 +22,14 @@ pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 
-pub const fn agent_display(agent: Agent) -> &'static str {
+pub(crate) const fn agent_display(agent: Agent) -> &'static str {
     match agent {
         Agent::Claude => "Claude",
         Agent::Codex => "Codex",
     }
 }
 
-pub const fn mode_str(m: AuthForwardMode) -> &'static str {
+pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
         AuthForwardMode::Sync => "sync",
         AuthForwardMode::ApiKey => "api_key",

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -1,0 +1,395 @@
+//! Render path for [`super::AuthPanelState`].
+//!
+//! Three sections, top-to-bottom:
+//!
+//!   1. **Global defaults** — read-only, hint links to global-config screen.
+//!   2. **This workspace** — `[edit]` / `[reset]` affordances per row.
+//!   3. **Per role × agent** — `[edit]` affordance per row.
+//!
+//! Each row renders as: `<label>: <mode> (<provenance>)  <badge>` where
+//! `<badge>` is one of `OK resolves`, `! unset`, or `-` (not applicable).
+//! Selection highlight follows the canonical phosphor list-modal style
+//! used by [`crate::console::widgets::op_picker::render`].
+//!
+//! This is a pure render — no input handling, no form mounting (those
+//! land in Task 17/18/19).
+//!
+//! The selection cursor is supplied by the parent panel out-of-band via
+//! the `selected` argument; row indexing is the flattened concatenation
+//! of `workspace_rows` + `role_agent_rows` (the global section is
+//! read-only and not part of the selectable surface).
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+use super::state::{AuthPanelState, AuthRow, CredentialBadge, ProvenanceTag};
+use crate::agent::Agent;
+use crate::config::AuthForwardMode;
+
+const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
+const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
+const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
+const WHITE: Color = Color::Rgb(255, 255, 255);
+const DANGER_RED: Color = Color::Rgb(255, 94, 122);
+
+/// Render `state` into `area` with no row selected (read-only display).
+pub fn render(frame: &mut Frame, area: Rect, state: &AuthPanelState) {
+    render_with_selection(frame, area, state, None);
+}
+
+/// Render `state` into `area` with `selected` highlighted.
+///
+/// `selected` indexes the flattened list of editable rows
+/// (`workspace_rows` followed by `role_agent_rows`). The global section
+/// is read-only and is never highlighted.
+pub fn render_with_selection(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AuthPanelState,
+    selected: Option<usize>,
+) {
+    let title = Span::styled(
+        " Auth ",
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let lines = build_lines(state, selected);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Build the panel's full set of lines, including section headers,
+/// dividers, rows, and the global-section hint.
+fn build_lines(state: &AuthPanelState, selected: Option<usize>) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let editable_offset_workspace = 0usize;
+    let editable_offset_role = state.workspace_rows.len();
+
+    // Section 1: Global defaults (read-only).
+    lines.push(section_header("Global defaults"));
+    for row in &state.global_rows {
+        lines.push(format_row_line(row, false, /* show_role = */ false));
+    }
+    lines.push(Line::from(Span::styled(
+        "  (edit on the global-config screen)",
+        Style::default().fg(PHOSPHOR_DIM),
+    )));
+
+    // Divider between sections 1 and 2.
+    lines.push(divider());
+
+    // Section 2: This workspace (editable).
+    lines.push(section_header("This workspace"));
+    for (i, row) in state.workspace_rows.iter().enumerate() {
+        let is_selected = selected == Some(editable_offset_workspace + i);
+        lines.push(format_row_line(
+            row,
+            is_selected,
+            /* show_role = */ false,
+        ));
+    }
+
+    // Divider between sections 2 and 3.
+    lines.push(divider());
+
+    // Section 3: Per role × agent (editable).
+    lines.push(section_header("Per role x agent"));
+    for (i, row) in state.role_agent_rows.iter().enumerate() {
+        let is_selected = selected == Some(editable_offset_role + i);
+        lines.push(format_row_line(
+            row,
+            is_selected,
+            /* show_role = */ true,
+        ));
+    }
+
+    lines
+}
+
+fn section_header(text: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn divider() -> Line<'static> {
+    Line::from(Span::styled(
+        "  ".to_string() + &"-".repeat(48),
+        Style::default().fg(PHOSPHOR_DARK),
+    ))
+}
+
+fn format_row_line(row: &AuthRow, is_selected: bool, show_role: bool) -> Line<'static> {
+    let prefix = if is_selected { "\u{25b8} " } else { "  " };
+    let label = if show_role {
+        format!(
+            "{prefix}{role} / {agent}: {mode}",
+            role = row.role,
+            agent = agent_display(row.agent),
+            mode = mode_str(row.mode),
+        )
+    } else {
+        format!(
+            "{prefix}{agent}: {mode}",
+            agent = agent_display(row.agent),
+            mode = mode_str(row.mode),
+        )
+    };
+    let label_style = if is_selected {
+        Style::default()
+            .fg(PHOSPHOR_GREEN)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(WHITE)
+    };
+
+    let provenance = format!(" ({})", provenance_str(row.provenance));
+    let provenance_style = Style::default().fg(PHOSPHOR_DIM);
+
+    let (badge_text, badge_style) = badge_display(row.credential);
+
+    Line::from(vec![
+        Span::styled(label, label_style),
+        Span::styled(provenance, provenance_style),
+        Span::raw("  "),
+        Span::styled(badge_text, badge_style),
+    ])
+}
+
+const fn agent_display(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "Claude",
+        Agent::Codex => "Codex",
+    }
+}
+
+const fn mode_str(m: AuthForwardMode) -> &'static str {
+    match m {
+        AuthForwardMode::Sync => "sync",
+        AuthForwardMode::ApiKey => "api_key",
+        AuthForwardMode::OAuthToken => "oauth_token",
+        AuthForwardMode::Ignore => "ignore",
+    }
+}
+
+const fn provenance_str(p: ProvenanceTag) -> &'static str {
+    match p {
+        ProvenanceTag::Global => "global",
+        ProvenanceTag::Workspace => "workspace",
+        ProvenanceTag::MostSpecific => "most-specific",
+        ProvenanceTag::Inherited => "inherited",
+    }
+}
+
+/// Render the credential badge as plain ASCII so terminal-renderer
+/// snapshots stay portable. The check / cross / dash characters in
+/// the design doc map to `OK`, `!`, and `-` respectively.
+const fn badge_display(b: CredentialBadge) -> (&'static str, Style) {
+    match b {
+        CredentialBadge::Resolves => (
+            "OK resolves",
+            Style {
+                fg: Some(PHOSPHOR_GREEN),
+                bg: None,
+                underline_color: None,
+                add_modifier: Modifier::empty(),
+                sub_modifier: Modifier::empty(),
+            },
+        ),
+        CredentialBadge::Unset => (
+            "! unset",
+            Style {
+                fg: Some(DANGER_RED),
+                bg: None,
+                underline_color: None,
+                add_modifier: Modifier::BOLD,
+                sub_modifier: Modifier::empty(),
+            },
+        ),
+        CredentialBadge::NotApplicable => (
+            "-",
+            Style {
+                fg: Some(PHOSPHOR_DIM),
+                bg: None,
+                underline_color: None,
+                add_modifier: Modifier::empty(),
+                sub_modifier: Modifier::empty(),
+            },
+        ),
+    }
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+    use crate::config::{AgentAuthConfig, AppConfig};
+    use crate::operator_env::EnvValue;
+    use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn dump(state: &AuthPanelState, selected: Option<usize>) -> String {
+        let backend = TestBackend::new(100, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let area = f.area();
+            render_with_selection(f, area, state, selected);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    fn cfg_with_role(role: &str) -> AppConfig {
+        let mut cfg = AppConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::Sync,
+            }),
+            ..AppConfig::default()
+        };
+        let ws = WorkspaceConfig {
+            workdir: "/tmp/proj".to_string(),
+            allowed_roles: vec![role.to_string()],
+            ..Default::default()
+        };
+        cfg.workspaces.insert("proj".into(), ws);
+        cfg
+    }
+
+    #[test]
+    fn renders_three_sections_with_dividers() {
+        let cfg = cfg_with_role("smith");
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let s = dump(&state, None);
+
+        assert!(
+            s.contains("Global defaults"),
+            "missing Global defaults header; dump:\n{s}"
+        );
+        assert!(
+            s.contains("This workspace"),
+            "missing This workspace header; dump:\n{s}"
+        );
+        assert!(
+            s.contains("Per role x agent"),
+            "missing Per role x agent header; dump:\n{s}"
+        );
+        // Dividers (long run of '-' characters between sections).
+        assert!(
+            s.contains(&"-".repeat(20)),
+            "missing divider between sections; dump:\n{s}"
+        );
+        // Both agents present in global + workspace sections.
+        assert!(s.contains("Claude"), "missing Claude label; dump:\n{s}");
+        assert!(s.contains("Codex"), "missing Codex label; dump:\n{s}");
+        // Role appears in role × agent section.
+        assert!(
+            s.contains("smith"),
+            "missing role name in role x agent section; dump:\n{s}"
+        );
+        // Hint pointing at global-config screen.
+        assert!(
+            s.contains("global-config screen"),
+            "missing global-config hint; dump:\n{s}"
+        );
+    }
+
+    #[test]
+    fn row_displays_mode_provenance_and_badge() {
+        let mut cfg = cfg_with_role("smith");
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let s = dump(&state, None);
+
+        // Mode label rendered.
+        assert!(
+            s.contains("api_key"),
+            "missing api_key mode label; dump:\n{s}"
+        );
+        // Provenance tag rendered (workspace overrides global → workspace prov).
+        assert!(
+            s.contains("workspace"),
+            "missing workspace provenance tag; dump:\n{s}"
+        );
+        // Unset badge rendered (ANTHROPIC_API_KEY not set anywhere).
+        assert!(s.contains("unset"), "missing unset badge; dump:\n{s}");
+    }
+
+    #[test]
+    fn resolves_badge_shown_when_env_var_present() {
+        let mut cfg = cfg_with_role("smith");
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        ws.env.insert(
+            "ANTHROPIC_API_KEY".into(),
+            EnvValue::Plain("sk-ant-test".into()),
+        );
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let s = dump(&state, None);
+
+        assert!(
+            s.contains("resolves"),
+            "missing resolves badge when env var is set; dump:\n{s}"
+        );
+    }
+
+    #[test]
+    fn most_specific_provenance_rendered_for_role_override() {
+        let mut cfg = cfg_with_role("smith");
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.roles.insert(
+            "smith".into(),
+            WorkspaceRoleOverride {
+                claude: Some(AgentAuthConfig {
+                    auth_forward: AuthForwardMode::OAuthToken,
+                }),
+                ..Default::default()
+            },
+        );
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let s = dump(&state, None);
+
+        assert!(
+            s.contains("oauth_token"),
+            "role override mode missing; dump:\n{s}"
+        );
+        assert!(
+            s.contains("most-specific"),
+            "missing most-specific provenance for role override; dump:\n{s}"
+        );
+    }
+
+    #[test]
+    fn selection_marker_appears_on_selected_row() {
+        let cfg = cfg_with_role("smith");
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        // Select the first workspace row (index 0 in the editable surface).
+        let s = dump(&state, Some(0));
+        assert!(
+            s.contains('\u{25b8}'),
+            "selected row must render the triangle cursor; dump:\n{s}"
+        );
+    }
+}

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -1,27 +1,11 @@
 //! Pure data types for the Auth panel.
 //!
-//! Provides [`ProvenanceTag`], [`CredentialBadge`], [`badge_for`], and
+//! Provides [`CredentialBadge`], [`badge_for`], and
 //! [`classify_env_value`]. These are consumed by the flat-row renderer in
 //! `src/console/manager/render/editor.rs`.
 
 use crate::agent::Agent;
 use crate::config::{AppConfig, AuthForwardMode};
-
-/// Which layer of the 3-layer resolver supplied this row's mode value.
-#[allow(dead_code)] // re-introduced as a footer hint in Task 13 of the auth-tab redesign
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProvenanceTag {
-    /// Mode came from `[<agent>]` (global default).
-    Global,
-    /// Mode came from `[workspaces.<ws>.<agent>]`.
-    Workspace,
-    /// Mode came from `[workspaces.<ws>.roles.<role>.<agent>]`.
-    MostSpecific,
-    /// No layer at this level; inherited from a broader layer above.
-    /// Used for the `workspace_rows` section's display when only the
-    /// global default applies.
-    Inherited,
-}
 
 /// Status badge displayed on a row showing whether the credential resolves.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -126,7 +110,13 @@ mod badge_for_tests {
             auth_forward: AuthForwardMode::ApiKey,
         });
         // ANTHROPIC_API_KEY is not set anywhere in cfg.
-        let badge = badge_for(&cfg, "proj", "smith", Agent::Claude, AuthForwardMode::ApiKey);
+        let badge = badge_for(
+            &cfg,
+            "proj",
+            "smith",
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+        );
         assert_eq!(badge, CredentialBadge::Unset);
     }
 
@@ -150,7 +140,13 @@ mod badge_for_tests {
                 "ANTHROPIC_API_KEY".into(),
                 EnvValue::Plain("sk-ant-test".into()),
             );
-        let badge = badge_for(&cfg, "proj", "smith", Agent::Claude, AuthForwardMode::ApiKey);
+        let badge = badge_for(
+            &cfg,
+            "proj",
+            "smith",
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+        );
         assert_eq!(badge, CredentialBadge::Resolves);
     }
 }

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -1,0 +1,345 @@
+//! Pure data types and state computation for the Auth panel.
+//!
+//! `AuthPanelState::compute_for` walks an [`AppConfig`] to materialize
+//! one row per (scope, agent) and (role, agent) pair. Each row carries:
+//!
+//! - the effective [`AuthForwardMode`] after the 3-layer resolver runs,
+//! - a [`ProvenanceTag`] saying *which* layer supplied that mode, and
+//! - a [`CredentialBadge`] saying whether the mode's required env var
+//!   resolves to a non-empty value in the merged 4-layer operator env.
+//!
+//! Rendering lives in `render.rs` (Task 16). This module deliberately
+//! avoids any ratatui dependency so the per-row computation is unit-
+//! testable in isolation.
+
+use crate::agent::Agent;
+use crate::config::{AppConfig, AuthForwardMode};
+
+/// Which layer of the 3-layer resolver supplied this row's mode value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvenanceTag {
+    /// Mode came from `[<agent>]` (global default).
+    Global,
+    /// Mode came from `[workspaces.<ws>.<agent>]`.
+    Workspace,
+    /// Mode came from `[workspaces.<ws>.roles.<role>.<agent>]`.
+    MostSpecific,
+    /// No layer at this level; inherited from a broader layer above.
+    /// Used for the `workspace_rows` section's display when only the
+    /// global default applies.
+    Inherited,
+}
+
+/// Status badge displayed on a row showing whether the credential resolves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialBadge {
+    /// Required env var resolves to non-empty in the merged operator env.
+    Resolves,
+    /// Required env var is unset or empty.
+    Unset,
+    /// Mode does not require a credential (Sync, Ignore).
+    NotApplicable,
+}
+
+/// A single row in the Auth panel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthRow {
+    pub role: String,
+    pub agent: Agent,
+    pub mode: AuthForwardMode,
+    pub provenance: ProvenanceTag,
+    pub credential: CredentialBadge,
+}
+
+/// State for the Auth panel within a workspace context.
+#[derive(Debug, Default, Clone)]
+pub struct AuthPanelState {
+    pub workspace: String,
+    /// One row per agent (Claude, Codex, ...) showing the global default.
+    pub global_rows: Vec<AuthRow>,
+    /// One row per agent showing the effective workspace-level mode.
+    pub workspace_rows: Vec<AuthRow>,
+    /// One row per (role, agent) showing the most-specific mode.
+    pub role_agent_rows: Vec<AuthRow>,
+}
+
+impl AuthPanelState {
+    /// Compute the panel state for `workspace` from `cfg`.
+    ///
+    /// For each agent (Claude, Codex), produces:
+    ///   - 1 global row (`role: ""`, provenance: `Global`)
+    ///   - 1 workspace row (`role: ""`, provenance: `Workspace` if set,
+    ///     `Inherited` otherwise)
+    ///   - 1 role × agent row per role in the workspace's `allowed_roles`
+    ///
+    /// The credential badge is computed against the 4-layer operator env
+    /// using the same precedence the launch path applies (workspace ×
+    /// role > workspace > role > global). `Resolves` is reported
+    /// optimistically for `OpRef` entries — the picker validated them at
+    /// commit time, and re-running `op read` here would block the render
+    /// loop. `Plain` resolves only when the persisted string is non-empty.
+    pub fn compute_for(cfg: &AppConfig, workspace: &str) -> Self {
+        let mut state = Self {
+            workspace: workspace.to_string(),
+            ..Self::default()
+        };
+
+        for agent in [Agent::Claude, Agent::Codex] {
+            // Global row.
+            let global_mode = match agent {
+                Agent::Claude => cfg.claude.as_ref().map(|c| c.auth_forward),
+                Agent::Codex => cfg.codex.as_ref().map(|c| c.auth_forward),
+            }
+            .unwrap_or_default();
+            state.global_rows.push(AuthRow {
+                role: String::new(),
+                agent,
+                mode: global_mode,
+                provenance: ProvenanceTag::Global,
+                credential: badge_for(cfg, workspace, "", agent, global_mode),
+            });
+
+            // Workspace row — explicit when set, Inherited from global otherwise.
+            let ws_explicit = cfg.workspaces.get(workspace).and_then(|ws| match agent {
+                Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
+                Agent::Codex => ws.codex.as_ref().map(|c| c.auth_forward),
+            });
+            let (ws_mode, ws_prov) = ws_explicit
+                .map_or((global_mode, ProvenanceTag::Inherited), |m| {
+                    (m, ProvenanceTag::Workspace)
+                });
+            state.workspace_rows.push(AuthRow {
+                role: String::new(),
+                agent,
+                mode: ws_mode,
+                provenance: ws_prov,
+                credential: badge_for(cfg, workspace, "", agent, ws_mode),
+            });
+
+            // Role × agent rows — one per allowed role.
+            if let Some(ws) = cfg.workspaces.get(workspace) {
+                for role in &ws.allowed_roles {
+                    let mode = crate::config::resolve_mode(cfg, agent, workspace, role);
+                    let role_explicit = ws.roles.get(role).and_then(|ro| match agent {
+                        Agent::Claude => ro.claude.as_ref().map(|c| c.auth_forward),
+                        Agent::Codex => ro.codex.as_ref().map(|c| c.auth_forward),
+                    });
+                    let provenance = if role_explicit.is_some() {
+                        ProvenanceTag::MostSpecific
+                    } else if ws_explicit.is_some() {
+                        ProvenanceTag::Workspace
+                    } else {
+                        ProvenanceTag::Global
+                    };
+                    state.role_agent_rows.push(AuthRow {
+                        role: role.clone(),
+                        agent,
+                        mode,
+                        provenance,
+                        credential: badge_for(cfg, workspace, role, agent, mode),
+                    });
+                }
+            }
+        }
+
+        state
+    }
+}
+
+/// Compute the credential badge for a given (workspace, role, agent, mode).
+///
+/// Walks the 4 env layers in launch-time precedence order (workspace × role
+/// → workspace → role → global) and returns the badge for the first hit.
+/// `OpRef` entries report `Resolves` optimistically — the picker validated
+/// them at commit time, and verifying again here would require running
+/// `op read`, which the panel deliberately avoids.
+fn badge_for(
+    cfg: &AppConfig,
+    workspace: &str,
+    role: &str,
+    agent: Agent,
+    mode: AuthForwardMode,
+) -> CredentialBadge {
+    let Some(env_var) = agent.required_env_var(mode) else {
+        return CredentialBadge::NotApplicable;
+    };
+
+    if let Some(value) = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.roles.get(role))
+        .and_then(|ro| ro.env.get(env_var))
+    {
+        return classify_env_value(value);
+    }
+    if let Some(value) = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.env.get(env_var))
+    {
+        return classify_env_value(value);
+    }
+    if let Some(value) = cfg.roles.get(role).and_then(|r| r.env.get(env_var)) {
+        return classify_env_value(value);
+    }
+    if let Some(value) = cfg.env.get(env_var) {
+        return classify_env_value(value);
+    }
+    CredentialBadge::Unset
+}
+
+const fn classify_env_value(value: &crate::operator_env::EnvValue) -> CredentialBadge {
+    use crate::operator_env::EnvValue;
+    match value {
+        // OpRef: assume the picker validated at commit time. The panel
+        // does not run `op read` (would block render).
+        EnvValue::OpRef(_) => CredentialBadge::Resolves,
+        // Plain: resolves iff non-empty. The launch-time validator catches
+        // `$VAR`/`${VAR}` expansion that ends up empty; for panel display
+        // any non-empty persisted string is treated as `Resolves`.
+        EnvValue::Plain(s) if !s.is_empty() => CredentialBadge::Resolves,
+        EnvValue::Plain(_) => CredentialBadge::Unset,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AgentAuthConfig;
+    use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+
+    fn build_cfg() -> AppConfig {
+        let mut cfg = AppConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::Sync,
+            }),
+            ..AppConfig::default()
+        };
+        let ws = WorkspaceConfig {
+            workdir: "/tmp/proj".to_string(),
+            allowed_roles: vec!["smith".to_string()],
+            ..Default::default()
+        };
+        cfg.workspaces.insert("proj".into(), ws);
+        cfg
+    }
+
+    #[test]
+    fn provenance_global_when_only_global_set() {
+        let cfg = build_cfg();
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .expect("smith × Claude row");
+        assert_eq!(row.provenance, ProvenanceTag::Global);
+        assert_eq!(row.mode, AuthForwardMode::Sync);
+    }
+
+    #[test]
+    fn provenance_workspace_when_workspace_overrides_global() {
+        let mut cfg = build_cfg();
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .unwrap();
+        assert_eq!(row.provenance, ProvenanceTag::Workspace);
+        assert_eq!(row.mode, AuthForwardMode::ApiKey);
+    }
+
+    #[test]
+    fn provenance_most_specific_when_role_override_present() {
+        let mut cfg = build_cfg();
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.roles.insert(
+            "smith".into(),
+            WorkspaceRoleOverride {
+                claude: Some(AgentAuthConfig {
+                    auth_forward: AuthForwardMode::OAuthToken,
+                }),
+                ..Default::default()
+            },
+        );
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .unwrap();
+        assert_eq!(row.provenance, ProvenanceTag::MostSpecific);
+        assert_eq!(row.mode, AuthForwardMode::OAuthToken);
+    }
+
+    #[test]
+    fn credential_badge_not_applicable_for_sync() {
+        let cfg = build_cfg();
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .unwrap();
+        assert_eq!(row.credential, CredentialBadge::NotApplicable);
+    }
+
+    #[test]
+    fn credential_badge_unset_when_required_var_empty() {
+        let mut cfg = build_cfg();
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        // ANTHROPIC_API_KEY is not set anywhere in cfg.
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .unwrap();
+        assert_eq!(row.credential, CredentialBadge::Unset);
+    }
+
+    #[test]
+    fn credential_badge_resolves_when_env_var_present() {
+        use crate::operator_env::EnvValue;
+        let mut cfg = build_cfg();
+        let ws = cfg.workspaces.get_mut("proj").unwrap();
+        ws.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        ws.env.insert(
+            "ANTHROPIC_API_KEY".into(),
+            EnvValue::Plain("sk-ant-test".into()),
+        );
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        let row = state
+            .role_agent_rows
+            .iter()
+            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
+            .unwrap();
+        assert_eq!(row.credential, CredentialBadge::Resolves);
+    }
+
+    #[test]
+    fn global_rows_contain_one_per_agent() {
+        let cfg = build_cfg();
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        assert_eq!(state.global_rows.len(), 2);
+        assert!(state.global_rows.iter().any(|r| r.agent == Agent::Claude));
+        assert!(state.global_rows.iter().any(|r| r.agent == Agent::Codex));
+    }
+
+    #[test]
+    fn role_agent_rows_contain_one_per_role_per_agent() {
+        let cfg = build_cfg();
+        let state = AuthPanelState::compute_for(&cfg, "proj");
+        assert_eq!(state.role_agent_rows.len(), 2); // 1 role × 2 agents
+    }
+}

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -8,6 +8,7 @@ use crate::agent::Agent;
 use crate::config::{AppConfig, AuthForwardMode};
 
 /// Which layer of the 3-layer resolver supplied this row's mode value.
+#[allow(dead_code)] // re-introduced as a footer hint in Task 13 of the auth-tab redesign
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProvenanceTag {
     /// Mode came from `[<agent>]` (global default).
@@ -40,7 +41,7 @@ pub enum CredentialBadge {
 /// `OpRef` entries report `Resolves` optimistically — the picker validated
 /// them at commit time, and verifying again here would require running
 /// `op read`, which the panel deliberately avoids.
-pub fn badge_for(
+pub(crate) fn badge_for(
     cfg: &AppConfig,
     workspace: &str,
     role: &str,
@@ -75,7 +76,7 @@ pub fn badge_for(
     CredentialBadge::Unset
 }
 
-pub const fn classify_env_value(value: &crate::operator_env::EnvValue) -> CredentialBadge {
+pub(crate) const fn classify_env_value(value: &crate::operator_env::EnvValue) -> CredentialBadge {
     use crate::operator_env::EnvValue;
     match value {
         // OpRef: assume the picker validated at commit time. The panel
@@ -86,5 +87,70 @@ pub const fn classify_env_value(value: &crate::operator_env::EnvValue) -> Creden
         // any non-empty persisted string is treated as `Resolves`.
         EnvValue::Plain(s) if !s.is_empty() => CredentialBadge::Resolves,
         EnvValue::Plain(_) => CredentialBadge::Unset,
+    }
+}
+
+#[cfg(test)]
+mod badge_for_tests {
+    use super::*;
+    use crate::config::{AgentAuthConfig, AppConfig};
+    use crate::operator_env::EnvValue;
+    use crate::workspace::WorkspaceConfig;
+
+    fn base_cfg_with_ws() -> AppConfig {
+        let mut cfg = AppConfig::default();
+        let ws = WorkspaceConfig {
+            workdir: "/tmp/proj".to_string(),
+            allowed_roles: vec!["smith".to_string()],
+            ..Default::default()
+        };
+        cfg.workspaces.insert("proj".into(), ws);
+        cfg
+    }
+
+    /// Sync mode has no required env var, so badge must be NotApplicable
+    /// regardless of what the operator env contains.
+    #[test]
+    fn credential_badge_not_applicable_for_sync() {
+        let cfg = base_cfg_with_ws();
+        let badge = badge_for(&cfg, "proj", "smith", Agent::Claude, AuthForwardMode::Sync);
+        assert_eq!(badge, CredentialBadge::NotApplicable);
+    }
+
+    /// ApiKey mode requires ANTHROPIC_API_KEY, which is absent at all 4
+    /// layers — badge must be Unset.
+    #[test]
+    fn credential_badge_unset_when_required_var_empty() {
+        let mut cfg = base_cfg_with_ws();
+        cfg.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        // ANTHROPIC_API_KEY is not set anywhere in cfg.
+        let badge = badge_for(&cfg, "proj", "smith", Agent::Claude, AuthForwardMode::ApiKey);
+        assert_eq!(badge, CredentialBadge::Unset);
+    }
+
+    /// ApiKey mode with ANTHROPIC_API_KEY present at the workspace × role
+    /// layer (most specific) must yield Resolves.
+    #[test]
+    fn credential_badge_resolves_when_env_var_present() {
+        let mut cfg = base_cfg_with_ws();
+        cfg.claude = Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        });
+        // Place the key at workspace × role — the most-specific layer.
+        cfg.workspaces
+            .get_mut("proj")
+            .unwrap()
+            .roles
+            .entry("smith".into())
+            .or_default()
+            .env
+            .insert(
+                "ANTHROPIC_API_KEY".into(),
+                EnvValue::Plain("sk-ant-test".into()),
+            );
+        let badge = badge_for(&cfg, "proj", "smith", Agent::Claude, AuthForwardMode::ApiKey);
+        assert_eq!(badge, CredentialBadge::Resolves);
     }
 }

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -1,16 +1,8 @@
-//! Pure data types and state computation for the Auth panel.
+//! Pure data types for the Auth panel.
 //!
-//! `AuthPanelState::compute_for` walks an [`AppConfig`] to materialize
-//! one row per (scope, agent) and (role, agent) pair. Each row carries:
-//!
-//! - the effective [`AuthForwardMode`] after the 3-layer resolver runs,
-//! - a [`ProvenanceTag`] saying *which* layer supplied that mode, and
-//! - a [`CredentialBadge`] saying whether the mode's required env var
-//!   resolves to a non-empty value in the merged 4-layer operator env.
-//!
-//! Rendering lives in `render.rs` (Task 16). This module deliberately
-//! avoids any ratatui dependency so the per-row computation is unit-
-//! testable in isolation.
+//! Provides [`ProvenanceTag`], [`CredentialBadge`], [`badge_for`], and
+//! [`classify_env_value`]. These are consumed by the flat-row renderer in
+//! `src/console/manager/render/editor.rs`.
 
 use crate::agent::Agent;
 use crate::config::{AppConfig, AuthForwardMode};
@@ -41,111 +33,6 @@ pub enum CredentialBadge {
     NotApplicable,
 }
 
-/// A single row in the Auth panel.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AuthRow {
-    pub role: String,
-    pub agent: Agent,
-    pub mode: AuthForwardMode,
-    pub provenance: ProvenanceTag,
-    pub credential: CredentialBadge,
-}
-
-/// State for the Auth panel within a workspace context.
-#[derive(Debug, Default, Clone)]
-pub struct AuthPanelState {
-    pub workspace: String,
-    /// One row per agent (Claude, Codex, ...) showing the global default.
-    pub global_rows: Vec<AuthRow>,
-    /// One row per agent showing the effective workspace-level mode.
-    pub workspace_rows: Vec<AuthRow>,
-    /// One row per (role, agent) showing the most-specific mode.
-    pub role_agent_rows: Vec<AuthRow>,
-}
-
-impl AuthPanelState {
-    /// Compute the panel state for `workspace` from `cfg`.
-    ///
-    /// For each agent (Claude, Codex), produces:
-    ///   - 1 global row (`role: ""`, provenance: `Global`)
-    ///   - 1 workspace row (`role: ""`, provenance: `Workspace` if set,
-    ///     `Inherited` otherwise)
-    ///   - 1 role × agent row per role in the workspace's `allowed_roles`
-    ///
-    /// The credential badge is computed against the 4-layer operator env
-    /// using the same precedence the launch path applies (workspace ×
-    /// role > workspace > role > global). `Resolves` is reported
-    /// optimistically for `OpRef` entries — the picker validated them at
-    /// commit time, and re-running `op read` here would block the render
-    /// loop. `Plain` resolves only when the persisted string is non-empty.
-    pub fn compute_for(cfg: &AppConfig, workspace: &str) -> Self {
-        let mut state = Self {
-            workspace: workspace.to_string(),
-            ..Self::default()
-        };
-
-        for agent in [Agent::Claude, Agent::Codex] {
-            // Global row.
-            let global_mode = match agent {
-                Agent::Claude => cfg.claude.as_ref().map(|c| c.auth_forward),
-                Agent::Codex => cfg.codex.as_ref().map(|c| c.auth_forward),
-            }
-            .unwrap_or_default();
-            state.global_rows.push(AuthRow {
-                role: String::new(),
-                agent,
-                mode: global_mode,
-                provenance: ProvenanceTag::Global,
-                credential: badge_for(cfg, workspace, "", agent, global_mode),
-            });
-
-            // Workspace row — explicit when set, Inherited from global otherwise.
-            let ws_explicit = cfg.workspaces.get(workspace).and_then(|ws| match agent {
-                Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
-                Agent::Codex => ws.codex.as_ref().map(|c| c.auth_forward),
-            });
-            let (ws_mode, ws_prov) = ws_explicit
-                .map_or((global_mode, ProvenanceTag::Inherited), |m| {
-                    (m, ProvenanceTag::Workspace)
-                });
-            state.workspace_rows.push(AuthRow {
-                role: String::new(),
-                agent,
-                mode: ws_mode,
-                provenance: ws_prov,
-                credential: badge_for(cfg, workspace, "", agent, ws_mode),
-            });
-
-            // Role × agent rows — one per allowed role.
-            if let Some(ws) = cfg.workspaces.get(workspace) {
-                for role in &ws.allowed_roles {
-                    let mode = crate::config::resolve_mode(cfg, agent, workspace, role);
-                    let role_explicit = ws.roles.get(role).and_then(|ro| match agent {
-                        Agent::Claude => ro.claude.as_ref().map(|c| c.auth_forward),
-                        Agent::Codex => ro.codex.as_ref().map(|c| c.auth_forward),
-                    });
-                    let provenance = if role_explicit.is_some() {
-                        ProvenanceTag::MostSpecific
-                    } else if ws_explicit.is_some() {
-                        ProvenanceTag::Workspace
-                    } else {
-                        ProvenanceTag::Global
-                    };
-                    state.role_agent_rows.push(AuthRow {
-                        role: role.clone(),
-                        agent,
-                        mode,
-                        provenance,
-                        credential: badge_for(cfg, workspace, role, agent, mode),
-                    });
-                }
-            }
-        }
-
-        state
-    }
-}
-
 /// Compute the credential badge for a given (workspace, role, agent, mode).
 ///
 /// Walks the 4 env layers in launch-time precedence order (workspace × role
@@ -153,7 +40,7 @@ impl AuthPanelState {
 /// `OpRef` entries report `Resolves` optimistically — the picker validated
 /// them at commit time, and verifying again here would require running
 /// `op read`, which the panel deliberately avoids.
-fn badge_for(
+pub fn badge_for(
     cfg: &AppConfig,
     workspace: &str,
     role: &str,
@@ -188,7 +75,7 @@ fn badge_for(
     CredentialBadge::Unset
 }
 
-const fn classify_env_value(value: &crate::operator_env::EnvValue) -> CredentialBadge {
+pub const fn classify_env_value(value: &crate::operator_env::EnvValue) -> CredentialBadge {
     use crate::operator_env::EnvValue;
     match value {
         // OpRef: assume the picker validated at commit time. The panel
@@ -199,147 +86,5 @@ const fn classify_env_value(value: &crate::operator_env::EnvValue) -> Credential
         // any non-empty persisted string is treated as `Resolves`.
         EnvValue::Plain(s) if !s.is_empty() => CredentialBadge::Resolves,
         EnvValue::Plain(_) => CredentialBadge::Unset,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::AgentAuthConfig;
-    use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
-
-    fn build_cfg() -> AppConfig {
-        let mut cfg = AppConfig {
-            claude: Some(AgentAuthConfig {
-                auth_forward: AuthForwardMode::Sync,
-            }),
-            ..AppConfig::default()
-        };
-        let ws = WorkspaceConfig {
-            workdir: "/tmp/proj".to_string(),
-            allowed_roles: vec!["smith".to_string()],
-            ..Default::default()
-        };
-        cfg.workspaces.insert("proj".into(), ws);
-        cfg
-    }
-
-    #[test]
-    fn provenance_global_when_only_global_set() {
-        let cfg = build_cfg();
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .expect("smith × Claude row");
-        assert_eq!(row.provenance, ProvenanceTag::Global);
-        assert_eq!(row.mode, AuthForwardMode::Sync);
-    }
-
-    #[test]
-    fn provenance_workspace_when_workspace_overrides_global() {
-        let mut cfg = build_cfg();
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        });
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .unwrap();
-        assert_eq!(row.provenance, ProvenanceTag::Workspace);
-        assert_eq!(row.mode, AuthForwardMode::ApiKey);
-    }
-
-    #[test]
-    fn provenance_most_specific_when_role_override_present() {
-        let mut cfg = build_cfg();
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.roles.insert(
-            "smith".into(),
-            WorkspaceRoleOverride {
-                claude: Some(AgentAuthConfig {
-                    auth_forward: AuthForwardMode::OAuthToken,
-                }),
-                ..Default::default()
-            },
-        );
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .unwrap();
-        assert_eq!(row.provenance, ProvenanceTag::MostSpecific);
-        assert_eq!(row.mode, AuthForwardMode::OAuthToken);
-    }
-
-    #[test]
-    fn credential_badge_not_applicable_for_sync() {
-        let cfg = build_cfg();
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .unwrap();
-        assert_eq!(row.credential, CredentialBadge::NotApplicable);
-    }
-
-    #[test]
-    fn credential_badge_unset_when_required_var_empty() {
-        let mut cfg = build_cfg();
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        });
-        // ANTHROPIC_API_KEY is not set anywhere in cfg.
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .unwrap();
-        assert_eq!(row.credential, CredentialBadge::Unset);
-    }
-
-    #[test]
-    fn credential_badge_resolves_when_env_var_present() {
-        use crate::operator_env::EnvValue;
-        let mut cfg = build_cfg();
-        let ws = cfg.workspaces.get_mut("proj").unwrap();
-        ws.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        });
-        ws.env.insert(
-            "ANTHROPIC_API_KEY".into(),
-            EnvValue::Plain("sk-ant-test".into()),
-        );
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        let row = state
-            .role_agent_rows
-            .iter()
-            .find(|r| r.role == "smith" && r.agent == Agent::Claude)
-            .unwrap();
-        assert_eq!(row.credential, CredentialBadge::Resolves);
-    }
-
-    #[test]
-    fn global_rows_contain_one_per_agent() {
-        let cfg = build_cfg();
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        assert_eq!(state.global_rows.len(), 2);
-        assert!(state.global_rows.iter().any(|r| r.agent == Agent::Claude));
-        assert!(state.global_rows.iter().any(|r| r.agent == Agent::Codex));
-    }
-
-    #[test]
-    fn role_agent_rows_contain_one_per_role_per_agent() {
-        let cfg = build_cfg();
-        let state = AuthPanelState::compute_for(&cfg, "proj");
-        assert_eq!(state.role_agent_rows.len(), 2); // 1 role × 2 agents
     }
 }

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -7,6 +7,7 @@
 //! exposes only a single shared `dir_style`). All are consumed by both
 //! the manager (PR 2) and the Secrets tab (PR 3).
 
+pub mod auth_panel;
 pub mod confirm;
 pub mod confirm_save;
 pub mod error_popup;

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -273,6 +273,14 @@ mod consistency_tests {
         (buf, area)
     }
 
+    fn render_agent_choice() -> (Buffer, Rect) {
+        use super::agent_choice::{AgentChoiceState, render};
+        let area = Rect::new(0, 0, 50, 7);
+        let state = AgentChoiceState::new();
+        let buf = draw(area.width, area.height, |f| render(f, area, &state));
+        (buf, area)
+    }
+
     /// Every choice/list modal's title must start AND end with a space so
     /// `┌ Title ...` renders with breathing room around the label.
     #[test]
@@ -286,6 +294,7 @@ mod consistency_tests {
             ("GithubPicker", render_github_picker()),
             ("AgentPicker", render_role_picker()),
             ("ConfirmSave", render_confirm_save()),
+            ("AgentChoice", render_agent_choice()),
         ] {
             let title = top_border_title(&buf);
             assert!(
@@ -311,6 +320,7 @@ mod consistency_tests {
             ("GithubPicker", render_github_picker()),
             ("AgentPicker", render_role_picker()),
             ("ConfirmSave", render_confirm_save()),
+            ("AgentChoice", render_agent_choice()),
         ] {
             assert_border_is_phosphor_dark(&buf, area, name);
         }
@@ -329,6 +339,7 @@ mod consistency_tests {
             ("GithubPicker", render_github_picker()),
             ("AgentPicker", render_role_picker()),
             ("ConfirmSave", render_confirm_save()),
+            ("AgentChoice", render_agent_choice()),
         ] {
             assert_hint_row_present(&buf, area, name);
         }

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -7,6 +7,7 @@
 //! exposes only a single shared `dir_style`). All are consumed by both
 //! the manager (PR 2) and the Secrets tab (PR 3).
 
+pub mod agent_choice;
 pub mod auth_panel;
 pub mod confirm;
 pub mod confirm_save;

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 impl RoleState {
     /// Provision Codex's host-side `config.toml` (always written) and,
     /// under `auth_forward = sync`, its `auth.json` (copied from the
-    /// host's `~/.codex/auth.json` when present, deleted under `ignore`,
-    /// untouched under `oauth_token` / `api_key`).
+    /// host's `~/.codex/auth.json` when present, deleted under `ignore`
+    /// / `api_key`).
     ///
     /// The generated `config.toml` sets `approval_policy = "never"` and
     /// `sandbox_mode = "danger-full-access"` to match the operator
@@ -27,9 +27,13 @@ impl RoleState {
     ///   * **Sync** + host file absent → leave any existing role-state
     ///     `auth.json` untouched (it may survive from a prior synced
     ///     run), return `HostMissing`.
-    ///   * **`OAuthToken`** / **`ApiKey`** → no-op (jackin does not own the
-    ///     auth state in these modes; operator drives auth via env),
-    ///     return `TokenMode`. Tasks 10/11 will split per-mode behavior.
+    ///   * **`ApiKey`** → wipe the role-state `auth.json` (the agent
+    ///     authenticates via `OPENAI_API_KEY`; a forwarded auth.json
+    ///     would let it silently fall back to OAuth credentials the
+    ///     operator chose to bypass), return `TokenMode`.
+    ///   * **`OAuthToken`** → unreachable in production: parser-rejected
+    ///     for Codex (Task 6). Defensive arm returns `TokenMode` without
+    ///     touching role-state files.
     ///   * **Ignore** → delete the role-state `auth.json` if present,
     ///     return `Skipped`.
     ///
@@ -81,15 +85,24 @@ impl RoleState {
 
         let host_auth_json = host_home.join(".codex/auth.json");
         let outcome = match mode {
-            // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
-            // Tasks 10/11 will split provisioning per credential variant.
-            AuthForwardMode::OAuthToken | AuthForwardMode::ApiKey => {
+            // OAuthToken is parser-rejected for Codex (Task 6), so this arm
+            // is unreachable in production — kept for match exhaustiveness
+            // and to preserve historical no-wipe behavior if a config ever
+            // bypasses the parser. Treated as TokenMode without touching
+            // role-state files.
+            AuthForwardMode::OAuthToken => AuthProvisionOutcome::TokenMode,
+            // ApiKey is env-driven (OPENAI_API_KEY): the agent inside the
+            // container must NOT see a forwarded auth.json from a prior
+            // Sync run, otherwise it would silently fall back to OAuth
+            // credentials that the operator has explicitly chosen to
+            // bypass. Wipe role-state auth.json identically to Ignore,
+            // and surface the env-driven nature via TokenMode.
+            AuthForwardMode::ApiKey => {
+                wipe_codex_state(auth_json)?;
                 AuthProvisionOutcome::TokenMode
             }
             AuthForwardMode::Ignore => {
-                if auth_json.exists() {
-                    std::fs::remove_file(auth_json)?;
-                }
+                wipe_codex_state(auth_json)?;
                 AuthProvisionOutcome::Skipped
             }
             AuthForwardMode::Sync => match std::fs::read_to_string(&host_auth_json) {
@@ -221,6 +234,26 @@ fn wipe_claude_state(account_json: &Path, credentials_json: &Path) -> anyhow::Re
     }
     if credentials_json.exists() {
         std::fs::remove_file(credentials_json)?;
+    }
+    Ok(())
+}
+
+/// Wipe the container's Codex auth state to a clean empty shape.
+///
+/// Used by every non-Sync mode that owns the file (`Ignore`, `ApiKey`)
+/// — they must guarantee no stale `auth.json` from a prior Sync run
+/// survives so the agent inside the container authenticates exclusively
+/// via env vars (or fresh `codex login`) rather than re-using forwarded
+/// credentials.
+///
+/// Unlike `wipe_claude_state`, there is no companion "account" file to
+/// reset — Codex's role-state surface is just `auth.json`. Removing it
+/// is sufficient because the launcher only bind-mounts `auth.json` when
+/// `provision_codex_auth` reports it exists post-call (see
+/// `mounted_auth_json` in the caller).
+fn wipe_codex_state(auth_json: &Path) -> anyhow::Result<()> {
+    if auth_json.exists() {
+        std::fs::remove_file(auth_json)?;
     }
     Ok(())
 }
@@ -1374,6 +1407,12 @@ agents = ["codex"]
         assert!(!auth_json.exists());
     }
 
+    /// `OAuthToken` is parser-rejected for Codex (Task 6) so this arm is
+    /// unreachable from operator config in production. The test pins the
+    /// defensive no-wipe behavior of the `OAuthToken` arm anyway: if a
+    /// parser bypass ever lands a Codex+OAuthToken config at this layer,
+    /// the existing role-state `auth.json` is preserved (rather than
+    /// silently destroyed) so the operator can recover.
     #[test]
     fn token_mode_leaves_role_auth_json_untouched() {
         let temp = tempdir().unwrap();
@@ -1397,6 +1436,79 @@ agents = ["codex"]
             std::fs::read_to_string(&auth_json).unwrap(),
             "{\"existing\":true}"
         );
+    }
+
+    /// `ApiKey` mode authenticates via `OPENAI_API_KEY`; a leftover
+    /// `auth.json` from a prior Sync run would let Codex silently fall
+    /// back to forwarded OAuth credentials that the operator has
+    /// explicitly chosen to bypass. Pin the wipe contract here so a
+    /// future refactor can't quietly downgrade `ApiKey` to no-op.
+    #[test]
+    fn api_key_mode_wipes_role_auth_json() {
+        let temp = tempdir().unwrap();
+        let manifest = manifest_with_codex_model(&temp, None);
+        let config_toml = temp.path().join("config.toml");
+        let auth_json = temp.path().join("auth.json");
+        std::fs::write(&auth_json, "{\"stale\":\"creds\"}").unwrap();
+        // Stage a host auth.json too — api_key mode must NOT copy it,
+        // and must NOT leave the stale role-state file in place either.
+        let (host_home, _) = stage_host_auth_json(&temp, "should-not-be-copied");
+
+        let (outcome, mounted) = RoleState::provision_codex_auth(
+            &config_toml,
+            &auth_json,
+            &manifest,
+            AuthForwardMode::ApiKey,
+            &host_home,
+        )
+        .unwrap();
+
+        assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
+        assert!(
+            !auth_json.exists(),
+            "api_key mode must wipe role-state auth.json"
+        );
+        assert!(
+            mounted.is_none(),
+            "api_key mode must report no auth.json to mount"
+        );
+    }
+
+    /// Switching from Sync (creds present on host) to `ApiKey` must wipe
+    /// the synced `auth.json` so the next container start cannot fall
+    /// back to forwarded OAuth credentials. Without this, an operator
+    /// who toggles to `ApiKey` to use `OPENAI_API_KEY` would still be
+    /// running on stale OAuth state from the previous sync run.
+    #[test]
+    fn switching_from_sync_to_api_key_wipes_synced_auth_json() {
+        let temp = tempdir().unwrap();
+        let manifest = manifest_with_codex_model(&temp, None);
+        let config_toml = temp.path().join("config.toml");
+        let auth_json = temp.path().join("auth.json");
+        let (host_home, _) = stage_host_auth_json(&temp, "switch.test");
+
+        let (outcome, _) = RoleState::provision_codex_auth(
+            &config_toml,
+            &auth_json,
+            &manifest,
+            AuthForwardMode::Sync,
+            &host_home,
+        )
+        .unwrap();
+        assert_eq!(outcome, AuthProvisionOutcome::Synced);
+        assert!(auth_json.exists());
+
+        let (outcome, mounted) = RoleState::provision_codex_auth(
+            &config_toml,
+            &auth_json,
+            &manifest,
+            AuthForwardMode::ApiKey,
+            &host_home,
+        )
+        .unwrap();
+        assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
+        assert!(!auth_json.exists(), "ApiKey must wipe prior synced creds");
+        assert!(mounted.is_none());
     }
 
     #[cfg(unix)]

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -157,27 +157,18 @@ impl RoleState {
                 // Always ensure a clean slate — if switching from sync/token
                 // to ignore, the previously forwarded credentials must be
                 // revoked.
-                if !account_json.exists() || std::fs::read_to_string(account_json)? != "{}" {
-                    write_private_file(account_json, "{}")?;
-                }
-                if credentials_json.exists() {
-                    std::fs::remove_file(&credentials_json)?;
-                }
+                wipe_claude_state(account_json, &credentials_json)?;
                 AuthProvisionOutcome::Skipped
             }
-            // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
-            // Tasks 10/11 will split per-mode credential provisioning. Both
-            // env-driven modes provision the same empty shape as Ignore — the
-            // agent inside the container authenticates via env vars, not via
+            // ApiKey and OAuthToken share filesystem behavior: both env-driven
+            // modes provision the same empty shape as Ignore — the agent
+            // inside the container authenticates via env vars, not via
             // filesystem credentials. Switching from sync → token/api_key must
-            // still wipe any previously forwarded creds.
+            // still wipe any previously forwarded creds. They differ only in
+            // which env var the launcher sets (CLAUDE_CODE_OAUTH_TOKEN vs
+            // ANTHROPIC_API_KEY); host-state provisioning is identical.
             AuthForwardMode::OAuthToken | AuthForwardMode::ApiKey => {
-                if !account_json.exists() || std::fs::read_to_string(account_json)? != "{}" {
-                    write_private_file(account_json, "{}")?;
-                }
-                if credentials_json.exists() {
-                    std::fs::remove_file(&credentials_json)?;
-                }
+                wipe_claude_state(account_json, &credentials_json)?;
                 AuthProvisionOutcome::TokenMode
             }
             AuthForwardMode::Sync => {
@@ -211,6 +202,27 @@ impl RoleState {
 fn copy_host_claude_json(host_path: &Path, dest_path: &Path) -> anyhow::Result<()> {
     let content = std::fs::read_to_string(host_path).unwrap_or_else(|_| "{}".to_string());
     write_private_file(dest_path, &content)
+}
+
+/// Wipe the container's Claude auth state to a clean empty shape.
+///
+/// Used by every non-Sync mode (`Ignore`, `OAuthToken`, `ApiKey`) — they
+/// all must guarantee no stale `.credentials.json` survives from a
+/// prior Sync run, and that `.claude.json` is `{}` so Claude Code
+/// inside the container authenticates exclusively via env vars (or
+/// fresh login) rather than re-using forwarded credentials.
+///
+/// `account_json` is rewritten only when its current contents differ
+/// from `{}` (or the file doesn't exist), to avoid touching mtime on
+/// every launch.
+fn wipe_claude_state(account_json: &Path, credentials_json: &Path) -> anyhow::Result<()> {
+    if !account_json.exists() || std::fs::read_to_string(account_json)? != "{}" {
+        write_private_file(account_json, "{}")?;
+    }
+    if credentials_json.exists() {
+        std::fs::remove_file(credentials_json)?;
+    }
+    Ok(())
 }
 
 /// Read the host's Claude Code OAuth credentials.
@@ -602,6 +614,67 @@ plugins = []
                 .join(".credentials.json")
                 .exists(),
             "token mode must not write .credentials.json"
+        );
+        assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
+    }
+
+    /// `ApiKey` shares the wipe-state contract with `OAuthToken` (both
+    /// env-driven modes) but is dispatched as a distinct enum variant —
+    /// pin its filesystem behavior independently so a future per-mode
+    /// split can't silently break the `ApiKey` path. The pre-seeded
+    /// `.credentials.json` here doubles as a "switching from sync to
+    /// `ApiKey` revokes forwarded creds" assertion: the file existed
+    /// before the `ApiKey` run and must be gone after.
+    #[test]
+    fn api_key_mode_wipes_credentials_and_writes_empty_json() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        // Seed host auth — api_key mode must NOT copy it.
+        seed_host_auth(&temp);
+        let manifest = simple_manifest(&temp);
+
+        // First run: sync mode writes credentials we'll then need to verify
+        // get wiped under api_key.
+        let (state, _) = RoleState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::Sync,
+            temp.path(),
+            crate::agent::Agent::Claude,
+        )
+        .unwrap();
+        assert!(
+            state
+                .claude_state_dir()
+                .unwrap()
+                .join(".credentials.json")
+                .exists(),
+            "precondition: sync seeded .credentials.json"
+        );
+
+        let (state2, outcome) = RoleState::prepare(
+            &paths,
+            "jackin-agent-smith",
+            &manifest,
+            AuthForwardMode::ApiKey,
+            temp.path(),
+            crate::agent::Agent::Claude,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            "{}",
+            "api_key mode must reset .claude.json to empty object"
+        );
+        assert!(
+            !state2
+                .claude_state_dir()
+                .unwrap()
+                .join(".credentials.json")
+                .exists(),
+            "api_key mode must wipe .credentials.json"
         );
         assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
     }

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -6,7 +6,7 @@ impl RoleState {
     /// Provision Codex's host-side `config.toml` (always written) and,
     /// under `auth_forward = sync`, its `auth.json` (copied from the
     /// host's `~/.codex/auth.json` when present, deleted under `ignore`,
-    /// untouched under `token`).
+    /// untouched under `oauth_token` / `api_key`).
     ///
     /// The generated `config.toml` sets `approval_policy = "never"` and
     /// `sandbox_mode = "danger-full-access"` to match the operator
@@ -27,9 +27,9 @@ impl RoleState {
     ///   * **Sync** + host file absent → leave any existing role-state
     ///     `auth.json` untouched (it may survive from a prior synced
     ///     run), return `HostMissing`.
-    ///   * **Token** → no-op (jackin does not own the auth state in
-    ///     this mode; operator drives auth via `OPENAI_API_KEY` env),
-    ///     return `TokenMode`.
+    ///   * **`OAuthToken`** / **`ApiKey`** → no-op (jackin does not own the
+    ///     auth state in these modes; operator drives auth via env),
+    ///     return `TokenMode`. Tasks 10/11 will split per-mode behavior.
     ///   * **Ignore** → delete the role-state `auth.json` if present,
     ///     return `Skipped`.
     ///
@@ -81,7 +81,11 @@ impl RoleState {
 
         let host_auth_json = host_home.join(".codex/auth.json");
         let outcome = match mode {
-            AuthForwardMode::Token => AuthProvisionOutcome::TokenMode,
+            // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
+            // Tasks 10/11 will split provisioning per credential variant.
+            AuthForwardMode::OAuthToken | AuthForwardMode::ApiKey => {
+                AuthProvisionOutcome::TokenMode
+            }
             AuthForwardMode::Ignore => {
                 if auth_json.exists() {
                     std::fs::remove_file(auth_json)?;
@@ -161,12 +165,13 @@ impl RoleState {
                 }
                 AuthProvisionOutcome::Skipped
             }
-            AuthForwardMode::Token => {
-                // Token mode provisions the same empty shape as Ignore —
-                // Claude Code inside the container authenticates via
-                // CLAUDE_CODE_OAUTH_TOKEN from the resolved env, not via
-                // filesystem credentials. Switching from sync → token must
-                // still wipe any previously forwarded creds.
+            // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
+            // Tasks 10/11 will split per-mode credential provisioning. Both
+            // env-driven modes provision the same empty shape as Ignore — the
+            // agent inside the container authenticates via env vars, not via
+            // filesystem credentials. Switching from sync → token/api_key must
+            // still wipe any previously forwarded creds.
+            AuthForwardMode::OAuthToken | AuthForwardMode::ApiKey => {
                 if !account_json.exists() || std::fs::read_to_string(account_json)? != "{}" {
                     write_private_file(account_json, "{}")?;
                 }
@@ -580,7 +585,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Token,
+            AuthForwardMode::OAuthToken,
             temp.path(),
             crate::agent::Agent::Claude,
         )
@@ -633,7 +638,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Token,
+            AuthForwardMode::OAuthToken,
             temp.path(),
             crate::agent::Agent::Claude,
         )
@@ -664,7 +669,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Token,
+            AuthForwardMode::OAuthToken,
             temp.path(),
             crate::agent::Agent::Claude,
         )
@@ -709,7 +714,7 @@ plugins = []
             &paths,
             "jackin-agent-smith",
             &manifest,
-            AuthForwardMode::Token,
+            AuthForwardMode::OAuthToken,
             temp.path(),
             crate::agent::Agent::Claude,
         )
@@ -1309,7 +1314,7 @@ agents = ["codex"]
             &config_toml,
             &auth_json,
             &manifest,
-            AuthForwardMode::Token,
+            AuthForwardMode::OAuthToken,
             &host_home,
         )
         .unwrap();
@@ -1374,7 +1379,7 @@ agents = ["codex"]
         assert_eq!(std::fs::read_to_string(&decoy).unwrap(), "secret");
     }
 
-    /// Pin symlink rejection across all three modes via the
+    /// Pin symlink rejection across all credential-bearing modes via the
     /// pre-mode-dispatch check at the top of `provision_codex_auth`.
     /// Without this, a compromised role could plant a symlink at the
     /// role-state `auth.json` and have subsequent sync/token-mode
@@ -1382,7 +1387,11 @@ agents = ["codex"]
     #[cfg(unix)]
     #[test]
     fn rejects_symlink_at_auth_json_under_sync_and_token() {
-        for mode in [AuthForwardMode::Sync, AuthForwardMode::Token] {
+        for mode in [
+            AuthForwardMode::Sync,
+            AuthForwardMode::OAuthToken,
+            AuthForwardMode::ApiKey,
+        ] {
             let temp = tempdir().unwrap();
             let manifest = manifest_with_codex_model(&temp, None);
             let config_toml = temp.path().join("config.toml");

--- a/src/operator_env.rs
+++ b/src/operator_env.rs
@@ -1819,7 +1819,6 @@ mod tests {
         let mut role = crate::config::RoleSource {
             git: "https://example.com/x.git".to_string(),
             trusted: true,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         };
         role.env
@@ -1943,7 +1942,6 @@ mod tests {
         let mut role_source = crate::config::RoleSource {
             git: "https://example.com/x.git".to_string(),
             trusted: true,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         };
         role_source

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1029,7 +1029,12 @@ fn load_role_with(
         // released on exit (or process crash).
         let (container_name, _name_lock) = claim_container_name(paths, selector, runner)?;
 
-        let auth_mode = config.resolve_auth_forward_mode(&selector.key());
+        let auth_mode = crate::config::resolve_mode(
+            config,
+            agent,
+            workspace_name.as_deref().unwrap_or(""),
+            &selector.key(),
+        );
 
         // Token mode requires CLAUDE_CODE_OAUTH_TOKEN in the resolved
         // operator env; fail fast with an actionable error if it is

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1042,15 +1042,27 @@ fn load_role_with(
         // problem before we spend time starting the network and DinD
         // sidecar. Sync / Ignore short-circuit inside the helper.
         //
-        // Task 14 will replace the empty `env_layers` slice with a
-        // real per-layer trace derived from the operator env config.
+        // Build the per-layer mode-resolution and env-layer traces
+        // here (in the caller) so the structured error carries the
+        // full picture. The helpers mirror the layers walked by
+        // `crate::config::resolve_mode` and
+        // `operator_env::build_attributed_layers` respectively.
+        let workspace_name_str = workspace_name.as_deref().unwrap_or("");
+        let role_key = selector.key();
+        let mode_resolution = build_mode_resolution(config, agent, workspace_name_str, &role_key);
+        let env_layers = agent
+            .required_env_var(auth_mode)
+            .map_or_else(Vec::new, |env_var| {
+                build_env_layer_states(config, workspace_name_str, &role_key, env_var)
+            });
         verify_credential_env_present(
             agent,
             auth_mode,
             &operator_env,
-            &[],
-            workspace_name.as_deref().unwrap_or(""),
-            &selector.key(),
+            &mode_resolution,
+            &env_layers,
+            workspace_name_str,
+            &role_key,
         )?;
 
         let (state, auth_outcome) = RoleState::prepare(
@@ -1068,26 +1080,21 @@ fn load_role_with(
         // reference or $NAME ref as written). Resolved values are never
         // printed.
         if agent == crate::agent::Agent::Claude {
-            match auth_mode {
-                // ApiKey mirrors OAuthToken's notice in this commit; Tasks
-                // 10/11 will split per-mode env-source diagnostics.
-                crate::config::AuthForwardMode::OAuthToken
-                | crate::config::AuthForwardMode::ApiKey => {
-                    let raw = lookup_operator_env_raw(
-                        config,
-                        Some(&selector.key()),
-                        workspace_name.as_deref(),
-                        "CLAUDE_CODE_OAUTH_TOKEN",
-                    );
-                    let source_ref = auth_token_source_reference(raw.as_deref());
-                    tui::auth_mode_notice(&auth_mode.to_string(), Some(&source_ref));
-                }
-                crate::config::AuthForwardMode::Sync => {
-                    tui::auth_mode_notice("sync", None);
-                }
-                crate::config::AuthForwardMode::Ignore => {
-                    tui::auth_mode_notice("ignore", None);
-                }
+            // Per-mode auth notice: for credential-injecting modes we look
+            // up the raw declaration of the mode's required env var
+            // (resolved through `Agent::required_env_var`) and surface its
+            // source reference; sync/ignore have no env source to print.
+            if let Some(env_var) = agent.required_env_var(auth_mode) {
+                let raw = lookup_operator_env_raw(
+                    config,
+                    Some(&role_key),
+                    workspace_name.as_deref(),
+                    env_var,
+                );
+                let source_ref = auth_token_source_reference(env_var, raw.as_deref());
+                tui::auth_mode_notice(&auth_mode.to_string(), Some(&source_ref));
+            } else {
+                tui::auth_mode_notice(&auth_mode.to_string(), None);
             }
 
             // Verbose outcome notices kept for operator context.
@@ -1099,49 +1106,38 @@ fn load_role_with(
                     );
                 }
                 crate::instance::AuthProvisionOutcome::TokenMode => {
-                    // Tasks 10/11/13 will route this through Agent::required_env_var.
-                    match auth_mode {
-                        crate::config::AuthForwardMode::OAuthToken => {
-                            eprintln!(
-                                "[jackin] auth_forward={auth_mode} — role will use \
-                                 CLAUDE_CODE_OAUTH_TOKEN from the resolved env."
-                            );
-                        }
-                        crate::config::AuthForwardMode::ApiKey => {
-                            eprintln!(
-                                "[jackin] auth_forward={auth_mode} — role will use \
-                                 ANTHROPIC_API_KEY from the resolved env."
-                            );
-                        }
-                        crate::config::AuthForwardMode::Sync
-                        | crate::config::AuthForwardMode::Ignore => {}
+                    if let Some(env_var) = agent.required_env_var(auth_mode) {
+                        eprintln!(
+                            "[jackin] auth_forward={auth_mode} — role will use \
+                             {env_var} from the resolved env."
+                        );
                     }
                 }
-                crate::instance::AuthProvisionOutcome::HostMissing => match auth_mode {
-                    crate::config::AuthForwardMode::Sync => {
+                crate::instance::AuthProvisionOutcome::HostMissing => {
+                    if matches!(auth_mode, crate::config::AuthForwardMode::Sync) {
                         eprintln!(
                             "[jackin] auth_forward=sync but no host credentials found; \
                                  preserving existing container auth if present."
                         );
                     }
-                    crate::config::AuthForwardMode::Ignore
-                    | crate::config::AuthForwardMode::OAuthToken
-                    | crate::config::AuthForwardMode::ApiKey => {}
-                },
+                }
                 crate::instance::AuthProvisionOutcome::Skipped => {}
             }
         } else if agent == crate::agent::Agent::Codex {
-            let raw_source = lookup_operator_env_raw(
-                config,
-                Some(&selector.key()),
-                workspace_name.as_deref(),
-                "OPENAI_API_KEY",
-            );
-            let resolved_source = resolved_env
-                .vars
-                .iter()
-                .any(|(k, v)| k == "OPENAI_API_KEY" && !v.trim().is_empty())
-                .then(|| raw_source.as_deref().unwrap_or("OPENAI_API_KEY"));
+            // For Codex, the credential env var is OPENAI_API_KEY in
+            // ApiKey mode and absent for Sync/Ignore. Drive the lookup
+            // through `Agent::required_env_var` to keep this generic.
+            let codex_env_var = agent.required_env_var(auth_mode);
+            let raw_source = codex_env_var.and_then(|v| {
+                lookup_operator_env_raw(config, Some(&role_key), workspace_name.as_deref(), v)
+            });
+            let resolved_source = codex_env_var.and_then(|v| {
+                resolved_env
+                    .vars
+                    .iter()
+                    .any(|(k, value)| k == v && !value.trim().is_empty())
+                    .then(|| raw_source.as_deref().unwrap_or(v))
+            });
             tui::codex_auth_notice(resolved_source, (auth_mode, auth_outcome).into());
         }
 
@@ -1383,13 +1379,11 @@ fn claim_container_name(
 /// Carried inside `LaunchError::AuthCredentialMissing` so both CLI text
 /// rendering and TUI structured rendering can reuse the same trace
 /// without re-deriving it from the resolved env map.
-//
-// `ResolvedLiteral` / `ResolvedOpRef` are produced by Task 14's caller
-// when it derives the per-layer state from the operator env config.
-// `Unset` is constructed by Task 13's `verify_credential_env_present`
-// today; the resolved variants stay allowed-dead until Task 14 wires
-// the per-layer derivation.
-#[allow(dead_code)]
+///
+/// All three variants are constructed today: `Unset` by both
+/// `verify_credential_env_present`'s tests and `build_env_layer_states`
+/// when a layer is silent; `ResolvedLiteral` / `ResolvedOpRef` by
+/// `build_env_layer_states` when a layer declares the var.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvLayerState {
     /// Layer does not declare the var at all.
@@ -1590,13 +1584,17 @@ fn render_auth_credential_missing(
 ///
 /// Otherwise looks up the well-known env var in `merged_env`. If the
 /// value is non-empty, returns `Ok(())`. If it is missing or empty,
-/// returns `LaunchError::AuthCredentialMissing` carrying the layer
-/// trace passed in by the caller, so both CLI and TUI rendering can
-/// surface a structured remediation panel.
+/// returns `LaunchError::AuthCredentialMissing` carrying the
+/// `mode_resolution` and `env_layers` traces passed in by the caller,
+/// so both CLI and TUI rendering can surface a structured remediation
+/// panel. The caller (`load_role_with`, see `build_mode_resolution` /
+/// `build_env_layer_states`) owns trace derivation; this helper only
+/// looks up the env var and constructs the error.
 pub fn verify_credential_env_present(
     agent: crate::agent::Agent,
     mode: crate::config::AuthForwardMode,
     merged_env: &std::collections::BTreeMap<String, String>,
+    mode_resolution: &[(String, Option<crate::config::AuthForwardMode>)],
     env_layers: &[(String, EnvLayerState)],
     workspace: &str,
     role: &str,
@@ -1609,39 +1607,109 @@ pub fn verify_credential_env_present(
         return Ok(());
     }
 
-    // Mode-resolution trace: most-specific first. The caller (Task 14)
-    // owns the per-layer mode lookup; this helper only knows the leaf
-    // (the resolved mode that triggered the check), so the broader
-    // layers are left as `None`. The renderer prints those as
-    // `(none)`, which is correct: when the checker is invoked the
-    // caller has already collapsed the 3 layers down to one decision.
-    let mode_resolution = vec![
-        (format!("workspace × role × {agent}"), Some(mode)),
-        (format!("workspace × {agent}"), None),
-        (format!("global × {agent}"), None),
-    ];
-
     Err(LaunchError::AuthCredentialMissing {
         agent,
         mode,
         env_var,
         workspace: workspace.to_string(),
         role: role.to_string(),
-        mode_resolution,
+        mode_resolution: mode_resolution.to_vec(),
         env_layers: env_layers.to_vec(),
     })
 }
 
-/// Return a printable source reference for `CLAUDE_CODE_OAUTH_TOKEN`
+/// Build the 3-layer mode-resolution trace (most-specific first) that
+/// `LaunchError::AuthCredentialMissing` carries for rendering. Walks
+/// the same layers as [`crate::config::resolve_mode`] but records each
+/// layer's value (or `None` when silent) so the operator can see at a
+/// glance which TOML layer wins.
+fn build_mode_resolution(
+    cfg: &AppConfig,
+    agent: crate::agent::Agent,
+    workspace: &str,
+    role: &str,
+) -> Vec<(String, Option<crate::config::AuthForwardMode>)> {
+    use crate::agent::Agent;
+    let agent_at_global = match agent {
+        Agent::Claude => cfg.claude.as_ref().map(|c| c.auth_forward),
+        Agent::Codex => cfg.codex.as_ref().map(|c| c.auth_forward),
+    };
+    let agent_at_workspace = cfg.workspaces.get(workspace).and_then(|ws| match agent {
+        Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
+        Agent::Codex => ws.codex.as_ref().map(|c| c.auth_forward),
+    });
+    let agent_at_ws_role = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.roles.get(role))
+        .and_then(|ro| match agent {
+            Agent::Claude => ro.claude.as_ref().map(|c| c.auth_forward),
+            Agent::Codex => ro.codex.as_ref().map(|c| c.auth_forward),
+        });
+    vec![
+        (format!("workspace × role × {agent}"), agent_at_ws_role),
+        (format!("workspace × {agent}"), agent_at_workspace),
+        (format!("global × {agent}"), agent_at_global),
+    ]
+}
+
+/// Build the 4-layer env-layer trace (lowest precedence first) for the
+/// credential var. Layers mirror `operator_env::build_attributed_layers`:
+/// `[env]` < `[roles.<role>.env]` < `[workspaces.<ws>.env]` <
+/// `[workspaces.<ws>.roles.<role>.env]`. Each entry records whether the
+/// layer declared the var as a literal, an `op://...` reference, or
+/// not at all.
+fn build_env_layer_states(
+    cfg: &AppConfig,
+    workspace: &str,
+    role: &str,
+    env_var: &str,
+) -> Vec<(String, EnvLayerState)> {
+    const fn classify(value: &crate::operator_env::EnvValue) -> EnvLayerState {
+        match value {
+            crate::operator_env::EnvValue::Plain(_) => EnvLayerState::ResolvedLiteral,
+            crate::operator_env::EnvValue::OpRef(_) => EnvLayerState::ResolvedOpRef,
+        }
+    }
+    let global = cfg.env.get(env_var).map_or(EnvLayerState::Unset, classify);
+    let role_global = cfg
+        .roles
+        .get(role)
+        .and_then(|r| r.env.get(env_var))
+        .map_or(EnvLayerState::Unset, classify);
+    let workspace_global = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.env.get(env_var))
+        .map_or(EnvLayerState::Unset, classify);
+    let workspace_role = cfg
+        .workspaces
+        .get(workspace)
+        .and_then(|ws| ws.roles.get(role))
+        .and_then(|ro| ro.env.get(env_var))
+        .map_or(EnvLayerState::Unset, classify);
+    vec![
+        ("[env]".to_string(), global),
+        (format!("[roles.{role}.env]"), role_global),
+        (format!("[workspaces.{workspace}.env]"), workspace_global),
+        (
+            format!("[workspaces.{workspace}.roles.{role}.env]"),
+            workspace_role,
+        ),
+    ]
+}
+
+/// Return a printable source reference for the credential env var
+/// `env_var` (e.g. `"CLAUDE_CODE_OAUTH_TOKEN"`, `"ANTHROPIC_API_KEY"`)
 /// given the raw (unresolved) declaration value from the operator env
 /// config (e.g. `"Private/Claude/security/auth token"` or
 /// `"$CLAUDE_CODE_OAUTH_TOKEN"`). Produces the `"KEY ← value"` form
 /// consumed by `tui::auth_mode_notice`. When `raw` is `None` or the
 /// display string is empty, falls back to the bare env-var name.
-fn auth_token_source_reference(raw: Option<&str>) -> String {
+fn auth_token_source_reference(env_var: &str, raw: Option<&str>) -> String {
     match raw {
-        None | Some("") => "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
-        Some(value) => format!("CLAUDE_CODE_OAUTH_TOKEN \u{2190} {value}"),
+        None | Some("") => env_var.to_string(),
+        Some(value) => format!("{env_var} \u{2190} {value}"),
     }
 }
 
@@ -4004,6 +4072,7 @@ plugins = []
             Agent::Claude,
             AuthForwardMode::Sync,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4021,6 +4090,7 @@ plugins = []
             Agent::Claude,
             AuthForwardMode::Ignore,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4039,6 +4109,7 @@ plugins = []
             Agent::Claude,
             AuthForwardMode::ApiKey,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4061,10 +4132,19 @@ plugins = []
                 EnvLayerState::Unset,
             ),
         ];
+        let mode_resolution = vec![
+            (
+                "workspace × role × claude".into(),
+                Some(AuthForwardMode::ApiKey),
+            ),
+            ("workspace × claude".into(), None),
+            ("global × claude".into(), None),
+        ];
         let r = verify_credential_env_present(
             Agent::Claude,
             AuthForwardMode::ApiKey,
             &merged,
+            &mode_resolution,
             &layers,
             "proj",
             "smith",
@@ -4078,6 +4158,7 @@ plugins = []
                 workspace,
                 role,
                 env_layers,
+                mode_resolution,
                 ..
             } => {
                 assert_eq!(env_var, "ANTHROPIC_API_KEY");
@@ -4085,8 +4166,10 @@ plugins = []
                 assert_eq!(mode, AuthForwardMode::ApiKey);
                 assert_eq!(workspace, "proj");
                 assert_eq!(role, "smith");
-                // Helper passes the caller's env-layer trace through verbatim.
+                // Helper passes the caller's traces through verbatim.
                 assert_eq!(env_layers.len(), 4);
+                assert_eq!(mode_resolution.len(), 3);
+                assert_eq!(mode_resolution[0].1, Some(AuthForwardMode::ApiKey));
             }
         }
     }
@@ -4102,6 +4185,7 @@ plugins = []
             Agent::Claude,
             AuthForwardMode::ApiKey,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4119,6 +4203,7 @@ plugins = []
             Agent::Claude,
             AuthForwardMode::OAuthToken,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4141,6 +4226,7 @@ plugins = []
             Agent::Codex,
             AuthForwardMode::ApiKey,
             &merged,
+            &[],
             &layers,
             "proj",
             "smith",
@@ -4152,6 +4238,112 @@ plugins = []
                 assert_eq!(agent, Agent::Codex);
             }
         }
+    }
+
+    #[test]
+    fn build_mode_resolution_populates_all_3_layers() {
+        use crate::agent::Agent;
+        use crate::config::{AgentAuthConfig, AuthForwardMode};
+        use crate::workspace::WorkspaceConfig;
+
+        let ws = WorkspaceConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::ApiKey,
+            }),
+            ..WorkspaceConfig::default()
+        };
+        let mut cfg = AppConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::Sync,
+            }),
+            ..AppConfig::default()
+        };
+        cfg.workspaces.insert("proj".into(), ws);
+
+        let trace = build_mode_resolution(&cfg, Agent::Claude, "proj", "smith");
+        assert_eq!(trace.len(), 3);
+        // Ordered most-specific first: ws × role × claude (no override),
+        // then ws × claude (api_key), then global × claude (sync).
+        assert_eq!(trace[0].0, "workspace × role × claude");
+        assert_eq!(trace[0].1, None);
+        assert_eq!(trace[1].0, "workspace × claude");
+        assert_eq!(trace[1].1, Some(AuthForwardMode::ApiKey));
+        assert_eq!(trace[2].0, "global × claude");
+        assert_eq!(trace[2].1, Some(AuthForwardMode::Sync));
+    }
+
+    #[test]
+    fn build_mode_resolution_role_override_wins() {
+        use crate::agent::Agent;
+        use crate::config::{AgentAuthConfig, AuthForwardMode};
+        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+
+        let ro = WorkspaceRoleOverride {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::OAuthToken,
+            }),
+            ..Default::default()
+        };
+        let mut ws = WorkspaceConfig::default();
+        ws.roles.insert("smith".into(), ro);
+        let mut cfg = AppConfig::default();
+        cfg.workspaces.insert("proj".into(), ws);
+
+        let trace = build_mode_resolution(&cfg, Agent::Claude, "proj", "smith");
+        assert_eq!(trace[0].1, Some(AuthForwardMode::OAuthToken));
+        assert_eq!(trace[1].1, None);
+        assert_eq!(trace[2].1, None);
+    }
+
+    #[test]
+    fn build_env_layer_states_classifies_present_vs_absent() {
+        use crate::operator_env::{EnvValue, OpRef};
+        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
+
+        let mut ro = WorkspaceRoleOverride::default();
+        ro.env.insert(
+            "ANTHROPIC_API_KEY".into(),
+            EnvValue::OpRef(OpRef {
+                op: "op://uuid/test/field".into(),
+                path: "Test/api/key".into(),
+            }),
+        );
+        let mut ws = WorkspaceConfig::default();
+        ws.roles.insert("smith".into(), ro);
+        let mut cfg = AppConfig::default();
+        cfg.workspaces.insert("proj".into(), ws);
+
+        let layers = build_env_layer_states(&cfg, "proj", "smith", "ANTHROPIC_API_KEY");
+        assert_eq!(layers.len(), 4);
+        assert_eq!(layers[0].0, "[env]");
+        assert_eq!(layers[0].1, EnvLayerState::Unset);
+        assert_eq!(layers[1].0, "[roles.smith.env]");
+        assert_eq!(layers[1].1, EnvLayerState::Unset);
+        assert_eq!(layers[2].0, "[workspaces.proj.env]");
+        assert_eq!(layers[2].1, EnvLayerState::Unset);
+        assert_eq!(layers[3].0, "[workspaces.proj.roles.smith.env]");
+        assert_eq!(layers[3].1, EnvLayerState::ResolvedOpRef);
+    }
+
+    #[test]
+    fn build_env_layer_states_classifies_literal_at_global() {
+        use crate::operator_env::EnvValue;
+
+        let mut env = std::collections::BTreeMap::new();
+        env.insert(
+            "ANTHROPIC_API_KEY".into(),
+            EnvValue::Plain("$ANTHROPIC_API_KEY".into()),
+        );
+        let cfg = AppConfig {
+            env,
+            ..AppConfig::default()
+        };
+
+        let layers = build_env_layer_states(&cfg, "proj", "smith", "ANTHROPIC_API_KEY");
+        assert_eq!(layers[0].1, EnvLayerState::ResolvedLiteral);
+        assert_eq!(layers[1].1, EnvLayerState::Unset);
+        assert_eq!(layers[2].1, EnvLayerState::Unset);
+        assert_eq!(layers[3].1, EnvLayerState::Unset);
     }
 
     #[test]

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1036,21 +1036,22 @@ fn load_role_with(
             &selector.key(),
         );
 
-        // Token mode requires CLAUDE_CODE_OAUTH_TOKEN in the resolved
-        // operator env; fail fast with an actionable error if it is
-        // missing so the operator sees the problem before we spend time
-        // starting the network and DinD sidecar.
+        // Modes that inject a credential require the well-known env
+        // var to resolve to a non-empty value; fail fast with an
+        // actionable structured error so the operator sees the
+        // problem before we spend time starting the network and DinD
+        // sidecar. Sync / Ignore short-circuit inside the helper.
         //
-        // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
-        // Tasks 10/11 will split the credential check per mode.
-        if agent == crate::agent::Agent::Claude
-            && matches!(
-                auth_mode,
-                crate::config::AuthForwardMode::OAuthToken | crate::config::AuthForwardMode::ApiKey
-            )
-        {
-            verify_token_env_present(&operator_env)?;
-        }
+        // Task 14 will replace the empty `env_layers` slice with a
+        // real per-layer trace derived from the operator env config.
+        verify_credential_env_present(
+            agent,
+            auth_mode,
+            &operator_env,
+            &[],
+            workspace_name.as_deref().unwrap_or(""),
+            &selector.key(),
+        )?;
 
         let (state, auth_outcome) = RoleState::prepare(
             paths,
@@ -1383,10 +1384,11 @@ fn claim_container_name(
 /// rendering and TUI structured rendering can reuse the same trace
 /// without re-deriving it from the resolved env map.
 //
-// `ResolvedLiteral` / `ResolvedOpRef` are only constructed by Task 13's
-// validator (next commit). Allowed dead until then so this commit can
-// land the structured-error scaffolding without churning the wider
-// codebase.
+// `ResolvedLiteral` / `ResolvedOpRef` are produced by Task 14's caller
+// when it derives the per-layer state from the operator env config.
+// `Unset` is constructed by Task 13's `verify_credential_env_present`
+// today; the resolved variants stay allowed-dead until Task 14 wires
+// the per-layer derivation.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvLayerState {
@@ -1420,11 +1422,8 @@ impl std::fmt::Display for EnvLayerState {
 /// etc.) can grow structured variants alongside it without churning the
 /// type at every call site.
 //
-// Constructed by Task 13's `verify_credential_env_present` (next
-// commit) and bubbled through Task 14's `load_role_with` integration.
-// Allowed dead until then so this commit can land the structured-error
-// scaffolding in isolation.
-#[allow(dead_code)]
+// Constructed by Task 13's `verify_credential_env_present` and bubbled
+// through Task 14's `load_role_with` integration.
 #[derive(Debug, thiserror::Error)]
 pub enum LaunchError {
     /// `auth_forward` mode requires a credential env var to resolve to
@@ -1496,11 +1495,6 @@ fn render_label_width<T>(rows: &[(String, T)]) -> usize {
 /// for CLI display. The TUI panel consumes the structured fields
 /// directly and ignores this rendering — they intentionally share the
 /// data, not the formatting.
-//
-// Constructed only when `LaunchError::AuthCredentialMissing` is built,
-// which today only happens from the test module. Allowed dead until
-// Task 13's validator wires it from production code.
-#[allow(dead_code)]
 fn render_auth_credential_missing(
     agent: crate::agent::Agent,
     mode: crate::config::AuthForwardMode,
@@ -1583,40 +1577,59 @@ fn render_auth_credential_missing(
     out
 }
 
-/// Verify that `CLAUDE_CODE_OAUTH_TOKEN` is present in the resolved
-/// operator env when `auth_forward == Token`. Returns an actionable
-/// error listing both remediation paths (1Password `op://` reference
-/// and `$CLAUDE_CODE_OAUTH_TOKEN` host shell forwarding) when the
-/// token is missing or empty.
+/// Verify that the credential env var required by the resolved
+/// `auth_forward` mode is present (and non-empty) in the merged
+/// operator-env map. Drives the per-(agent, mode) lookup through
+/// `Agent::required_env_var`, which is the single source of truth
+/// for which env var carries which credential.
 ///
-/// Kept as a small pure helper over `BTreeMap<String, String>` so it
-/// can be unit-tested without faking the workspace env resolver.
-fn verify_token_env_present(
-    vars: &std::collections::BTreeMap<String, String>,
-) -> anyhow::Result<()> {
-    if vars
-        .get("CLAUDE_CODE_OAUTH_TOKEN")
-        .is_some_and(|v| !v.is_empty())
-    {
+/// Returns `Ok(())` for modes that don't inject a credential
+/// (`Sync`, `Ignore`) — the operator may still need a host-side
+/// credential in those modes, but the launch-time pre-flight has
+/// nothing to verify in the merged env.
+///
+/// Otherwise looks up the well-known env var in `merged_env`. If the
+/// value is non-empty, returns `Ok(())`. If it is missing or empty,
+/// returns `LaunchError::AuthCredentialMissing` carrying the layer
+/// trace passed in by the caller, so both CLI and TUI rendering can
+/// surface a structured remediation panel.
+pub fn verify_credential_env_present(
+    agent: crate::agent::Agent,
+    mode: crate::config::AuthForwardMode,
+    merged_env: &std::collections::BTreeMap<String, String>,
+    env_layers: &[(String, EnvLayerState)],
+    workspace: &str,
+    role: &str,
+) -> Result<(), LaunchError> {
+    let Some(env_var) = agent.required_env_var(mode) else {
+        return Ok(());
+    };
+    let value = merged_env.get(env_var).map_or("", String::as_str);
+    if !value.is_empty() {
         return Ok(());
     }
-    anyhow::bail!(
-        "auth_forward = \"token\" but CLAUDE_CODE_OAUTH_TOKEN is not set in the resolved \
-         operator env.\n\
-         \n\
-         Add it in your workspace config under [env]. Either:\n\
-         \n\
-         - Reference a 1Password secret:\n  \
-             [env]\n  \
-             CLAUDE_CODE_OAUTH_TOKEN = \"op://vault/claude/token\"\n\
-         \n\
-         - Forward from the host shell:\n  \
-             [env]\n  \
-             CLAUDE_CODE_OAUTH_TOKEN = \"$CLAUDE_CODE_OAUTH_TOKEN\"\n\
-         \n\
-         Generate a token with `claude setup-token`, then either store it in \
-         1Password (first form) or export it in your shell (second form)."
-    );
+
+    // Mode-resolution trace: most-specific first. The caller (Task 14)
+    // owns the per-layer mode lookup; this helper only knows the leaf
+    // (the resolved mode that triggered the check), so the broader
+    // layers are left as `None`. The renderer prints those as
+    // `(none)`, which is correct: when the checker is invoked the
+    // caller has already collapsed the 3 layers down to one decision.
+    let mode_resolution = vec![
+        (format!("workspace × role × {agent}"), Some(mode)),
+        (format!("workspace × {agent}"), None),
+        (format!("global × {agent}"), None),
+    ];
+
+    Err(LaunchError::AuthCredentialMissing {
+        agent,
+        mode,
+        env_var,
+        workspace: workspace.to_string(),
+        role: role.to_string(),
+        mode_resolution,
+        env_layers: env_layers.to_vec(),
+    })
 }
 
 /// Return a printable source reference for `CLAUDE_CODE_OAUTH_TOKEN`
@@ -3982,34 +3995,163 @@ plugins = []
     }
 
     #[test]
-    fn verify_token_env_present_accepts_resolved_token() {
-        let mut vars = std::collections::BTreeMap::new();
-        vars.insert(
-            "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
-            "sk-ant-oat01-redacted".to_string(),
+    fn verify_credential_sync_returns_ok_regardless() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let merged: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let layers: Vec<(String, EnvLayerState)> = vec![];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::Sync,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
         );
-        assert!(verify_token_env_present(&vars).is_ok());
+        assert!(r.is_ok());
     }
 
     #[test]
-    fn verify_token_env_missing_returns_actionable_error() {
-        let vars = std::collections::BTreeMap::<String, String>::new();
-        let err = verify_token_env_present(&vars).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("CLAUDE_CODE_OAUTH_TOKEN"), "got: {msg}");
-        // Both remediation paths must be surfaced.
-        assert!(
-            msg.contains("op://"),
-            "error should mention the 1Password remediation path; got: {msg}"
+    fn verify_credential_ignore_returns_ok_regardless() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let merged: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let layers: Vec<(String, EnvLayerState)> = vec![];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::Ignore,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
         );
-        assert!(
-            msg.contains("$CLAUDE_CODE_OAUTH_TOKEN"),
-            "error should mention the host env remediation path; got: {msg}"
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn verify_credential_api_key_present_ok() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let mut merged = std::collections::BTreeMap::new();
+        merged.insert("ANTHROPIC_API_KEY".into(), "sk-ant-xxx".into());
+        let layers: Vec<(String, EnvLayerState)> = vec![];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
         );
-        assert!(
-            msg.contains("[env]"),
-            "error should point the operator at the [env] manifest table; got: {msg}"
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn verify_credential_api_key_missing_returns_structured_error() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let mut merged = std::collections::BTreeMap::new();
+        merged.insert("ANTHROPIC_API_KEY".into(), String::new());
+        let layers = vec![
+            ("[env]".into(), EnvLayerState::Unset),
+            ("[roles.smith.env]".into(), EnvLayerState::Unset),
+            ("[workspaces.proj.env]".into(), EnvLayerState::Unset),
+            (
+                "[workspaces.proj.roles.smith.env]".into(),
+                EnvLayerState::Unset,
+            ),
+        ];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
         );
+        let err = r.unwrap_err();
+        match err {
+            LaunchError::AuthCredentialMissing {
+                env_var,
+                agent,
+                mode,
+                workspace,
+                role,
+                env_layers,
+                ..
+            } => {
+                assert_eq!(env_var, "ANTHROPIC_API_KEY");
+                assert_eq!(agent, Agent::Claude);
+                assert_eq!(mode, AuthForwardMode::ApiKey);
+                assert_eq!(workspace, "proj");
+                assert_eq!(role, "smith");
+                // Helper passes the caller's env-layer trace through verbatim.
+                assert_eq!(env_layers.len(), 4);
+            }
+        }
+    }
+
+    #[test]
+    fn verify_credential_api_key_unset_returns_structured_error() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        // ANTHROPIC_API_KEY not in map at all.
+        let merged: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let layers: Vec<(String, EnvLayerState)> = vec![];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::ApiKey,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
+        );
+        assert!(matches!(r, Err(LaunchError::AuthCredentialMissing { .. })));
+    }
+
+    #[test]
+    fn verify_credential_oauth_token_missing_for_claude() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let merged: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let layers = vec![("[env]".into(), EnvLayerState::Unset)];
+        let r = verify_credential_env_present(
+            Agent::Claude,
+            AuthForwardMode::OAuthToken,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
+        );
+        let err = r.unwrap_err();
+        match err {
+            LaunchError::AuthCredentialMissing { env_var, .. } => {
+                assert_eq!(env_var, "CLAUDE_CODE_OAUTH_TOKEN");
+            }
+        }
+    }
+
+    #[test]
+    fn verify_credential_codex_api_key_missing() {
+        use crate::agent::Agent;
+        use crate::config::AuthForwardMode;
+        let merged: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+        let layers: Vec<(String, EnvLayerState)> = vec![];
+        let r = verify_credential_env_present(
+            Agent::Codex,
+            AuthForwardMode::ApiKey,
+            &merged,
+            &layers,
+            "proj",
+            "smith",
+        );
+        let err = r.unwrap_err();
+        match err {
+            LaunchError::AuthCredentialMissing { env_var, agent, .. } => {
+                assert_eq!(env_var, "OPENAI_API_KEY");
+                assert_eq!(agent, Agent::Codex);
+            }
+        }
     }
 
     #[test]
@@ -4174,7 +4316,7 @@ plugins = []
     }
 
     #[test]
-    fn auth_credential_missing_codex_oauth_token_renders() {
+    fn auth_credential_missing_codex_api_key_renders() {
         let err = LaunchError::AuthCredentialMissing {
             agent: crate::agent::Agent::Codex,
             mode: crate::config::AuthForwardMode::ApiKey,

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1093,10 +1093,23 @@ fn load_role_with(
                     );
                 }
                 crate::instance::AuthProvisionOutcome::TokenMode => {
-                    eprintln!(
-                        "[jackin] auth_forward=token — role will use CLAUDE_CODE_OAUTH_TOKEN \
-                         from the resolved env."
-                    );
+                    // Tasks 10/11/13 will route this through Agent::required_env_var.
+                    match auth_mode {
+                        crate::config::AuthForwardMode::OAuthToken => {
+                            eprintln!(
+                                "[jackin] auth_forward={auth_mode} — role will use \
+                                 CLAUDE_CODE_OAUTH_TOKEN from the resolved env."
+                            );
+                        }
+                        crate::config::AuthForwardMode::ApiKey => {
+                            eprintln!(
+                                "[jackin] auth_forward={auth_mode} — role will use \
+                                 ANTHROPIC_API_KEY from the resolved env."
+                            );
+                        }
+                        crate::config::AuthForwardMode::Sync
+                        | crate::config::AuthForwardMode::Ignore => {}
+                    }
                 }
                 crate::instance::AuthProvisionOutcome::HostMissing => match auth_mode {
                     crate::config::AuthForwardMode::Sync => {

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1035,8 +1035,14 @@ fn load_role_with(
         // operator env; fail fast with an actionable error if it is
         // missing so the operator sees the problem before we spend time
         // starting the network and DinD sidecar.
+        //
+        // ApiKey mirrors OAuthToken's filesystem behavior in this commit;
+        // Tasks 10/11 will split the credential check per mode.
         if agent == crate::agent::Agent::Claude
-            && matches!(auth_mode, crate::config::AuthForwardMode::Token)
+            && matches!(
+                auth_mode,
+                crate::config::AuthForwardMode::OAuthToken | crate::config::AuthForwardMode::ApiKey
+            )
         {
             verify_token_env_present(&operator_env)?;
         }
@@ -1057,7 +1063,10 @@ fn load_role_with(
         // printed.
         if agent == crate::agent::Agent::Claude {
             match auth_mode {
-                crate::config::AuthForwardMode::Token => {
+                // ApiKey mirrors OAuthToken's notice in this commit; Tasks
+                // 10/11 will split per-mode env-source diagnostics.
+                crate::config::AuthForwardMode::OAuthToken
+                | crate::config::AuthForwardMode::ApiKey => {
                     let raw = lookup_operator_env_raw(
                         config,
                         Some(&selector.key()),
@@ -1065,7 +1074,7 @@ fn load_role_with(
                         "CLAUDE_CODE_OAUTH_TOKEN",
                     );
                     let source_ref = auth_token_source_reference(raw.as_deref());
-                    tui::auth_mode_notice("token", Some(&source_ref));
+                    tui::auth_mode_notice(&auth_mode.to_string(), Some(&source_ref));
                 }
                 crate::config::AuthForwardMode::Sync => {
                     tui::auth_mode_notice("sync", None);
@@ -1097,7 +1106,8 @@ fn load_role_with(
                         );
                     }
                     crate::config::AuthForwardMode::Ignore
-                    | crate::config::AuthForwardMode::Token => {}
+                    | crate::config::AuthForwardMode::OAuthToken
+                    | crate::config::AuthForwardMode::ApiKey => {}
                 },
                 crate::instance::AuthProvisionOutcome::Skipped => {}
             }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1376,6 +1376,213 @@ fn claim_container_name(
     }
 }
 
+/// What we found in a single env layer when looking up the credential
+/// var required by an `auth_forward` mode.
+///
+/// Carried inside `LaunchError::AuthCredentialMissing` so both CLI text
+/// rendering and TUI structured rendering can reuse the same trace
+/// without re-deriving it from the resolved env map.
+//
+// `ResolvedLiteral` / `ResolvedOpRef` are only constructed by Task 13's
+// validator (next commit). Allowed dead until then so this commit can
+// land the structured-error scaffolding without churning the wider
+// codebase.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvLayerState {
+    /// Layer does not declare the var at all.
+    Unset,
+    /// Layer declares the var with a literal (or `$VAR`) value that
+    /// resolved to a non-empty string.
+    ResolvedLiteral,
+    /// Layer declares the var with an `op://...` reference that
+    /// resolved to a non-empty string.
+    ResolvedOpRef,
+}
+
+impl std::fmt::Display for EnvLayerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unset => write!(f, "unset"),
+            Self::ResolvedLiteral => write!(f, "resolved (literal)"),
+            Self::ResolvedOpRef => write!(f, "resolved (op://...)"),
+        }
+    }
+}
+
+/// Errors produced by launch-time validation that benefit from
+/// structured fields (e.g. TUI rendering, multi-line CLI output) rather
+/// than the stringy `anyhow::bail!` shape used elsewhere in this file.
+///
+/// Today this enum carries a single variant — the auth-credential
+/// pre-flight failure — but it's defined as an enum so that future
+/// launch-time validators (`DinD` readiness, image build preconditions,
+/// etc.) can grow structured variants alongside it without churning the
+/// type at every call site.
+//
+// Constructed by Task 13's `verify_credential_env_present` (next
+// commit) and bubbled through Task 14's `load_role_with` integration.
+// Allowed dead until then so this commit can land the structured-error
+// scaffolding in isolation.
+#[allow(dead_code)]
+#[derive(Debug, thiserror::Error)]
+pub enum LaunchError {
+    /// `auth_forward` mode requires a credential env var to resolve to
+    /// a non-empty value, but the resolved operator env doesn't carry
+    /// it. Carries enough structure for both CLI rendering (multi-line
+    /// text via the `Display` impl) and TUI rendering (structured
+    /// panel) to reuse the same data without re-deriving it.
+    #[error("{}", render_auth_credential_missing(
+        *.agent,
+        *.mode,
+        .env_var,
+        .workspace,
+        .role,
+        .mode_resolution,
+        .env_layers,
+    ))]
+    AuthCredentialMissing {
+        /// Agent the launch was for (drives the var name and remediation copy).
+        agent: crate::agent::Agent,
+        /// Resolved `auth_forward` mode that requires the credential.
+        mode: crate::config::AuthForwardMode,
+        /// Well-known credential env var (e.g. `ANTHROPIC_API_KEY`,
+        /// `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`) that must
+        /// resolve to a non-empty value for `mode`.
+        env_var: &'static str,
+        /// Workspace name the launch targets (for messaging).
+        workspace: String,
+        /// Role selector key the launch targets (for messaging).
+        role: String,
+        /// Trace of the 3-layer mode resolution: each entry pairs a
+        /// human-readable layer label (e.g. `"workspace × role × claude"`)
+        /// with the mode value declared at that layer (`None` = layer
+        /// is silent). Layers are ordered most-specific first.
+        mode_resolution: Vec<(String, Option<crate::config::AuthForwardMode>)>,
+        /// Trace of the env-layer resolution for `env_var`: each entry
+        /// pairs a TOML-table label (e.g. `"[workspaces.proj.env]"`)
+        /// with what we found in that layer. Layers are ordered
+        /// lowest-to-highest priority so the rendered output reads
+        /// chronologically the same way operators read TOML.
+        env_layers: Vec<(String, EnvLayerState)>,
+    },
+}
+
+/// Constant gutter between the layer-label column and the `->` arrow
+/// in `render_auth_credential_missing` output. Sized so even the longest
+/// label has visible whitespace before the arrow (matches the spec test
+/// fixture `workspace × role × claude    -> api_key`).
+const RENDER_LABEL_GUTTER: usize = 4;
+
+/// Cap on the layer-label column width. Keeps a pathologically-long
+/// label (60+ chars) from blowing up line width while still
+/// comfortably fitting any realistic env-table path.
+const RENDER_LABEL_WIDTH_CAP: usize = 60;
+
+/// Compute the padded column width used for the layer-label column in
+/// `render_auth_credential_missing`. Pulled out so both the
+/// mode-resolution and env-layer sections share the same arithmetic
+/// without repeating the gutter / cap constants inline.
+fn render_label_width<T>(rows: &[(String, T)]) -> usize {
+    rows.iter()
+        .map(|(l, _)| l.chars().count())
+        .max()
+        .unwrap_or(0)
+        .saturating_add(RENDER_LABEL_GUTTER)
+        .min(RENDER_LABEL_WIDTH_CAP)
+}
+
+/// Render the structured multi-line `AuthCredentialMissing` message
+/// for CLI display. The TUI panel consumes the structured fields
+/// directly and ignores this rendering — they intentionally share the
+/// data, not the formatting.
+//
+// Constructed only when `LaunchError::AuthCredentialMissing` is built,
+// which today only happens from the test module. Allowed dead until
+// Task 13's validator wires it from production code.
+#[allow(dead_code)]
+fn render_auth_credential_missing(
+    agent: crate::agent::Agent,
+    mode: crate::config::AuthForwardMode,
+    env_var: &str,
+    workspace: &str,
+    role: &str,
+    mode_resolution: &[(String, Option<crate::config::AuthForwardMode>)],
+    env_layers: &[(String, EnvLayerState)],
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    let _ = writeln!(
+        out,
+        "cannot launch {agent} in workspace '{workspace}' role '{role}'"
+    );
+    let _ = writeln!(
+        out,
+        "       \u{2014} auth_forward is '{mode}', which requires {env_var}"
+    );
+    let _ = writeln!(
+        out,
+        "         to resolve to a non-empty value, but it is unset."
+    );
+
+    if !mode_resolution.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "  Effective auth resolution:");
+        let label_width = render_label_width(mode_resolution);
+        for (idx, (label, value)) in mode_resolution.iter().enumerate() {
+            let value_str = value
+                .as_ref()
+                .map_or_else(|| "(none)".to_string(), ToString::to_string);
+            let suffix = if idx == 0 { "  (most-specific)" } else { "" };
+            let _ = writeln!(out, "    {label:<label_width$}-> {value_str}{suffix}");
+        }
+    }
+
+    if !env_layers.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "  Env layer resolution for {env_var} (lowest -> highest):"
+        );
+        let label_width = render_label_width(env_layers);
+        for (label, state) in env_layers {
+            let _ = writeln!(out, "    {label:<label_width$}-> {state}");
+        }
+    }
+
+    let agent_title = match agent {
+        crate::agent::Agent::Claude => "Claude",
+        crate::agent::Agent::Codex => "Codex",
+    };
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  Fix one of:");
+    let _ = writeln!(
+        out,
+        "    - Open the Auth panel:  jackin tui workspaces  \u{2192} '{workspace}' \u{2192} Auth \u{2192} {role} / {agent_title}"
+    );
+    // `jackin config env set` does not yet support `--workspace`; show
+    // the role-scoped form (the closest existing remediation) so we
+    // don't print a flag the operator can't actually use today.
+    let _ = writeln!(
+        out,
+        "    - Or by hand:           jackin config env set {env_var} <value> --role {role}"
+    );
+    let _ = writeln!(
+        out,
+        "    - Or change the mode:   set auth_forward = 'sync' at one of the layers above"
+    );
+
+    // Trim the trailing newline left by the final `writeln!` so callers
+    // composing this into larger errors don't get an awkward extra blank
+    // line.
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
 /// Verify that `CLAUDE_CODE_OAUTH_TOKEN` is present in the resolved
 /// operator env when `auth_forward == Token`. Returns an actionable
 /// error listing both remediation paths (1Password `op://` reference
@@ -3924,5 +4131,61 @@ plugins = []
         let mut runner = inspect_runner("hibernated", 0, false);
         let outcome = inspect_attach_outcome(&mut runner, "jackin-x").unwrap();
         assert_eq!(outcome, AttachOutcome::still_running());
+    }
+
+    #[test]
+    fn auth_credential_missing_displays_layer_trace() {
+        let err = LaunchError::AuthCredentialMissing {
+            agent: crate::agent::Agent::Claude,
+            mode: crate::config::AuthForwardMode::ApiKey,
+            env_var: "ANTHROPIC_API_KEY",
+            workspace: "proj".into(),
+            role: "smith".into(),
+            mode_resolution: vec![
+                (
+                    "workspace × role × claude".into(),
+                    Some(crate::config::AuthForwardMode::ApiKey),
+                ),
+                ("workspace × claude".into(), None),
+                (
+                    "global × claude".into(),
+                    Some(crate::config::AuthForwardMode::Sync),
+                ),
+            ],
+            env_layers: vec![
+                ("[env]".into(), EnvLayerState::Unset),
+                ("[roles.smith.env]".into(), EnvLayerState::Unset),
+                ("[workspaces.proj.env]".into(), EnvLayerState::Unset),
+                (
+                    "[workspaces.proj.roles.smith.env]".into(),
+                    EnvLayerState::Unset,
+                ),
+            ],
+        };
+        let s = err.to_string();
+        assert!(s.contains("auth_forward is 'api_key'"), "got: {s}");
+        assert!(s.contains("ANTHROPIC_API_KEY"), "got: {s}");
+        assert!(
+            s.contains("workspace × role × claude    -> api_key"),
+            "got: {s}"
+        );
+        assert!(s.contains("[workspaces.proj.roles.smith.env]"), "got: {s}");
+        assert!(s.contains("Open the Auth panel"), "got: {s}");
+    }
+
+    #[test]
+    fn auth_credential_missing_codex_oauth_token_renders() {
+        let err = LaunchError::AuthCredentialMissing {
+            agent: crate::agent::Agent::Codex,
+            mode: crate::config::AuthForwardMode::ApiKey,
+            env_var: "OPENAI_API_KEY",
+            workspace: "proj".into(),
+            role: "smith".into(),
+            mode_resolution: vec![],
+            env_layers: vec![],
+        };
+        let s = err.to_string();
+        assert!(s.contains("codex"), "got: {s}");
+        assert!(s.contains("OPENAI_API_KEY"), "got: {s}");
     }
 }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1977,7 +1977,6 @@ plugins = []
         let source = crate::config::RoleSource {
             git: "https://github.com/evil-org/jackin-backdoor.git".to_string(),
             trusted: false,
-            claude: None,
             env: std::collections::BTreeMap::new(),
         };
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -95,9 +95,9 @@ pub mod prompt;
 
 pub use animation::{intro_animation, outro_animation, simple_outro};
 pub use output::{
-    CodexSyncState, auth_mode_notice, clear_screen, codex_auth_notice, deprecation_warning, fatal,
-    hint, print_config_table, print_deploying, print_logo, set_terminal_title, shorten_home,
-    step_fail, step_quiet, step_shimmer,
+    CodexSyncState, auth_mode_notice, clear_screen, codex_auth_notice, fatal, hint,
+    print_config_table, print_deploying, print_logo, set_terminal_title, shorten_home, step_fail,
+    step_quiet, step_shimmer,
 };
 pub use prompt::{prompt_choice, require_interactive_stdin, spin_wait};
 

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -193,8 +193,8 @@ pub fn hint(prefix: &str, command: &str, suffix: &str) {
 ///   claude auth: none (ignore — /login required inside the container)
 ///   claude auth: OAuth token (`CLAUDE_CODE_OAUTH_TOKEN` ← <source-reference>)
 ///
-/// `source_reference` is consulted only by the `token` arm; pass the
-/// resolver's source description for the `CLAUDE_CODE_OAUTH_TOKEN`
+/// `source_reference` is consulted only by the env-driven token/api-key
+/// arms; pass the resolver's source description for the relevant env
 /// entry (e.g. `"op://vault/claude/token"` or
 /// `"$CLAUDE_CODE_OAUTH_TOKEN"`). Other modes pass `None`.
 pub fn auth_mode_notice(mode: &str, source_reference: Option<&str>) {
@@ -209,9 +209,15 @@ pub fn auth_mode_notice(mode: &str, source_reference: Option<&str>) {
 fn format_auth_mode_notice_for_test(mode: &str, source_reference: Option<&str>) -> String {
     let label = "claude auth:".color(rgb(PHOSPHOR_GREEN)).bold().to_string();
     let body = match mode {
-        "token" => {
+        // Tasks 10/11 will split per-mode notices; today both env-driven
+        // modes render a token/key notice off the same source_reference.
+        "oauth_token" => {
             let src = source_reference.unwrap_or("CLAUDE_CODE_OAUTH_TOKEN");
             format!("OAuth token ({src})")
+        }
+        "api_key" => {
+            let src = source_reference.unwrap_or("ANTHROPIC_API_KEY");
+            format!("API key ({src})")
         }
         "sync" => "host session (sync)".to_string(),
         "ignore" => "none (ignore — /login required inside the container)".to_string(),
@@ -258,7 +264,7 @@ impl
             // is added, these arms become reachable and the `unreachable!`
             // will fire in tests/debug — preferable to silently routing
             // a new outcome to the wrong notice.
-            (M::Sync | M::Token, O::Skipped) => unreachable!(
+            (M::Sync | M::OAuthToken | M::ApiKey, O::Skipped) => unreachable!(
                 "AuthProvisionOutcome::Skipped should only be returned for AuthForwardMode::Ignore"
             ),
         }
@@ -325,9 +331,9 @@ mod tests {
     }
 
     #[test]
-    fn auth_mode_notice_token_mentions_source_reference() {
+    fn auth_mode_notice_oauth_token_mentions_source_reference() {
         let line = format_auth_mode_notice_for_test(
-            "token",
+            "oauth_token",
             Some("CLAUDE_CODE_OAUTH_TOKEN ← op://vault/claude/token"),
         );
         let clean = strip_ansi(&line);
@@ -423,7 +429,8 @@ mod tests {
         let cases = [
             (M::Sync, O::Synced, CodexSyncState::Synced),
             (M::Sync, O::HostMissing, CodexSyncState::HostMissing),
-            (M::Token, O::TokenMode, CodexSyncState::TokenMode),
+            (M::OAuthToken, O::TokenMode, CodexSyncState::TokenMode),
+            (M::ApiKey, O::TokenMode, CodexSyncState::TokenMode),
             (M::Ignore, O::Skipped, CodexSyncState::Ignored),
         ];
         for (mode, outcome, expected) in cases {

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -139,17 +139,6 @@ pub fn fatal(msg: &str) {
     );
 }
 
-/// One-line yellow deprecation warning to stderr. Used for soft-migration
-/// notices like "config field X is deprecated — migrated to Y".
-pub fn deprecation_warning(msg: &str) {
-    const AMBER: (u8, u8, u8) = (230, 180, 80);
-    eprintln!(
-        "  {} {}",
-        "warning:".color(rgb(AMBER)).bold(),
-        msg.color(rgb(AMBER)),
-    );
-}
-
 pub fn set_terminal_title(title: &str) {
     eprint!("\x1b]0;jackin' \u{00b7} {title}\x07");
     let _ = io::stderr().flush();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -131,6 +131,17 @@ pub struct WorkspaceRoleOverride {
     pub codex: Option<crate::config::CodexAuthConfig>,
 }
 
+impl WorkspaceRoleOverride {
+    /// Returns `true` when this role-override entry carries any
+    /// per-agent auth override (Claude or Codex). Used by the Auth-tab
+    /// renderer to decide whether to materialize a `RoleHeader` row,
+    /// and by the input dispatcher to filter out already-overridden
+    /// roles in the `+ Add` flow.
+    pub const fn has_auth_override(&self) -> bool {
+        self.claude.is_some() || self.codex.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct WorkspaceEdit {
     pub workdir: Option<String>,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -61,6 +61,16 @@ pub struct WorkspaceConfig {
     pub roles: std::collections::BTreeMap<String, WorkspaceRoleOverride>,
     #[serde(default, skip_serializing_if = "KeepAwakeConfig::is_default")]
     pub keep_awake: KeepAwakeConfig,
+    /// Workspace-level Claude auth configuration. Forms the middle
+    /// layer of the 3-layer auth resolver
+    /// (global → workspace → workspace × role × agent). Inert until
+    /// Task 8 wires the resolver to consult this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<crate::config::AgentAuthConfig>,
+    /// Workspace-level Codex auth configuration. See `claude` above —
+    /// same role in the resolver, parallel field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex: Option<crate::config::AgentAuthConfig>,
 }
 
 /// Per-workspace power-management opt-in.
@@ -660,12 +670,37 @@ isolation = "worktree"
             env: BTreeMap::new(),
             roles: BTreeMap::new(),
             keep_awake: KeepAwakeConfig::default(),
+            claude: None,
+            codex: None,
         };
         let err = validate_workspace_config("ws", &workspace).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("nested inside"),
             "validate_workspace_config must surface the nested-worktrees error from validate_isolation_layout; got: {msg}",
+        );
+    }
+
+    #[test]
+    fn parse_workspace_with_agent_auth_blocks() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+
+[claude]
+auth_forward = "api_key"
+
+[codex]
+auth_forward = "sync"
+"#;
+        let cfg: WorkspaceConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            cfg.claude.as_ref().unwrap().auth_forward,
+            crate::config::AuthForwardMode::ApiKey,
+        );
+        assert_eq!(
+            cfg.codex.as_ref().unwrap().auth_forward,
+            crate::config::AuthForwardMode::Sync,
         );
     }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -110,14 +110,25 @@ impl WorkspaceConfig {
 
 /// Per-(workspace × role) operator overrides.
 ///
-/// Currently only `env` is supported; the struct exists as a named type
-/// so future overrides (e.g. `auth_forward`) can be added without a
-/// TOML schema break.
+/// Holds the **most-specific** layer of the 3-layer auth resolver
+/// (global → workspace → workspace × role × agent). The `claude` and
+/// `codex` fields here override anything set at the workspace or global
+/// layer for the matching agent. They are inert until Task 8 wires the
+/// resolver to consult them.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WorkspaceRoleOverride {
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub env: std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    /// Per-(workspace × role) Claude auth override — most-specific
+    /// layer of the 3-layer auth resolver. Inert until Task 8 wires
+    /// the resolver to consult this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude: Option<crate::config::AgentAuthConfig>,
+    /// Per-(workspace × role) Codex auth override. See `claude` above —
+    /// same role in the resolver, parallel field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex: Option<crate::config::AgentAuthConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -729,6 +740,67 @@ OLD = "op://Vault/Item/Field"
             ws.env.get("OLD").expect("OLD env var present"),
             &crate::operator_env::EnvValue::Plain("op://Vault/Item/Field".into()),
             "bare op:// scalar must deserialize as Plain, not OpRef",
+        );
+    }
+
+    #[test]
+    fn parse_workspace_role_override_with_agent_auth() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+
+[roles.smith]
+[roles.smith.claude]
+auth_forward = "oauth_token"
+[roles.smith.codex]
+auth_forward = "ignore"
+"#;
+        let cfg: WorkspaceConfig = toml::from_str(toml).unwrap();
+        let smith = cfg.roles.get("smith").expect("smith role must be present");
+        assert_eq!(
+            smith.claude.as_ref().unwrap().auth_forward,
+            crate::config::AuthForwardMode::OAuthToken,
+        );
+        assert_eq!(
+            smith.codex.as_ref().unwrap().auth_forward,
+            crate::config::AuthForwardMode::Ignore,
+        );
+    }
+
+    #[test]
+    fn parse_workspace_without_agent_auth_blocks() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+"#;
+        let cfg: WorkspaceConfig = toml::from_str(toml).unwrap();
+        assert!(
+            cfg.claude.is_none(),
+            "WorkspaceConfig.claude must default to None"
+        );
+        assert!(
+            cfg.codex.is_none(),
+            "WorkspaceConfig.codex must default to None"
+        );
+    }
+
+    #[test]
+    fn parse_workspace_role_override_without_agent_auth() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+
+[roles.smith]
+"#;
+        let cfg: WorkspaceConfig = toml::from_str(toml).unwrap();
+        let smith = cfg.roles.get("smith").expect("smith role must be present");
+        assert!(
+            smith.claude.is_none(),
+            "role override claude must default to None"
+        );
+        assert!(
+            smith.codex.is_none(),
+            "role override codex must default to None"
         );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -70,7 +70,7 @@ pub struct WorkspaceConfig {
     /// Workspace-level Codex auth configuration. See `claude` above —
     /// same role in the resolver, parallel field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub codex: Option<crate::config::AgentAuthConfig>,
+    pub codex: Option<crate::config::CodexAuthConfig>,
 }
 
 /// Per-workspace power-management opt-in.
@@ -128,7 +128,7 @@ pub struct WorkspaceRoleOverride {
     /// Per-(workspace × role) Codex auth override. See `claude` above —
     /// same role in the resolver, parallel field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub codex: Option<crate::config::AgentAuthConfig>,
+    pub codex: Option<crate::config::CodexAuthConfig>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -781,6 +781,41 @@ allowed_roles = ["smith"]
         assert!(
             cfg.codex.is_none(),
             "WorkspaceConfig.codex must default to None"
+        );
+    }
+
+    #[test]
+    fn reject_codex_oauth_token_in_workspace() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+
+[codex]
+auth_forward = "oauth_token"
+"#;
+        let err = toml::from_str::<WorkspaceConfig>(toml).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not supported for codex"),
+            "expected codex-rejection message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_codex_oauth_token_in_workspace_role_override() {
+        let toml = r#"
+workdir = "/tmp/proj"
+allowed_roles = ["smith"]
+
+[roles.smith]
+[roles.smith.codex]
+auth_forward = "oauth_token"
+"#;
+        let err = toml::from_str::<WorkspaceConfig>(toml).expect_err("must reject");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not supported for codex"),
+            "expected codex-rejection message, got: {msg}"
         );
     }
 

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -387,7 +387,6 @@ mod tests {
             crate::config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -432,7 +431,6 @@ mod tests {
             crate::config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -538,7 +536,6 @@ mod tests {
             crate::config::RoleSource {
                 git: "https://github.com/jackin-project/jackin-agent-smith.git".to_string(),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );

--- a/tests/e2e_auth_modes.rs
+++ b/tests/e2e_auth_modes.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "e2e")]
+//! End-to-end smoke tests covering each (agent, mode) pair against a real
+//! container. Skipped on machines without a docker daemon.
+//!
+//! Run with `cargo nextest run --features e2e` on a host with Docker.
+//!
+//! These skeletons document the expected end-to-end contract for each
+//! (agent, mode) pair. A future task fills in the real docker-driving
+//! logic — for now the bodies `panic!("smoke test stub")` so that anyone
+//! who runs the e2e feature on a docker-equipped host gets a clear
+//! "implement me" signal rather than a silent pass.
+
+use std::process::Command;
+
+fn skip_if_no_docker() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| !o.status.success())
+        .unwrap_or(true)
+}
+
+#[test]
+fn claude_sync_copies_host_credentials() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: Implement smoke test:
+    //   - Pre-seed config with [workspaces.e2e.claude].auth_forward = "sync"
+    //   - Run jackin in docker with claude agent + e2e workspace + smith role
+    //   - Assert container has /home/agent/.claude/.credentials.json matching host
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn claude_api_key_wipes_state_and_injects_env() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: same skeleton, mode = ApiKey
+    //   - Assert /home/agent/.claude/.credentials.json absent inside container
+    //   - Assert ANTHROPIC_API_KEY is present in the agent process env
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn claude_oauth_token_wipes_state_and_injects_env() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: mode = OAuthToken
+    //   - Assert /home/agent/.claude state files absent
+    //   - Assert CLAUDE_CODE_OAUTH_TOKEN is present in the agent process env
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn claude_ignore_wipes_state() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: mode = Ignore
+    //   - Assert /home/agent/.claude state files absent
+    //   - Assert no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN in env
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn codex_sync_copies_host_auth_json() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: mode = Sync
+    //   - Assert container has /home/agent/.codex/auth.json matching host
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn codex_api_key_wipes_auth_json() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: mode = ApiKey
+    //   - Assert /home/agent/.codex/auth.json absent inside container
+    //   - Assert OPENAI_API_KEY is present in the agent process env
+    panic!("smoke test stub — implement when e2e infra is in place");
+}
+
+#[test]
+fn codex_ignore_wipes_auth_json() {
+    if skip_if_no_docker() {
+        return;
+    }
+    // TODO: mode = Ignore
+    //   - Assert /home/agent/.codex/auth.json absent
+    //   - Assert no OPENAI_API_KEY in env
+    panic!("smoke test stub — implement when e2e infra is in place");
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2638,3 +2638,144 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
     assert_eq!(role.key(), "chainargos/agent-smith");
     Ok(())
 }
+
+// ── Auth tab integration test ─────────────────────────────────────────
+//
+// End-to-end coverage of the auth-form save path: open the form on a
+// workspace × Claude row, set mode = api_key + a literal credential,
+// commit the form, save the editor, reload from disk, and assert the
+// persisted TOML carries BOTH the `auth_forward = "api_key"` block AND
+// the `ANTHROPIC_API_KEY` env var.
+//
+// The bug this guards against: prior to the C1 fixup, the auth-form
+// commit only mutated `editor.pending.{claude,codex,roles[*]…}`, but
+// `build_workspace_edit` / `WorkspaceEdit` carried no auth-forward
+// field, so `edit_workspace` re-rendered the workspace table from the
+// parsed-from-disk in-memory copy — silently overwriting the operator's
+// mode change. The credential env var landed (env diff is wired
+// separately) but the mode never reached disk; on reload, the resolver
+// fell back to the global default and ignored the freshly-written key.
+#[test]
+fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    // Start the manager on the Auth tab, cursor on row 0 = workspace ×
+    // Claude.
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config
+        .workspaces
+        .get("big-monorepo")
+        .expect("seed must create big-monorepo")
+        .clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.active_field = FieldFocus::Row(0);
+    state.stage = ManagerStage::Editor(ed);
+
+    // Enter opens the auth-edit form modal on workspace × Claude.
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthForm { .. })),
+        "Enter on auth row 0 must open the auth-form modal; got {:?}",
+        editor(&state).modal
+    );
+
+    // Cycle mode: None → Sync → ApiKey (two Spaces).
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    // Enter advances to credential block (CredentialSource).
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    // Enter again moves into LiteralValue (default credential is Literal).
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    // Type "sk-ant-test".
+    for ch in "sk-ant-test".chars() {
+        handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Char(ch)))?;
+    }
+    // Tab to Save, Enter to commit the form.
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(
+        editor(&state).modal.is_none(),
+        "auth-form save must close the modal"
+    );
+
+    // pending.claude reflects ApiKey, pending.env carries the credential.
+    let pending = &editor(&state).pending;
+    assert_eq!(
+        pending.claude.as_ref().map(|c| c.auth_forward),
+        Some(jackin::config::AuthForwardMode::ApiKey),
+        "form commit must set workspace × claude mode in pending"
+    );
+    assert!(
+        pending.env.contains_key("ANTHROPIC_API_KEY"),
+        "form commit must set credential env var in pending"
+    );
+
+    // Save the editor: `s` opens the ConfirmSave modal (no collapses
+    // expected here since the seed has a single mount), Enter commits
+    // and bounces back to List.
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char('s')),
+    )?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+
+    // Reload AppConfig from disk and assert both halves of the auth
+    // change survived the round-trip.
+    let reloaded = AppConfig::load_or_init(&paths)?;
+    let ws_on_disk = reloaded
+        .workspaces
+        .get("big-monorepo")
+        .expect("workspace must still exist on disk");
+    assert_eq!(
+        ws_on_disk.claude.as_ref().map(|c| c.auth_forward),
+        Some(jackin::config::AuthForwardMode::ApiKey),
+        "reload must see [workspaces.big-monorepo.claude] auth_forward = api_key"
+    );
+    let env_value = ws_on_disk
+        .env
+        .get("ANTHROPIC_API_KEY")
+        .expect("reload must see ANTHROPIC_API_KEY in workspace env");
+    match env_value {
+        jackin::operator_env::EnvValue::Plain(s) => assert_eq!(s, "sk-ant-test"),
+        jackin::operator_env::EnvValue::OpRef(_) => {
+            panic!("expected literal credential, got OpRef")
+        }
+    }
+
+    // Belt-and-braces: read the raw TOML and confirm the literal text is
+    // there. Catches a future regression where a typed accessor papered
+    // over a missing block (e.g. resolver fall-through).
+    let toml = std::fs::read_to_string(&paths.config_file)?;
+    assert!(
+        toml.contains("[workspaces.big-monorepo.claude]"),
+        "raw TOML must carry the workspace claude block; got:\n{toml}"
+    );
+    assert!(
+        toml.contains(r#"auth_forward = "api_key""#),
+        "raw TOML must carry auth_forward = \"api_key\"; got:\n{toml}"
+    );
+    assert!(
+        toml.contains(r#"ANTHROPIC_API_KEY = "sk-ant-test""#),
+        "raw TOML must carry the credential env var; got:\n{toml}"
+    );
+    Ok(())
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2849,3 +2849,31 @@ fn auth_add_role_override_three_step_flow() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut over = WorkspaceRoleOverride::default();
+    over.claude = Some(jackin::config::AgentAuthConfig {
+        auth_forward: jackin::config::AuthForwardMode::Ignore,
+    });
+    ws.roles.insert("the-architect".into(), over);
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
+    ed.active_field = FieldFocus::Row(header_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Right))?;
+    assert!(editor(&state).auth_expanded.contains("the-architect"));
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Left))?;
+    assert!(!editor(&state).auth_expanded.contains("the-architect"));
+    Ok(())
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2639,6 +2639,19 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
     Ok(())
 }
 
+// ── Auth tab helpers ──────────────────────────────────────────────────
+
+use jackin::console::manager::render::editor::{AuthRow, auth_flat_rows};
+use jackin::agent::Agent;
+
+/// Return the flat-row index of the first `AuthRow` that matches `pred`.
+fn auth_row_idx(ed: &EditorState<'_>, pred: impl Fn(&AuthRow) -> bool) -> usize {
+    auth_flat_rows(ed)
+        .iter()
+        .position(pred)
+        .expect("required auth row not found")
+}
+
 // ── Auth tab integration test ─────────────────────────────────────────
 //
 // End-to-end coverage of the auth-form save path: open the form on a
@@ -2662,8 +2675,7 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     let mut config = seed_config(&paths, temp.path())?;
     let cwd = temp.path();
 
-    // Start the manager on the Auth tab, cursor on row 0 = workspace ×
-    // Claude.
+    // Start the manager on the Auth tab, cursor on the workspace × Claude row.
     let mut state = ManagerState::from_config(&config, cwd);
     let ws = config
         .workspaces
@@ -2672,14 +2684,17 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.active_field = FieldFocus::Row(0);
+    let ws_claude_idx = auth_row_idx(&ed, |r| {
+        matches!(r, AuthRow::WorkspaceDefault { agent: Agent::Claude })
+    });
+    ed.active_field = FieldFocus::Row(ws_claude_idx);
     state.stage = ManagerStage::Editor(ed);
 
     // Enter opens the auth-edit form modal on workspace × Claude.
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert!(
         matches!(editor(&state).modal, Some(Modal::AuthForm { .. })),
-        "Enter on auth row 0 must open the auth-form modal; got {:?}",
+        "Enter on WorkspaceDefault/Claude must open AuthForm; got {:?}",
         editor(&state).modal
     );
 
@@ -2777,5 +2792,50 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         toml.contains(r#"ANTHROPIC_API_KEY = "sk-ant-test""#),
         "raw TOML must carry the credential env var; got:\n{toml}"
     );
+    Ok(())
+}
+
+#[test]
+fn auth_add_role_override_three_step_flow() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config
+        .workspaces
+        .get("big-monorepo")
+        .expect("seed must create big-monorepo")
+        .clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+
+    let sentinel_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::AddSentinel { .. }));
+    ed.active_field = FieldFocus::Row(sentinel_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthRolePicker { .. })),
+        "Enter on AddSentinel must open AuthRolePicker; got {:?}",
+        editor(&state).modal
+    );
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthAgentPicker { .. })),
+        "Enter on AuthRolePicker must open AuthAgentPicker; got {:?}",
+        editor(&state).modal
+    );
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    match &editor(&state).modal {
+        Some(Modal::AuthForm {
+            target: jackin::console::manager::state::AuthFormTarget::WorkspaceRole { agent, .. },
+            ..
+        }) => assert_eq!(*agent, Agent::Claude),
+        other => panic!("expected AuthForm/WorkspaceRole, got {other:?}"),
+    }
     Ok(())
 }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2877,3 +2877,62 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
     assert!(!editor(&state).auth_expanded.contains("the-architect"));
     Ok(())
 }
+
+#[test]
+fn auth_role_header_d_opens_confirm_then_clears_overrides() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut over = WorkspaceRoleOverride::default();
+    over.claude = Some(jackin::config::AgentAuthConfig {
+        auth_forward: jackin::config::AuthForwardMode::Ignore,
+    });
+    over.codex = Some(jackin::config::CodexAuthConfig(
+        jackin::config::AgentAuthConfig {
+            auth_forward: jackin::config::AuthForwardMode::ApiKey,
+        },
+    ));
+    ws.roles.insert("the-architect".into(), over);
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
+    ed.active_field = FieldFocus::Row(header_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char('d')),
+    )?;
+    assert!(matches!(
+        editor(&state).modal,
+        Some(Modal::Confirm {
+            target: jackin::console::manager::state::ConfirmTarget::ClearAuthRoleOverride { .. },
+            ..
+        })
+    ));
+
+    // Confirm with 'y' (default focus is No; Enter would dismiss without action).
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char('y')),
+    )?;
+    let role_over = editor(&state)
+        .pending
+        .roles
+        .get("the-architect")
+        .expect("override entry stays even after clear");
+    assert!(role_over.claude.is_none());
+    assert!(role_over.codex.is_none());
+    Ok(())
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -1317,7 +1317,6 @@ fn seed_config_with_agents(
             jackin::config::RoleSource {
                 git: format!("https://example.invalid/jackin-{key}.git"),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );
@@ -1738,7 +1737,6 @@ fn seed_override_picker_workspace(
             jackin::config::RoleSource {
                 git: format!("https://example.invalid/{name}.git"),
                 trusted: true,
-                claude: None,
                 env: std::collections::BTreeMap::new(),
             },
         );

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -5,11 +5,13 @@
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use jackin::{
+    agent::Agent,
     config::{AppConfig, ConfigEditor},
     console::{
         ConsoleStage, ConsoleState,
         manager::{
             ManagerStage, ManagerState, handle_key,
+            render::editor::{AuthRow, auth_flat_rows},
             state::{EditorState, EditorTab, FieldFocus, Modal, TextInputTarget},
         },
     },
@@ -2641,9 +2643,6 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
 
 // ── Auth tab helpers ──────────────────────────────────────────────────
 
-use jackin::console::manager::render::editor::{AuthRow, auth_flat_rows};
-use jackin::agent::Agent;
-
 /// Return the flat-row index of the first `AuthRow` that matches `pred`.
 fn auth_row_idx(ed: &EditorState<'_>, pred: impl Fn(&AuthRow) -> bool) -> usize {
     auth_flat_rows(ed)
@@ -2685,7 +2684,12 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
     let ws_claude_idx = auth_row_idx(&ed, |r| {
-        matches!(r, AuthRow::WorkspaceDefault { agent: Agent::Claude })
+        matches!(
+            r,
+            AuthRow::WorkspaceDefault {
+                agent: Agent::Claude
+            }
+        )
     });
     ed.active_field = FieldFocus::Row(ws_claude_idx);
     state.stage = ManagerStage::Editor(ed);
@@ -2832,9 +2836,15 @@ fn auth_add_role_override_three_step_flow() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     match &editor(&state).modal {
         Some(Modal::AuthForm {
-            target: jackin::console::manager::state::AuthFormTarget::WorkspaceRole { agent, .. },
+            target: jackin::console::manager::state::AuthFormTarget::WorkspaceRole { role, agent },
             ..
-        }) => assert_eq!(*agent, Agent::Claude),
+        }) => {
+            assert_eq!(*agent, Agent::Claude);
+            assert!(
+                !role.is_empty(),
+                "role must propagate from AuthRolePicker → AuthAgentPicker → AuthForm"
+            );
+        }
         other => panic!("expected AuthForm/WorkspaceRole, got {other:?}"),
     }
     Ok(())

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2377,11 +2377,11 @@ fn tab_on_agent_header_advances_tab_normally() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Down))?;
     assert!(matches!(editor(&state).active_field, FieldFocus::Row(2)));
 
-    // `Tab` from Secrets must wrap to General regardless of focus.
+    // `Tab` from Secrets must advance to Auth (the next tab) regardless of focus.
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
     assert_eq!(
         editor(&state).active_tab,
-        EditorTab::General,
+        EditorTab::Auth,
         "Tab on a header must still advance the active tab"
     );
     Ok(())

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2936,3 +2936,55 @@ fn auth_role_header_d_opens_confirm_then_clears_overrides() -> Result<()> {
     assert!(role_over.codex.is_none());
     Ok(())
 }
+
+#[test]
+fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut over = WorkspaceRoleOverride::default();
+    over.claude = Some(jackin::config::AgentAuthConfig {
+        auth_forward: jackin::config::AuthForwardMode::Ignore,
+    });
+    over.codex = Some(jackin::config::CodexAuthConfig(
+        jackin::config::AgentAuthConfig {
+            auth_forward: jackin::config::AuthForwardMode::ApiKey,
+        },
+    ));
+    ws.roles.insert("the-architect".into(), over);
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_expanded.insert("the-architect".into());
+    let claude_idx = auth_row_idx(&ed, |r| {
+        matches!(
+            r,
+            AuthRow::RoleAgentRow {
+                agent: jackin::agent::Agent::Claude,
+                ..
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(claude_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char('d')),
+    )?;
+    assert!(
+        editor(&state).modal.is_none(),
+        "single-agent clear must be silent (no modal)"
+    );
+    let ro = editor(&state).pending.roles.get("the-architect").unwrap();
+    assert!(ro.claude.is_none());
+    assert!(ro.codex.is_some(), "Codex override must be untouched");
+    Ok(())
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -415,7 +415,11 @@ fn secrets_agent_section_expand_collapse() -> Result<()> {
     let mut roles = std::collections::BTreeMap::new();
     roles.insert(
         "agent-smith".into(),
-        WorkspaceRoleOverride { env: role_env },
+        WorkspaceRoleOverride {
+            env: role_env,
+            claude: None,
+            codex: None,
+        },
     );
     let ws = WorkspaceConfig {
         workdir: host_path.clone(),
@@ -1600,7 +1604,11 @@ fn env_key_modal_blocks_duplicate_agent_key() -> Result<()> {
     let mut roles = std::collections::BTreeMap::new();
     roles.insert(
         "agent-smith".into(),
-        WorkspaceRoleOverride { env: role_env },
+        WorkspaceRoleOverride {
+            env: role_env,
+            claude: None,
+            codex: None,
+        },
     );
     let ws = WorkspaceConfig {
         workdir: host_path.clone(),
@@ -1751,7 +1759,14 @@ fn seed_override_picker_workspace(
             "LOG_LEVEL".into(),
             jackin::operator_env::EnvValue::Plain("debug".into()),
         );
-        roles_map.insert((*name).into(), WorkspaceRoleOverride { env });
+        roles_map.insert(
+            (*name).into(),
+            WorkspaceRoleOverride {
+                env,
+                claude: None,
+                codex: None,
+            },
+        );
     }
 
     let ws = WorkspaceConfig {


### PR DESCRIPTION
## Summary

Implements the spec at `docs/superpowers/specs/2026-05-05-agent-auth-config-redesign.md` and rebuilds the workspace-manager Auth tab to mirror the Environments tab. Layered per-agent auth configuration at three levels (global → workspace → workspace × role × agent), generalized to Claude and Codex, with a sentinel-driven 3-step add flow, lazy role-override rendering, and 1Password picker integration.

**Breaking change** per `AGENTS.md` "Project status: pre-release". Stale configs that still use `[roles.<role>.claude]` blocks fail to parse. No migration shim.

## What's in this PR

- ~40+ commits, +5800/-940 lines.
- 1534 unit/integration tests passing on the merged branch.
- `cargo fmt --check`, `cargo clippy --lib -- -D warnings`, `cargo nextest run` all clean.
- Merged with `main` (PRs #225, #227, #228); `WorkspaceConfig` now carries both the new `claude`/`codex` auth fields and `git_pull_on_entry`.

### Schema

- `AuthForwardMode` variants: `sync` (default) / `api_key` / `oauth_token` (Claude only) / `ignore`. The old `Token` variant renamed to `OAuthToken`; deprecated `"copy"` alias removed.
- `AgentAuthConfig` wrapper at all three layers; `CodexAuthConfig` newtype rejects `oauth_token` at parse time.
- Per-role-global `[roles.<role>.claude]` slot deleted (compile-error parse rejection).
- 3-layer resolver `resolve_mode(cfg, agent, ws, role)` walks most-specific first.

### Provisioning + Launch

- `provision_claude_auth` / `provision_codex_auth` dispatch on resolved mode (Sync copies host; ApiKey/OAuthToken/Ignore wipe state).
- `wipe_claude_state` / `wipe_codex_state` helpers extracted.
- `LaunchError::AuthCredentialMissing` carries structured `mode_resolution` and `env_layers` fields.
- `verify_credential_env_present(agent, mode, ...)` driven by `Agent::required_env_var(mode)` table.

### TUI Auth tab — Environments-style redesign

The Auth tab now mirrors the Secrets/Environments tab's lazy, sentinel-driven shape:

- Single `auth_flat_rows()` row model — both rendering and input dispatch index into the same `Vec<AuthRow>`, eliminating the row-index drift that motivated the rewrite.
- `AuthRow` variants: `GlobalHeader`, `GlobalDefault`, `WorkspaceHeader`, `WorkspaceDefault`, `OverridesHeader`, `RoleHeader`, `RoleAgentRow`, `AddSentinel`, `Divider`.
- Per-role overrides render only when set; the panel starts with just the read-only Global block, the editable Workspace defaults, and a `+ Add per-role override (N eligible)` sentinel.
- 3-step add flow: Enter on the sentinel → `RolePicker` → `AgentChoice` (new 2-row Claude/Codex widget) → existing `AuthForm` modal mounts with `WorkspaceRole { role, agent }` target.
- `←` / `→` collapse/expand a role header; cursor stays absorbed (Tab still cycles tabs).
- `D` on a role header opens a confirm modal that wipes both agents' overrides for that role; `D` on a single agent row silently clears just that one.
- Footer-only provenance hint: when focused on a `RoleAgentRow`, the editor footer shows `<role> / <Agent> · <mode> (overrides workspace default | inherits workspace default | inherits global default)`.
- Zero-eligible sentinel (every role already has an override) renders dimmed with `(all roles overridden)` so silent no-op is visibly differentiated from "Enter is broken".
- The old `AuthPanelState` precomputed view-model and the `auth_panel::render` / `auth_panel::render_with_selection` surfaces are removed entirely (no shim, per pre-release rule).
- `AuthForm` modal itself is unchanged — same Mode/CredentialSource/Save flow, same 1Password `try_commit_op_ref` contract.

### Tests

- 5 row-shape unit tests in `auth_flat_rows_tests`.
- 4 widget tests for `AgentChoice` Up/Down clamp + Enter commit + Esc cancel.
- 3 `badge_for` tests covering `Resolves` / `Unset` / `NotApplicable`.
- 3 e2e tests in `tests/manager_flow.rs`:
  - `auth_form_save_persists_mode_and_credential_to_disk` — open form → save → reload from disk → assert TOML.
  - `auth_add_role_override_three_step_flow` — drives Enter on sentinel → role picker → agent picker → form.
  - `auth_role_header_left_right_toggles_expansion`, `auth_role_header_d_opens_confirm_then_clears_overrides`, `auth_role_agent_row_d_silently_clears_single_agent`.
- Pre-existing integration test rebased onto dynamic `auth_flat_rows` lookup (no hardcoded row indices).

### Docs

- `docs/src/content/docs/guides/authentication.mdx` rewritten to describe the new 3-section layout and the sentinel-driven add flow.
- Stale references to `[roles.<r>.claude]`, the `copy` alias, the `Token` mode, and `auth set --role` removed across all docs.
- `AGENTS.md` extended with a "verify subcommand against `--help` before quoting it" rule + a CLI cheat-sheet.

### CHANGELOG

The `Unreleased` section has been intentionally cleared on this branch — release notes will be assembled at version-cut time rather than accreted on the feature branch.

## Test plan

- [x] CI passes (`cargo fmt --check`, `cargo clippy --lib -- -D warnings`, `cargo nextest run`).
- [ ] Manual smoke (defer to follow-up PR per operator):
  - Open `jackin console --debug`, navigate to a workspace, Auth tab.
  - Cursor on `+ Add per-role override`, Enter → role picker → agent picker → form. Save with `api_key` + literal credential.
  - `→` expands the new role row; `←` collapses.
  - `D` on the role header opens confirm modal; `D` on a single agent row silently clears.
  - Footer hint shows resolved mode + provenance for focused override row.
  - With `mode = "api_key"` set but no `ANTHROPIC_API_KEY`, `jackin load <role> --debug` returns the structured `LaunchError::AuthCredentialMissing` trace.
  - Stale `[roles.<r>.claude]` block in config fails to parse with `unknown field 'claude'`.

## Known follow-ups (deferred)

- Auth tab footer hint doesn't surface Reset action.
- `ErrorPopup`-on-read-failure clobbers `AuthForm` modal (operator must re-open form to retry).
- `tests/e2e_auth_modes.rs` stubs need real-docker implementations.
- Roadmap doc `docs/src/content/docs/reference/roadmap/claude-auth-strategy.mdx` references the now-removed `copy` migration — separate roadmap-cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)