### PR TITLE
fix(tui): remove workspace save toast

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -71,9 +71,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full DCO v1.1 text.
 
 Agent-specific attribution trailer requirements (e.g., for the Codex agent) are in [AGENTS.md](AGENTS.md).
 
-## Pre-commit Verification
+## Merge-readiness Verification
 
-Before committing **any** change, run all three checks and ensure zero warnings and zero failures:
+Do not run the full verification suite before every commit by default. Run it
+when a pull request is ready to be merged, or earlier only when the operator
+explicitly asks for it. The merge-readiness check is:
 
 ```sh
 cargo fmt -- --check && cargo clippy -- -D warnings && cargo nextest run

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,12 +28,14 @@ cargo nextest run -E 'test(/module::tests/)'
 
 Do **not** use `cargo test` — always use `cargo nextest run`.
 
-## Pre-commit Verification
+## Merge-readiness Verification
 
-Before committing any changes, **always** run formatting, clippy, and tests:
+Do not run formatting, clippy, and the full test suite before every commit by
+default. Run the full verification suite when a pull request is ready to be
+merged, or earlier only when the operator explicitly asks for it:
 
 ```sh
-cargo fmt -- --check && cargo clippy && cargo nextest run
+cargo fmt -- --check && cargo clippy -- -D warnings && cargo nextest run
 ```
 
 All three must pass with zero warnings and zero failures.

--- a/docs/superpowers/specs/2026-04-23-workspace-manager-tui-design.md
+++ b/docs/superpowers/specs/2026-04-23-workspace-manager-tui-design.md
@@ -49,7 +49,7 @@ The launcher gains a third stage, `LaunchStage::Manager`, reached via `m` from t
   - Mounts are added by pressing `a`, which opens a **file browser** rooted at `$HOME`. After picking a host folder, a follow-up modal collects `dst` (pre-filled with the same absolute path as host `src`) and `readonly` (single checkbox, off by default).
   - Agents tab: `Space` toggles `allowed`, `*` sets `default_role`. Checkbox-style UI.
   - Edits stage in a pending `WorkspaceConfig`; dirty markers (`● unsaved`) appear on changed rows. The footer save prompt shows the count of pending changes (`s save (3 changes)`).
-  - `s` persists through `ConfigEditor::edit_workspace` + `editor.save()?`. On success, the editor redraws with a `✓ saved · N changes written` banner; dirty markers clear.
+  - `s` persists through `ConfigEditor::edit_workspace` + `editor.save()?`. On success, dirty markers clear without showing a separate saved-status banner.
   - `Esc` with pending changes opens a **Y/N/C confirm modal**: Discard / Save+leave / Cancel.
 - **Act 3 — create new.** From the manager list, `Enter` on `[+ New workspace]` (or pressing `n`) starts the **mounts-first create wizard**:
   1. File browser for the first mount's host source.

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -3,7 +3,6 @@
 
 use super::super::state::{
     EditorMode, EditorSaveFlow, EditorState, ManagerListRow, ManagerStage, ManagerState, Modal,
-    Toast, ToastKind,
 };
 use crate::config::AppConfig;
 use crate::config::editor::EnvScope;
@@ -388,7 +387,6 @@ pub(super) fn commit_editor_save_with_runner(
                 if let Some(new_name) = pending_rename {
                     editor.mode = EditorMode::Edit { name: new_name };
                 }
-                let change_count = editor.change_count();
                 if let EditorMode::Edit { name } = &editor.mode
                     && let Some(ws) = config.workspaces.get(name)
                 {
@@ -396,11 +394,6 @@ pub(super) fn commit_editor_save_with_runner(
                     editor.pending = ws.clone();
                 }
                 editor.save_flow = EditorSaveFlow::Idle;
-                state.toast = Some(Toast {
-                    message: format!("saved · {change_count} changes written"),
-                    kind: ToastKind::Success,
-                    shown_at: std::time::Instant::now(),
-                });
             }
             if exit_on_success
                 || matches!(
@@ -411,15 +404,10 @@ pub(super) fn commit_editor_save_with_runner(
                     })
                 )
             {
-                // Carry the toast across `from_config_with_cache_and_op`
-                // (which would otherwise discard it) so create-save and
-                // Esc→Save keep positive feedback parity with direct `s`.
-                let carry_toast = state.toast.take();
                 let cache = state.op_cache.clone();
                 let op_available = state.op_available;
                 *state =
                     ManagerState::from_config_with_cache_and_op(config, cwd, cache, op_available);
-                state.toast = carry_toast;
                 // Land on the workspace that was just saved.
                 let saved_count = state.workspaces.len();
                 if let Some(idx) = state.workspaces.iter().position(|w| w.name == current_name) {
@@ -972,7 +960,7 @@ pub(super) fn build_workspace_edit(
 #[allow(clippy::too_many_lines)]
 mod tests {
     use super::super::super::state::{
-        EditorMode, EditorSaveFlow, EditorState, ManagerStage, ManagerState, Modal, ToastKind,
+        EditorMode, EditorSaveFlow, EditorState, ManagerStage, ManagerState, Modal,
     };
     use super::super::test_support::{key, mount};
     use super::{begin_editor_save, commit_editor_save};
@@ -1468,13 +1456,7 @@ mod tests {
     }
 
     #[test]
-    fn exit_on_success_save_preserves_success_toast_across_state_refresh() {
-        // Finding #3: when `commit_editor_save` exits to the list view,
-        // it reinitialises the whole `ManagerState` via
-        // `ManagerState::from_config` — which allocates `toast: None`.
-        // That discarded the success toast the same function had just
-        // set. Verify the carry-across keeps it intact so the operator
-        // still sees the positive feedback after the reset.
+    fn exit_on_success_save_does_not_show_success_toast() {
         let ws = WorkspaceConfig {
             workdir: "/w".into(),
             mounts: vec![mount("/w", "/w")],
@@ -1496,14 +1478,10 @@ mod tests {
             "exit_on_success should land us in the list; got {:?}",
             state.stage,
         );
-        let toast = state
-            .toast
-            .as_ref()
-            .expect("success toast must survive the exit-to-list reset");
         assert!(
-            matches!(toast.kind, ToastKind::Success),
-            "carried-across toast must be the Success kind; got {:?}",
-            toast.kind,
+            state.toast.is_none(),
+            "saving should not show a success toast; got {:?}",
+            state.toast,
         );
     }
 
@@ -1580,9 +1558,7 @@ mod tests {
     }
 
     #[test]
-    fn create_mode_save_preserves_success_toast_across_state_refresh() {
-        // Create mode also goes through the `ManagerState::from_config`
-        // reset. Same regression guard as the Edit-with-exit flow above.
+    fn create_mode_save_does_not_show_success_toast() {
         let (tmp, paths, mut config) = {
             let tmp = tempfile::tempdir().unwrap();
             let paths = JackinPaths::for_tests(tmp.path());
@@ -1609,11 +1585,11 @@ mod tests {
             "create save should return to the list; got {:?}",
             state.stage,
         );
-        let toast = state
-            .toast
-            .as_ref()
-            .expect("create-save success toast must survive the reset");
-        assert!(matches!(toast.kind, ToastKind::Success));
+        assert!(
+            state.toast.is_none(),
+            "create save should not show a success toast; got {:?}",
+            state.toast,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Removes the workspace save success toast so returning to the workspace list after saving does not show a redundant saved-status banner.

Changes:
- Stop creating and carrying the save success toast after workspace saves.
- Update save-flow regression tests to assert the save path stays quiet.
- Update the workspace-manager design note to match the current behavior.
- Update repository guidance so full verification is required at merge-readiness time or when explicitly requested, not before every commit.

Verified:
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo nextest run

Verify locally:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin pull/240/head:pr-240
git checkout pr-240

cargo fmt -- --check
cargo clippy -- -D warnings
cargo nextest run
```