### PR TITLE
docs: improve landing hero nav and PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,34 @@ When the first release is being cut, the operator will explicitly ask for the ch
 
 If you are uncertain whether authorization applies to the PR in front of you, ask. The cost of pausing is ~30 seconds; the cost of merging something the operator wasn't ready for is much higher.
 
+### Include local checkout instructions in every PR
+
+Every pull request created by an agent must include a copy-pasteable "Verify locally" section in the PR body, and the agent's final response should repeat the same commands after sharing the PR URL.
+
+Use the real PR number, repository URL, branch name, and verification commands for the change. Start from a separate test directory so the operator can inspect the PR without disturbing their normal working tree. The clone step must be idempotent: reuse the folder if it already exists, otherwise clone it.
+
+Template:
+
+```sh
+mkdir -p "$HOME/Projects/jackin-project/test"
+cd "$HOME/Projects/jackin-project/test"
+
+if [ ! -d jackin/.git ]; then
+  git clone https://github.com/jackin-project/jackin.git
+fi
+
+cd jackin
+git fetch origin pull/<PR_NUMBER>/head:pr-<PR_NUMBER>
+git checkout pr-<PR_NUMBER>
+
+# Run the checks relevant to this PR, for example:
+# cd docs
+# bun install --frozen-lockfile
+# bun run dev
+```
+
+If the PR needs a different validation flow, replace the final example commands with the exact commands the operator should run. When those commands invoke `jackin`, include `--debug` as required by "Walking the operator through local validation".
+
 ### CI must be green before merging
 
 **Never merge a pull request unless all required CI checks pass.** This is non-negotiable regardless of how the operator phrases the merge request.

--- a/docs/src/components/landing/HeroStage.tsx
+++ b/docs/src/components/landing/HeroStage.tsx
@@ -10,7 +10,13 @@ export function HeroStage() {
       <nav className="landing-topnav">
         <div className="landing-logo">jackin<span className="tick">'</span></div>
         <div className="landing-nav-right">
-          <ThemeToggle />
+          <a className="landing-star" href="/getting-started/why">
+            <svg className="landing-star-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5z" />
+            </svg>
+            Docs
+          </a>
           <a className="landing-star" href="https://github.com/jackin-project/jackin" target="_blank" rel="noopener">
             <svg className="landing-star-icon" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
@@ -24,6 +30,7 @@ export function HeroStage() {
           <HeroContent />
         </div>
       </div>
+      <ThemeToggle />
     </section>
   );
 }

--- a/docs/src/components/landing/hero-nav.css
+++ b/docs/src/components/landing/hero-nav.css
@@ -1,0 +1,33 @@
+/* Small first-screen overrides layered after the main landing stylesheet. */
+.landing-hero-stage > .landing-theme-toggle {
+  position: absolute;
+  right: 40px;
+  bottom: 40px;
+  z-index: 4;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32);
+}
+
+@media (max-width: 720px) {
+  nav.landing-topnav {
+    padding: 18px 20px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 18px;
+  }
+
+  .landing-nav-right {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .landing-star {
+    padding: 7px 10px;
+    font-size: 10px;
+  }
+
+  .landing-hero-stage > .landing-theme-toggle {
+    right: 20px;
+    bottom: 24px;
+  }
+}

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import '../components/landing/styles.css'
+import '../components/landing/hero-nav.css'
 // Preload the two woff2s used above the fold:
 //   - variable Inter for hero headline + body copy (weights 400–800)
 //   - static Inter Black (weight 900) for top-nav logo + giant footer wordmark


### PR DESCRIPTION
Adds a first-screen Docs link next to GitHub, moves the landing theme toggle to the bottom-right of the hero so it scrolls away with the first screen, and documents the local-verification instructions agents must include when opening PRs.

Verification:
- git diff --check HEAD^..HEAD

Note: docs build was not run earlier because bun was unavailable in the execution environment.

Verify locally:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
git fetch origin pull/231/head:pr-231
git checkout pr-231

cd docs
bun install --frozen-lockfile
bun run dev
```