### PR TITLE
docs: document agent squash merge standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,21 +86,49 @@ Don't ask the operator for permission to bring the metadata into agreement with 
 
 Why this rule exists: the operator relies on PR titles and bodies as the long-term navigable record of what shipped. Drift between description and diff is the single most common cause of "what does this PR actually do?" archaeology after the fact.
 
-### PR merge commit titles
+### PR squash merge messages
 
-When an agent merges a pull request, the resulting squash/merge commit title must preserve the GitHub PR reference.
+When an agent merges a pull request, the resulting squash commit must preserve the GitHub PR reference and enough attribution to make the shipped history auditable.
 
 - Always use squash merge unless the human operator explicitly requests a different merge method for that specific PR.
-- Prefer GitHub's default squash/merge title when it already includes `(#PR_NUMBER)`.
+- The squash commit title must be the final PR title with the PR number suffix: `type(scope): summary (#PR_NUMBER)`.
+- Prefer GitHub's default squash title when it already matches that format.
 - If overriding the commit title, manually append `(#PR_NUMBER)`.
 - For Codex/GitHub connector merges: do not pass a custom `commit_title` unless necessary; if one is passed, it must include `(#PR_NUMBER)`.
-- Example: `docs(roadmap): refine per-mount isolation design (#168)`
+- The squash commit body must retain the PR details and a direct link to the original pull request. At minimum, include `Pull request: https://github.com/<owner>/<repo>/pull/<PR_NUMBER>` before trailers if GitHub's generated body does not already include the PR URL.
+- The squash commit trailers must include the operator's `Signed-off-by` trailer when present/required and one `Co-authored-by` trailer for each AI agent that materially contributed to the PR. Include multiple agent trailers when multiple agents contributed.
+
+Good squash titles:
+
+```text
+docs: include mise trust in PR verification (#232)
+docs: improve landing hero nav and PR guidance (#231)
+chore(deps): update taiki-e/install-action action to v2.77.1 (#222)
+refactor!: relocate host→container handoff under /jackin/, drop ~/.claude bind mount (#229)
+```
+
+Good squash trailers for a Codex-authored PR:
+
+```text
+Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>
+Co-authored-by: Codex <codex@openai.com>
+```
+
+Good squash trailers for a PR with multiple AI agents:
+
+```text
+Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>
+Co-authored-by: Codex <codex@openai.com>
+Co-authored-by: Claude <noreply@anthropic.com>
+```
 
 This keeps commit history, GitHub commit pages, and local `git log --oneline` visibly linked back to the PR.
 
 ## Commit Attribution (agent-only)
 
 Every commit created by an AI agent in this repository must include **exactly one** `Co-authored-by` trailer identifying the agent that made the commit. The trailer identifies the **agent tool**, not the underlying model — **never stack multiple agent trailers on one commit** (for example, an Amp-generated commit must not also carry `Co-authored-by: Claude` or `Co-authored-by: Codex` just because Amp used one of those vendors' models under the hood).
+
+Exception: a squash merge commit may include multiple `Co-authored-by` trailers when multiple AI agents materially contributed to the PR. In that case, include one trailer per contributing agent as described in "PR squash merge messages".
 
 Until the listed agents emit their trailers automatically, the trailer must be added by hand when creating or amending the commit.
 

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -19,10 +19,13 @@ format = "compact"
 index_files = ["index.html"]
 max_concurrency = 32
 max_redirects = 10
-max_retries = 2
+
+# GitHub issue pages occasionally return transient 5xx responses during broad
+# docs checks. Prefer slower retries over accepting server errors as valid.
+max_retries = 5
 mode = "plain"
 no_progress = true
-retry_wait_time = 2
+retry_wait_time = 5
 timeout = 20
 user_agent = "jackin-docs-link-checker"
 
@@ -31,4 +34,4 @@ scheme = ["https", "http", "file", "mailto"]
 
 [hosts."github.com"]
 concurrency = 4
-request_interval = "250ms"
+request_interval = "500ms"

--- a/docs/src/content/docs/reference/roadmap/selectable-sandbox-backends.mdx
+++ b/docs/src/content/docs/reference/roadmap/selectable-sandbox-backends.mdx
@@ -827,11 +827,12 @@ The practical resolution, as of April 2026, is to **always create jackin's machi
 - v2.1.0 (April 19, 2026): "Isolated machines without filesystem integration" — an isolated machine has no automatic `/Users` mount and the host filesystem is not visible
 - v2.1.1 (April 20, 2026): "Selective file sharing mounts in isolated machines" — inside an isolated machine, specific host paths can be declared as shares
 
-Historical context (kept for audit trail — these are now resolved upstream):
+Historical context (kept for audit trail — these are now resolved upstream by
+OrbStack v2.1.x, so the roadmap no longer links to the old tracking issues):
 
-- [orbstack/orbstack#169](https://github.com/orbstack/orbstack/issues/169) (2023) — the long-standing request that tracked this. The feature shipped as "isolated machines" + "selective shares" in v2.1.x.
-- [orbstack/orbstack#1243](https://github.com/orbstack/orbstack/issues/1243) (2024) — closed as duplicate.
-- [orbstack/orbstack#2308](https://github.com/orbstack/orbstack/issues/2308) (January 2026) — superseded by v2.1.x.
+- orbstack/orbstack#169 (2023) — the long-standing request that tracked this. The feature shipped as "isolated machines" + "selective shares" in v2.1.x.
+- orbstack/orbstack#1243 (2024) — closed as duplicate.
+- orbstack/orbstack#2308 (January 2026) — superseded by v2.1.x.
 
 Implication for jackin: the `orbstack` provider should default to `--isolated` and reject any flow that would fall back to the default machine mode, unless the user opts out explicitly. The `umount /Users` workaround is no longer needed.
 


### PR DESCRIPTION
## Summary

- document the required squash merge title/body format for agent merges
- require the original PR link to be retained in squash commit bodies
- clarify that squash merges may include one Co-authored-by trailer per contributing AI agent
- remove stale direct OrbStack issue links from the selectable sandbox backend roadmap item
- slow down and increase retries for GitHub link checks to reduce transient 5xx flakes

## Verify locally

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin pull/234/head:pr-234
git checkout pr-234

# Documentation/config-only change; inspect the updated guidance and roadmap text.
sed -n '80,150p' AGENTS.md\nsed -n '820,840p' docs/src/content/docs/reference/roadmap/selectable-sandbox-backends.mdx\nsed -n '15,36p' docs/lychee.toml\n```