### PR TITLE
fix: rustfmt, CI gate + changelog rules for git_pull_on_entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,14 @@ Do not memorialize old shapes in code comments ("formerly named X", "old locatio
 
 This rule retires when jackin ships its first tagged release.
 
+## Changelog (agent-only)
+
+**Do not add entries to `CHANGELOG.md` until the first tagged release.**
+
+The changelog exists to communicate breaking changes and new features to *users of released software*. Before a first release there are no such users, and every change is implicitly "unreleased" — adding entries now creates noise that will need to be cleaned up before the release and may give a false impression that the project follows a stable release cadence.
+
+When the first release is being cut, the operator will explicitly ask for the changelog to be populated. Until then, leave `CHANGELOG.md` unchanged.
+
 ## Pull Request Merging (agent-only)
 
 **Agents must never merge a pull request without explicit per-PR confirmation from the human operator.**
@@ -21,6 +29,20 @@ This rule retires when jackin ships its first tagged release.
 - Bounded authorization: if the operator says "merge all the PRs we just discussed" or similar, merge only the named set — not unrelated PRs that exist or that you open later.
 
 If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
+
+### CI must be green before merging
+
+**Never merge a pull request unless all required CI checks pass.** This is non-negotiable regardless of how the operator phrases the merge request.
+
+Before invoking the merge command:
+
+1. **Check CI status**: run `gh pr checks <PR> --repo <owner/repo>` and confirm every required check shows `pass`. A check in `pending` or `fail` state means do not merge — wait or fix first.
+2. **Do not force-merge to bypass failures**: do not use `--admin` or other bypass flags to override failing checks unless the operator explicitly names the specific failing check and states it is safe to bypass for an articulated reason.
+3. **Always use `gh` (GitHub CLI) for all GitHub interactions**: PR creation, review, status checks, and merging must go through `gh`, not raw `git push` to protected branches or direct API calls. This keeps the audit trail consistent and ensures branch-protection rules are respected.
+
+If CI is red when the operator says "merge it", respond: "CI is failing on `<check name>` — I won't merge until it's green. Fix the failure and then I'll merge." If the operator insists on merging anyway, ask them to explicitly acknowledge the specific failing check.
+
+Why this rule exists: a red main branch blocks the whole team. The cost of one bad merge far exceeds the cost of pausing to fix CI.
 
 ### Verify PR title and description before merging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 
 ## [Unreleased]
-
-### Added
-
-- **Workspace git pull on entry** — a per-workspace toggle (`git_pull_on_entry`) that runs `git pull` on every mounted git repository from the host before the agent container starts. Opt in with `--git-pull` on `workspace create` or `workspace edit`; toggle in the TUI General tab (Space on the new "Git pull" row). Failures are non-fatal: a warning is printed and the launch continues so the workspace remains usable when offline or the working tree is dirty.

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -650,8 +650,16 @@ fn build_confirm_save_lines(
             if editor.pending.git_pull_on_entry != editor.original.git_pull_on_entry {
                 out.push(Line::raw(""));
                 out.push(Line::from(Span::styled("Git pull:", heading)));
-                let old_label = if editor.original.git_pull_on_entry { "enabled" } else { "disabled" };
-                let new_label = if editor.pending.git_pull_on_entry { "enabled" } else { "disabled" };
+                let old_label = if editor.original.git_pull_on_entry {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
+                let new_label = if editor.pending.git_pull_on_entry {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
                 out.push(Line::from(Span::styled(format!("  - {old_label}"), dim)));
                 out.push(Line::from(Span::styled(format!("  + {new_label}"), value)));
             }

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -1149,7 +1149,7 @@ mod tests {
             }],
             default_agent: None,
             keep_awake_enabled: false,
-        git_pull_on_entry: false,
+            git_pull_on_entry: false,
         }
     }
 
@@ -1236,7 +1236,7 @@ mod tests {
             }],
             default_agent: None,
             keep_awake_enabled: false,
-        git_pull_on_entry: false,
+            git_pull_on_entry: false,
         };
         let mut runner = FakeRunner::default();
         let mat = materialize_workspace(

--- a/src/runtime/identity.rs
+++ b/src/runtime/identity.rs
@@ -101,7 +101,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
-        git_pull_on_entry: false,
+            git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: String::new(),
@@ -132,7 +132,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
-        git_pull_on_entry: false,
+            git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: "Alice".to_string(),
@@ -166,7 +166,7 @@ mod tests {
             mounts: vec![],
             default_agent: None,
             keep_awake_enabled: false,
-        git_pull_on_entry: false,
+            git_pull_on_entry: false,
         };
         let git = GitIdentity {
             user_name: String::new(),

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -892,7 +892,11 @@ fn pull_workspace_repos(workspace: &crate::workspace::ResolvedWorkspace, debug: 
             }
             Ok(out) => {
                 let stderr = String::from_utf8_lossy(&out.stderr);
-                eprintln!("  Warning: git pull failed in {}: {}", mount.src, stderr.trim());
+                eprintln!(
+                    "  Warning: git pull failed in {}: {}",
+                    mount.src,
+                    stderr.trim()
+                );
             }
             Err(e) => {
                 eprintln!("  Warning: could not run git pull in {}: {e}", mount.src);

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -18,6 +18,9 @@ pub use sensitive::{SensitiveMount, confirm_sensitive_mounts, find_sensitive_mou
 
 use serde::{Deserialize, Serialize};
 
+// serde skip_serializing_if requires &T; clippy's trivially_copy_pass_by_ref
+// lint does not apply here because the signature is mandated by the attribute.
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(b: &bool) -> bool {
     !b
 }

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -110,7 +110,7 @@ model = "gpt-5"
         }],
         default_agent: Some(Agent::Codex),
         keep_awake_enabled: false,
-    git_pull_on_entry: false,
+        git_pull_on_entry: false,
     };
     let mut runner = FakeRunner::for_load_agent([String::new()]);
 
@@ -212,7 +212,7 @@ plugins = []
         }],
         default_agent: Some(Agent::Claude),
         keep_awake_enabled: false,
-    git_pull_on_entry: false,
+        git_pull_on_entry: false,
     };
     let mut runner = FakeRunner::for_load_agent([String::new()]);
     let opts = LoadOptions {

--- a/tests/per_mount_isolation_e2e.rs
+++ b/tests/per_mount_isolation_e2e.rs
@@ -79,7 +79,7 @@ fn materialize_then_clean_exit_removes_record_and_branch() {
         }],
         default_agent: None,
         keep_awake_enabled: false,
-    git_pull_on_entry: false,
+        git_pull_on_entry: false,
     };
 
     // materialize_workspace capture queue:


### PR DESCRIPTION
Fixes the red main introduced by #227.

**fmt fixes (cargo fmt --check was failing):**
- Expand inline `if/else` in `save.rs` to multi-line form
- Fix 8→12 space indentation in `materialize.rs` and `identity.rs`
- Expand inline `eprintln!` in `launch.rs` to multi-line form
- Fix 4→8 space indentation in `codex_launch.rs` and `per_mount_isolation_e2e.rs`

**AGENTS.md:**
- "CI must be green before merging" — always run `gh pr checks` before merge, never force-merge through failures, always use gh CLI
- "Changelog" — do not add entries until the first tagged release

**CHANGELOG.md:**
- Revert the Unreleased entry added by #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)