### PR TITLE
feat(isolation): add clone mount mode

### DIFF
--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -30,7 +30,7 @@ Create a new workspace definition.
 | `--allowed-role <NAME>` | Restrict to these roles (repeatable) |
 | `--default-role <NAME>` | Role to auto-select |
 | `--default-agent <claude\|codex>` | Default agent for this workspace |
-| `--mount-isolation <DST>=<TYPE>` | Set per-mount isolation by container destination. Repeatable. `<TYPE>` is `shared` or `worktree`. The `<DST>` must match a mount destination present in the final mount plan; an unknown `<DST>` is a hard error. |
+| `--mount-isolation <DST>=<TYPE>` | Set per-mount isolation by container destination. Repeatable. `<TYPE>` is `shared`, `worktree`, or `clone`. The `<DST>` must match a mount destination present in the final mount plan; an unknown `<DST>` is a hard error. |
 | `--keep-awake` | macOS only: opt this workspace into the keep-awake reconciler. While any agent in the workspace is running, jackin keeps a single detached `caffeinate -imsu` alive so the host stays awake. No-op on Linux/Windows. See [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake). |
 | `--git-pull` | Run `git pull` on every mounted git repository from the host before the agent container starts. Failures are non-fatal — the launch continues even when offline or the working tree is dirty. See [Git pull on entry](/guides/workspaces/#git-pull-on-entry). |
 
@@ -66,7 +66,7 @@ jackin workspace show <NAME>
 
 Display details of a specific workspace including workdir, mounts, and role restrictions.
 
-The mount table includes an **Isolation** column showing each mount's effective isolation mode (`shared` or `worktree`). Mounts with no `isolation` field in TOML display as `shared`.
+The mount table includes an **Isolation** column showing each mount's effective isolation mode (`shared`, `worktree`, or `clone`). Mounts with no `isolation` field in TOML display as `shared`.
 
 ### `workspace edit`
 

--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -141,12 +141,13 @@ Ad-hoc `-v` mounts passed on the command line at launch time are not collapsed; 
 
 ## Mount isolation
 
-Workspace mounts accept an `isolation` field that controls whether the host path is bind-mounted as-is or materialized into a per-container `git worktree` first.
+Workspace mounts accept an `isolation` field that controls whether the host path is bind-mounted as-is or materialized into a per-container git checkout first.
 
 | Value | Default | Behavior |
 |---|---|---|
 | `shared` | yes | Host path bind-mounted as-is. |
-| `worktree` | no | jackin' runs `git worktree add` on the host repo and bind-mounts the worktree. Each container gets its own checkout and scratch branch. |
+| `worktree` | no | jackin' runs `git worktree add` on the host repo and bind-mounts the worktree. Each container gets its own checkout and scratch branch, while refs remain shared with the host repo. |
+| `clone` | no | jackin' runs `git clone --local` into the per-container state dir and bind-mounts the clone. Each container gets its own `.git/` and independent refs. |
 
 ```toml
 [[workspaces.my-app.mounts]]

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -110,13 +110,14 @@ Setting `isolation = "worktree"` on a source mount tells jackin' to materialize 
 | Mode | Status | Behavior |
 |---|---|---|
 | `shared` | Default | Host path bind-mounted as-is. Today's behavior. |
-| `worktree` | V1 | Materialize a `git worktree` per container; bind-mount the worktree path. Branch defaults to `jackin/scratch/<container>`, base is host `HEAD`. |
+| `worktree` | Available | Materialize a `git worktree` per container; bind-mount the worktree path. Branch defaults to `jackin/scratch/<container>`, base is host `HEAD`. Refs are shared with the host repo. |
+| `clone` | Available | Materialize a per-container `git clone --local`; bind-mount the clone path. The clone has its own `.git/` and independent refs; branches appear on the host only after an explicit push. |
 
-A `clone` mode (per-agent `git clone --local --shared` for full ref isolation) is on the [roadmap for V1.1](/reference/roadmap/per-mount-isolation/) but is not part of the V1 vocabulary — passing `--mount-isolation /…=clone` today errors with the standard "invalid isolation" message.
+Use `worktree` when immediate host-side branch visibility is useful and the agent is trusted with the host repo's `.git/`. Use `clone` when ref isolation is more important than immediate host visibility.
 
 ### Validation
 
-`worktree` mounts have a few preconditions enforced before materialization:
+`worktree` and `clone` mounts have a few preconditions enforced before materialization:
 
 - `src` must be a git repository **root** (not a subdirectory).
 - The host repo must not be mid-rebase, mid-merge, or mid-cherry-pick.

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -108,9 +108,9 @@ Workspace mounts pass through three distinct shapes between operator intent and 
 |---|---|---|
 | `WorkspaceConfig` | `~/.config/jackin/config.toml` | Persisted operator intent — raw `src`/`dst`/`readonly`/`isolation` fields per mount. |
 | `ResolvedWorkspace` | `resolve_load_workspace` | Expanded host paths plus the merged composition of workspace, ad-hoc, and global mounts. Still independent of the actual container instance. |
-| `MaterializedWorkspace` | post-name-claim materializer | Final host paths Docker should bind-mount for *this* container. Worktrees have been created on disk; isolated `src` values point at the per-container worktree path. |
+| `MaterializedWorkspace` | post-name-claim materializer | Final host paths Docker should bind-mount for *this* container. Isolated checkouts have been created on disk; isolated `src` values point at the per-container worktree or clone path. |
 
-Materialization happens **after** jackin claims the final container name (e.g. resolves `-clone-N` collisions) and the per-container state directory exists. For each non-`shared` mount, materialization is idempotent: first load creates the scratch branch from host `HEAD` and records `base_commit`; later loads to the same container reuse the existing worktree as-is — no reset, no rebase, no fast-forward.
+Materialization happens **after** jackin claims the final container name (e.g. resolves `-clone-N` collisions) and the per-container state directory exists. For each non-`shared` mount, materialization is idempotent: first load creates the scratch branch from host `HEAD` and records `base_commit`; later loads to the same container reuse the existing checkout as-is — no reset, no rebase, no fast-forward.
 
 On first worktree creation for a host repo, jackin' enables `extensions.worktreeConfig` (bumping `core.repositoryformatversion` to 1 if needed) so per-worktree config writes via `git config --worktree` don't leak into the shared host `.git/config`.
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -136,7 +136,7 @@ git_pull_on_entry = true
 | `mounts[].src` | Host path |
 | `mounts[].dst` | Container path |
 | `mounts[].readonly` | Read-only flag |
-| `mounts[].isolation` | Per-mount isolation mode: `shared` (default) or `worktree`. Omitting the field deserializes to `shared`, but every save writes the field explicitly so old configs migrate to the new shape on first save. Global mounts (under `[docker.mounts]` or `[[mounts]]`) reject this field at parse time. A `clone` mode is on the [V1.1 roadmap](/reference/roadmap/per-mount-isolation/) but is not part of the V1 enum vocabulary. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation). |
+| `mounts[].isolation` | Per-mount isolation mode: `shared` (default), `worktree`, or `clone`. Omitting the field deserializes to `shared`, but every save writes the field explicitly so old configs migrate to the new shape on first save. Global mounts (under `[docker.mounts]` or `[[mounts]]`) reject this field at parse time. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation). |
 | `allowed_roles` | List of allowed role selectors |
 | `default_role` | Default role selector |
 | `default_agent` | Optional workspace default agent (`"claude"` or `"codex"`). Omit to default to Claude. |

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -62,7 +62,7 @@ The current implementation is Claude-specific end-to-end (manifest schema, deriv
 
 ### Workflow improvements
 
-- **[Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/)** — declarative `shared | worktree` mode per mount (clone mode planned for V1.1) so parallel agents stop sharing one working tree
+- **[Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/)** — declarative `shared | worktree | clone` mode per mount so parallel agents stop sharing one working tree
 
 ### Operator surface and fleet operations
 

--- a/docs/src/content/docs/reference/roadmap/ephemeral-mount-modes.mdx
+++ b/docs/src/content/docs/reference/roadmap/ephemeral-mount-modes.mdx
@@ -8,8 +8,8 @@ import RepoFile from '../../../../components/RepoFile.astro'
 ## Problem
 
 jackin's [per-mount isolation](/reference/roadmap/per-mount-isolation/)
-vocabulary is `shared | worktree` (V1), with `clone` planned for V1.1.
-These modes describe **git semantics** for the mounted path. They don't
+vocabulary is `shared | worktree | clone`. These modes describe **git
+semantics** for the mounted path. They don't
 cover a different axis the operator also cares about: **storage kind**.
 
 Specifically, two storage shapes have no declarative way to be expressed

--- a/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
+++ b/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
@@ -246,8 +246,8 @@ not duplicated, here:
   / Amp / Claude as selectable per-instance runtimes. This program's Phase 2+
   items assume the runtime adapter seam from that work exists.
 - [Per-mount isolation](/reference/roadmap/per-mount-isolation/) — `worktree`
-  mode shipped in V1; `clone` mode planned for V1.1. This program's queue
-  and parallel-agent assumptions rely on isolated mounts.
+  and `clone` modes provide isolated source mounts. This program's queue and
+  parallel-agent assumptions rely on isolated mounts.
 - [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) —
   cross-backend resource-limit translation lives there, not in this program.
 - [1Password integration](/reference/roadmap/onepassword-integration/) and

--- a/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
+++ b/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
@@ -44,8 +44,8 @@ isolation = "shared"             # build cache, shared on purpose
 Modes:
 
 - **`shared`** — current behavior. Host path bind-mounted as-is.
-- **`worktree`** — jackin' runs `git worktree add` on the host against the configured `src`, then bind-mounts the worktree path into the container. Each agent gets its own working tree, HEAD, and index, but **refs and the object database are shared with the host repo** — this is fundamental to git worktrees, there's only one ref namespace per repo. Branches the agent creates appear immediately in the host's `git branch -a` without an explicit push step. To make git work inside the container, jackin' also bind-mounts the host repo's `.git/` directory into the container (see [Design Decision: Worktree Materialization Layout](#design-decision-worktree-materialization-layout) below); this means the agent has read-write access to that `.git/`. Use worktree mode for **trusted agents on personal projects** where immediate ref visibility is valuable; use clone mode (planned) for the untrusted-agent / fully-isolated case. Branch is hardcoded as `jackin/scratch/<container>` — an ephemeral scratch ref whose only job is to keep the agent's in-progress work reachable until it pushes. Agents (or external tooling such as the Superpowers plugin in Claude Code) rename the branch before pushing a PR. Base is always the host repo's current `HEAD`.
-- **`clone`** — planned for V1.1, **not part of the V1 enum vocabulary**. Will run `git clone --local --shared <src> <per-agent-copy>`, hardlinking objects for disk efficiency. Each agent will get a fully self-contained `.git/` with **independent refs** — the agent's branches won't appear on the host's `git branch -a` until `git push origin <branch>` is run from inside the container against the host clone path. The concrete operator situations clone mode targets:
+- **`worktree`** — jackin' runs `git worktree add` on the host against the configured `src`, then bind-mounts the worktree path into the container. Each agent gets its own working tree, HEAD, and index, but **refs and the object database are shared with the host repo** — this is fundamental to git worktrees, there's only one ref namespace per repo. Branches the agent creates appear immediately in the host's `git branch -a` without an explicit push step. To make git work inside the container, jackin' also bind-mounts the host repo's `.git/` directory into the container (see [Design Decision: Worktree Materialization Layout](#design-decision-worktree-materialization-layout) below); this means the agent has read-write access to that `.git/`. Use worktree mode for **trusted agents on personal projects** where immediate ref visibility is valuable. Branch is hardcoded as `jackin/scratch/<container>` — an ephemeral scratch ref whose only job is to keep the agent's in-progress work reachable until it pushes. Agents (or external tooling such as the Superpowers plugin in Claude Code) rename the branch before pushing a PR. Base is always the host repo's current `HEAD`.
+- **`clone`** — jackin' runs `git clone --local <src> <per-agent-copy>`, using local object hardlinks for disk efficiency while giving the agent a fully self-contained `.git/` with **independent refs**. The agent's branches don't appear on the host's `git branch -a` until `git push origin <branch>` is run from inside the container against the host clone path. The concrete operator situations clone mode targets:
   - **Untrusted or experimental agent.** Worktree mode gives the agent rw access to the host repo's `.git/` directory. A misbehaving agent can `git branch -D main`, rewrite refs, or corrupt the object database. Clone mode confines the blast radius to the per-agent `.git/` — the host's refs and objects are never touched by the agent's process.
   - **Many parallel agents fanning out scratch branches.** With 6 worktree agents running, the host's `git branch -a` shows 6 `jackin/scratch/...` lines mixed in with the operator's real branches. Clone mode keeps those refs invisible until an explicit `git push` makes one of them real.
   - **Editor / IDE noise.** VS Code, JetBrains, and `gitui` all watch `.git/refs/` for changes. Worktree-mode agents trigger refresh churn in every editor pointed at the host repo. Clone-mode agents don't.
@@ -53,7 +53,7 @@ Modes:
 
   Worktree mode (V1) covers the trusted-agent / immediate-visibility case (solo developer, want to `git diff jackin/scratch/...` from a host shell, agent is allowed to touch the local repo); clone mode is the complementary tool. See [Comparison with Other Tools](#comparison-with-other-tools) for how it will differ from worktree mode and from prior art (Docker Sandboxes, Conductor).
 
-V1's mode vocabulary is `shared | worktree`. `shared` is the canonical spelling, not `share`, because it describes the mount state and matches the persisted TOML value. `clone` is documented above as a planned future mode but is not in the enum today: V1 doesn't pre-add API for unimplemented features, and a value the runtime can't honor would only confuse operators (TOML linting tools accept it, the CLI accepts it, then materialization fails). When clone mode lands, `clone` is added back to the enum, the parser, and the docs in the same change.
+The mode vocabulary is `shared | worktree | clone`. `shared` is the canonical spelling, not `share`, because it describes the mount state and matches the persisted TOML value.
 
 Branch naming (Model B — full container name verbatim):
 
@@ -82,7 +82,7 @@ jackin workspace edit jackin \
   --mount-isolation /workspace/jackin=shared
 ```
 
-`--mount-isolation <dst>=<type>` is keyed by mount destination because destination is already the identity used by workspace upserts and removals. `<type>` uses the same canonical isolation enum as TOML (V1: `shared | worktree`). Keeping isolation out of the `--mount` string avoids overloading the existing `src:dst[:ro]` grammar and lets operators change only the isolation mode without retyping the mount source.
+`--mount-isolation <dst>=<type>` is keyed by mount destination because destination is already the identity used by workspace upserts and removals. `<type>` uses the same canonical isolation enum as TOML (`shared | worktree | clone`). Keeping isolation out of the `--mount` string avoids overloading the existing `src:dst[:ro]` grammar and lets operators change only the isolation mode without retyping the mount source.
 
 CLI behavior:
 
@@ -90,7 +90,7 @@ CLI behavior:
 - `workspace edit` can change isolation for an existing mount without also passing `--mount`. It can also set isolation for a mount being upserted in the same command. The same unknown-destination rule applies — the `<dst>` must match either an existing mount on the workspace or one being upserted in the same invocation.
 - `workspace show` adds an **Isolation** column. Omitted TOML fields display as `shared`.
 - `shared` is the canonical CLI/config spelling. Do not document `share` as an alias in V1; exact copy-paste between CLI output, TOML, and docs is more valuable than a second spelling.
-- `clone` is **not** part of V1's parser vocabulary. Passing `--mount-isolation /…=clone` falls through to the standard "invalid isolation `clone`; expected one of: shared, worktree" error. The keyword will be re-added when clone mode ships (V1.1) — V1 does not pre-add API for unimplemented modes.
+- `clone` is part of the parser vocabulary and can be set anywhere `worktree` can be set: `--mount-isolation /…=clone` or `isolation = "clone"`.
 - `workspace list` may stay count-only for V1; detailed per-mount isolation belongs in `workspace show`.
 - `config mount add` and global/scoped Docker mounts do **not** gain an isolation flag in V1. Isolation remains a workspace-mount concept.
 - Ad-hoc `jackin load --mount` mounts do **not** gain isolation support. They always remain `shared`; operators who want isolated source mounts should create or edit a saved workspace.
@@ -275,17 +275,17 @@ Cost: four mounts per isolated worktree instead of one, plus ~150 lines of mater
 
 ### Option C — Jackin-owned bare repo with worktrees branched off it
 
-Conceptually: `git clone --bare` the host repo into jackin's data dir, then `git worktree add` against that bare clone. The agent gets a fully isolated set of refs/objects (with `--shared` to hardlink object storage so disk overhead is negligible). To send work back to host, the agent runs `git push <host-path> <branch>`.
+Conceptually: `git clone --bare` the host repo into jackin's data dir, then `git worktree add` against that bare clone. The agent gets a fully isolated set of refs/objects. To send work back to host, the agent runs `git push <host-path> <branch>`.
 
 This gives **true ref isolation** — the agent's branches never touch the host's `.git/refs/`. The host's `git branch -a` doesn't show the agent's work until the agent (or operator) explicitly pushes.
 
-That's exactly **clone mode's** value proposition. Whether implemented with a bare clone + worktrees or with `git clone --local --shared`, the operator-facing semantics are identical: isolated refs, explicit push to share. Shipping Option C now while planning a separate `clone` mode for V1.1 would create two config values doing functionally the same thing — confusing for operators, doubled support burden, and "worktree" loses its only distinct property (shared refs).
+That's exactly **clone mode's** value proposition. Jackin implements it with `git clone --local`, giving the same operator-facing semantics: isolated refs and explicit push to share. `--shared` is intentionally avoided because it writes an alternates file pointing at the host repo's absolute `.git/objects` path, which is not mounted inside the container. Shipping Option C as a separate mode would create two config values doing functionally the same thing — confusing for operators, doubled support burden, and "worktree" loses its only distinct property (shared refs).
 
-Worktree mode in jackin' deliberately keeps the "shared refs" property and pays for it with the extra mount complexity in Option B. Clone mode (planned) is the right answer when the operator wants ref isolation; worktree mode is the right answer when they want immediate ref visibility on the host.
+Worktree mode in jackin' deliberately keeps the "shared refs" property and pays for it with the extra mount complexity in Option B. Clone mode is the right answer when the operator wants ref isolation; worktree mode is the right answer when they want immediate ref visibility on the host.
 
 ## Comparison with Other Tools
 
-| | jackin' worktree (V1) | jackin' clone (planned, V1.1) | Docker Sandboxes `--branch` | Conductor |
+| | jackin' worktree | jackin' clone | Docker Sandboxes `--branch` | Conductor |
 |---|---|---|---|---|
 | Sandbox runtime | Docker container (Linux namespaces) | Docker container (Linux namespaces) | microVM (hypervisor) | Native macOS process |
 | Host file exposure | Bind mount at operator-chosen `dst` | Bind mount at operator-chosen `dst` | Filesystem passthrough at *same* absolute path | None — same filesystem |
@@ -293,7 +293,7 @@ Worktree mode in jackin' deliberately keeps the "shared refs" property and pays 
 | Per-agent HEAD / index | ✓ | ✓ | ✓ | ✓ |
 | Branches visible on host without push | ✓ | ✗ (push required) | ✓ | ✓ |
 | Refs/objects shared with host repo | ✓ | ✗ (isolated) | ✓ | ✓ |
-| Worktree storage location | `<jackin_data>/<container>/git/worktree/repo/<dst>/<container>/` | `<jackin_data>/<container>/git/clone/...` (planned) | `<host_repo>/.sbx/<sandbox>-worktrees/<branch>/` | `<host_repo>/.conductor/<workspace>/` |
+| Worktree storage location | `<jackin_data>/<container>/git/worktree/repo/<dst>/<container>/` | `<jackin_data>/<container>/git/clone/repo/<dst>/<container>/` | `<host_repo>/.sbx/<sandbox>-worktrees/<branch>/` | `<host_repo>/.conductor/<workspace>/` |
 | Bind mounts per isolated mount | 4 (worktree, host `.git/`, two `:ro` `.git`/gitdir overrides) | 1 (clone is self-contained) | n/a (passthrough, not bind mount) | n/a (no sandbox) |
 | Host repo polluted with tool dirs | ✗ | ✗ | `.sbx/` (must be gitignored) | `.conductor/` |
 | Agent sees host main-tree files | ✗ (only the worktree) | ✗ | ✗ (worktree only; main tree explicitly hidden) | n/a (native process) |
@@ -305,9 +305,9 @@ Worktree mode in jackin' deliberately keeps the "shared refs" property and pays 
 
 We can't adopt Sandboxes' approach in jackin' because Docker containers don't provide hypervisor-level passthrough. Even if jackin' bind-mounted the host repo at the same absolute path inside the container (e.g., `/Users/foo/repo` → `/Users/foo/repo`), it would tie the operator's container layout to their host paths and break the `dst` abstraction every other mount in the workspace already uses. Sandboxes' approach is an elegant fit for their hypervisor model; ours is the corresponding fit for the container model — same problem, different cost (4 mounts + override files instead of "just works").
 
-**Jackin' clone mode (planned)** is the right tool when the operator wants ref isolation: the agent's experiments don't pollute the host's branch list, and an untrusted or experimental agent can't accidentally `git branch -D main` on the host. Cost is a `git push` step to share work and the agent's branches not appearing in editor git UIs until that push.
+**Jackin' clone mode** is the right tool when the operator wants ref isolation: the agent's experiments don't pollute the host's branch list, and an untrusted or experimental agent can't accidentally `git branch -D main` on the host. Cost is a `git push` step to share work and the agent's branches not appearing in editor git UIs until that push.
 
-The decision to ship worktree mode (Option B) **and** plan clone mode separately is deliberate: they serve different operator intents and both have legitimate use cases. Operators can pick per mount.
+The decision to support both worktree mode (Option B) and clone mode is deliberate: they serve different operator intents and both have legitimate use cases. Operators can pick per mount.
 
 ## Lifecycle
 
@@ -349,17 +349,17 @@ The decision to ship worktree mode (Option B) **and** plan clone mode separately
 
 Ship:
 
-- `isolation` field on workspace mounts, values `shared | worktree`. Absent → `shared` (backward-compatible; zero-migration for existing TOMLs). Global mounts reject the field at parse time.
+- `isolation` field on workspace mounts, values `shared | worktree | clone`. Absent → `shared` (backward-compatible; zero-migration for existing TOMLs). Global mounts reject the field at parse time.
 - CLI support for setting isolation on saved workspace mounts:
   - `workspace create --mount-isolation <dst>=<type>`
   - `workspace edit --mount-isolation <dst>=<type>`
   - `workspace show` displays each mount's effective isolation
-- A shared `MountIsolation` parser/model for TOML and CLI, with V1 canonical values `shared | worktree`. `clone` is documented as a planned V1.1 mode but is not in V1's enum/parser — the keyword is re-added when clone mode ships.
+- A shared `MountIsolation` parser/model for TOML and CLI, with canonical values `shared | worktree | clone`.
 - `jackin load --force` dirty-host acknowledgement for non-interactive worktree materialization; `jackin launch` gets an interactive confirmation path.
 - Dirty-host checks include staged changes, unstaged tracked changes, and untracked files; ignored files do not require acknowledgement.
 - Branch naming hardcoded as `jackin/scratch/<container>` (ephemeral scratch ref, Model B — full container name verbatim; see "Branch naming" earlier and the dedicated V1 Scope bullet below). Base is always host `HEAD`. No configurable template or base in V1.
 - Branch reuse is strict: first materialization branches from host `HEAD`; later loads reuse the existing worktree/branch without reset, rebase, or fast-forward.
-- Duplicate isolated mounts for the same repo root are allowed; each mount gets its own worktree, and branch names disambiguate by mount-destination slug when needed.
+- Duplicate clone mounts for the same repo root are allowed; each mount gets its own clone. Duplicate worktree mounts for the same repo root remain rejected because the host worktree admin entry is keyed by container name.
 - Runtime materialization happens after container-name claim, not inside `resolve_load_workspace`; introduce a materialized-workspace handoff into Docker launch.
 - Docker bind-mount emission preserves parent-before-child ordering so explicit shared cache child mounts overlay isolated source parents.
 - `.jackin/isolation.json` records materialized isolated mounts so `purge` and `cd` work even after config changes.
@@ -367,8 +367,9 @@ Ship:
 - Clean-exit cleanup deletes clean worktrees automatically when no commits would be lost, including clean branches whose local commits are already reachable from their upstream/remote tracking branch. Preserved states use `active | preserved_dirty | preserved_unpushed`; successful cleanup removes the state record.
 - `extensions.worktreeConfig` enabled on the host repo on first worktree creation.
 - For each isolated worktree, **four** bind mounts wired up at Docker run time so git works inside the container: the worktree at `<dst>` (rw), host's `.git/` at `/jackin/host/<dst-stripped>/.git` (rw, includes the per-worktree admin dir natively), plus two jackin-owned `:ro` override files (replacement `.git` pointer at `<dst>/.git`, replacement back-pointer at the admin's `gitdir`). The override files live at `<data_dir>/jackin-<container>/git/overrides/<dst-stripped>/{.git,gitdir}` with filenames matching their docker mount destinations. The materialized worktree lives at `<data_dir>/jackin-<container>/git/worktree/repo/<dst-stripped>/<container>/` — `repo/` marks the subtree as git-managed, `<container>` basename ensures globally unique admin entries in the host repo's `.git/worktrees/`. See [Container-side mount layout](#host-side-materialization) and [Design Decision: Worktree Materialization Layout](#design-decision-worktree-materialization-layout).
+- For each isolated clone, one bind mount is enough: the materialized clone at `<data_dir>/jackin-<container>/git/clone/repo/<dst-stripped>/<container>/` is mounted at `<dst>` (rw). The clone carries its own `.git/`, so no host `.git/` auxiliary mounts or override files are needed.
 - Branch naming uses the full container name verbatim: `jackin/scratch/<container>` (e.g. `jackin/scratch/jackin-the-architect-clone-1`). Globally unique by construction; trivial container → branch mapping; no instance-suffix derivation logic.
-- `validate_isolation_layout` rejects two isolated mounts that resolve to the same host repository within one workspace. V1 limitation; revisit when a real operator workflow surfaces.
+- `validate_isolation_layout` rejects two worktree mounts that resolve to the same host repository within one workspace. Clone mounts can share the same host repository because each has an independent `.git/`.
 - `load` materializes, foreground session finalization safely removes throwaway isolated worktrees when no work would be lost, unsafe clean-exit cleanup asks interactive operators whether to return to the agent, preserve recovery state, or force-delete, `eject` leaves worktrees alone, and `purge` force-deletes everything (container, DinD sidecar, the per-container `git/` tree, worktree, local branch).
 - `purge` refuses on running agents (also closes the pre-existing gap for `shared` mode).
 - Hooks inherit from host by default (no opt-out flag).
@@ -379,11 +380,10 @@ Known limitations for v1 (document, don't invest):
 
 - **Submodules and git-LFS.** Worktrees handle submodules the way the parent repo does; no extra jackin'-side orchestration. If a team hits an edge case, they'll tell us.
 - **Shared `.git/config` for remotes, credentials, and non-`--worktree` writes.** `extensions.worktreeConfig` closes the accidental-leak path for tools that use `git config --worktree`, but config written without that flag, plus `remote.*` and `credential.*`, still lands in shared `.git/config`. An agent that deliberately writes shared config can still affect the host — this is a trust question, not a boundary.
-- **Naming collision with existing `-clone-N` suffix.** <RepoFile path="src/instance/naming.rs" /> already uses `-clone-N` for collision-avoidance in container names (e.g. `jackin-the-architect-clone-1`). When `isolation = "clone"` lands, the word "clone" will have two meanings in the data-dir layout. To be resolved when clone mode ships — not a V1 blocker.
+- **Naming collision with existing `-clone-N` suffix.** <RepoFile path="src/instance/naming.rs" /> already uses `-clone-N` for collision-avoidance in container names (e.g. `jackin-the-architect-clone-1`). With `isolation = "clone"`, the word "clone" has two meanings in logs and paths: an instance suffix and a git-isolation mode. The mode's on-disk discriminator is explicit (`git/clone/repo/...`) so this is cosmetic.
 
 Defer:
 
-- `isolation = "clone"` mode (planned for V1.1). Each agent gets a fully self-contained `.git/` directory via `git clone --local --shared <src> <per-agent-copy>` — objects are hardlinked so disk overhead is negligible, but refs are independent. The agent's branches don't appear on the host's `git branch -a` until `git push origin <branch>` is run from inside the container against the host clone path. Right answer for parallel agents on shared/untrusted workloads, where ref isolation matters more than immediate visibility. Worktree mode (V1) covers the trusted-agent / immediate-visibility case; clone mode is planned for the complementary use case. See the [Comparison with Other Tools](#comparison-with-other-tools) table above for how worktree and clone differ across mount layout, ref visibility, and trust model.
 - Configurable `branch_template` / `base_branch`. The V1 branch name is ephemeral scratch; no user-facing use case has surfaced that a hardcoded name doesn't cover.
 - CLI override of isolation on ad-hoc `jackin load --mount` mounts. Isolation is intentionally a saved-workspace mount feature.
 - `--no-hooks` flag to skip host hooks per worktree.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1098,7 +1098,7 @@ fn render_auth_show(config: &AppConfig) -> String {
 /// Render the `workspace show <name>` output as a string. Includes the info
 /// table (name/workdir/allowed/default-role), and, when there are mounts, a
 /// trailing mounts table with one row per mount. The mounts table renders the
-/// canonical lowercase isolation name (`shared`/`worktree`) so the output
+/// canonical lowercase isolation name (`shared`/`worktree`/`clone`) so the output
 /// matches TOML/CLI input verbatim.
 fn render_workspace_show(name: &str, workspace: &WorkspaceConfig) -> String {
     use std::fmt::Write as _;

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -57,7 +57,7 @@ Examples:
         #[arg(long, value_parser = parse_agent)]
         default_agent: Option<crate::agent::Agent>,
         /// Set isolation mode for a mount destination. Repeatable.
-        /// Format: `<container-dst>=<shared|worktree>`.
+        /// Format: `<container-dst>=<shared|worktree|clone>`.
         #[arg(
             long = "mount-isolation",
             value_name = "DST=TYPE",
@@ -154,7 +154,7 @@ Examples:
         #[arg(long, default_value_t = false)]
         prune: bool,
         /// Set isolation mode for a mount destination. Repeatable.
-        /// Format: `<container-dst>=<shared|worktree>`.
+        /// Format: `<container-dst>=<shared|worktree|clone>`.
         #[arg(
             long = "mount-isolation",
             value_name = "DST=TYPE",
@@ -725,13 +725,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_mount_isolation_rejects_clone() {
-        // `clone` is documented in the roadmap as a planned future mode
-        // but is intentionally NOT in V1's enum vocabulary — it must
-        // fall through to the standard "invalid isolation" error so the
-        // CLI doesn't promise behavior the runtime can't deliver.
-        let err = parse_mount_isolation("/workspace/jackin=clone").unwrap_err();
-        assert!(err.to_string().contains("invalid isolation `clone`"));
+    fn parse_mount_isolation_accepts_clone() {
+        let (dst, mode) = parse_mount_isolation("/workspace/jackin=clone").unwrap();
+        assert_eq!(dst, "/workspace/jackin");
+        assert_eq!(mode, MountIsolation::Clone);
     }
 
     #[test]

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -701,15 +701,16 @@ impl EditorState<'_> {
     }
 
     /// Cycle the per-mount isolation strategy on the highlighted mount row.
-    /// Sequence: `Shared → Worktree → Shared`. Silent no-op when the cursor
+    /// Sequence: `Shared → Worktree → Clone → Shared`. Silent no-op when the cursor
     /// is on the `+ Add mount` sentinel (i.e. past the last data row).
     pub fn cycle_isolation_for_selected_mount(&mut self) {
-        use crate::isolation::MountIsolation::{Shared, Worktree};
+        use crate::isolation::MountIsolation::{Clone, Shared, Worktree};
         let FieldFocus::Row(n) = self.active_field;
         if let Some(m) = self.pending.mounts.get_mut(n) {
             m.isolation = match m.isolation {
                 Shared => Worktree,
-                Worktree => Shared,
+                Worktree => Clone,
+                Clone => Shared,
             };
         }
     }
@@ -1298,8 +1299,14 @@ mod tests {
         e.cycle_isolation_for_selected_mount();
         assert_eq!(
             e.pending.mounts[0].isolation,
+            crate::isolation::MountIsolation::Clone,
+            "two I presses must cycle Worktree to Clone",
+        );
+        e.cycle_isolation_for_selected_mount();
+        assert_eq!(
+            e.pending.mounts[0].isolation,
             crate::isolation::MountIsolation::Shared,
-            "two I presses must net back to Shared (Clone is reserved-but-rejected in V1)"
+            "three I presses must net back to Shared",
         );
         assert_eq!(
             e.change_count(),

--- a/src/isolation/cleanup.rs
+++ b/src/isolation/cleanup.rs
@@ -22,6 +22,10 @@ pub fn force_cleanup_isolated(
     container_state_dir: &Path,
     runner: &mut impl CommandRunner,
 ) -> anyhow::Result<()> {
+    if matches!(record.isolation, crate::isolation::MountIsolation::Clone) {
+        return force_cleanup_clone(record, container_state_dir);
+    }
+
     let host_repo_exists = std::path::Path::new(&record.original_src).exists();
     debug_log!(
         "isolation",
@@ -162,6 +166,35 @@ pub fn force_cleanup_isolated(
     Ok(())
 }
 
+fn force_cleanup_clone(record: &IsolationRecord, container_state_dir: &Path) -> anyhow::Result<()> {
+    debug_log!(
+        "isolation",
+        "force_cleanup_clone: container={c} mount={d} clone={w}",
+        c = record.container_name,
+        d = record.mount_dst,
+        w = record.worktree_path,
+    );
+    let clone_path = std::path::Path::new(&record.worktree_path);
+    if clone_path.exists() {
+        std::fs::remove_dir_all(clone_path).map_err(|e| {
+            anyhow::anyhow!(
+                "could not remove clone directory `{}`: {e}; record retained at `{}` so re-running `jackin purge` is possible after resolving the underlying issue",
+                record.worktree_path,
+                container_state_dir.display(),
+            )
+        })?;
+    }
+    if clone_path.exists() {
+        anyhow::bail!(
+            "clone directory `{}` still present after cleanup; record retained at `{}` so re-running `jackin purge` is possible.",
+            record.worktree_path,
+            container_state_dir.display(),
+        );
+    }
+    remove_record(container_state_dir, &record.mount_dst)?;
+    Ok(())
+}
+
 /// Best-effort check: is `branch` still present on `repo`? Returns
 /// `Some(true)` if confirmed present, `Some(false)` if confirmed absent,
 /// `None` if we couldn't tell (e.g., `git branch --list` itself errored).
@@ -264,6 +297,29 @@ mod tests {
                 .iter()
                 .any(|c| c.contains("branch -D jackin/scratch/x"))
         );
+        assert!(read_records(container_dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn force_cleanup_clone_removes_directory_without_host_git_ops() {
+        let repo_dir = TempDir::new().unwrap();
+        let container_dir = TempDir::new().unwrap();
+        let clone_dir = container_dir
+            .path()
+            .join("git/clone/repo/workspace/jackin/jackin-x");
+        std::fs::create_dir_all(clone_dir.join(".git")).unwrap();
+        let rec = IsolationRecord {
+            isolation: MountIsolation::Clone,
+            worktree_path: clone_dir.to_string_lossy().into(),
+            ..rec_for(repo_dir.path(), container_dir.path())
+        };
+        write_records(container_dir.path(), std::slice::from_ref(&rec)).unwrap();
+
+        let mut runner = FakeRunner::default();
+        force_cleanup_isolated(&rec, container_dir.path(), &mut runner).unwrap();
+
+        assert!(runner.run_recorded.is_empty());
+        assert!(!clone_dir.exists());
         assert!(read_records(container_dir.path()).unwrap().is_empty());
     }
 

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -112,6 +112,25 @@ pub fn worktree_path_for(container_state_dir: &Path, dst: &str, container_name: 
         .join(container_name)
 }
 
+/// Compute the host-side clone path for an isolated mount.
+///
+/// Clone mode stores a full per-agent repository under the same
+/// per-container `git/` tree as worktree mode, but uses a separate
+/// top-level discriminator so cleanup and manual inspection are obvious:
+///
+/// ```text
+/// <container_state>/git/clone/repo/<dst-stripped>/<container>/
+/// ```
+pub fn clone_path_for(container_state_dir: &Path, dst: &str, container_name: &str) -> PathBuf {
+    let rel = dst.trim_matches('/');
+    container_state_dir
+        .join("git")
+        .join("clone")
+        .join("repo")
+        .join(rel)
+        .join(container_name)
+}
+
 /// Container-side path where the host repo's `.git/` is bind-mounted.
 /// Mirrors the host topology under `/jackin/host/` so:
 ///
@@ -374,29 +393,31 @@ pub struct PreflightContext {
     pub interactive: bool,
 }
 
-/// Validation that must pass before `git worktree add`. Layout validation
-/// (parent/child rejection) happens earlier at config-validation time;
-/// this is per-mount.
-pub fn preflight_worktree(
+/// Validation that must pass before host-side git materialization. Layout
+/// validation (parent/child rejection) happens earlier at config-validation
+/// time; this is per-mount.
+pub fn preflight_isolated(
     mount: &MountConfig,
     ctx: &PreflightContext,
     runner: &mut impl CommandRunner,
 ) -> anyhow::Result<()> {
-    // readonly is incompatible with worktree mode.
+    // readonly is incompatible with isolated editable source modes.
     anyhow::ensure!(
         !mount.readonly,
-        "isolated mount `{}` cannot be readonly (isolation = worktree)",
-        mount.dst
+        "isolated mount `{}` cannot be readonly (isolation = {})",
+        mount.dst,
+        mount.isolation
     );
 
     // Sensitive mount overlap.
     let sensitives = crate::workspace::find_sensitive_mounts(std::slice::from_ref(mount));
     if let Some(s) = sensitives.first() {
         anyhow::bail!(
-            "isolated mount `{}` overlaps sensitive path `{}` ({}) (isolation = worktree)",
+            "isolated mount `{}` overlaps sensitive path `{}` ({}) (isolation = {})",
             mount.dst,
             s.src,
-            s.reason
+            s.reason,
+            mount.isolation,
         );
     }
 
@@ -451,6 +472,14 @@ pub fn preflight_worktree(
     Ok(())
 }
 
+pub fn preflight_worktree(
+    mount: &MountConfig,
+    ctx: &PreflightContext,
+    runner: &mut impl CommandRunner,
+) -> anyhow::Result<()> {
+    preflight_isolated(mount, ctx, runner)
+}
+
 fn check_dirty_tree(
     mount: &MountConfig,
     ctx: &PreflightContext,
@@ -497,7 +526,7 @@ pub fn materialize_workspace(
     let isolated_count = resolved
         .mounts
         .iter()
-        .filter(|m| matches!(m.isolation, MountIsolation::Worktree))
+        .filter(|m| !m.isolation.is_shared())
         .count();
     debug_log!(
         "isolation",
@@ -534,6 +563,15 @@ pub fn materialize_workspace(
                 }
             }
             MountIsolation::Worktree => materialize_one(
+                mount,
+                container_state_dir,
+                selector_key,
+                container_name,
+                workspace_name,
+                ctx,
+                runner,
+            )?,
+            MountIsolation::Clone => materialize_clone(
                 mount,
                 container_state_dir,
                 selector_key,
@@ -588,11 +626,24 @@ fn materialize_one(
                 configured = mount.src,
             );
             anyhow::bail!(
-                "source drift on container `{}`, mount `{}`: recorded src `{}` differs from configured src `{}`; preserved worktree at `{}`. Restore the previous src, inspect the worktree at the path above, or `jackin purge {}` to discard.",
+                "source drift on container `{}`, mount `{}`: recorded src `{}` differs from configured src `{}`; preserved {} at `{}`. Restore the previous src, inspect the path above, or `jackin purge {}` to discard.",
                 container_name,
                 mount.dst,
                 record.original_src,
                 mount.src,
+                record.isolation,
+                record.worktree_path,
+                container_name,
+            );
+        }
+        if record.isolation != MountIsolation::Worktree {
+            anyhow::bail!(
+                "isolation mode drift on container `{}`, mount `{}`: recorded mode `{}` differs from configured mode `{}`; preserved {} at `{}`. Run `jackin purge {}` to discard the old isolated state before switching modes.",
+                container_name,
+                mount.dst,
+                record.isolation,
+                mount.isolation,
+                record.isolation,
                 record.worktree_path,
                 container_name,
             );
@@ -792,6 +843,134 @@ fn materialize_one(
     })
 }
 
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn materialize_clone(
+    mount: &MountConfig,
+    container_state_dir: &Path,
+    selector_key: &str,
+    container_name: &str,
+    workspace_name: &str,
+    ctx: &PreflightContext,
+    runner: &mut impl CommandRunner,
+) -> anyhow::Result<MaterializedMount> {
+    let clone_path = clone_path_for(container_state_dir, &mount.dst, container_name);
+    debug_log!(
+        "isolation",
+        "mount {dst}: clone (src={src} → clone_path={cp})",
+        dst = mount.dst,
+        src = mount.src,
+        cp = clone_path.display(),
+    );
+
+    if let Some(record) = read_record(container_state_dir, &mount.dst)? {
+        if record.original_src != mount.src {
+            anyhow::bail!(
+                "source drift on container `{}`, mount `{}`: recorded src `{}` differs from configured src `{}`; preserved {} at `{}`. Restore the previous src, inspect the path above, or `jackin purge {}` to discard.",
+                container_name,
+                mount.dst,
+                record.original_src,
+                mount.src,
+                record.isolation,
+                record.worktree_path,
+                container_name,
+            );
+        }
+        if record.isolation != MountIsolation::Clone {
+            anyhow::bail!(
+                "isolation mode drift on container `{}`, mount `{}`: recorded mode `{}` differs from configured mode `{}`; preserved {} at `{}`. Run `jackin purge {}` to discard the old isolated state before switching modes.",
+                container_name,
+                mount.dst,
+                record.isolation,
+                mount.isolation,
+                record.isolation,
+                record.worktree_path,
+                container_name,
+            );
+        }
+        if clone_path.join(".git").exists() {
+            debug_log!(
+                "isolation",
+                "mount {dst}: reusing existing clone (record matches and .git present)",
+                dst = mount.dst,
+            );
+            return Ok(MaterializedMount {
+                bind_src: clone_path.to_string_lossy().into(),
+                dst: mount.dst.clone(),
+                readonly: mount.readonly,
+                isolation: MountIsolation::Clone,
+                worktree_aux: None,
+            });
+        }
+        debug_log!(
+            "isolation",
+            "mount {dst}: record present but clone directory missing — recreating",
+            dst = mount.dst,
+        );
+    }
+
+    preflight_isolated(mount, ctx, runner)?;
+
+    let host_head = runner
+        .capture("git", &["-C", &mount.src, "rev-parse", "HEAD"], None)?
+        .trim()
+        .to_string();
+    let scratch_branch = branch_name(container_name, None);
+
+    if let Some(parent) = clone_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create parent dir for clone at {}", parent.display()))?;
+    }
+
+    runner.run(
+        "git",
+        &[
+            "clone",
+            "--local",
+            &mount.src,
+            &clone_path.to_string_lossy(),
+        ],
+        None,
+        &crate::docker::RunOptions::default(),
+    )?;
+    runner.run(
+        "git",
+        &[
+            "-C",
+            &clone_path.to_string_lossy(),
+            "checkout",
+            "-B",
+            &scratch_branch,
+            &host_head,
+        ],
+        None,
+        &crate::docker::RunOptions::default(),
+    )?;
+
+    upsert_record(
+        container_state_dir,
+        IsolationRecord {
+            workspace: workspace_name.into(),
+            mount_dst: mount.dst.clone(),
+            original_src: mount.src.clone(),
+            isolation: MountIsolation::Clone,
+            worktree_path: clone_path.to_string_lossy().into(),
+            scratch_branch,
+            base_commit: host_head,
+            selector_key: selector_key.into(),
+            container_name: container_name.into(),
+            cleanup_status: CleanupStatus::Active,
+        },
+    )?;
+
+    Ok(MaterializedMount {
+        bind_src: clone_path.to_string_lossy().into(),
+        dst: mount.dst.clone(),
+        readonly: mount.readonly,
+        isolation: MountIsolation::Clone,
+        worktree_aux: None,
+    })
+}
+
 /// Order mounts so parents appear before children. Docker overlays later
 /// mounts on earlier ones, so this lets a shared cache child mount land
 /// inside an isolated worktree parent.
@@ -837,6 +1016,15 @@ mod tests {
         assert_eq!(
             worktree_path_for(&base, "/workspace/jackin/", "jackin-x"),
             PathBuf::from("/data/jackin-x/git/worktree/repo/workspace/jackin/jackin-x"),
+        );
+    }
+
+    #[test]
+    fn clone_path_uses_clone_repo_layout() {
+        let base = PathBuf::from("/data/jackin-x");
+        assert_eq!(
+            clone_path_for(&base, "/workspace/jackin", "jackin-x"),
+            PathBuf::from("/data/jackin-x/git/clone/repo/workspace/jackin/jackin-x"),
         );
     }
 
@@ -1153,6 +1341,22 @@ mod tests {
         }
     }
 
+    fn resolved_with_one_clone(repo: &std::path::Path, dst: &str) -> ResolvedWorkspace {
+        ResolvedWorkspace {
+            label: "jackin".into(),
+            workdir: dst.into(),
+            mounts: vec![MountConfig {
+                src: repo.to_string_lossy().into(),
+                dst: dst.into(),
+                readonly: false,
+                isolation: MountIsolation::Clone,
+            }],
+            default_agent: None,
+            keep_awake_enabled: false,
+            git_pull_on_entry: false,
+        }
+    }
+
     #[test]
     fn first_materialization_runs_worktree_add_and_writes_record() {
         let repo = make_repo_root();
@@ -1259,6 +1463,109 @@ mod tests {
             runner.run_recorded.is_empty(),
             "no git ops for shared mounts"
         );
+    }
+
+    #[test]
+    fn clone_materialization_runs_local_shared_clone_and_writes_record() {
+        let repo = make_repo_root();
+        let data = tempfile::TempDir::new().unwrap();
+        let container_dir = data.path().join("jackin-x");
+        std::fs::create_dir_all(&container_dir).unwrap();
+
+        let resolved = resolved_with_one_clone(repo.path(), "/workspace/jackin");
+        let mut runner = fake_with_outputs(&[
+            &repo.path().to_string_lossy(), // rev-parse --show-toplevel
+            "",                             // status --porcelain
+            "deadbeef\n",                   // rev-parse HEAD
+        ]);
+
+        let mat = materialize_workspace(
+            &resolved,
+            &container_dir,
+            "x",
+            "jackin-x",
+            "jackin",
+            &PreflightContext {
+                workspace_name: "jackin".into(),
+                force: false,
+                interactive: false,
+            },
+            &mut runner,
+        )
+        .unwrap();
+
+        assert_eq!(mat.mounts[0].isolation, MountIsolation::Clone);
+        assert!(mat.mounts[0].worktree_aux.is_none());
+        assert!(
+            mat.mounts[0]
+                .bind_src
+                .contains("/git/clone/repo/workspace/jackin/jackin-x"),
+            "got {}",
+            mat.mounts[0].bind_src,
+        );
+        assert!(
+            runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("git clone --local"))
+        );
+        assert!(
+            runner
+                .run_recorded
+                .iter()
+                .any(|c| c.contains("checkout -B jackin/scratch/jackin-x deadbeef"))
+        );
+        let recs = read_records(&container_dir).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].isolation, MountIsolation::Clone);
+        assert_eq!(recs[0].base_commit, "deadbeef");
+    }
+
+    #[test]
+    fn clone_reuse_skips_git_ops_when_git_dir_exists() {
+        let repo = make_repo_root();
+        let data = tempfile::TempDir::new().unwrap();
+        let container_dir = data.path().join("jackin-x");
+        std::fs::create_dir_all(&container_dir).unwrap();
+
+        let dst = "/workspace/jackin";
+        let cp = clone_path_for(&container_dir, dst, "jackin-x");
+        std::fs::create_dir_all(cp.join(".git")).unwrap();
+        crate::isolation::state::write_records(
+            &container_dir,
+            std::slice::from_ref(&crate::isolation::state::IsolationRecord {
+                workspace: "jackin".into(),
+                mount_dst: dst.into(),
+                original_src: repo.path().to_string_lossy().into(),
+                isolation: MountIsolation::Clone,
+                worktree_path: cp.to_string_lossy().into(),
+                scratch_branch: "jackin/scratch/jackin-x".into(),
+                base_commit: "abc".into(),
+                selector_key: "x".into(),
+                container_name: "jackin-x".into(),
+                cleanup_status: CleanupStatus::Active,
+            }),
+        )
+        .unwrap();
+
+        let resolved = resolved_with_one_clone(repo.path(), dst);
+        let mut runner = FakeRunner::default();
+        let mat = materialize_workspace(
+            &resolved,
+            &container_dir,
+            "x",
+            "jackin-x",
+            "jackin",
+            &PreflightContext {
+                workspace_name: "jackin".into(),
+                force: false,
+                interactive: false,
+            },
+            &mut runner,
+        )
+        .unwrap();
+        assert_eq!(mat.mounts[0].bind_src, cp.to_string_lossy());
+        assert!(runner.run_recorded.is_empty(), "no git ops on clone reuse");
     }
 
     #[test]

--- a/src/isolation/mod.rs
+++ b/src/isolation/mod.rs
@@ -14,6 +14,7 @@ pub enum MountIsolation {
     #[default]
     Shared,
     Worktree,
+    Clone,
 }
 
 impl MountIsolation {
@@ -25,6 +26,7 @@ impl MountIsolation {
         match self {
             Self::Shared => "shared",
             Self::Worktree => "worktree",
+            Self::Clone => "clone",
         }
     }
 }
@@ -41,8 +43,11 @@ impl FromStr for MountIsolation {
         match s {
             "shared" => Ok(Self::Shared),
             "worktree" => Ok(Self::Worktree),
+            "clone" => Ok(Self::Clone),
             other => {
-                anyhow::bail!("invalid isolation `{other}`; expected one of: shared, worktree")
+                anyhow::bail!(
+                    "invalid isolation `{other}`; expected one of: shared, worktree, clone"
+                )
             }
         }
     }
@@ -62,6 +67,10 @@ mod tests {
             MountIsolation::from_str("worktree").unwrap(),
             MountIsolation::Worktree
         );
+        assert_eq!(
+            MountIsolation::from_str("clone").unwrap(),
+            MountIsolation::Clone
+        );
     }
 
     #[test]
@@ -77,17 +86,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_clone_until_implemented() {
-        // `clone` is documented in the roadmap as a planned future mode
-        // (V1.1) but is not in V1's enum vocabulary — make sure it falls
-        // through to the standard "invalid isolation" error rather than
-        // silently parsing or being treated as a reserved keyword.
-        let err = MountIsolation::from_str("clone").unwrap_err();
-        assert!(err.to_string().contains("invalid isolation `clone`"));
-        assert!(err.to_string().contains("shared, worktree"));
-    }
-
-    #[test]
     fn default_is_shared() {
         assert_eq!(MountIsolation::default(), MountIsolation::Shared);
     }
@@ -96,11 +94,13 @@ mod tests {
     fn is_shared_predicate() {
         assert!(MountIsolation::Shared.is_shared());
         assert!(!MountIsolation::Worktree.is_shared());
+        assert!(!MountIsolation::Clone.is_shared());
     }
 
     #[test]
     fn display_renders_canonical_lowercase() {
         assert_eq!(MountIsolation::Shared.to_string(), "shared");
         assert_eq!(MountIsolation::Worktree.to_string(), "worktree");
+        assert_eq!(MountIsolation::Clone.to_string(), "clone");
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -172,10 +172,9 @@ pub struct WorkspaceEdit {
     pub git_pull_on_entry_enabled: Option<bool>,
 }
 
-/// Validate the isolation layout for a workspace's mounts. Two rules
-/// today, both worktree-specific:
+/// Validate the isolation layout for a workspace's mounts. Two rules:
 ///
-/// 1. **No nested isolated mounts.** Two `Worktree` mounts where one's
+/// 1. **No nested isolated mounts.** Two non-`Shared` mounts where one's
 ///    `dst` is a strict ancestor of the other's are rejected. The
 ///    inner worktree's `.git` would land inside the outer worktree's
 ///    tree, which is unsafe regardless of mode.
@@ -196,7 +195,7 @@ pub fn validate_isolation_layout(mounts: &[MountConfig]) -> anyhow::Result<()> {
     let isolated: Vec<(usize, &MountConfig, &str)> = mounts
         .iter()
         .enumerate()
-        .filter(|(_, m)| matches!(m.isolation, MountIsolation::Worktree))
+        .filter(|(_, m)| !m.isolation.is_shared())
         .map(|(i, m)| (i, m, m.dst.trim_end_matches('/')))
         .collect();
 
@@ -212,11 +211,14 @@ pub fn validate_isolation_layout(mounts: &[MountConfig]) -> anyhow::Result<()> {
                     b = if is_strict_ancestor(a, b) { b } else { a },
                 );
             }
-            // Rule 2: same host repo (same `src` after canonicalization
+            // Rule 2: same host repo for worktree mode (same `src` after canonicalization
             // best-effort; falls back to literal string equality if a
             // path can't be canonicalized — e.g., `src` doesn't exist
             // yet on disk).
-            if same_host_repo(&ma.src, &mb.src) {
+            if matches!(ma.isolation, MountIsolation::Worktree)
+                && matches!(mb.isolation, MountIsolation::Worktree)
+                && same_host_repo(&ma.src, &mb.src)
+            {
                 anyhow::bail!(
                     "isolated mounts `{}` and `{}` cannot share the same host repository `{}`; \
                      remove one of them or change one to `shared` (V1 limitation — see roadmap)",
@@ -538,6 +540,16 @@ isolation = "worktree"
     }
 
     #[test]
+    fn mount_config_parses_clone_isolation() {
+        let toml = r#"src = "/tmp/src"
+dst = "/workspace/x"
+isolation = "clone"
+"#;
+        let mount: MountConfig = toml::from_str(toml).unwrap();
+        assert_eq!(mount.isolation, MountIsolation::Clone);
+    }
+
+    #[test]
     fn mount_config_writes_isolation_field_even_when_shared_on_serialize() {
         // Old configs without `isolation` deserialize to Shared (the default);
         // on save we re-emit the field explicitly so the stored TOML always
@@ -574,6 +586,15 @@ isolation = "worktree"
             dst: dst.into(),
             readonly: false,
             isolation: MountIsolation::Worktree,
+        }
+    }
+
+    fn clone_mount(src: &str, dst: &str) -> MountConfig {
+        MountConfig {
+            src: src.into(),
+            dst: dst.into(),
+            readonly: false,
+            isolation: MountIsolation::Clone,
         }
     }
 
@@ -667,6 +688,25 @@ isolation = "worktree"
             worktree_mount("/host/jackin-docs", "/workspace/jackin-docs"),
         ];
         validate_isolation_layout(&mounts).unwrap();
+    }
+
+    #[test]
+    fn isolation_layout_allows_two_clone_mounts_on_same_repo() {
+        let mounts = vec![
+            clone_mount("/host/jackin", "/workspace/jackin"),
+            clone_mount("/host/jackin", "/workspace/jackin-copy"),
+        ];
+        validate_isolation_layout(&mounts).unwrap();
+    }
+
+    #[test]
+    fn isolation_layout_rejects_nested_clone_mounts() {
+        let mounts = vec![
+            clone_mount("/tmp/proj", "/workspace/proj"),
+            clone_mount("/tmp/sub", "/workspace/proj/sub"),
+        ];
+        let err = validate_isolation_layout(&mounts).unwrap_err().to_string();
+        assert!(err.contains("nested inside"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `clone` as a first-class mount isolation mode for config, CLI, and workspace manager TUI
- materialize clone mounts under `<container-state>/git/clone/repo/<dst>/<container>` using `git clone --local` plus the existing scratch branch naming
- clean up clone records by deleting the per-container clone directory without touching host worktrees or host branches
- update isolation layout validation and docs for `shared | worktree | clone`

## Verification
- `cargo test -q isolation`
- `cargo test -q --test per_mount_isolation_e2e`
- `cargo test -q -- --test-threads=1`

## Manual TUI check
- Open `jackin console`, edit or create a workspace, go to the Mounts tab, focus a mount row, press `I`.
- The isolation value cycles `shared -> worktree -> clone -> shared`.
- Save and confirm the workspace config writes `isolation = "clone"`.
