### PR TITLE
fix: split role cache default and branch checkouts

### DIFF
--- a/docs/src/content/docs/guides/role-repos.mdx
+++ b/docs/src/content/docs/guides/role-repos.mdx
@@ -72,7 +72,7 @@ This name appears in jackin's TUI and output. When omitted, the role selector na
 
 ## Caching
 
-Role repos are cloned to `~/.jackin/roles/` on first load. Subsequent loads use the cached checkout. jackin' updates the repo on each load to keep the cache current.
+Role repos are cloned under `~/.jackin/roles/` on first load. The default branch checkout lives at `~/.jackin/roles/<role>/default`, and branch-specific checkouts live under `~/.jackin/roles/<role>/branches/<branch>`. Subsequent loads use the cached checkout. jackin' updates the repo on each load to keep the cache current.
 
 jackin' is intentionally strict about that cache:
 

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -304,6 +304,10 @@ jackin workspace edit my-app --no-git-pull
 
 `jackin workspace show <name>` surfaces a `Git Pull: on entry` row when the flag is on.
 
+## Jackin development workspace
+
+When the saved workspace is named `jackin`, jackin automatically injects `MISE_TRUSTED_CONFIG_PATHS` into the role container. The value covers the workspace `workdir` and every mount destination, so mise trusts the Jackin project checkouts without requiring a manual `mise trust` inside the container. Other workspaces are not affected, and an explicitly configured `MISE_TRUSTED_CONFIG_PATHS` env var still wins.
+
 ## Workspace auto-detection
 
 When you open the operator console (`jackin console`), it checks whether your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths. If it does, that workspace is preselected — saving you a selection step and reinforcing the value of naming project boundaries once. Container-only `workdir` values like `/workspace` can still be auto-detected as long as one of the workspace's mounted host paths contains your current directory. You can always override the preselection by choosing a different workspace or "Current directory."

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -943,7 +943,7 @@ mod tests {
         let paths = paths::JackinPaths::for_tests(temp.path());
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
-            &paths.roles_dir.join(&selector.name),
+            &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
             r#"dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -968,7 +968,7 @@ plugins = []
         let paths = paths::JackinPaths::for_tests(temp.path());
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
-            &paths.roles_dir.join(&selector.name),
+            &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
             r#"dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -993,7 +993,7 @@ plugins = []
         let paths = paths::JackinPaths::for_tests(temp.path());
         let selector = crate::selector::RoleSelector::parse("solo").unwrap();
         write_role_manifest(
-            &paths.roles_dir.join(&selector.name),
+            &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
             r#"dockerfile = "Dockerfile"
 agents = ["codex"]
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -11,15 +11,17 @@ pub struct CachedRepo {
 }
 
 impl CachedRepo {
-    pub fn new(paths: &JackinPaths, selector: &RoleSelector) -> Self {
-        let repo_dir = selector.namespace.as_ref().map_or_else(
+    fn role_cache_root(paths: &JackinPaths, selector: &RoleSelector) -> PathBuf {
+        selector.namespace.as_ref().map_or_else(
             || paths.roles_dir.join(&selector.name),
             |namespace| paths.roles_dir.join(namespace).join(&selector.name),
-        );
+        )
+    }
 
+    pub fn new(paths: &JackinPaths, selector: &RoleSelector) -> Self {
         Self {
             key: selector.key(),
-            repo_dir,
+            repo_dir: Self::role_cache_root(paths, selector).join("default"),
         }
     }
 
@@ -29,15 +31,13 @@ impl CachedRepo {
     /// named `feat-my-pr` (with a dash) would live at `…/branches/feat-my-pr`,
     /// which is a different path, eliminating any ambiguity.
     pub fn for_branch(paths: &JackinPaths, selector: &RoleSelector, branch: &str) -> Self {
-        let base = selector.namespace.as_ref().map_or_else(
-            || paths.roles_dir.join(&selector.name),
-            |namespace| paths.roles_dir.join(namespace).join(&selector.name),
-        );
         Self {
             key: format!("{}@{branch}", selector.key()),
             // Path::join handles forward slashes as directory separators, so
             // "feat/my-pr" naturally becomes …/branches/feat/my-pr on disk.
-            repo_dir: base.join("branches").join(branch),
+            repo_dir: Self::role_cache_root(paths, selector)
+                .join("branches")
+                .join(branch),
         }
     }
 }
@@ -180,7 +180,30 @@ mod tests {
 
         assert_eq!(
             repo.repo_dir,
-            paths.roles_dir.join("chainargos").join("the-architect")
+            paths
+                .roles_dir
+                .join("chainargos")
+                .join("the-architect")
+                .join("default")
+        );
+    }
+
+    #[test]
+    fn computes_branch_cache_path_as_sibling_of_default() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let selector = RoleSelector::new(None, "the-architect");
+
+        let repo = CachedRepo::for_branch(&paths, &selector, "feat/caveman-all-install");
+
+        assert_eq!(
+            repo.repo_dir,
+            paths
+                .roles_dir
+                .join("the-architect")
+                .join("branches")
+                .join("feat")
+                .join("caveman-all-install")
         );
     }
 

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -20,6 +20,8 @@ use super::naming::{
 };
 use super::repo_cache::resolve_agent_repo;
 
+const MISE_TRUSTED_CONFIG_PATHS_ENV: &str = "MISE_TRUSTED_CONFIG_PATHS";
+
 // Four launch-time toggles (no_intro / debug / rebuild / force) all map
 // directly to CLI flags; bundling them into nested structs would obscure
 // rather than clarify the call sites.
@@ -281,6 +283,44 @@ fn build_workspace_mount_strings(
         }
     }
     out
+}
+
+fn jackin_workspace_mise_trusted_config_paths(
+    workspace_name: Option<&str>,
+    workspace: &crate::workspace::ResolvedWorkspace,
+) -> Option<String> {
+    if workspace_name != Some("jackin") {
+        return None;
+    }
+
+    let mut paths = std::collections::BTreeSet::new();
+    if !workspace.workdir.trim().is_empty() {
+        paths.insert(workspace.workdir.clone());
+    }
+    for mount in &workspace.mounts {
+        if !mount.dst.trim().is_empty() {
+            paths.insert(mount.dst.clone());
+        }
+    }
+
+    (!paths.is_empty()).then(|| paths.into_iter().collect::<Vec<_>>().join(":"))
+}
+
+fn inject_jackin_workspace_env(
+    vars: &mut Vec<(String, String)>,
+    workspace_name: Option<&str>,
+    workspace: &crate::workspace::ResolvedWorkspace,
+) {
+    if vars
+        .iter()
+        .any(|(key, _)| key == MISE_TRUSTED_CONFIG_PATHS_ENV)
+    {
+        return;
+    }
+
+    if let Some(value) = jackin_workspace_mise_trusted_config_paths(workspace_name, workspace) {
+        vars.push((MISE_TRUSTED_CONFIG_PATHS_ENV.to_string(), value));
+    }
 }
 
 /// Resolve the TERM value and an optional terminfo bind-mount for the
@@ -1180,6 +1220,7 @@ fn load_role_with(
             merged_vars.push((k.clone(), v.clone()));
         }
     }
+    inject_jackin_workspace_env(&mut merged_vars, workspace_name.as_deref(), workspace);
     let resolved_env = crate::env_resolver::ResolvedEnv { vars: merged_vars };
 
     // Launch-time diagnostic: emit a single compact line summarising
@@ -2475,6 +2516,60 @@ agents = ["codex"]
         assert_eq!(strings, vec!["/host/cache:/workspace/cache:ro".to_string()]);
     }
 
+    #[test]
+    fn jackin_workspace_mise_paths_cover_workdir_and_mount_destinations() {
+        let workspace = crate::workspace::ResolvedWorkspace {
+            label: "jackin".to_string(),
+            workdir: "/workspace".to_string(),
+            mounts: vec![
+                crate::workspace::MountConfig {
+                    src: "/host/jackin".to_string(),
+                    dst: "/workspace/jackin".to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+                crate::workspace::MountConfig {
+                    src: "/host/homebrew-tap".to_string(),
+                    dst: "/workspace/homebrew-tap".to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            ],
+            default_agent: None,
+            keep_awake_enabled: false,
+            git_pull_on_entry: false,
+        };
+
+        let value = jackin_workspace_mise_trusted_config_paths(Some("jackin"), &workspace).unwrap();
+
+        assert_eq!(
+            value,
+            "/workspace:/workspace/homebrew-tap:/workspace/jackin"
+        );
+        assert!(
+            jackin_workspace_mise_trusted_config_paths(Some("scentbird"), &workspace).is_none()
+        );
+    }
+
+    #[test]
+    fn jackin_workspace_mise_env_does_not_override_operator_value() {
+        let workspace = repo_workspace(std::path::Path::new("/host/repo"));
+        let mut vars = vec![(
+            MISE_TRUSTED_CONFIG_PATHS_ENV.to_string(),
+            "/operator/trusted".to_string(),
+        )];
+
+        inject_jackin_workspace_env(&mut vars, Some("jackin"), &workspace);
+
+        assert_eq!(
+            vars,
+            vec![(
+                MISE_TRUSTED_CONFIG_PATHS_ENV.to_string(),
+                "/operator/trusted".to_string()
+            )]
+        );
+    }
+
     fn repo_workspace(repo_dir: &std::path::Path) -> crate::workspace::ResolvedWorkspace {
         crate::workspace::ResolvedWorkspace {
             label: repo_dir.display().to_string(),
@@ -2587,7 +2682,7 @@ plugins = []
         let selector = RoleSelector::new(Some("chainargos"), "the-architect");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("chainargos").join("the-architect");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -2676,7 +2771,7 @@ plugins = ["code-review@claude-plugins-official"]
         let selector = RoleSelector::new(Some("evil-org"), "backdoor");
         let mut runner = FakeRunner::for_load_agent([String::new(), String::new()]);
 
-        let repo_dir = paths.roles_dir.join("evil-org").join("backdoor");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -2728,7 +2823,7 @@ plugins = []
         let selector = RoleSelector::new(Some("chainargos"), "agent-brown");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("chainargos").join("agent-brown");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -2804,7 +2899,7 @@ trusted = true
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -2888,7 +2983,7 @@ trusted = true
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -2968,7 +3063,7 @@ trusted = true
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3020,7 +3115,7 @@ agents = ["codex"]
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3091,7 +3186,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3158,7 +3253,7 @@ plugins = []
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3204,7 +3299,7 @@ plugins = []
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3253,7 +3348,7 @@ plugins = []
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3302,7 +3397,7 @@ plugins = []
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner::for_load_agent([String::new()]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3360,7 +3455,7 @@ plugins = []
             ..Default::default()
         };
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3433,7 +3528,7 @@ plugins = ["code-review@claude-plugins-official"]
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3502,7 +3597,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3597,7 +3692,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3650,7 +3745,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3709,7 +3804,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3767,7 +3862,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3819,7 +3914,7 @@ plugins = []
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3922,7 +4017,7 @@ trusted = true
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -3958,6 +4053,100 @@ plugins = []
         assert!(
             run_cmd.contains("-e OPERATOR_SMOKE=smoke-literal"),
             "docker run must inject operator env; got: {run_cmd}"
+        );
+    }
+
+    #[test]
+    fn load_agent_injects_mise_trusted_paths_for_jackin_workspace_only() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+
+        std::fs::write(
+            &paths.config_file,
+            r#"[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[workspaces.jackin]
+workdir = "/workspace"
+
+[[workspaces.jackin.mounts]]
+src = "/tmp"
+dst = "/workspace"
+"#,
+        )
+        .unwrap();
+
+        let mut config = AppConfig::load_or_init(&paths).unwrap();
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = FakeRunner::for_load_agent([
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "jackin-agent-smith".to_string(),
+        ]);
+
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::write(
+            repo_dir.join("Dockerfile"),
+            "FROM projectjackin/construct:trixie\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("jackin.role.toml"),
+            r#"dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        )
+        .unwrap();
+
+        let workspace = crate::workspace::ResolvedWorkspace {
+            label: "jackin".to_string(),
+            workdir: "/workspace".to_string(),
+            mounts: vec![
+                crate::workspace::MountConfig {
+                    src: repo_dir.display().to_string(),
+                    dst: "/workspace/jackin".to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+                crate::workspace::MountConfig {
+                    src: repo_dir.display().to_string(),
+                    dst: "/workspace/homebrew-tap".to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            ],
+            default_agent: None,
+            keep_awake_enabled: false,
+            git_pull_on_entry: false,
+        };
+
+        load_role(
+            &paths,
+            &mut config,
+            &selector,
+            &workspace,
+            &mut runner,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+
+        let run_cmd = runner
+            .recorded
+            .iter()
+            .find(|call| call.contains("docker run -d -it"))
+            .unwrap();
+        assert!(
+            run_cmd.contains(
+                "-e MISE_TRUSTED_CONFIG_PATHS=/workspace:/workspace/homebrew-tap:/workspace/jackin"
+            ),
+            "jackin workspace must inject mise trusted paths; got: {run_cmd}"
         );
     }
 
@@ -4001,7 +4190,7 @@ trusted = true
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -4080,7 +4269,7 @@ trusted = true
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -4176,7 +4365,7 @@ trusted = true
             "jackin-agent-smith".to_string(),
         ]);
 
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(&repo_dir).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -57,6 +57,82 @@ pub(super) fn repo_matches(expected: &str, actual: &str) -> bool {
     }
 }
 
+fn role_cache_root(paths: &JackinPaths, selector: &RoleSelector) -> std::path::PathBuf {
+    selector.namespace.as_ref().map_or_else(
+        || paths.roles_dir.join(&selector.name),
+        |namespace| paths.roles_dir.join(namespace).join(&selector.name),
+    )
+}
+
+fn migrate_legacy_default_cache(
+    paths: &JackinPaths,
+    selector: &RoleSelector,
+    cached_repo: &CachedRepo,
+) -> anyhow::Result<()> {
+    let root = role_cache_root(paths, selector);
+    if cached_repo.repo_dir != root.join("default")
+        || cached_repo.repo_dir.exists()
+        || !root.join(".git").is_dir()
+    {
+        return Ok(());
+    }
+
+    let parent = root
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("role cache path has no parent: {}", root.display()))?;
+    let root_name = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("role");
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let legacy_root = parent.join(format!(".{root_name}.legacy-cache-{suffix}"));
+
+    std::fs::rename(&root, &legacy_root).with_context(|| {
+        format!(
+            "failed to move legacy role cache {} before migrating to default/",
+            root.display()
+        )
+    })?;
+    std::fs::create_dir_all(&root)?;
+
+    let legacy_branches = legacy_root.join("branches");
+    if legacy_branches.exists() {
+        std::fs::rename(&legacy_branches, root.join("branches")).with_context(|| {
+            format!(
+                "failed to move legacy branch cache {}",
+                legacy_branches.display()
+            )
+        })?;
+    }
+
+    std::fs::rename(&legacy_root, &cached_repo.repo_dir).with_context(|| {
+        format!(
+            "failed to move legacy role cache into {}",
+            cached_repo.repo_dir.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn role_root_has_unexpected_entries(root: &std::path::Path) -> anyhow::Result<bool> {
+    if !root.exists() {
+        return Ok(false);
+    }
+
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_name() != "branches" {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 /// Derive a short repository name from a git remote URL (e.g. `jackin-project/jackin`).
 pub(super) fn git_repo_name(
     dir: &std::path::Path,
@@ -148,7 +224,8 @@ pub(super) fn register_agent_repo(
     persist_registration: impl FnOnce() -> anyhow::Result<()>,
 ) -> anyhow::Result<(CachedRepo, crate::repo::ValidatedRoleRepo)> {
     let cached_repo = CachedRepo::new(paths, selector);
-    if cached_repo.repo_dir.join(".git").is_dir() {
+    let legacy_root = role_cache_root(paths, selector);
+    if cached_repo.repo_dir.join(".git").is_dir() || legacy_root.join(".git").is_dir() {
         let (cached_repo, validated_repo, _lock_file) =
             resolve_agent_repo_with(paths, selector, git_url, runner, debug, None, || Ok(false))?;
         persist_registration()?;
@@ -163,6 +240,17 @@ pub(super) fn register_agent_repo(
     })?;
     std::fs::create_dir_all(repo_parent)?;
     std::fs::create_dir_all(&paths.data_dir)?;
+
+    let role_root = role_cache_root(paths, selector);
+    if !cached_repo.repo_dir.exists()
+        && !role_root.join(".git").is_dir()
+        && role_root_has_unexpected_entries(&role_root)?
+    {
+        anyhow::bail!(
+            "cached role path exists but is not a git repository: {}",
+            role_root.display()
+        );
+    }
 
     if cached_repo.repo_dir.exists() {
         anyhow::bail!(
@@ -261,10 +349,7 @@ pub(super) fn resolve_agent_repo_with(
     // named `feat/my-pr` and one named `feat-my-pr` (slug collision) always
     // get distinct lock files. The roles_dir prefix is stripped to produce
     // the relative path; `std::fs::create_dir_all` creates intermediate dirs.
-    let selector_base = selector.namespace.as_ref().map_or_else(
-        || paths.roles_dir.join(&selector.name),
-        |ns| paths.roles_dir.join(ns).join(&selector.name),
-    );
+    let selector_base = role_cache_root(paths, selector);
     let rel = cached_repo
         .repo_dir
         .strip_prefix(&selector_base)
@@ -292,6 +377,10 @@ pub(super) fn resolve_agent_repo_with(
         quiet: !debug,
         ..RunOptions::default()
     };
+
+    if branch_override.is_none() {
+        migrate_legacy_default_cache(paths, selector, &cached_repo)?;
+    }
 
     let repo_path = cached_repo.repo_dir.display().to_string();
     if cached_repo.repo_dir.join(".git").is_dir() {
@@ -429,7 +518,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -470,7 +559,7 @@ plugins = []
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -541,7 +630,7 @@ plugins = []
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -585,7 +674,7 @@ plugins = []
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -624,7 +713,7 @@ plugins = []
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -686,7 +775,7 @@ plugins = []
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let selector = RoleSelector::new(None, "agent-smith");
-        let repo_dir = paths.roles_dir.join("agent-smith");
+        let repo_dir = CachedRepo::new(&paths, &selector).repo_dir;
         std::fs::create_dir_all(repo_dir.join(".git")).unwrap();
         std::fs::write(
             repo_dir.join("Dockerfile"),
@@ -737,6 +826,46 @@ plugins = []
                 .any(|call| call.contains("git -C") && call.contains("merge --ff-only")),
             "expected a git merge --ff-only: {:?}",
             runner.run_recorded
+        );
+    }
+
+    #[test]
+    fn resolve_agent_repo_migrates_legacy_root_repo_to_default_sibling_layout() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let selector = RoleSelector::new(None, "agent-smith");
+        let legacy_root = paths.roles_dir.join("agent-smith");
+        seed_valid_role_repo(&legacy_root);
+        std::fs::create_dir_all(legacy_root.join("branches/feat/caveman-all-install")).unwrap();
+        std::fs::write(
+            legacy_root.join("branches/feat/caveman-all-install/README.md"),
+            "branch cache\n",
+        )
+        .unwrap();
+
+        let mut runner = FakeRunner::with_capture_queue([
+            "git@github.com:jackin-project/jackin-agent-smith.git".to_string(),
+            String::new(),      // git status --porcelain (clean)
+            "main".to_string(), // git rev-parse --abbrev-ref HEAD
+        ]);
+
+        let (cached_repo, _, _) = resolve_agent_repo(
+            &paths,
+            &selector,
+            "https://github.com/jackin-project/jackin-agent-smith.git",
+            &mut runner,
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cached_repo.repo_dir, legacy_root.join("default"));
+        assert!(legacy_root.join("default/.git").is_dir());
+        assert!(!legacy_root.join(".git").exists());
+        assert!(
+            legacy_root
+                .join("branches/feat/caveman-all-install/README.md")
+                .is_file()
         );
     }
 
@@ -791,7 +920,7 @@ plugins = []
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
         let selector = RoleSelector::new(None, "agent-broken");
-        let cached_dir = paths.roles_dir.join("agent-broken");
+        let cached_dir = CachedRepo::new(&paths, &selector).repo_dir;
 
         let data_dir = paths.data_dir.clone();
         let mut runner = FakeRunner::default();
@@ -845,7 +974,7 @@ plugins = []
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
         let selector = RoleSelector::new(None, "agent-persist-fail");
-        let cached_dir = paths.roles_dir.join("agent-persist-fail");
+        let cached_dir = CachedRepo::new(&paths, &selector).repo_dir;
 
         let data_dir = paths.data_dir.clone();
         let mut runner = FakeRunner::default();

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -70,7 +70,8 @@ trusted = true
     )
     .unwrap();
 
-    let repo_dir = paths.roles_dir.join("agent-smith");
+    let selector = RoleSelector::new(None, "agent-smith");
+    let repo_dir = jackin::repo::CachedRepo::new(&paths, &selector).repo_dir;
     std::fs::create_dir_all(&repo_dir).unwrap();
     std::fs::write(
         repo_dir.join("Dockerfile"),
@@ -98,7 +99,6 @@ model = "gpt-5"
     assert!(dockerfile.contains("openai/codex/releases"));
 
     let mut config = AppConfig::load_or_init(&paths).unwrap();
-    let selector = RoleSelector::new(None, "agent-smith");
     let workspace = ResolvedWorkspace {
         label: repo_dir.display().to_string(),
         workdir: "/workspace".to_string(),
@@ -179,7 +179,8 @@ trusted = true
     )
     .unwrap();
 
-    let repo_dir = paths.roles_dir.join("agent-smith");
+    let selector = RoleSelector::new(None, "agent-smith");
+    let repo_dir = jackin::repo::CachedRepo::new(&paths, &selector).repo_dir;
     std::fs::create_dir_all(&repo_dir).unwrap();
     std::fs::write(
         repo_dir.join("Dockerfile"),
@@ -200,7 +201,6 @@ plugins = []
     .unwrap();
 
     let mut config = AppConfig::load_or_init(&paths).unwrap();
-    let selector = RoleSelector::new(None, "agent-smith");
     let workspace = ResolvedWorkspace {
         label: repo_dir.display().to_string(),
         workdir: "/workspace".to_string(),


### PR DESCRIPTION
## Summary
- store default role checkouts under `~/.jackin/roles/<role>/default` and branch checkouts under sibling `branches/<branch>`
- migrate existing legacy root checkouts into the new layout while preserving branch caches
- inject `MISE_TRUSTED_CONFIG_PATHS` only for the saved `jackin` workspace, unless explicitly configured

## Tests
- `cargo fmt --check`
- `cargo test runtime::repo_cache::tests --lib`
- `cargo test runtime::launch::tests --lib`
- `cargo test repo::tests --lib`
- `cargo test app::context::tests::requires_prompt_when_role_supports_two_agents_and_no_workspace_default --lib`
- `cargo test --lib` (one unrelated fake-op Text file busy flake, reran failing test successfully)
- `cargo test operator_env::tests::op_cli_nonzero_exit_propagates_stderr_bounded --lib`