### PR TITLE
feat(cli): add --role-branch flag to jackin load for PR branch testing

### DIFF
--- a/docs/src/content/docs/commands/load.mdx
+++ b/docs/src/content/docs/commands/load.mdx
@@ -28,6 +28,7 @@ Load an agent into an isolated Docker container. This is the primary command for
 |---|---|
 | `--mount <SPEC>` | Additional bind-mount spec. Repeatable. Format: `path[:ro]` or `src:dst[:ro]` |
 | `--rebuild` | Force rebuild the Docker image and refresh agent CLI install layers |
+| `--role-branch <BRANCH>` | Check out a specific branch of the role repository for local testing. See **Testing a role branch** below. |
 | `--force` | Acknowledge a dirty host working tree when materializing an isolated mount in non-interactive mode. Required only when (a) the workspace has at least one `worktree`-isolated mount and (b) the host repo's tree has staged, unstaged-tracked, or untracked files. Ignored otherwise. |
 | `--no-intro` | Skip the animated intro sequence |
 | `--debug` | Print raw container output for troubleshooting |
@@ -59,20 +60,24 @@ jackin load agent-smith big-monorepo --mount ~/extra-data
 
 # Path with read-only additional mount
 jackin load agent-smith ~/app --mount ~/cache:/cache:ro
+
+# Build and test a specific role branch locally before it merges
+jackin load the-architect --role-branch feat/my-pr
 ```
 
 ## What happens
 
-1. Resolves the role and clones/updates its repository
+1. Resolves the role and clones/updates its repository (or the specified branch when `--role-branch` is set)
 2. Validates the role repo contract (`jackin.role.toml` + Dockerfile) with strict manifest parsing
 3. **If the agent source has never been trusted**, prompts the operator to review and confirm before proceeding (see [Agent source trust](/guides/security-model#4-agent-source-trust))
-4. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
-5. Prompts for interactive environment variables declared in the manifest
-6. Generates and builds a derived Docker image (cached if unchanged)
-7. Creates a per-agent Docker network and DinD sidecar
-8. Launches the agent container with all resolved mounts and environment variables
-9. Runs the pre-launch hook if declared
-10. Starts Claude Code with `--dangerously-skip-permissions`
+4. **If `--role-branch` is set**, always prompts to confirm the branch is safe to build, regardless of the role's trust status (see [Branch trust gate](/guides/security-model#branch-trust-gate))
+5. Checks resolved mounts for sensitive host paths (`~/.ssh`, `~/.aws`, etc.) and prompts for confirmation if any are detected
+6. Prompts for interactive environment variables declared in the manifest
+7. Generates and builds a derived Docker image (cached if unchanged; branch builds ignore `published_image` and always build from source)
+8. Creates a per-agent Docker network and DinD sidecar
+9. Launches the agent container with all resolved mounts and environment variables
+10. Runs the pre-launch hook if declared
+11. Starts Claude Code with `--dangerously-skip-permissions`
 
 <Aside type="note">
 If the agent manifest declares interactive environment variables, `jackin load` prompts for their values before building the Docker image. This ensures no build time is wasted if you cancel.
@@ -89,6 +94,62 @@ If two resolved mounts target the same container destination, `jackin load` fail
 <Aside type="tip">
 If no selector is given and the current directory falls under a saved workspace's host `workdir` or one of its mounted host paths, that workspace's default or last-used agent is used automatically.
 </Aside>
+## Testing a role branch (`--role-branch`)
+
+`--role-branch` lets you build and run a specific branch of a role repository locally before it merges to the default branch. This is the intended workflow for verifying a PR on a role repo (for example, checking that a Dockerfile change works end-to-end) without affecting your stable local image or other operators who may share the same role.
+
+```bash
+jackin load the-architect --role-branch feat/caveman-all-install
+```
+
+### What changes when `--role-branch` is set
+
+| Behaviour | Default | With `--role-branch` |
+|---|---|---|
+| Role repo cache path | `~/.jackin/roles/<name>/` | `~/.jackin/roles/<name>/branches/<branch>/` |
+| Image tag | `jackin-<name>` | `jackin-<name>-<branch-slug>` |
+| Uses `published_image` | Yes (if declared in manifest) | No — always builds from the branch Dockerfile |
+| Docker layer cache | Used | Used (no forced rebuild unless `--rebuild` is also passed) |
+| Repo lock file | Shared with default-branch loads | Separate — branch builds never block default-branch loads |
+| Trust confirmation | First-use only | **Always** — regardless of the role's trusted status |
+
+The branch cache (`branches/<branch>/`) is completely separate from the default-branch cache. Running `jackin load the-architect` after a branch build still uses the unchanged default-branch image.
+
+Branch names with slashes are preserved as nested directories on disk (`feat/my-pr` → `branches/feat/my-pr/`), so a branch named `feat/my-pr` and one named `feat-my-pr` are always stored at distinct paths and use distinct lock files.
+
+### Branch trust gate
+
+Every `--role-branch` load triggers an interactive confirmation, even for roles you have already trusted:
+
+```
+!! Unreviewed branch — verify before proceeding !!
+
+  role:   the-architect
+  source: https://github.com/jackin-project/jackin-the-architect.git
+  branch: feat/caveman-all-install
+
+  This branch has not been merged to the default branch.
+  Its Dockerfile and scripts may differ from the trusted main branch.
+  A malicious contributor could introduce harmful code that runs
+  on your machine during the image build.
+
+  Review the branch diff in the role repository before continuing.
+
+Have you reviewed branch "feat/caveman-all-install" and verified it is safe to build? [y/N]
+```
+
+This gate exists because `trusted = true` in your config covers the default branch of a role, not every PR branch an external contributor might open against it. See [Branch trust gate](/guides/security-model#branch-trust-gate) for the full threat model.
+
+`--role-branch` requires an interactive terminal. Non-interactive contexts (CI, scripts) will exit with an error — this is intentional.
+
+### Combining with `--rebuild`
+
+`--role-branch` alone does not bust the Docker layer cache. If you push new commits to the branch and want a clean rebuild:
+
+```bash
+jackin load the-architect --role-branch feat/my-pr --rebuild
+```
+
 ## Dirty-host acknowledgement (`--force`)
 
 When a workspace mount has `isolation = "worktree"`, `jackin load` materializes a new `git worktree` from the host repo's current `HEAD` before starting the container. If the host tree is dirty (staged changes, unstaged tracked changes, or untracked files — ignored files do not count), those edits stay on the host and are **not** carried into the agent's worktree.

--- a/docs/src/content/docs/guides/security-model.mdx
+++ b/docs/src/content/docs/guides/security-model.mdx
@@ -90,6 +90,35 @@ trusted = true
 <Aside type="note">
 Trust is tied to the agent selector (e.g., `org/agent-name`), not the git URL. If an agent's cached repo URL no longer matches the configured source, jackin' rejects it with a separate remote-mismatch error regardless of trust status.
 </Aside>
+### Branch trust gate
+
+Loading a role from an unmerged branch (`--role-branch`) triggers a separate, always-on confirmation prompt — even if the role is already trusted.
+
+The reason: `trusted = true` in your config records that you reviewed the role's **default branch**. An external contributor can open a pull request on that same role repository with a modified Dockerfile that runs arbitrary commands during the image build. If you loaded the branch without a prompt, you could unknowingly execute code you never reviewed, in a context where you expected the behaviour of the trusted default branch.
+
+The branch trust gate shows the role, source repository, and branch name, then asks you to confirm that you have reviewed the diff:
+
+```
+!! Unreviewed branch — verify before proceeding !!
+
+  role:   the-architect
+  source: https://github.com/jackin-project/jackin-the-architect.git
+  branch: feat/some-pr
+
+  This branch has not been merged to the default branch.
+  Its Dockerfile and scripts may differ from the trusted main branch.
+  A malicious contributor could introduce harmful code that runs
+  on your machine during the image build.
+
+  Review the branch diff in the role repository before continuing.
+
+Have you reviewed branch "feat/some-pr" and verified it is safe to build? [y/N]
+```
+
+This gate cannot be bypassed: there is no `--force-branch` flag, no config option to skip it, and non-interactive terminals bail with an error rather than defaulting to yes.
+
+The threat model entry for this is listed in the table below.
+
 ### 5. Per-agent network separation
 
 Each runtime gets its own Docker network. The agent container and its DinD sidecar share that network, but different agents do not share a network by default.
@@ -190,6 +219,7 @@ jackin' is designed to reduce the most common operator risks:
 | Agent interferes with another agent | Separate containers, networks, and state | Shared host kernel remains a common lower layer |
 | Agent persists random system changes | Runtime root filesystem is ephemeral | Persisted tool state and mounted files still survive |
 | Typosquatted or malicious role repo | Trust-on-first-use prompt before building | User must review the source; trusted flag persists |
+| Malicious code in an unmerged PR branch | Branch trust gate always fires for `--role-branch` | User must confirm they reviewed the branch diff; cannot be skipped |
 
 ## What jackin' does NOT protect against
 
@@ -209,6 +239,7 @@ This is where people often over-claim container isolation. Don't do that. jackin
 3. **Do not mount credential directories.** Avoid `~/.ssh`, `~/.aws`, `~/.gnupg`, and similar paths. jackin' warns and asks for confirmation when it detects these, but avoiding them entirely is the safest approach.
 4. **Treat runtime login as sensitive.** If you authenticate inside the runtime, assume the agent can read that state.
 5. **Review role repos before loading.** The Dockerfile defines what the runtime contains. jackin' prompts for trust confirmation on first use of third-party agents, but you should inspect the repository yourself before confirming.
-6. **Split roles by scope.** Keep frontend, backend, infra, and review workflows in separate environments when appropriate.
-7. **Use `jackin purge` when a runtime no longer needs its persisted state.**
-8. **Keep Docker updated.** Container isolation is only as strong as the Docker runtime underneath it.
+6. **Always review the branch diff before loading a role branch.** `--role-branch` always prompts for confirmation, but the prompt is only as useful as your review. Open the pull request, check the Dockerfile and any scripts, and confirm only after you understand what changed.
+7. **Split roles by scope.** Keep frontend, backend, infra, and review workflows in separate environments when appropriate.
+8. **Use `jackin purge` when a runtime no longer needs its persisted state.**
+9. **Keep Docker updated.** Container isolation is only as strong as the Docker runtime underneath it.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -60,6 +60,7 @@ pub fn run(cli: Cli) -> Result<()> {
             debug,
             force,
             agent,
+            role_branch,
         }) => {
             runner.debug = debug;
             tui::set_debug_mode(debug);
@@ -113,6 +114,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     prompt_agent_choice_if_needed(&paths, &class, resolved_workspace.default_agent)?
                 }
             };
+            opts.role_branch = role_branch;
             // Pre-launch reconcile: if a previous role in a keep_awake
             // workspace already runs, ensure caffeinate is up before we
             // build/launch (so a long Docker build doesn't see the host

--- a/src/cli/role.rs
+++ b/src/cli/role.rs
@@ -25,7 +25,8 @@ Examples:
   jackin load agent-smith ~/Projects/my-app:/app
   jackin load agent-smith big-monorepo
   jackin load agent-smith big-monorepo --mount ~/extra-data
-  jackin load agent-smith ~/app --mount ~/cache:/cache:ro"
+  jackin load agent-smith ~/app --mount ~/cache:/cache:ro
+  jackin load the-architect --role-branch feat/my-pr   # build + test a PR branch locally"
 )]
 pub struct LoadArgs {
     /// Role class selector (e.g. `agent-smith`, `chainargos/agent-brown`).
@@ -67,6 +68,12 @@ pub struct LoadArgs {
     /// neither is set, defaults to claude.
     #[arg(long, value_parser = parse_agent)]
     pub agent: Option<crate::agent::Agent>,
+    /// Check out a specific branch of the role repository for local testing.
+    /// The published image is ignored and the image is built from the branch's
+    /// Dockerfile using Docker's layer cache. Useful for verifying a PR before
+    /// it merges to the default branch.
+    #[arg(long)]
+    pub role_branch: Option<String>,
 }
 
 fn parse_agent(s: &str) -> Result<crate::agent::Agent, String> {
@@ -176,6 +183,37 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Load(super::LoadArgs { agent: None, .. }))
+        ));
+    }
+
+    #[test]
+    fn load_args_parses_branch_flag() {
+        let cli = Cli::try_parse_from([
+            "jackin",
+            "load",
+            "the-architect",
+            "--role-branch",
+            "feat/my-pr",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Load(super::LoadArgs {
+                role_branch: Some(ref b),
+                ..
+            })) if b == "feat/my-pr"
+        ));
+    }
+
+    #[test]
+    fn load_args_branch_optional() {
+        let cli = Cli::try_parse_from(["jackin", "load", "the-architect"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Load(super::LoadArgs {
+                role_branch: None,
+                ..
+            }))
         ));
     }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -22,6 +22,24 @@ impl CachedRepo {
             repo_dir,
         }
     }
+
+    /// Cache directory isolated to a specific branch, leaving the default-branch
+    /// cache entry untouched. The branch name is used directly as a path
+    /// component so `feat/my-pr` lives at `…/branches/feat/my-pr` — a branch
+    /// named `feat-my-pr` (with a dash) would live at `…/branches/feat-my-pr`,
+    /// which is a different path, eliminating any ambiguity.
+    pub fn for_branch(paths: &JackinPaths, selector: &RoleSelector, branch: &str) -> Self {
+        let base = selector.namespace.as_ref().map_or_else(
+            || paths.roles_dir.join(&selector.name),
+            |namespace| paths.roles_dir.join(namespace).join(&selector.name),
+        );
+        Self {
+            key: format!("{}@{branch}", selector.key()),
+            // Path::join handles forward slashes as directory separators, so
+            // "feat/my-pr" naturally becomes …/branches/feat/my-pr on disk.
+            repo_dir: base.join("branches").join(branch),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -21,6 +21,7 @@ pub(super) fn build_agent_image(
     rebuild: bool,
     agent_update: bool,
     debug: bool,
+    branch_override: Option<&str>,
     runner: &mut impl CommandRunner,
     repo_lock: std::fs::File,
 ) -> anyhow::Result<String> {
@@ -34,7 +35,10 @@ pub(super) fn build_agent_image(
     // Workspace mode: either `--rebuild` was requested or no `published_image`
     // is declared. We build from the workspace Dockerfile from scratch.
     let published_image = validated_repo.manifest.published_image.as_deref();
-    let use_prebuilt = published_image.is_some() && !rebuild;
+    // Branch builds always use the workspace Dockerfile regardless of
+    // `published_image` — the operator is testing uncommitted code that has
+    // not been pushed to the registry.
+    let use_prebuilt = published_image.is_some() && !rebuild && branch_override.is_none();
     let base_image_override = use_prebuilt.then(|| published_image.unwrap());
 
     // create_derived_build_context copies the repo into a temp directory,
@@ -57,7 +61,10 @@ pub(super) fn build_agent_image(
             .dimmed()
         );
     }
-    let image = image_name(selector);
+    let image = branch_override.map_or_else(
+        || image_name(selector),
+        |b| super::naming::image_name_for_branch(selector, b),
+    );
 
     let build_arg_uid = format!("JACKIN_HOST_UID={}", host.uid);
     let build_arg_gid = format!("JACKIN_HOST_GID={}", host.gid);

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -16,7 +16,7 @@ use super::identity::{GitIdentity, build_config_rows, load_git_identity, load_ho
 use super::image::build_agent_image;
 use super::naming::{
     LABEL_KEEP_AWAKE, LABEL_KIND_DIND, LABEL_KIND_ROLE, LABEL_MANAGED, dind_certs_volume,
-    format_role_display, image_name,
+    format_role_display, image_name, image_name_for_branch,
 };
 use super::repo_cache::resolve_agent_repo;
 
@@ -48,6 +48,12 @@ pub struct LoadOptions {
     /// CLI override for the agent. `None` means "use the workspace's
     /// `default_agent` field, falling back to `Agent::Claude` when unset".
     pub agent: Option<crate::agent::Agent>,
+
+    /// When set, resolve this branch of the role repo instead of the default
+    /// branch, build the image locally from the branch's Dockerfile (ignoring
+    /// any `published_image`), and tag it with a branch-specific name so the
+    /// stable image is not overwritten.
+    pub role_branch: Option<String>,
 }
 
 impl LoadOptions {
@@ -61,6 +67,7 @@ impl LoadOptions {
             op_runner: None,
             host_env: None,
             agent: None,
+            role_branch: None,
         }
     }
 
@@ -75,6 +82,7 @@ impl LoadOptions {
             op_runner: None,
             host_env: None,
             agent: None,
+            role_branch: None,
         }
     }
 }
@@ -89,6 +97,7 @@ impl Default for LoadOptions {
             op_runner: None,
             host_env: None,
             agent: None,
+            role_branch: None,
         }
     }
 }
@@ -355,6 +364,72 @@ fn export_host_terminfo(
 
 /// Display an untrusted-role warning and ask the operator to confirm.
 /// Aborts when stdin is not a terminal or the operator declines.
+/// Branch-specific trust confirmation.
+///
+/// Even when a role is already trusted, an unmerged branch contains unreviewed
+/// code. The operator trusted the *default* branch, not this PR. A malicious
+/// contributor could craft a branch whose Dockerfile runs arbitrary commands
+/// during the image build on the operator's machine.
+///
+/// This gate always fires when `--role-branch` is set, regardless of the
+/// role's `trusted` state in config. It is intentionally separate from
+/// `confirm_agent_trust` so the two gates compose: loading an *untrusted*
+/// role on a branch requires confirming both.
+fn confirm_branch_trust(
+    selector: &RoleSelector,
+    source: &crate::config::RoleSource,
+    branch: &str,
+) -> anyhow::Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "role \"{selector}\" is being loaded from unmerged branch \"{branch}\".\n\
+             Branch builds require interactive confirmation — run the command in a terminal."
+        );
+    }
+
+    eprintln!();
+    eprintln!(
+        "{}",
+        "!! Unreviewed branch — verify before proceeding !!"
+            .red()
+            .bold()
+    );
+    eprintln!();
+    eprintln!("  role:   {}", selector.to_string().bold());
+    eprintln!("  source: {}", source.git.yellow());
+    eprintln!("  branch: {}", branch.yellow().bold());
+    eprintln!();
+    eprintln!(
+        "  {}",
+        "This branch has not been merged to the default branch.".bold()
+    );
+    eprintln!("  Its Dockerfile and scripts may differ from the trusted main branch.");
+    eprintln!("  A malicious contributor could introduce harmful code that runs");
+    eprintln!("  on your machine during the image build.");
+    eprintln!();
+    eprintln!(
+        "  {}",
+        "Review the branch diff in the role repository before continuing.".dimmed()
+    );
+    eprintln!();
+
+    let confirmed = dialoguer::Confirm::new()
+        .with_prompt(format!(
+            "Have you reviewed branch \"{branch}\" and verified it is safe to build?"
+        ))
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        anyhow::bail!(
+            "branch \"{branch}\" not confirmed — aborting.\n\
+             Review the Dockerfile and scripts on that branch before loading it."
+        );
+    }
+
+    Ok(())
+}
+
 fn confirm_agent_trust(
     selector: &RoleSelector,
     source: &crate::config::RoleSource,
@@ -886,10 +961,11 @@ pub fn load_role(
         runner,
         opts,
         confirm_agent_trust,
+        confirm_branch_trust,
     )
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 fn load_role_with(
     paths: &JackinPaths,
     config: &mut AppConfig,
@@ -898,6 +974,7 @@ fn load_role_with(
     runner: &mut impl CommandRunner,
     opts: &LoadOptions,
     confirm_trust: impl FnOnce(&RoleSelector, &crate::config::RoleSource) -> anyhow::Result<()>,
+    confirm_branch: impl FnOnce(&RoleSelector, &crate::config::RoleSource, &str) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     // Pre-launch garbage collection: remove orphaned DinD containers and
     // networks left behind by hard kills, terminal closures, or startup
@@ -924,8 +1001,14 @@ fn load_role_with(
     // Step 1: Resolve role identity (clone or update repo)
     steps.next("Resolving role identity");
 
-    let (cached_repo, validated_repo, repo_lock) =
-        resolve_agent_repo(paths, selector, &source.git, runner, opts.debug)?;
+    let (cached_repo, validated_repo, repo_lock) = resolve_agent_repo(
+        paths,
+        selector,
+        &source.git,
+        runner,
+        opts.debug,
+        opts.role_branch.as_deref(),
+    )?;
 
     // Trust gate: prompt the operator before running an untrusted third-party role
     let newly_trusted = if source.trusted {
@@ -955,12 +1038,21 @@ fn load_role_with(
     let agent = resolve_agent(opts.agent, workspace.default_agent);
     validate_agent_supported(selector, &validated_repo.manifest, agent)?;
 
+    // Branch trust gate: fires even for already-trusted roles because the
+    // operator trusted the default branch, not this unreviewed PR branch.
+    if let Some(branch) = opts.role_branch.as_deref() {
+        confirm_branch(selector, &source, branch)?;
+    }
+
     // Logo (if present in role repo)
     tui::print_logo(&cached_repo.repo_dir.join("logo.txt"));
 
     // Show a preliminary config summary (container name will be
     // confirmed after the image build, right before launch).
-    let image_tag = image_name(selector);
+    let image_tag = opts.role_branch.as_deref().map_or_else(
+        || image_name(selector),
+        |b| image_name_for_branch(selector, b),
+    );
     let preliminary_name = primary_container_name(selector);
     let config_rows = build_config_rows(
         &agent_display_name,
@@ -1088,6 +1180,7 @@ fn load_role_with(
             rebuild,
             agent_update,
             opts.debug,
+            opts.role_branch.as_deref(),
             runner,
             repo_lock,
         )?;
@@ -2164,6 +2257,7 @@ plugins = ["code-review@claude-plugins-official"]
             &mut runner,
             &LoadOptions::default(),
             auto_trust,
+            |_, _, _| Ok(()),
         )
         .unwrap();
 
@@ -2252,6 +2346,7 @@ plugins = []
             &mut runner,
             &LoadOptions::default(),
             deny_trust,
+            |_, _, _| Ok(()),
         )
         .unwrap_err();
 

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -55,6 +55,14 @@ pub(super) fn image_name(selector: &RoleSelector) -> String {
     format!("jackin-{}", crate::instance::runtime_slug(selector))
 }
 
+/// Image tag for a branch-specific local build. Branch slashes become dashes
+/// so the tag is a valid Docker name and does not overwrite the stable image
+/// (e.g. `jackin-the-architect-feat-my-pr`).
+pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
+    let slug = branch.replace('/', "-").to_ascii_lowercase();
+    format!("jackin-{}-{slug}", crate::instance::runtime_slug(selector))
+}
+
 /// Docker volume name for the TLS client certificates shared between the
 /// `DinD` sidecar (writer) and the role container (reader).
 pub(super) fn dind_certs_volume(container_name: &str) -> String {

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -112,6 +112,7 @@ pub(super) fn resolve_agent_repo(
     git_url: &str,
     runner: &mut impl CommandRunner,
     debug: bool,
+    branch_override: Option<&str>,
 ) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedRoleRepo, std::fs::File)> {
     resolve_agent_repo_with(
         paths,
@@ -119,6 +120,7 @@ pub(super) fn resolve_agent_repo(
         git_url,
         runner,
         debug,
+        branch_override,
         confirm_repo_removal_interactive,
     )
 }
@@ -148,7 +150,7 @@ pub(super) fn register_agent_repo(
     let cached_repo = CachedRepo::new(paths, selector);
     if cached_repo.repo_dir.join(".git").is_dir() {
         let (cached_repo, validated_repo, _lock_file) =
-            resolve_agent_repo_with(paths, selector, git_url, runner, debug, || Ok(false))?;
+            resolve_agent_repo_with(paths, selector, git_url, runner, debug, None, || Ok(false))?;
         persist_registration()?;
         return Ok((cached_repo, validated_repo));
     }
@@ -217,15 +219,30 @@ pub(super) fn register_agent_repo(
     Ok((cached_repo, validated_repo))
 }
 
+/// Build the argument list for `git clone`, optionally scoped to a single branch.
+/// `git clone -b <branch>` fetches only that branch, making the clone faster and
+/// leaving the working tree on the right branch without a separate checkout step.
+fn clone_args<'a>(git_url: &'a str, dest: &'a str, branch: Option<&'a str>) -> Vec<&'a str> {
+    branch.map_or_else(
+        || vec!["clone", git_url, dest],
+        |b| vec!["clone", "-b", b, git_url, dest],
+    )
+}
+
+#[allow(clippy::too_many_lines)]
 pub(super) fn resolve_agent_repo_with(
     paths: &JackinPaths,
     selector: &RoleSelector,
     git_url: &str,
     runner: &mut impl CommandRunner,
     debug: bool,
+    branch_override: Option<&str>,
     confirm_removal: impl FnOnce() -> anyhow::Result<bool>,
 ) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedRoleRepo, std::fs::File)> {
-    let cached_repo = CachedRepo::new(paths, selector);
+    let cached_repo = branch_override.map_or_else(
+        || CachedRepo::new(paths, selector),
+        |branch| CachedRepo::for_branch(paths, selector, branch),
+    );
     let repo_parent = cached_repo.repo_dir.parent().ok_or_else(|| {
         anyhow::anyhow!(
             "role repo path has no parent: {}",
@@ -239,10 +256,33 @@ pub(super) fn resolve_agent_repo_with(
     // role class (spawning clones); the lock serializes only the git
     // clone/fetch/merge so they don't race on the same working tree.
     // The lock is released as soon as the git section completes.
-    let lock_path = paths
-        .data_dir
-        .join(format!("{}.repo.lock", primary_container_name(selector)));
-    std::fs::create_dir_all(&paths.data_dir)?;
+    //
+    // Lock path mirrors the repo_dir path under data_dir so that a branch
+    // named `feat/my-pr` and one named `feat-my-pr` (slug collision) always
+    // get distinct lock files. The roles_dir prefix is stripped to produce
+    // the relative path; `std::fs::create_dir_all` creates intermediate dirs.
+    let selector_base = selector.namespace.as_ref().map_or_else(
+        || paths.roles_dir.join(&selector.name),
+        |ns| paths.roles_dir.join(ns).join(&selector.name),
+    );
+    let rel = cached_repo
+        .repo_dir
+        .strip_prefix(&selector_base)
+        .unwrap_or_else(|_| std::path::Path::new(""));
+    // Build lock path: data_dir/<container>.locks/<rel>.repo.lock
+    let lock_path = {
+        let rel_str = rel.to_string_lossy();
+        let file_name = if rel_str.is_empty() {
+            "default.repo.lock".to_string()
+        } else {
+            format!("{rel_str}.repo.lock")
+        };
+        paths
+            .data_dir
+            .join(format!("{}.locks", primary_container_name(selector)))
+            .join(file_name)
+    };
+    std::fs::create_dir_all(lock_path.parent().unwrap_or(&paths.data_dir))?;
     let lock_file = std::fs::File::create(&lock_path)?;
     lock_file
         .lock_exclusive()
@@ -274,8 +314,9 @@ pub(super) fn resolve_agent_repo_with(
 
             if confirm_removal()? {
                 std::fs::remove_dir_all(&cached_repo.repo_dir)?;
+                let clone_args = clone_args(git_url, &repo_path, branch_override);
                 runner
-                    .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
+                    .run("git", &clone_args, None, &git_run_opts)
                     .map_err(RepoError::CloneFailed)?;
                 let validated_repo = validate_role_repo(&cached_repo.repo_dir)
                     .map_err(RepoError::InvalidRoleRepo)?;
@@ -305,13 +346,19 @@ pub(super) fn resolve_agent_repo_with(
 
         // Fetch + merge instead of pull to avoid "Cannot fast-forward to
         // multiple branches" errors that occur with `git pull` when the
-        // remote has multiple branches.
-        let branch = git_branch(&cached_repo.repo_dir, runner).ok_or_else(|| {
-            anyhow::anyhow!(
-                "could not determine current branch of cached role repo at {}",
-                cached_repo.repo_dir.display()
-            )
-        })?;
+        // remote has multiple branches. When a branch is pinned via
+        // `--branch`, use it directly; otherwise derive from HEAD.
+        let branch = branch_override.map_or_else(
+            || {
+                git_branch(&cached_repo.repo_dir, runner).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "could not determine current branch of cached role repo at {}",
+                        cached_repo.repo_dir.display()
+                    )
+                })
+            },
+            |b| Ok(b.to_string()),
+        )?;
         runner.run(
             "git",
             &["-C", &repo_path, "fetch", "origin", &branch],
@@ -325,8 +372,9 @@ pub(super) fn resolve_agent_repo_with(
             &git_run_opts,
         )?;
     } else {
+        let clone_args = clone_args(git_url, &repo_path, branch_override);
         runner
-            .run("git", &["clone", git_url, &repo_path], None, &git_run_opts)
+            .run("git", &clone_args, None, &git_run_opts)
             .map_err(RepoError::CloneFailed)?;
     }
 
@@ -406,6 +454,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
         )
         .unwrap_err();
 
@@ -476,6 +525,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
             || Ok(true), // user confirms removal
         );
 
@@ -516,6 +566,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
             || Ok(false), // user declines
         )
         .unwrap_err();
@@ -561,6 +612,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
         )
         .unwrap_err();
 
@@ -619,6 +671,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
             || Ok(true),
         );
 
@@ -662,6 +715,7 @@ plugins = []
             "https://github.com/jackin-project/jackin-agent-smith.git",
             &mut runner,
             false,
+            None,
         );
 
         assert!(


### PR DESCRIPTION
## Summary

- Adds `--role-branch <branch>` flag to `jackin load` for testing role repo PR branches locally before they merge to the default branch
- Role repo cloned into a branch-specific cache dir (`roles/<name>/branches/<branch>/`) preserving slashes — `feat/my-pr` and `feat-my-pr` are always distinct paths
- `published_image` is ignored for branch builds; always builds from the branch Dockerfile using Docker's layer cache (no forced rebuild unless `--rebuild` is also passed)
- Image tagged with a branch-specific name (`jackin-<role>-<branch-slug>`) — never overwrites the stable image
- Lock files derived from the repo path structure, not slugs — no ambiguity between `feat/x` and `feat-x`
- **Branch trust gate**: always prompts for explicit confirmation even for already-trusted roles, because `trusted = true` covers the default branch, not unreviewed PR branches; non-interactive terminals bail
- Docs updated: `commands/load.mdx` (full `--role-branch` section) and `guides/security-model.mdx` (branch trust gate + threat model row)

## Test plan

- [ ] `jackin load the-architect` (no flag) still works as before
- [ ] `jackin load the-architect --role-branch feat/caveman-all-install` clones the branch into `branches/feat/caveman-all-install/` and builds the image
- [ ] Image tag differs from the stable one (contains the branch slug)
- [ ] Re-running the same command hits Docker layer cache (no full rebuild)
- [ ] `--role-branch` + `--rebuild` busts the cache as expected
- [ ] `--role-branch` with a non-existent branch fails with a clear git error
- [ ] Trust confirmation prompt appears even for a role already marked `trusted = true`
- [ ] Non-interactive terminal (piped stdin) bails with an error rather than defaulting

🤖 Generated with [Claude Code](https://claude.com/claude-code)