### PR TITLE
feat(workspace): git pull on workspace entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased]
+
+### Added
+
+- **Workspace git pull on entry** — a per-workspace toggle (`git_pull_on_entry`) that runs `git pull` on every mounted git repository from the host before the agent container starts. Opt in with `--git-pull` on `workspace create` or `workspace edit`; toggle in the TUI General tab (Space on the new "Git pull" row). Failures are non-fatal: a warning is printed and the launch continues so the workspace remains usable when offline or the working tree is dirty.

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -32,6 +32,7 @@ Create a new workspace definition.
 | `--default-agent <claude\|codex>` | Default agent for this workspace |
 | `--mount-isolation <DST>=<TYPE>` | Set per-mount isolation by container destination. Repeatable. `<TYPE>` is `shared` or `worktree`. The `<DST>` must match a mount destination present in the final mount plan; an unknown `<DST>` is a hard error. |
 | `--keep-awake` | macOS only: opt this workspace into the keep-awake reconciler. While any agent in the workspace is running, jackin keeps a single detached `caffeinate -imsu` alive so the host stays awake. No-op on Linux/Windows. See [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake). |
+| `--git-pull` | Run `git pull` on every mounted git repository from the host before the agent container starts. Failures are non-fatal — the launch continues even when offline or the working tree is dirty. See [Git pull on entry](/guides/workspaces/#git-pull-on-entry). |
 
 ```bash
 jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app
@@ -90,6 +91,8 @@ Modify an existing workspace.
 | `--delete-isolated-state` | Acknowledge deleting preserved isolated state when an edit changes the `src` of a materialized isolated mount. Required for non-interactive source-drift edits; ignored when no preserved state exists. |
 | `--keep-awake` | macOS only: enable the keep-awake reconciler on this workspace. Mutually exclusive with `--no-keep-awake`. |
 | `--no-keep-awake` | Disable the keep-awake reconciler on this workspace. Mutually exclusive with `--keep-awake`. |
+| `--git-pull` | Enable git pull on entry for this workspace. Mutually exclusive with `--no-git-pull`. |
+| `--no-git-pull` | Disable git pull on entry for this workspace. Mutually exclusive with `--git-pull`. |
 
 ```bash
 jackin workspace edit my-app --workdir ~/new-dir
@@ -102,6 +105,8 @@ jackin workspace edit my-app --default-agent codex
 jackin workspace edit my-app --clear-default-agent
 jackin workspace edit my-app --keep-awake
 jackin workspace edit my-app --no-keep-awake
+jackin workspace edit my-app --git-pull
+jackin workspace edit my-app --no-git-pull
 
 # Flip an existing mount to per-container worktrees
 jackin workspace edit my-app --mount-isolation /workspace/my-app=worktree

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -265,6 +265,45 @@ jackin workspace edit my-app --no-keep-awake
 
 `jackin workspace show <name>` surfaces a `Keep Awake: enabled (macOS only)` row when the flag is on, so you can confirm at a glance which workspaces are holding power assertions.
 
+## Git pull on entry
+
+When you open a workspace, your local branches may have drifted behind their remotes. The git-pull-on-entry toggle runs `git pull` on every mounted git repository from the **host** before the agent container starts — so the agent always sees the latest committed code without you needing to remember a manual pull first.
+
+```toml
+[workspaces.my-app]
+workdir = "/workspace/my-app"
+git_pull_on_entry = true
+
+[[workspaces.my-app.mounts]]
+src = "~/Projects/my-app"
+dst = "/workspace/my-app"
+```
+
+Failures are **non-fatal**: if a pull fails (offline, uncommitted changes, protected branch, etc.) jackin prints a warning and continues the launch. The workspace remains fully usable — the toggle is a convenience, not a gate.
+
+<Aside type="caution">
+`git pull` is run on the **host** directory, not inside the container. Any uncommitted local changes or an active rebase will cause the pull to fail; jackin will warn and proceed.
+</Aside>
+
+### Setting git pull on entry
+
+**CLI** — paired flags on `workspace create` and `workspace edit`:
+
+```bash
+# Opt in at creation time
+jackin workspace create my-app --workdir ~/Projects/my-app --mount ~/Projects/my-app --git-pull
+
+# Toggle on an existing workspace
+jackin workspace edit my-app --git-pull
+jackin workspace edit my-app --no-git-pull
+```
+
+`--git-pull` and `--no-git-pull` are mutually exclusive. Omit both for "no change."
+
+**Operator console** — the **General** tab of the workspace editor has a `Git pull` row. Press `Space` to toggle it; the change persists when you save the workspace.
+
+`jackin workspace show <name>` surfaces a `Git Pull: on entry` row when the flag is on.
+
 ## Workspace auto-detection
 
 When you open the operator console (`jackin console`), it checks whether your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths. If it does, that workspace is preselected — saving you a selection step and reinforcing the value of naming project boundaries once. Container-only `workdir` values like `/workspace` can still be auto-detected as long as one of the workspace's mounted host paths contains your current directory. You can always override the preselection by choosing a different workspace or "Current directory."

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -95,6 +95,8 @@ readonly = true
 
 [workspaces.my-app.keep_awake]
 enabled = true
+
+git_pull_on_entry = true
 ```
 
 | Field | Description |
@@ -110,6 +112,7 @@ enabled = true
 | `default_agent` | Optional workspace default agent (`"claude"` or `"codex"`). Omit to default to Claude. |
 | `last_role` | Most recently used role selector for this workspace |
 | `keep_awake.enabled` | macOS-only: keep the host awake while any agent in this workspace is running (see [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake)). On Linux/Windows the flag is silently accepted but has no effect — useful when sharing a `config.toml` across machines, but the host will still sleep. |
+| `git_pull_on_entry` | Run `git pull` on every mounted git repository from the host before the agent container starts. Failures are non-fatal — the launch continues even when offline or the working tree is dirty. Omitted from TOML when `false` (the default). See [Git pull on entry](/guides/workspaces/#git-pull-on-entry). |
 
 When you use `jackin workspace create`, `workdir` is only the container start path. Add an explicit `--mount` for every directory the container should see.
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -478,6 +478,7 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                git_pull_on_entry: false,
             },
         );
 
@@ -522,6 +523,7 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                git_pull_on_entry: false,
             },
         );
 
@@ -565,6 +567,7 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                git_pull_on_entry: false,
             },
         );
 
@@ -617,6 +620,7 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: workspace::KeepAwakeConfig::default(),
+                git_pull_on_entry: false,
             },
         );
         config

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -483,6 +483,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 default_agent,
                 mount_isolation,
                 keep_awake,
+                git_pull,
             } => {
                 let expanded_workdir = workspace::resolve_path(&workdir);
                 let parsed_mounts = mounts
@@ -522,6 +523,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     keep_awake: crate::workspace::KeepAwakeConfig {
                         enabled: keep_awake,
                     },
+                    git_pull_on_entry: git_pull,
                 };
                 let mut editor = crate::config::ConfigEditor::open(&paths)?;
                 editor.create_workspace(&name, ws)?;
@@ -605,10 +607,19 @@ pub fn run(cli: Cli) -> Result<()> {
                 delete_isolated_state,
                 keep_awake,
                 no_keep_awake,
+                git_pull,
+                no_git_pull,
             } => {
                 // Map paired flags to Option<bool>: None = no change.
                 // Mutual exclusion is enforced at parse time by clap's
                 // `conflicts_with`, so at most one of the two is true.
+                let git_pull_change = if git_pull {
+                    Some(true)
+                } else if no_git_pull {
+                    Some(false)
+                } else {
+                    None
+                };
                 let keep_awake_change = if keep_awake {
                     Some(true)
                 } else if no_keep_awake {
@@ -747,6 +758,12 @@ pub fn run(cli: Cli) -> Result<()> {
                         if v { "enabled" } else { "disabled" }
                     ));
                 }
+                if let Some(v) = git_pull_change {
+                    changes.push(format!(
+                        "git_pull_on_entry → {}",
+                        if v { "enabled" } else { "disabled" }
+                    ));
+                }
 
                 // Build the prospective mount list (mirrors edit_workspace's
                 // merge order) so we can check for source drift on any mount
@@ -828,6 +845,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         },
                         mount_isolation_overrides: mount_isolation,
                         keep_awake_enabled: keep_awake_change,
+                        git_pull_on_entry_enabled: git_pull_change,
                     },
                 )?;
                 editor.save()?;
@@ -1125,6 +1143,9 @@ fn render_workspace_show(name: &str, workspace: &WorkspaceConfig) -> String {
     if workspace.keep_awake.enabled {
         info.push(("Keep Awake", "enabled (macOS only)"));
     }
+    if workspace.git_pull_on_entry {
+        info.push(("Git Pull", "on entry"));
+    }
     let mut info_table = Table::builder(info.iter().map(|(k, v)| [*k, *v])).build();
     info_table
         .with(Style::modern_rounded())
@@ -1208,6 +1229,7 @@ mod auth_set_tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         };
         let out = render_workspace_show("jackin", &ws);
         assert!(out.contains("Isolation"));

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -71,6 +71,11 @@ Examples:
         /// no-op on Linux/Windows.
         #[arg(long = "keep-awake", default_value_t = false)]
         keep_awake: bool,
+        /// Run `git pull` on all mounted git repositories before starting the
+        /// agent. Executed on the host. Failures are warnings — the launch
+        /// continues even when offline.
+        #[arg(long = "git-pull", default_value_t = false)]
+        git_pull: bool,
     },
     /// List all saved workspaces
     #[command(before_help = BANNER, styles = HELP_STYLES)]
@@ -174,6 +179,18 @@ Examples:
             default_value_t = false
         )]
         no_keep_awake: bool,
+        /// Enable git pull on entry for this workspace. Mutually exclusive with
+        /// `--no-git-pull`.
+        #[arg(long = "git-pull", default_value_t = false)]
+        git_pull: bool,
+        /// Disable git pull on entry for this workspace. Mutually exclusive with
+        /// `--git-pull`.
+        #[arg(
+            long = "no-git-pull",
+            conflicts_with = "git_pull",
+            default_value_t = false
+        )]
+        no_git_pull: bool,
     },
     /// Remove redundant mounts (rule-C violations) from a saved workspace
     #[command(

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -181,6 +181,10 @@ impl AppConfig {
             workspace.keep_awake.enabled = enabled;
         }
 
+        if let Some(enabled) = edit.git_pull_on_entry_enabled {
+            workspace.git_pull_on_entry = enabled;
+        }
+
         // Rule-C invariant: after applying this edit, the mount list must be
         // pairwise non-covering under rule C. The CLI layer pre-collapses
         // redundants; if any remain here, the caller is buggy (non-CLI) or
@@ -266,6 +270,7 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         };
         config
             .create_workspace("big-monorepo", original.clone())

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -187,11 +187,13 @@ pub(super) fn handle_editor_key(
             toggle_agent_allowed_at_cursor(editor, config);
         }
         KeyCode::Char(' ') if editor.active_tab == EditorTab::General => {
-            // Row 2 is the keep_awake toggle. Other General rows
-            // ignore Space — Enter is the modal-opening key for them.
+            // Row 2 = keep_awake toggle, row 3 = git_pull_on_entry toggle.
+            // Other General rows ignore Space — Enter is the modal-opening key for them.
             let FieldFocus::Row(n) = editor.active_field;
             if n == 2 {
                 editor.pending.keep_awake.enabled = !editor.pending.keep_awake.enabled;
+            } else if n == 3 {
+                editor.pending.git_pull_on_entry = !editor.pending.git_pull_on_entry;
             }
         }
         KeyCode::Char('*') if editor.active_tab == EditorTab::Roles => {
@@ -295,7 +297,8 @@ pub(super) fn handle_editor_key(
 fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
     match editor.active_tab {
         // 0=Name, 1=Working dir, 2=Keep awake
-        EditorTab::General => 2,
+        // 0=Name, 1=Working dir, 2=Keep awake, 3=Git pull
+        EditorTab::General => 3,
         EditorTab::Mounts => editor.pending.mounts.len(),
         // One extra sentinel row: + Add role.
         EditorTab::Roles => config.roles.len(),

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -508,6 +508,13 @@ fn build_confirm_save_lines(
                     Span::styled("enabled", value),
                 ]));
             }
+            if editor.pending.git_pull_on_entry {
+                out.push(Line::raw(""));
+                out.push(Line::from(vec![
+                    Span::styled("Git pull: ", heading),
+                    Span::styled("enabled", value),
+                ]));
+            }
             let env_lines = env_diff_lines(&editor.original, &editor.pending, value, dim);
             if !env_lines.is_empty() {
                 out.push(Line::raw(""));
@@ -636,6 +643,15 @@ fn build_confirm_save_lines(
                 } else {
                     "disabled"
                 };
+                out.push(Line::from(Span::styled(format!("  - {old_label}"), dim)));
+                out.push(Line::from(Span::styled(format!("  + {new_label}"), value)));
+            }
+
+            if editor.pending.git_pull_on_entry != editor.original.git_pull_on_entry {
+                out.push(Line::raw(""));
+                out.push(Line::from(Span::styled("Git pull:", heading)));
+                let old_label = if editor.original.git_pull_on_entry { "enabled" } else { "disabled" };
+                let new_label = if editor.pending.git_pull_on_entry { "enabled" } else { "disabled" };
                 out.push(Line::from(Span::styled(format!("  - {old_label}"), dim)));
                 out.push(Line::from(Span::styled(format!("  + {new_label}"), value)));
             }
@@ -866,6 +882,9 @@ pub(super) fn build_workspace_edit(
     }
     if pending.keep_awake.enabled != original.keep_awake.enabled {
         edit.keep_awake_enabled = Some(pending.keep_awake.enabled);
+    }
+    if pending.git_pull_on_entry != original.git_pull_on_entry {
+        edit.git_pull_on_entry_enabled = Some(pending.git_pull_on_entry);
     }
     edit
 }
@@ -1838,6 +1857,7 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         };
         let (tmp, paths, config) = setup_with_workspace(ws_name, ws.clone()).unwrap();
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -116,6 +116,7 @@ fn contextual_row_items(
             //   row 0 = Name        (editable — Enter opens rename)
             //   row 1 = Working dir (editable — Enter opens workdir picker)
             //   row 2 = Keep awake  (toggle — Space flips on/off)
+            //   row 3 = Git pull    (toggle — Space flips on/off)
             match cursor {
                 0 => vec![FooterItem::Key("Enter"), FooterItem::Text("rename")],
                 // WorkdirPick requires at least one mount to choose from;
@@ -125,7 +126,7 @@ fn contextual_row_items(
                     FooterItem::Key("Enter"),
                     FooterItem::Text("pick working directory"),
                 ],
-                2 => vec![FooterItem::Key("Space"), FooterItem::Text("toggle")],
+                2 | 3 => vec![FooterItem::Key("Space"), FooterItem::Text("toggle")],
                 _ => Vec::new(),
             }
         }
@@ -319,10 +320,11 @@ fn render_general_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
         EditorMode::Create => state.pending_name.as_deref().unwrap_or("(new)"),
     };
 
-    // Both Edit and Create modes show the same three rows:
+    // Both Edit and Create modes show the same four rows:
     //   0 = Name        (editable; Enter opens rename TextInput)
     //   1 = Working dir (editable; Enter opens workdir picker)
     //   2 = Keep awake  (toggle; Space flips pending.keep_awake.enabled)
+    //   3 = Git pull    (toggle; Space flips pending.git_pull_on_entry)
     //
     // The former `Default role` (ro) and `Last used` (ro) rows were
     // removed from the General tab. `Default role` is now editable on the
@@ -358,6 +360,12 @@ fn render_general_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
         "Keep awake",
         keep_awake_display,
     ));
+    let git_pull_display = if state.pending.git_pull_on_entry {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    rows.push(render_editor_row(3, cursor, "Git pull", git_pull_display));
 
     frame.render_widget(Paragraph::new(rows).block(block), area);
 }

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -1000,6 +1000,7 @@ mod subpanel_padding_tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         }
     }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -567,6 +567,9 @@ impl EditorState<'_> {
         if self.pending.keep_awake != self.original.keep_awake {
             n += 1;
         }
+        if self.pending.git_pull_on_entry != self.original.git_pull_on_entry {
+            n += 1;
+        }
         // Rename in Edit mode counts as a change.
         if let EditorMode::Edit { name } = &self.mode
             && self.pending_name.as_deref().is_some_and(|pn| pn != name)
@@ -1159,6 +1162,7 @@ mod tests {
             env: BTreeMap::default(),
             roles: BTreeMap::default(),
             keep_awake: KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         };
         let mut e = EditorState::new_edit("ws".into(), ws);
         e.active_tab = EditorTab::Mounts;

--- a/src/console/state.rs
+++ b/src/console/state.rs
@@ -87,6 +87,7 @@ pub fn build_workspace_choice(
                     mounts: current.mounts,
                     default_agent: None,
                     keep_awake_enabled: false,
+                    git_pull_on_entry: false,
                 },
                 allowed_roles: configured_agents(config),
                 default_role: None,
@@ -108,6 +109,7 @@ pub fn build_workspace_choice(
                     mounts: saved.mounts.clone(),
                     default_agent: saved.default_agent,
                     keep_awake_enabled: saved.keep_awake.enabled,
+                    git_pull_on_entry: saved.git_pull_on_entry,
                 },
                 allowed_roles,
                 default_role: saved.default_role.clone(),
@@ -193,6 +195,7 @@ mod tests {
                 env: std::collections::BTreeMap::new(),
                 roles: std::collections::BTreeMap::new(),
                 keep_awake: crate::workspace::KeepAwakeConfig::default(),
+                git_pull_on_entry: false,
             },
         );
 
@@ -229,6 +232,7 @@ mod tests {
             env: std::collections::BTreeMap::new(),
             roles: std::collections::BTreeMap::new(),
             keep_awake: crate::workspace::KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         }
     }
 

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -1149,6 +1149,7 @@ mod tests {
             }],
             default_agent: None,
             keep_awake_enabled: false,
+        git_pull_on_entry: false,
         }
     }
 
@@ -1235,6 +1236,7 @@ mod tests {
             }],
             default_agent: None,
             keep_awake_enabled: false,
+        git_pull_on_entry: false,
         };
         let mut runner = FakeRunner::default();
         let mat = materialize_workspace(

--- a/src/runtime/identity.rs
+++ b/src/runtime/identity.rs
@@ -101,6 +101,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
+        git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: String::new(),
@@ -131,6 +132,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
+        git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: "Alice".to_string(),
@@ -164,6 +166,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
+        git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: String::new(),

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -798,6 +798,38 @@ pub fn inspect_attach_outcome(
     }
 }
 
+fn pull_workspace_repos(workspace: &crate::workspace::ResolvedWorkspace, debug: bool) {
+    for mount in &workspace.mounts {
+        let src = std::path::Path::new(&mount.src);
+        if !src.join(".git").exists() {
+            continue;
+        }
+        if debug {
+            eprintln!("[jackin debug] git pull in {}", mount.src);
+        }
+        eprintln!("  Pulling {} …", crate::tui::shorten_home(&mount.src));
+        match std::process::Command::new("git")
+            .args(["-C", &mount.src, "pull"])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let trimmed = stdout.trim();
+                if !trimmed.is_empty() {
+                    eprintln!("    {trimmed}");
+                }
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                eprintln!("  Warning: git pull failed in {}: {}", mount.src, stderr.trim());
+            }
+            Err(e) => {
+                eprintln!("  Warning: could not run git pull in {}: {e}", mount.src);
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn load_role(
     paths: &JackinPaths,
@@ -844,6 +876,10 @@ fn load_role_with(
             &git.user_name
         };
         tui::intro_animation(intro_name);
+    }
+
+    if workspace.git_pull_on_entry {
+        pull_workspace_repos(workspace, opts.debug);
     }
 
     let (source, is_new) = config.resolve_role_source(selector)?;
@@ -1898,6 +1934,7 @@ agents = ["codex"]
             }],
             default_agent: None,
             keep_awake_enabled: false,
+            git_pull_on_entry: false,
         }
     }
 
@@ -2184,6 +2221,7 @@ trusted = true
             ],
             default_agent: None,
             keep_awake_enabled: false,
+            git_pull_on_entry: false,
         };
 
         load_role(
@@ -2458,6 +2496,7 @@ plugins = []
             }],
             default_agent: None,
             keep_awake_enabled: false,
+            git_pull_on_entry: false,
         };
 
         load_role(
@@ -2528,6 +2567,7 @@ plugins = []
             }],
             default_agent: None,
             keep_awake_enabled: false,
+            git_pull_on_entry: false,
         };
 
         load_role(

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -18,6 +18,10 @@ pub use sensitive::{SensitiveMount, confirm_sensitive_mounts, find_sensitive_mou
 
 use serde::{Deserialize, Serialize};
 
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MountConfig {
     pub src: String,
@@ -61,6 +65,8 @@ pub struct WorkspaceConfig {
     pub roles: std::collections::BTreeMap<String, WorkspaceRoleOverride>,
     #[serde(default, skip_serializing_if = "KeepAwakeConfig::is_default")]
     pub keep_awake: KeepAwakeConfig,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub git_pull_on_entry: bool,
 }
 
 /// Per-workspace power-management opt-in.
@@ -129,6 +135,7 @@ pub struct WorkspaceEdit {
     /// `--keep-awake` / `--no-keep-awake` flags map onto this; the TUI
     /// derives it by diffing `pending.keep_awake` vs `original`.
     pub keep_awake_enabled: Option<bool>,
+    pub git_pull_on_entry_enabled: Option<bool>,
 }
 
 /// Validate the isolation layout for a workspace's mounts. Two rules
@@ -660,6 +667,7 @@ isolation = "worktree"
             env: BTreeMap::new(),
             roles: BTreeMap::new(),
             keep_awake: KeepAwakeConfig::default(),
+            git_pull_on_entry: false,
         };
         let err = validate_workspace_config("ws", &workspace).unwrap_err();
         let msg = err.to_string();

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -41,6 +41,7 @@ pub struct ResolvedWorkspace {
     /// workspaces). The launch flow combines this with any CLI override
     /// in `runtime::launch::resolve_agent`.
     pub default_agent: Option<crate::agent::Agent>,
+    pub git_pull_on_entry: bool,
 }
 
 fn host_path_match_depth(path: &str, canonical_cwd: &Path) -> Option<usize> {
@@ -185,6 +186,7 @@ pub fn resolve_load_workspace(
         mounts,
         keep_awake_enabled: workspace.keep_awake.enabled,
         default_agent: workspace.default_agent,
+        git_pull_on_entry: workspace.git_pull_on_entry,
     })
 }
 

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -110,6 +110,7 @@ model = "gpt-5"
         }],
         default_agent: Some(Agent::Codex),
         keep_awake_enabled: false,
+    git_pull_on_entry: false,
     };
     let mut runner = FakeRunner::for_load_agent([String::new()]);
 
@@ -211,6 +212,7 @@ plugins = []
         }],
         default_agent: Some(Agent::Claude),
         keep_awake_enabled: false,
+    git_pull_on_entry: false,
     };
     let mut runner = FakeRunner::for_load_agent([String::new()]);
     let opts = LoadOptions {

--- a/tests/per_mount_isolation_e2e.rs
+++ b/tests/per_mount_isolation_e2e.rs
@@ -79,6 +79,7 @@ fn materialize_then_clean_exit_removes_record_and_branch() {
         }],
         default_agent: None,
         keep_awake_enabled: false,
+    git_pull_on_entry: false,
     };
 
     // materialize_workspace capture queue:


### PR DESCRIPTION
## Summary

- Adds `git_pull_on_entry: bool` per-workspace toggle — TOML field omitted when `false`, so existing configs are byte-stable
- Before the container starts, runs `git pull -C <src>` on every mounted git repo from the **host**; warns and continues on failure (offline-safe)
- TUI General tab gains row 3 "Git pull" with Space toggle, save confirmation diff, and change count
- CLI: `--git-pull` on `workspace create`; `--git-pull`/`--no-git-pull` on `workspace edit`
- `workspace show` surfaces "Git Pull: on entry" when enabled
- Docs: updated commands/workspace, guides/workspaces (new section), reference/configuration, and CHANGELOG

## Test plan

- [ ] `jackin workspace create my-app --workdir /w --mount ~/Projects/my-app --git-pull` → workspace saved with `git_pull_on_entry = true` in TOML
- [ ] `jackin workspace edit my-app --no-git-pull` → field cleared (omitted from TOML)
- [ ] Open TUI, edit workspace → General tab row 3 "Git pull" row, press Space → "enabled", save → diff preview shows change
- [ ] `jackin load my-app` with git-pull enabled → "Pulling ~/Projects/my-app …" before role steps
- [ ] Load with network offline → warning printed, launch continues normally
- [ ] `jackin workspace show my-app` → "Git Pull: on entry" row visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)