### PR TITLE
feat(cli): interactive agent picker + diagnose premature container exits

### DIFF
--- a/docs/src/content/docs/commands/console.mdx
+++ b/docs/src/content/docs/commands/console.mdx
@@ -61,6 +61,24 @@ Pressing `Enter` on a workspace row routes by eligible-role count:
 The picker is anchored on the manager list — cancelling drops you back
 on the same workspace row with the launch unchanged.
 
+## Agent disambiguation
+
+Roles declare which agents (`claude`, `codex`) they can host via the
+`agents` field in their `jackin.role.toml`. Once the role is resolved,
+the console may prompt for the agent:
+
+- **`default_agent` set** on the workspace → launch with that agent. No
+  prompt.
+- **Role supports a single agent** → launch with it. No prompt.
+- **Role supports multiple agents and the workspace has no
+  `default_agent`** → after the TUI tears down, a one-shot terminal
+  prompt asks which agent to start. Press `Enter` on the highlighted
+  choice to commit, `Ctrl-C` to abort.
+
+The prompt is intentionally a plain terminal `Select`, not a TUI
+overlay — it sits on the same path as the sensitive-mount confirmation
+that runs between `run_console` and `load_role`.
+
 ## When to use the console vs `load`
 
 `jackin console` is the simplified, intuitive TUI for everyday

--- a/docs/src/content/docs/commands/load.mdx
+++ b/docs/src/content/docs/commands/load.mdx
@@ -31,6 +31,7 @@ Load an agent into an isolated Docker container. This is the primary command for
 | `--force` | Acknowledge a dirty host working tree when materializing an isolated mount in non-interactive mode. Required only when (a) the workspace has at least one `worktree`-isolated mount and (b) the host repo's tree has staged, unstaged-tracked, or untracked files. Ignored otherwise. |
 | `--no-intro` | Skip the animated intro sequence |
 | `--debug` | Print raw container output for troubleshooting |
+| `--agent <NAME>` | Override the launch agent (`claude` or `codex`). When omitted on a multi-agent role with no `default_agent` on the workspace, an interactive prompt asks. |
 
 ## Examples
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -301,6 +301,70 @@ pub(crate) fn resolve_running_container_from_context(
     }
 }
 
+/// Resolve which agent to launch when the operator hasn't explicitly
+/// chosen one (no `--agent` flag, no workspace `default_agent`).
+///
+/// Reads the role's cached `jackin.role.toml` to discover its
+/// `supported_agents` list. When the role allows multiple agents and
+/// stdin is interactive, prompts the operator with a `dialoguer::Select`
+/// menu. Single-agent roles, headless invocations, or a missing/invalid
+/// cached manifest all return `Ok(None)` so the caller falls back to
+/// the workspace `default_agent` → `Agent::Claude` resolution chain in
+/// `runtime::launch::resolve_agent`.
+///
+/// Loading the manifest from the local cache (no git fetch) keeps this
+/// fast and TUI-tear-down-safe: the prompt fires after `run_console`
+/// has already restored the terminal but before the heavy `load_role`
+/// pipeline begins.
+pub(crate) fn prompt_agent_choice_if_needed(
+    paths: &JackinPaths,
+    selector: &RoleSelector,
+    workspace_default: Option<crate::agent::Agent>,
+) -> Result<Option<crate::agent::Agent>> {
+    use std::io::IsTerminal;
+
+    let Some(supported) = supported_agents_requiring_prompt(paths, selector, workspace_default)
+    else {
+        return Ok(None);
+    };
+
+    if !std::io::stdin().is_terminal() {
+        return Ok(None);
+    }
+
+    let labels: Vec<String> = supported.iter().map(|a| a.slug().to_string()).collect();
+    let selection = dialoguer::Select::new()
+        .with_prompt(format!(
+            "Role \"{}\" supports multiple agents. Choose one",
+            selector.key()
+        ))
+        .items(&labels)
+        .default(0)
+        .interact()?;
+
+    Ok(Some(supported[selection]))
+}
+
+/// Returns `Some(supported)` when the operator should be asked to pick
+/// an agent, `None` when the choice is already determined (workspace
+/// default set, single-agent role, or unreadable manifest). Split from
+/// the prompting wrapper so the gating logic is unit-testable without
+/// stdin / dialoguer scaffolding.
+fn supported_agents_requiring_prompt(
+    paths: &JackinPaths,
+    selector: &RoleSelector,
+    workspace_default: Option<crate::agent::Agent>,
+) -> Option<Vec<crate::agent::Agent>> {
+    if workspace_default.is_some() {
+        return None;
+    }
+    let cached = crate::repo::CachedRepo::new(paths, selector);
+    let supported = crate::manifest::RoleManifest::load(&cached.repo_dir)
+        .ok()?
+        .supported_agents();
+    (supported.len() >= 2).then_some(supported)
+}
+
 pub(crate) fn remember_last_agent(
     paths: &JackinPaths,
     config: &mut AppConfig,
@@ -857,5 +921,91 @@ mod tests {
             "cwd inside a mount source must still preselect the workspace"
         );
         assert_eq!(result.unwrap().0, "jackin-roles");
+    }
+
+    // ── supported_agents_requiring_prompt gating ─────────────────────
+
+    fn write_role_manifest(role_dir: &std::path::Path, body: &str) {
+        std::fs::create_dir_all(role_dir).unwrap();
+        std::fs::write(role_dir.join("jackin.role.toml"), body).unwrap();
+    }
+
+    #[test]
+    fn requires_prompt_when_role_supports_two_agents_and_no_workspace_default() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths::JackinPaths::for_tests(temp.path());
+        let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
+        write_role_manifest(
+            &paths.roles_dir.join(&selector.name),
+            r#"dockerfile = "Dockerfile"
+agents = ["claude", "codex"]
+
+[claude]
+plugins = []
+
+[codex]
+"#,
+        );
+
+        let agents = supported_agents_requiring_prompt(&paths, &selector, None)
+            .expect("multi-agent role with no workspace default must trigger a prompt");
+        assert_eq!(
+            agents,
+            vec![crate::agent::Agent::Claude, crate::agent::Agent::Codex]
+        );
+    }
+
+    #[test]
+    fn skips_prompt_when_workspace_default_agent_is_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths::JackinPaths::for_tests(temp.path());
+        let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
+        write_role_manifest(
+            &paths.roles_dir.join(&selector.name),
+            r#"dockerfile = "Dockerfile"
+agents = ["claude", "codex"]
+
+[claude]
+plugins = []
+
+[codex]
+"#,
+        );
+
+        let result =
+            supported_agents_requiring_prompt(&paths, &selector, Some(crate::agent::Agent::Codex));
+        assert!(
+            result.is_none(),
+            "explicit workspace default_agent must short-circuit the prompt"
+        );
+    }
+
+    #[test]
+    fn skips_prompt_when_role_supports_a_single_agent() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths::JackinPaths::for_tests(temp.path());
+        let selector = crate::selector::RoleSelector::parse("solo").unwrap();
+        write_role_manifest(
+            &paths.roles_dir.join(&selector.name),
+            r#"dockerfile = "Dockerfile"
+agents = ["codex"]
+
+[codex]
+"#,
+        );
+
+        assert!(
+            supported_agents_requiring_prompt(&paths, &selector, None).is_none(),
+            "single-agent roles have nothing to disambiguate"
+        );
+    }
+
+    #[test]
+    fn skips_prompt_when_manifest_is_missing_or_unreadable() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = paths::JackinPaths::for_tests(temp.path());
+        let selector = crate::selector::RoleSelector::parse("ghost").unwrap();
+        // No manifest written — load_role will fetch and validate later.
+        assert!(supported_agents_requiring_prompt(&paths, &selector, None).is_none());
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,8 +21,8 @@ use crate::workspace::{
 };
 
 use self::context::{
-    TargetKind, classify_target, remember_last_agent, resolve_agent_from_context,
-    resolve_running_container_from_context, resolve_target_name,
+    TargetKind, classify_target, prompt_agent_choice_if_needed, remember_last_agent,
+    resolve_agent_from_context, resolve_running_container_from_context, resolve_target_name,
 };
 
 /// Parse an `auth_forward` mode value as it arrived from the CLI.
@@ -107,7 +107,12 @@ pub fn run(cli: Cli) -> Result<()> {
 
             let mut opts = runtime::LoadOptions::for_load(no_intro, debug, rebuild);
             opts.force = force;
-            opts.agent = agent;
+            opts.agent = match agent {
+                Some(explicit) => Some(explicit),
+                None => {
+                    prompt_agent_choice_if_needed(&paths, &class, resolved_workspace.default_agent)?
+                }
+            };
             // Pre-launch reconcile: if a previous role in a keep_awake
             // workspace already runs, ensure caffeinate is up before we
             // build/launch (so a long Docker build doesn't see the host
@@ -148,7 +153,8 @@ pub fn run(cli: Cli) -> Result<()> {
                 anyhow::bail!("aborted — sensitive mount paths were not confirmed");
             }
 
-            let opts = runtime::LoadOptions::for_launch(debug);
+            let mut opts = runtime::LoadOptions::for_launch(debug);
+            opts.agent = prompt_agent_choice_if_needed(&paths, &class, workspace.default_agent)?;
             runtime::reconcile_keep_awake(&paths, &mut runner);
             let result =
                 runtime::load_role(&paths, &mut config, &class, &workspace, &mut runner, &opts);

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -698,6 +698,16 @@ fn launch_role_runtime(
     // for a single interactive session.
     super::caffeinate::reconcile(paths, runner);
 
+    // Pre-attach safety check: if the container has already exited
+    // (entrypoint crashed, agent CLI failed at startup, etc.), `docker
+    // attach` will print the opaque "cannot attach to a stopped
+    // container, start it first" and we'd lose the actual reason.
+    // Capture `docker logs` and surface it in the error so the operator
+    // sees what really happened.
+    if let Some(err) = diagnose_premature_exit(runner, container_name) {
+        return Err(err);
+    }
+
     // Attach with signal forwarding disabled and the default detach shortcut
     // cleared: only an explicit exit from inside (or terminal close) ends the
     // foreground session, and closing the terminal leaves the container
@@ -715,9 +725,70 @@ fn launch_role_runtime(
     );
     // Ensure cleanup debug logs start on a fresh line after the interactive session
     eprintln!();
+    if attach_result.is_err()
+        && let Some(err) = diagnose_premature_exit(runner, container_name)
+    {
+        return Err(err);
+    }
     attach_result?;
 
     Ok(())
+}
+
+/// Detect a container that exited before (or during) the foreground attach
+/// and return an actionable error including the captured `docker logs`.
+///
+/// `docker attach` against a stopped container prints the opaque
+/// "cannot attach to a stopped container, start it first" with no hint
+/// at the underlying entrypoint failure (auth wiring crash, agent CLI
+/// startup error, missing mount, …). This wraps the inspect + log
+/// fetch so the surfaced error names the exit code, OOM flag, and the
+/// last lines of the container's combined stdout/stderr.
+///
+/// Returns `None` when the container is still running (the normal
+/// happy path) so the caller can proceed to attach.
+fn diagnose_premature_exit(
+    runner: &mut impl crate::docker::CommandRunner,
+    container_name: &str,
+) -> Option<anyhow::Error> {
+    use super::attach::{ContainerState, inspect_container_state};
+
+    match inspect_container_state(runner, container_name) {
+        // Default to letting `docker attach` proceed when state is
+        // ambiguous: the daemon's own error from a true `NotFound`
+        // (`No such container`) is just as actionable as anything we
+        // could synthesize, and a transient inspect hiccup must not
+        // hijack an otherwise-healthy launch.
+        ContainerState::Running | ContainerState::NotFound => None,
+        ContainerState::Stopped {
+            exit_code,
+            oom_killed,
+        } => {
+            let logs = runner
+                .capture("docker", &["logs", "--tail", "40", container_name], None)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            let reason = if oom_killed {
+                "OOM killed".to_string()
+            } else {
+                format!("exit {exit_code}")
+            };
+            let body = logs.map_or_else(
+                || {
+                    format!(
+                        "container {container_name} exited before attach ({reason}) and produced no log output"
+                    )
+                },
+                |text| {
+                    format!(
+                        "container {container_name} exited before attach ({reason}); last 40 log lines:\n{text}"
+                    )
+                },
+            );
+            Some(anyhow::anyhow!(body))
+        }
+    }
 }
 
 /// Query a container's post-attach state for use by `finalize_foreground_session`.
@@ -1488,6 +1559,75 @@ mod tests {
     use crate::selector::RoleSelector;
     use std::collections::VecDeque;
     use tempfile::tempdir;
+
+    #[test]
+    fn diagnose_premature_exit_returns_none_when_container_running() {
+        // Single inspect = "running" → fast path returns Ok(()) so attach
+        // proceeds. The function must NOT consume the logs queue entry in
+        // this case.
+        let mut runner = FakeRunner::with_capture_queue(["true 0 false".to_string()]);
+        let result = super::diagnose_premature_exit(&mut runner, "jackin-the-architect");
+        assert!(
+            result.is_none(),
+            "running container must not be diagnosed as a failure"
+        );
+    }
+
+    #[test]
+    fn diagnose_premature_exit_includes_logs_when_container_already_stopped() {
+        // First capture: inspect → exited 127 (entrypoint command not found).
+        // Second capture: docker logs → entrypoint stderr.
+        let mut runner = FakeRunner::with_capture_queue([
+            "false 127 false".to_string(),
+            "/home/agent/entrypoint.sh: line 85: exec: codex: not found".to_string(),
+        ]);
+        let err = super::diagnose_premature_exit(&mut runner, "jackin-the-architect")
+            .expect("stopped container must produce a diagnostic error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exit 127"),
+            "exit code missing from msg: {msg}"
+        );
+        assert!(
+            msg.contains("codex: not found"),
+            "logs missing from msg: {msg}"
+        );
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker logs --tail 40 jackin-the-architect")),
+            "must shell out to `docker logs` to capture the entrypoint output"
+        );
+    }
+
+    #[test]
+    fn diagnose_premature_exit_flags_oom_kill_distinct_from_normal_exit() {
+        let mut runner =
+            FakeRunner::with_capture_queue(["false 137 true".to_string(), String::new()]);
+        let err = super::diagnose_premature_exit(&mut runner, "jackin-x")
+            .expect("OOM-killed container is a premature exit");
+        let msg = err.to_string();
+        assert!(msg.contains("OOM killed"), "expected OOM marker in: {msg}");
+        assert!(
+            msg.contains("no log output"),
+            "empty logs branch missing: {msg}"
+        );
+    }
+
+    #[test]
+    fn diagnose_premature_exit_passes_through_when_inspect_returns_notfound() {
+        // Empty inspect output maps to `ContainerState::NotFound`. We
+        // intentionally let docker attach surface its own
+        // `No such container` rather than synthesize a less-helpful
+        // diagnostic — and a transient inspect hiccup must not abort
+        // an otherwise-healthy launch.
+        let mut runner = FakeRunner::with_capture_queue([String::new()]);
+        assert!(
+            super::diagnose_premature_exit(&mut runner, "jackin-x").is_none(),
+            "NotFound must defer to docker attach's own error path"
+        );
+    }
 
     #[test]
     fn agent_mounts_for_claude_includes_claude_state() {


### PR DESCRIPTION
## Summary

Two related changes addressing the `jackin load --agent codex --debug` flow:

### `fix(launch)` — surface docker logs when container exits before attach

When the role container's entrypoint crashed (auth wiring failure, agent CLI startup error, missing mount, …), `docker attach` returned the opaque `cannot attach to a stopped container, start it first` and the actual reason was invisible until the operator ran `docker logs` by hand.

`diagnose_premature_exit` runs at two boundaries:
1. **Before** `docker attach` — short-circuits with a captured-log error when the container is already stopped.
2. **After** `docker attach` returns an error — covers the race where the container exits between the pre-check and attach.

Output names the exit code, OOM flag, and the last 40 log lines. `NotFound` falls through to docker attach's own `No such container` so a transient inspect hiccup never hijacks an otherwise-healthy launch.

### `feat(cli)` — interactive agent picker for multi-agent roles

When a role's manifest declares `agents = ["claude", "codex"]` and the workspace has no `default_agent`, prompt the operator to pick one.

- `jackin load` — fires only when `--agent` is not passed.
- `jackin console` — fires after the TUI tears down, on the same path as the existing sensitive-mounts confirm prompt. No new TUI modal / widget — `dialoguer::Select` runs on a clean terminal.

Manifest is loaded from the local cache (`CachedRepo::new`) — no git fetch — so the prompt is fast. Missing / invalid cached manifests fall through silently; `load_role` still validates and refetches as needed.

## Test plan

- New unit tests:
  - `runtime::launch::tests::diagnose_premature_exit_*` — running, stopped+logs, OOM-killed, NotFound paths
  - `app::context::tests::*_prompt_*` — gate behavior across workspace-default-set / single-agent / multi-agent / missing-manifest cases
- `cargo test --lib --bin jackin`: 1334 passed
- `cargo clippy --bin jackin --no-deps`: clean

## Manual validation (operator)

```bash
cargo run --bin jackin -- load --agent codex --debug
```

Reruns of the failing flow now produce an error like:

```
Error: container jackin-the-architect-clone-2 exited before attach (exit 127); last 40 log lines:
+ '[' -x /usr/bin/gh ']'
…
[2J[H/home/agent/entrypoint.sh: line 85: exec: codex: not found
```

…instead of `cannot attach to a stopped container`. Operator can paste that log to root-cause the actual entrypoint failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)