### PR TITLE
docs: include mise trust in PR verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ if [ ! -d jackin/.git ]; then
 fi
 
 cd jackin
+mise trust
 git fetch origin pull/<PR_NUMBER>/head:pr-<PR_NUMBER>
 git checkout pr-<PR_NUMBER>
 


### PR DESCRIPTION
Adds `mise trust` to the agent PR verification template so locally checking out PRs into `$HOME/Projects/jackin-project/test` does not trip over an untrusted `mise.toml` before running validation commands.

Verification:
- `git diff --check origin/main..HEAD`

Verify locally:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin pull/232/head:pr-232
git checkout pr-232

git diff --check origin/main..HEAD
```
