### PR TITLE
docs(roadmap): restructure sidebar into programs / themed open / resolved

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -91,135 +91,165 @@ export default defineConfig({
               items: [
                 { label: 'Overview', slug: 'reference/roadmap' },
                 {
-                  label: 'Open items',
-                  collapsed: true,
+                  label: 'Active programs',
+                  collapsed: false,
                   items: [
-                    { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
-                    { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
-                    { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
-                    { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
-                    { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
-                    { label: 'Rootless DinD', slug: 'reference/roadmap/rootless-dind' },
-                    { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },
-                    { label: 'Reproducibility & provenance pinning', slug: 'reference/roadmap/reproducibility-pinning' },
-                    { label: 'Per-mount isolation', slug: 'reference/roadmap/per-mount-isolation' },
-                    { label: 'Worktree cleanup assessment', slug: 'reference/roadmap/worktree-cleanup-assessment' },
-                    { label: 'Devcontainer parity', slug: 'reference/roadmap/devcontainer-parity' },
-                    { label: 'Docs markdown linting', slug: 'reference/roadmap/docs-markdown-linting' },
-                    { label: 'Open review findings', slug: 'reference/roadmap/open-review-findings' },
+                    {
+                      label: 'Universal Orchestrator Program',
+                      collapsed: true,
+                      items: [
+                        { label: 'Overview', slug: 'reference/roadmap/multicode-inspired-features' },
+                        {
+                          label: 'Phase 1 — Foundation gaps',
+                          collapsed: true,
+                          items: [
+                            { label: 'Workspace description', slug: 'reference/roadmap/workspace-description' },
+                            { label: 'Operator handler system', slug: 'reference/roadmap/operator-handler-system' },
+                            { label: 'Workspace archive', slug: 'reference/roadmap/workspace-archive' },
+                            { label: 'Declarative resource limits', slug: 'reference/roadmap/declarative-resource-limits' },
+                            { label: 'Ephemeral mount modes', slug: 'reference/roadmap/ephemeral-mount-modes' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 2 — Live operator surface',
+                          collapsed: true,
+                          items: [
+                            { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
+                            { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
+                            { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
+                            { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
+                            { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 3 — Persistence & telemetry',
+                          collapsed: true,
+                          items: [
+                            { label: 'Persistent storage layer', slug: 'reference/roadmap/persistent-storage-layer' },
+                            { label: 'Token & cost telemetry', slug: 'reference/roadmap/token-cost-telemetry' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 4 — Fleet operations',
+                          collapsed: true,
+                          items: [
+                            { label: 'Task source abstraction', slug: 'reference/roadmap/task-source-abstraction' },
+                            { label: 'Autonomous task queue', slug: 'reference/roadmap/autonomous-task-queue' },
+                            { label: 'Idle runtime cleanup', slug: 'reference/roadmap/idle-runtime-cleanup' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 5 — Distributed & extensibility',
+                          collapsed: true,
+                          items: [
+                            { label: 'jackin-remote', slug: 'reference/roadmap/jackin-remote' },
+                            { label: 'Credential source pattern', slug: 'reference/roadmap/credential-source-pattern' },
+                            { label: 'Workspace skills mount', slug: 'reference/roadmap/workspace-skills-mount' },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      label: 'Codebase health',
+                      collapsed: true,
+                      items: [
+                        { label: 'Overview', slug: 'reference/roadmap/codebase-readability' },
+                        {
+                          label: 'Phase 1 — Documentation & setup',
+                          collapsed: true,
+                          items: [
+                            { label: 'Module contracts', slug: 'reference/roadmap/module-contracts' },
+                            { label: 'Behavioral spec: launch.rs', slug: 'reference/roadmap/behavioral-spec-launch' },
+                            { label: 'Behavioral spec: op_picker', slug: 'reference/roadmap/behavioral-spec-op-picker' },
+                            { label: 'Per-directory README + AGENTS.md', slug: 'reference/roadmap/per-directory-readme' },
+                            { label: 'Developer Reference setup', slug: 'reference/roadmap/developer-reference-setup' },
+                            { label: 'Update PROJECT_STRUCTURE.md', slug: 'reference/roadmap/project-structure-update' },
+                            { label: 'CI gate: PROJECT_STRUCTURE.md', slug: 'reference/roadmap/ci-project-structure-gate' },
+                            { label: 'pub(crate) visibility', slug: 'reference/roadmap/pub-crate-visibility' },
+                            { label: 'MSRV & toolchain', slug: 'reference/roadmap/msrv-toolchain' },
+                            { label: 'Architecture Decision Records', slug: 'reference/roadmap/architecture-decision-records' },
+                            { label: 'Snapshot tests for TUI', slug: 'reference/roadmap/snapshot-tests-tui' },
+                            { label: 'Agent workflow: cc-sdd', slug: 'reference/roadmap/agent-workflow-cc-sdd' },
+                            { label: 'Move CONTRIBUTING + TESTING', slug: 'reference/roadmap/move-contributing-testing' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 2 — File splits',
+                          collapsed: true,
+                          items: [
+                            { label: 'Split input/editor.rs', slug: 'reference/roadmap/split-input-editor' },
+                            { label: 'Split app/mod.rs', slug: 'reference/roadmap/split-app-mod' },
+                            { label: 'Split operator_env.rs', slug: 'reference/roadmap/split-operator-env' },
+                            { label: 'Split runtime/launch.rs', slug: 'reference/roadmap/split-runtime-launch' },
+                          ],
+                        },
+                        {
+                          label: 'Phase 3 — Future',
+                          collapsed: true,
+                          items: [
+                            { label: 'Greenfield workspace split', slug: 'reference/roadmap/greenfield-workspace' },
+                            { label: 'rustdoc JSON → Starlight', slug: 'reference/roadmap/rustdoc-json-starlight' },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  label: 'Open items',
+                  collapsed: false,
+                  items: [
+                    {
+                      label: 'Agent runtimes & authentication',
+                      collapsed: true,
+                      items: [
+                        { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
+                        { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
+                        { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
+                      ],
+                    },
+                    {
+                      label: 'Isolation & security',
+                      collapsed: true,
+                      items: [
+                        { label: 'Rootless DinD', slug: 'reference/roadmap/rootless-dind' },
+                        { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },
+                        { label: 'Reproducibility & provenance pinning', slug: 'reference/roadmap/reproducibility-pinning' },
+                        { label: 'Devcontainer parity', slug: 'reference/roadmap/devcontainer-parity' },
+                        { label: 'Open review findings', slug: 'reference/roadmap/open-review-findings' },
+                      ],
+                    },
+                    {
+                      label: 'Infrastructure',
+                      collapsed: true,
+                      items: [
+                        { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
+                        { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
+                      ],
+                    },
+                    {
+                      label: 'Documentation tooling',
+                      collapsed: true,
+                      items: [
+                        { label: 'Docs markdown linting', slug: 'reference/roadmap/docs-markdown-linting' },
+                      ],
+                    },
                   ],
                 },
                 {
                   label: 'Resolved',
                   collapsed: true,
                   items: [
-                    { label: 'Env var interpolation', slug: 'reference/roadmap/env-var-interpolation' },
-                    { label: 'Orphaned DinD cleanup', slug: 'reference/roadmap/orphaned-dind-cleanup' },
-                    { label: 'Sensitive mount warnings', slug: 'reference/roadmap/sensitive-mount-warnings' },
+                    { label: 'Agent source trust', slug: 'reference/roadmap/agent-source-trust' },
                     { label: 'Custom plugin marketplace', slug: 'reference/roadmap/custom-plugin-marketplace' },
                     { label: 'DinD hostname env var', slug: 'reference/roadmap/dind-hostname-env-var' },
-                    { label: 'Agent source trust', slug: 'reference/roadmap/agent-source-trust' },
                     { label: 'DinD TLS', slug: 'reference/roadmap/dind-tls' },
+                    { label: 'Env var interpolation', slug: 'reference/roadmap/env-var-interpolation' },
                     { label: 'JACKIN_DEBUG env var', slug: 'reference/roadmap/jackin-debug-env-var' },
-                  ],
-                },
-                {
-                  label: 'Operator surface',
-                  collapsed: true,
-                  items: [
-                    { label: 'Overview', slug: 'reference/roadmap/multicode-inspired-features' },
-                    {
-                      label: 'Phase 1 — Foundation gaps',
-                      collapsed: true,
-                      items: [
-                        { label: 'Workspace description', slug: 'reference/roadmap/workspace-description' },
-                        { label: 'Operator handler system', slug: 'reference/roadmap/operator-handler-system' },
-                        { label: 'Workspace archive', slug: 'reference/roadmap/workspace-archive' },
-                        { label: 'Declarative resource limits', slug: 'reference/roadmap/declarative-resource-limits' },
-                        { label: 'Ephemeral mount modes', slug: 'reference/roadmap/ephemeral-mount-modes' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 2 — Live operator surface',
-                      collapsed: true,
-                      items: [
-                        { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
-                        { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
-                        { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
-                        { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
-                        { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 3 — Persistence & telemetry',
-                      collapsed: true,
-                      items: [
-                        { label: 'Persistent storage layer', slug: 'reference/roadmap/persistent-storage-layer' },
-                        { label: 'Token & cost telemetry', slug: 'reference/roadmap/token-cost-telemetry' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 4 — Fleet operations',
-                      collapsed: true,
-                      items: [
-                        { label: 'Task source abstraction', slug: 'reference/roadmap/task-source-abstraction' },
-                        { label: 'Autonomous task queue', slug: 'reference/roadmap/autonomous-task-queue' },
-                        { label: 'Idle runtime cleanup', slug: 'reference/roadmap/idle-runtime-cleanup' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 5 — Distributed & extensibility',
-                      collapsed: true,
-                      items: [
-                        { label: 'jackin-remote', slug: 'reference/roadmap/jackin-remote' },
-                        { label: 'Credential source pattern', slug: 'reference/roadmap/credential-source-pattern' },
-                        { label: 'Workspace skills mount', slug: 'reference/roadmap/workspace-skills-mount' },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  label: 'Codebase health',
-                  collapsed: true,
-                  items: [
-                    { label: 'Overview', slug: 'reference/roadmap/codebase-readability' },
-                    {
-                      label: 'Phase 1 — Documentation & setup',
-                      collapsed: true,
-                      items: [
-                        { label: 'Module contracts', slug: 'reference/roadmap/module-contracts' },
-                        { label: 'Behavioral spec: launch.rs', slug: 'reference/roadmap/behavioral-spec-launch' },
-                        { label: 'Behavioral spec: op_picker', slug: 'reference/roadmap/behavioral-spec-op-picker' },
-                        { label: 'Per-directory README + AGENTS.md', slug: 'reference/roadmap/per-directory-readme' },
-                        { label: 'Developer Reference setup', slug: 'reference/roadmap/developer-reference-setup' },
-                        { label: 'Update PROJECT_STRUCTURE.md', slug: 'reference/roadmap/project-structure-update' },
-                        { label: 'CI gate: PROJECT_STRUCTURE.md', slug: 'reference/roadmap/ci-project-structure-gate' },
-                        { label: 'pub(crate) visibility', slug: 'reference/roadmap/pub-crate-visibility' },
-                        { label: 'MSRV & toolchain', slug: 'reference/roadmap/msrv-toolchain' },
-                        { label: 'Architecture Decision Records', slug: 'reference/roadmap/architecture-decision-records' },
-                        { label: 'Snapshot tests for TUI', slug: 'reference/roadmap/snapshot-tests-tui' },
-                        { label: 'Agent workflow: cc-sdd', slug: 'reference/roadmap/agent-workflow-cc-sdd' },
-                        { label: 'Move CONTRIBUTING + TESTING', slug: 'reference/roadmap/move-contributing-testing' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 2 — File splits',
-                      collapsed: true,
-                      items: [
-                        { label: 'Split input/editor.rs', slug: 'reference/roadmap/split-input-editor' },
-                        { label: 'Split app/mod.rs', slug: 'reference/roadmap/split-app-mod' },
-                        { label: 'Split operator_env.rs', slug: 'reference/roadmap/split-operator-env' },
-                        { label: 'Split runtime/launch.rs', slug: 'reference/roadmap/split-runtime-launch' },
-                      ],
-                    },
-                    {
-                      label: 'Phase 3 — Future',
-                      collapsed: true,
-                      items: [
-                        { label: 'Greenfield workspace split', slug: 'reference/roadmap/greenfield-workspace' },
-                        { label: 'rustdoc JSON → Starlight', slug: 'reference/roadmap/rustdoc-json-starlight' },
-                      ],
-                    },
+                    { label: 'Orphaned DinD cleanup', slug: 'reference/roadmap/orphaned-dind-cleanup' },
+                    { label: 'Per-mount isolation', slug: 'reference/roadmap/per-mount-isolation' },
+                    { label: 'Sensitive mount warnings', slug: 'reference/roadmap/sensitive-mount-warnings' },
+                    { label: 'Worktree cleanup assessment', slug: 'reference/roadmap/worktree-cleanup-assessment' },
                   ],
                 },
               ],


### PR DESCRIPTION
## Summary

The Roadmap sidebar in `docs/astro.config.ts` had grown messy:

- A flat 13-item **Open items** bucket mixed runtime, auth, security, infrastructure, and docs concerns with no theme.
- The two phased programs (**Operator surface**, **Codebase health**) sat as peers next to it, making the top-level shape *open / done / program / program*.
- Two items were misclassified as **Open** despite their `**Status**` fields declaring them done.
- **Resolved** was in random insertion order.

This PR is a sidebar-only restructure — no page content changes, no slug changes, no broken links.

## What changed

```
Before                              After
──────                              ─────
Roadmap                             Roadmap
├─ Overview                         ├─ Overview
├─ Open items   (flat, 13 mixed)    ├─ Active programs
├─ Resolved     (random order, 8)   │  ├─ Universal Orchestrator (5 phases)
├─ Operator surface (5 phases)      │  └─ Codebase health        (3 phases)
└─ Codebase health  (3 phases)      ├─ Open items
                                    │  ├─ Agent runtimes & auth   (3)
                                    │  ├─ Isolation & security    (5)
                                    │  ├─ Infrastructure          (2)
                                    │  └─ Documentation tooling   (1)
                                    └─ Resolved (alphabetised, 10)
```

Specifically:

1. **Wrapped the two phased programs under a new `Active programs` parent** so the top-level shape reads *programs / open / done* instead of *open / done / program / program*.
2. **Renamed `Operator surface` → `Universal Orchestrator Program`** to match its actual page title and overview prose.
3. **Themed `Open items` into four sub-groups** by domain:
   - *Agent runtimes & authentication* (3)
   - *Isolation & security* (5)
   - *Infrastructure* (2)
   - *Documentation tooling* (1)
4. **Moved two misclassified items** from Open → Resolved:
   - `per-mount-isolation` (`Status: Implemented in V1`)
   - `worktree-cleanup-assessment` (`Status: Resolved`)
5. **Alphabetised the Resolved list** (10 items) for easier scanning.

## What did *not* change

- No MDX page bodies were touched — the `**Status**` field on each page is the source of truth and was already correct on the two relocated items.
- No slugs changed — every existing `/reference/roadmap/*` URL still resolves.
- The two phased programs' internal structure (phases, item ordering) is unchanged.

## Verification

```sh
# Sidebar/directory invariant from docs/AGENTS.md
ls docs/src/content/docs/reference/roadmap/*.mdx \
  | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
grep -oE "reference/roadmap/[a-z0-9-]+" docs/astro.config.ts \
  | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-sidebar
diff /tmp/roadmap-files /tmp/roadmap-sidebar    # → empty (MATCH)

cd docs && bun run build                         # → 88 pages, no errors
```

## Verify locally

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin pull/235/head:pr-235
git checkout pr-235

cd docs
bun install --frozen-lockfile
bun run dev
# Open http://localhost:4321/reference/roadmap/ and confirm the sidebar
# shows: Overview / Active programs / Open items (themed) / Resolved.
```
