### PR TITLE
feat(console): focus auth tab by kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,8 @@ For console/TUI changes that can be manually verified in jackin itself, prefer:
 cargo run --bin jackin -- console --debug
 ```
 
-Do not combine `--debug` with `--no-intro`; debug mode already disables the intro.
+The `--debug` / `--no-intro` flag interaction is documented in full
+under "Walking the operator through local validation" below.
 
 ### CI must be green before merging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,8 @@ fi
 
 cd jackin
 mise trust
-git fetch origin <BRANCH_NAME>
-git checkout <BRANCH_NAME>
-git pull --ff-only origin <BRANCH_NAME>
+git fetch origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
+git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
 ```
 
 #### Static Checks
@@ -219,6 +218,33 @@ When the operator asks for code review fixes on a PR that has **not yet been mer
 - Check out the PR branch (`gh pr checkout <PR>` or `git checkout <branch>`) before making changes.
 - Commit fixes to that branch and push; the open PR picks up the new commits automatically.
 - Creating a separate PR on top of an unmerged PR fragments review history and forces an extra merge step — avoid it.
+
+### Iterating on operator feedback for an open PR
+
+When the operator gives design or behavior feedback on an open PR, treat it as
+an iteration step unless they explicitly say the PR is ready for final
+verification, merge preparation, or review handoff.
+
+During iteration:
+
+- Make the requested code changes on the PR branch.
+- Prefer the smallest relevant verification needed to catch obvious local
+  breakage for the touched path. Do not run the full formatting + clippy + full
+  test suite by default.
+- Do not update the PR body after every iteration unless the operator asks for
+  it or the PR description has become actively misleading for someone reviewing
+  right now.
+- Do not amend, force-push, or wait for GitHub Actions as a reflex after every
+  small feedback pass. If the branch already has a PR open, a normal follow-up
+  commit is acceptable during review unless the operator asked to keep the PR as
+  one amended commit.
+- Summarize what changed and tell the operator what lightweight local check, if
+  any, was run. Then stop so the operator can validate the UI/behavior.
+
+Move to merge-readiness only when the operator gives a clear signal such as
+"this is correct", "prepare it", "ready for review", "run the full checks", or
+"now we can merge". At that point run the full verification suite, reconcile the
+PR body with the final diff, push/update the branch, and check CI.
 
 ## Walking the operator through local validation (agent-only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,23 @@ cargo run --bin jackin -- console --debug
 
 If the PR needs a different validation flow, replace the final example commands with the exact commands the operator should run. When those commands invoke `jackin`, include `--debug` as required by "Walking the operator through local validation".
 
+For non-trivial code changes, structure the PR's "Verify locally" section by intent:
+
+- **Checkout** — copy-pasteable commands to fetch and check out the PR.
+- **Static Checks** — only checks that are relevant and expected to be run locally.
+- **Tests** — focused or full test commands that validate the changed behavior.
+- **User Smoke** — manual validation steps when behavior is visible in the CLI/TUI/runtime.
+
+Do not add generic commands that do not materially validate the PR. In particular, do not include `git diff --check` unless the PR is specifically about whitespace, patch hygiene, generated diffs, or another issue that command is meant to catch.
+
+For console/TUI changes that can be manually verified in jackin itself, prefer:
+
+```sh
+cargo run --bin jackin -- console --debug
+```
+
+Do not combine `--debug` with `--no-intro`; debug mode already disables the intro.
+
 ### CI must be green before merging
 
 **Never merge a pull request unless all required CI checks pass.** This is non-negotiable regardless of how the operator phrases the merge request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,9 +228,16 @@ verification, merge preparation, or review handoff.
 During iteration:
 
 - Make the requested code changes on the PR branch.
-- Prefer the smallest relevant verification needed to catch obvious local
-  breakage for the touched path. Do not run the full formatting + clippy + full
-  test suite by default.
+- It is okay to run a narrow, targeted test or command that directly exercises
+  the code just changed, especially when it catches obvious local breakage
+  cheaply.
+- Do **not** run broad/final verification by default during iteration. In
+  particular, do not run `cargo fmt -- --check`, `cargo clippy -- -D warnings`,
+  `cargo nextest run`, or GitHub Actions polling unless the operator explicitly
+  asks for verification/final prep or the PR is moving to merge-readiness.
+- If a small targeted run reveals a formatting or clippy issue, fix the obvious
+  local cause when it is part of the changed code, but do not escalate into the
+  full formatting + clippy + full-suite pipeline unless the operator asks.
 - Do not update the PR body after every iteration unless the operator asks for
   it or the PR description has become actively misleading for someone reviewing
   right now.
@@ -245,6 +252,11 @@ Move to merge-readiness only when the operator gives a clear signal such as
 "this is correct", "prepare it", "ready for review", "run the full checks", or
 "now we can merge". At that point run the full verification suite, reconcile the
 PR body with the final diff, push/update the branch, and check CI.
+
+Why this rule exists: the operator often needs several UI/behavior iterations
+before deciding the shape is right. Running formatting, clippy, the full test
+suite, PR body updates, and CI checks on every intermediate pass wastes time and
+tokens before the operator has validated the design.
 
 ## Walking the operator through local validation (agent-only)
 

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -67,6 +67,9 @@ is not set to the expected personal address, correct it **before**
 committing — do not paper over a wrong-author commit with an unrelated
 sign-off.
 
+Do not add `Signed-off-by` trailers for AI agents. Agent involvement is recorded
+only with the `Co-authored-by` trailer required by [AGENTS.md](AGENTS.md).
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full DCO v1.1 text.
 
 Agent-specific attribution trailer requirements (e.g., for the Codex agent) are in [AGENTS.md](AGENTS.md).

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -68,7 +68,9 @@ committing — do not paper over a wrong-author commit with an unrelated
 sign-off.
 
 Do not add `Signed-off-by` trailers for AI agents. Agent involvement is recorded
-only with the `Co-authored-by` trailer required by [AGENTS.md](AGENTS.md).
+only with `Co-authored-by` trailers as required by [AGENTS.md](AGENTS.md) — one
+per contributing agent (multiple trailers are allowed only on squash-merge
+commits when several agents materially contributed to the PR).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full DCO v1.1 text.
 

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -232,9 +232,7 @@ pub(super) fn handle_auth_form_key(
 /// - `Enter` → open the shared source picker (literal vs. 1Password).
 /// - `Down/j` → focus `Save`.
 /// - `Up/k` → focus `Mode`.
-/// - Anything else → no-op (Tab is intentionally NOT handled here so
-///   future bindings can add Tab cycling without colliding with the
-///   row-level navigation rule).
+/// - Anything else → no-op. Tab is reserved for row-level navigation.
 fn handle_credential_source_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
@@ -278,23 +276,17 @@ fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available:
         return false;
     };
 
-    let Some(mode) = state.mode else {
-        editor.modal = Some(Modal::AuthForm {
-            target,
-            state,
-            focus,
-            literal_buffer,
-        });
-        return false;
-    };
-    let Some(env_var) = state.agent.required_env_var(mode) else {
-        editor.modal = Some(Modal::AuthForm {
-            target,
-            state,
-            focus,
-            literal_buffer,
-        });
-        return false;
+    let env_var = match state.mode.and_then(|m| state.agent.required_env_var(m)) {
+        Some(v) => v,
+        None => {
+            editor.modal = Some(Modal::AuthForm {
+                target,
+                state,
+                focus,
+                literal_buffer,
+            });
+            return false;
+        }
     };
 
     editor.pending_auth_form_return = Some(AuthFormReturnPath {
@@ -312,16 +304,30 @@ fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available:
     true
 }
 
+/// Stash-miss debug-log codes. Emitted when a side modal commits or
+/// cancels and the auth form's `pending_auth_form_return` slot is
+/// unexpectedly empty — the side handler fired without a paired
+/// open. Codes are stable so grepping `--debug` output stays cheap.
+const AUTH_MISSING_PLAIN_SOURCE: &str = "AUTH001";
+const AUTH_MISSING_PLAIN_TEXT: &str = "AUTH002";
+const AUTH_MISSING_OP_SOURCE: &str = "AUTH003";
+const AUTH_MISSING_OP_CANCEL: &str = "AUTH004";
+const AUTH_MISSING_OP_COMMIT: &str = "AUTH005";
+
+fn log_missing_return_path(code: &'static str, fn_name: &'static str, suffix: &str) {
+    crate::debug_log!(
+        "auth",
+        "{} {}: pending_auth_form_return missing{}",
+        code,
+        fn_name,
+        suffix
+    );
+}
+
 /// Commit branch for `Modal::AuthSourcePicker` when the operator picks
 /// the plain-text source. Re-stashes the auth form's context with the
 /// focus pinned to `CredentialSource`, then mounts a `Modal::TextInput`
 /// pre-filled from the round-trip's literal buffer.
-///
-/// If `pending_auth_form_return` is unexpectedly empty the round-trip
-/// can't continue — log loudly and leave `editor.modal` untouched so
-/// the next dispatch tick can reset cleanly. This shouldn't be
-/// reachable in practice (see `open_auth_source_picker_from_form`),
-/// hence the AUTH001 error code for grepping debug output.
 pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_>) {
     let Some(AuthFormReturnPath {
         target,
@@ -330,9 +336,10 @@ pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_
         ..
     }) = editor.pending_auth_form_return.take()
     else {
-        crate::debug_log!(
-            "auth",
-            "AUTH001 apply_plain_source_picker_to_auth_form: pending_auth_form_return missing"
+        log_missing_return_path(
+            AUTH_MISSING_PLAIN_SOURCE,
+            "apply_plain_source_picker_to_auth_form",
+            "",
         );
         return;
     };
@@ -351,18 +358,15 @@ pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_
 /// Commit branch for the credential `Modal::TextInput`. Lifts the
 /// stashed auth form back, applies the typed value via `set_literal`,
 /// and re-mounts the form with focus on Save.
-///
-/// If `pending_auth_form_return` is empty the typed credential cannot
-/// be applied to the form — log AUTH002 with the reason rather than
-/// silently dropping the operator's input.
 pub(super) fn apply_plain_text_to_auth_form(editor: &mut EditorState<'_>, value: &str) {
     let Some(AuthFormReturnPath {
         target, mut state, ..
     }) = editor.pending_auth_form_return.take()
     else {
-        crate::debug_log!(
-            "auth",
-            "AUTH002 apply_plain_text_to_auth_form: pending_auth_form_return missing — typed credential dropped"
+        log_missing_return_path(
+            AUTH_MISSING_PLAIN_TEXT,
+            "apply_plain_text_to_auth_form",
+            " — typed credential dropped",
         );
         return;
     };
@@ -375,32 +379,19 @@ pub(super) fn apply_plain_text_to_auth_form(editor: &mut EditorState<'_>, value:
     });
 }
 
-/// Cancel branch for the credential `Modal::TextInput`. Restores the
-/// auth form unchanged from the stashed return path. Aliases
-/// [`restore_auth_form_after_op_picker_cancel`] because the recovery
-/// step is identical for the literal-text and 1Password legs of the
-/// source-picker round trip — separate names exist purely so each
-/// call site reads as its own intent.
-pub(super) fn restore_auth_form_after_plain_cancel(editor: &mut EditorState<'_>) {
-    restore_auth_form_after_op_picker_cancel(editor);
-}
-
 /// Commit branch for `Modal::AuthSourcePicker` when the operator picks
 /// the 1Password source. Pins the stashed return-path focus to
 /// `CredentialSource` (so cancel/error paths land back on the source
 /// row) and mounts a fresh `Modal::OpPicker`.
-///
-/// If `pending_auth_form_return` is unexpectedly empty there is no
-/// form to return to — clear `editor.modal` and log AUTH003 so the
-/// state desync is visible in `--debug` output.
 pub(super) fn open_op_picker_from_auth_source(
     editor: &mut EditorState<'_>,
     op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
 ) {
     let Some(return_path) = editor.pending_auth_form_return.as_mut() else {
-        crate::debug_log!(
-            "auth",
-            "AUTH003 open_op_picker_from_auth_source: pending_auth_form_return missing — closing modal"
+        log_missing_return_path(
+            AUTH_MISSING_OP_SOURCE,
+            "open_op_picker_from_auth_source",
+            " — closing modal",
         );
         editor.modal = None;
         return;
@@ -430,12 +421,8 @@ pub(super) fn apply_op_picker_to_auth_form(
 }
 
 /// Restore the auth-form modal unchanged after the operator cancels
-/// the `OpPicker`. Called from the `OpPicker` cancel branch in
-/// `editor.rs` when `pending_auth_form_return` was set.
-///
-/// Empty stash means the cancel handler fired without a paired open
-/// — log AUTH004 and leave the modal stack alone so the editor can
-/// recover on the next dispatch.
+/// the `OpPicker` or the literal `TextInput`. Both side modals share
+/// the same recovery shape, so the same helper handles both.
 pub(super) fn restore_auth_form_after_op_picker_cancel(editor: &mut EditorState<'_>) {
     let Some(AuthFormReturnPath {
         target,
@@ -444,9 +431,10 @@ pub(super) fn restore_auth_form_after_op_picker_cancel(editor: &mut EditorState<
         literal_buffer,
     }) = editor.pending_auth_form_return.take()
     else {
-        crate::debug_log!(
-            "auth",
-            "AUTH004 restore_auth_form_after_op_picker_cancel: pending_auth_form_return missing"
+        log_missing_return_path(
+            AUTH_MISSING_OP_CANCEL,
+            "restore_auth_form_after_op_picker_cancel",
+            "",
         );
         return;
     };
@@ -475,9 +463,10 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
         literal_buffer,
     }) = editor.pending_auth_form_return.take()
     else {
-        crate::debug_log!(
-            "auth",
-            "AUTH005 apply_op_picker_to_auth_form: pending_auth_form_return missing — OpRef commit dropped"
+        log_missing_return_path(
+            AUTH_MISSING_OP_COMMIT,
+            "apply_op_picker_to_auth_form",
+            " — OpRef commit dropped",
         );
         return;
     };
@@ -706,10 +695,8 @@ mod tests {
         std::rc::Rc::new(std::cell::RefCell::new(OpCache::default()))
     }
 
-    /// Test wrapper around `handle_auth_form_key`. The form no longer
-    /// owns the op-cache (the `Modal::OpPicker` opens with its own,
-    /// supplied by the dispatcher) so this helper only needs the
-    /// `op_available` gate, which most tests want set to `true`.
+    /// Test wrapper around `handle_auth_form_key` with
+    /// `op_available = true`.
     fn drive_key(editor: &mut EditorState<'_>, k: KeyEvent) -> bool {
         handle_auth_form_key(editor, k, true)
     }

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -276,17 +276,14 @@ fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available:
         return false;
     };
 
-    let env_var = match state.mode.and_then(|m| state.agent.required_env_var(m)) {
-        Some(v) => v,
-        None => {
-            editor.modal = Some(Modal::AuthForm {
-                target,
-                state,
-                focus,
-                literal_buffer,
-            });
-            return false;
-        }
+    let Some(env_var) = state.mode.and_then(|m| state.agent.required_env_var(m)) else {
+        editor.modal = Some(Modal::AuthForm {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        });
+        return false;
     };
 
     editor.pending_auth_form_return = Some(AuthFormReturnPath {

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -13,11 +13,13 @@ use super::super::super::widgets::role_picker::RolePickerState;
 use super::super::render::editor::resolve_auth_row_target;
 use super::super::state::{
     AuthFormFocus, AuthFormReturnPath, AuthFormTarget, EditorState, FieldFocus, Modal,
+    TextInputTarget,
 };
 use crate::agent::Agent;
 use crate::config::AppConfig;
 use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
 use crate::console::op_cache::OpCache;
+use crate::console::widgets::text_input::TextInputState;
 use crate::operator_env::EnvValue;
 use crate::workspace::WorkspaceRoleOverride;
 
@@ -167,26 +169,25 @@ fn current_mode_and_credential(
 /// `true` when the modal was closed (committed, cancelled, or
 /// transitioned to `Modal::OpPicker` for credential selection).
 ///
-/// `op_cache` is consumed when the operator presses Enter at
-/// `AuthFormFocus::OpRefValue` to mount a fresh `OpPicker` modal; the
-/// auth-form's context is stashed in
-/// `editor.pending_auth_form_return` so the picker's commit handler
-/// in `editor.rs` can re-mount the form with the picked `OpRef`
-/// applied (or unchanged on cancel).
+/// `op_cache` is consumed when the operator chooses 1Password from the
+/// credential source picker; the auth-form's context is stashed in
+/// `editor.pending_auth_form_return` so the picker's commit handler in
+/// `editor.rs` can re-mount the form with the picked `OpRef` applied
+/// (or unchanged on cancel).
 pub(super) fn handle_auth_form_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
     op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
+    op_available: bool,
 ) -> bool {
-    let Some(Modal::AuthForm {
-        state,
-        focus,
-        literal_buffer,
-        ..
-    }) = editor.modal.as_mut()
-    else {
+    if !matches!(editor.modal, Some(Modal::AuthForm { .. })) {
         return false;
+    }
+
+    let Some(Modal::AuthForm { focus, .. }) = editor.modal.as_ref() else {
+        unreachable!("guarded above");
     };
+    let current_focus = *focus;
 
     // Esc cancels at every focus. Drain the auth-form return stash too so
     // a stale OpPicker round-trip can't be re-applied to a future modal —
@@ -198,13 +199,23 @@ pub(super) fn handle_auth_form_key(
         return true;
     }
 
-    match *focus {
-        AuthFormFocus::Mode => {
-            handle_mode_key(focus, state.as_mut(), key);
-        }
-        AuthFormFocus::CredentialSource => {
-            handle_credential_source_key(focus, state.as_mut(), literal_buffer.as_str(), key);
-        }
+    if current_focus == AuthFormFocus::CredentialSource {
+        return handle_credential_source_key(editor, key, op_available);
+    }
+
+    let Some(Modal::AuthForm {
+        state,
+        focus,
+        literal_buffer,
+        ..
+    }) = editor.modal.as_mut()
+    else {
+        return false;
+    };
+
+    match current_focus {
+        AuthFormFocus::Mode => handle_mode_key(focus, state.as_mut(), key),
+        AuthFormFocus::CredentialSource => unreachable!("handled above"),
         AuthFormFocus::LiteralValue => {
             handle_literal_value_key(focus, state.as_mut(), literal_buffer, key);
         }
@@ -227,6 +238,130 @@ pub(super) fn handle_auth_form_key(
         }
     }
     false
+}
+
+fn handle_credential_source_key(
+    editor: &mut EditorState<'_>,
+    key: KeyEvent,
+    op_available: bool,
+) -> bool {
+    let Some(Modal::AuthForm { focus, .. }) = editor.modal.as_mut() else {
+        return false;
+    };
+
+    match key.code {
+        KeyCode::Enter => open_auth_source_picker_from_form(editor, op_available),
+        KeyCode::Down | KeyCode::Char('j') => {
+            *focus = AuthFormFocus::Save;
+            false
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            *focus = AuthFormFocus::Mode;
+            false
+        }
+        _ => false,
+    }
+}
+
+fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available: bool) -> bool {
+    let Some(Modal::AuthForm {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    }) = editor.modal.take()
+    else {
+        return false;
+    };
+
+    let Some(mode) = state.mode else {
+        editor.modal = Some(Modal::AuthForm {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        });
+        return false;
+    };
+    let Some(env_var) = state.agent.required_env_var(mode) else {
+        editor.modal = Some(Modal::AuthForm {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        });
+        return false;
+    };
+
+    editor.pending_auth_form_return = Some(AuthFormReturnPath {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    });
+    editor.modal = Some(Modal::AuthSourcePicker {
+        state: crate::console::widgets::source_picker::SourcePickerState::new(
+            env_var.to_string(),
+            op_available,
+        ),
+    });
+    true
+}
+
+pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_>) {
+    let Some(AuthFormReturnPath {
+        target,
+        state,
+        literal_buffer,
+        ..
+    }) = editor.pending_auth_form_return.take()
+    else {
+        return;
+    };
+    editor.pending_auth_form_return = Some(AuthFormReturnPath {
+        target,
+        state,
+        focus: AuthFormFocus::CredentialSource,
+        literal_buffer: literal_buffer.clone(),
+    });
+    editor.modal = Some(Modal::TextInput {
+        target: TextInputTarget::AuthCredential,
+        state: TextInputState::new("Credential", literal_buffer),
+    });
+}
+
+pub(super) fn apply_plain_text_to_auth_form(editor: &mut EditorState<'_>, value: &str) {
+    let Some(AuthFormReturnPath {
+        target, mut state, ..
+    }) = editor.pending_auth_form_return.take()
+    else {
+        return;
+    };
+    state.set_literal(value.to_string());
+    editor.modal = Some(Modal::AuthForm {
+        target,
+        state,
+        focus: AuthFormFocus::Save,
+        literal_buffer: value.to_string(),
+    });
+}
+
+pub(super) fn restore_auth_form_after_plain_cancel(editor: &mut EditorState<'_>) {
+    restore_auth_form_after_op_picker_cancel(editor);
+}
+
+pub(super) fn open_op_picker_from_auth_source(
+    editor: &mut EditorState<'_>,
+    op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
+) {
+    let Some(return_path) = editor.pending_auth_form_return.as_mut() else {
+        editor.modal = None;
+        return;
+    };
+    return_path.focus = AuthFormFocus::CredentialSource;
+    editor.modal = Some(Modal::OpPicker {
+        state: Box::new(OpPickerState::new_with_cache(op_cache)),
+    });
 }
 
 /// Detach the auth-form context into `editor.pending_auth_form_return`
@@ -324,8 +459,8 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
         // On success, drop the cursor onto Save so Enter commits.
         AuthFormFocus::Save
     } else {
-        // On failure, keep the cursor on OpRefValue so the operator
-        // can retry without navigating.
+        // On failure, keep the cursor on the credential row so the
+        // operator can retry through the same source picker flow.
         focus
     };
     editor.modal = Some(Modal::AuthForm {
@@ -346,31 +481,8 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
 
 fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent) {
     match key.code {
-        KeyCode::Tab | KeyCode::Char(' ') => cycle_mode(form),
-        KeyCode::Down | KeyCode::Char('j') => *focus = next_focus_after_mode(form),
-        KeyCode::Enter => {
-            *focus = if form.shows_credential_block() {
-                AuthFormFocus::CredentialSource
-            } else {
-                AuthFormFocus::Save
-            };
-        }
-        _ => {}
-    }
-}
-
-fn handle_credential_source_key(
-    focus: &mut AuthFormFocus,
-    form: &mut AuthForm,
-    literal_buffer: &str,
-    key: KeyEvent,
-) {
-    match key.code {
-        KeyCode::Char(' ') => toggle_credential_source(form, literal_buffer),
-        KeyCode::Down | KeyCode::Char('j') | KeyCode::Enter => {
-            *focus = focus_for_credential_value(form);
-        }
-        KeyCode::Up | KeyCode::Char('k') => *focus = AuthFormFocus::Mode,
+        KeyCode::Char(' ') => cycle_mode(form),
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => *focus = next_focus_after_mode(form),
         _ => {}
     }
 }
@@ -413,7 +525,7 @@ fn handle_save_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
         }
         KeyCode::Up => {
             *focus = if state.shows_credential_block() {
-                focus_for_credential_value(state.as_ref())
+                AuthFormFocus::CredentialSource
             } else {
                 AuthFormFocus::Mode
             };
@@ -474,14 +586,6 @@ fn handle_reset_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
     }
 }
 
-const fn focus_for_credential_value(form: &AuthForm) -> AuthFormFocus {
-    if matches!(form.credential, CredentialInput::OpRef(_)) {
-        AuthFormFocus::OpRefValue
-    } else {
-        AuthFormFocus::LiteralValue
-    }
-}
-
 fn cycle_mode(form: &mut AuthForm) {
     let modes = form.available_modes();
     if modes.is_empty() {
@@ -500,18 +604,6 @@ const fn next_focus_after_mode(form: &AuthForm) -> AuthFormFocus {
     } else {
         AuthFormFocus::Save
     }
-}
-
-fn toggle_credential_source(form: &mut AuthForm, literal_buffer: &str) {
-    use crate::operator_env::OpRef;
-    let next = match &form.credential {
-        CredentialInput::OpRef(_) => CredentialInput::Literal(literal_buffer.to_string()),
-        CredentialInput::None | CredentialInput::Literal(_) => CredentialInput::OpRef(OpRef {
-            op: String::new(),
-            path: String::new(),
-        }),
-    };
-    form.credential = next;
 }
 
 /// Apply a successful form commit to `editor.pending`. Writes both the
@@ -612,7 +704,7 @@ mod tests {
     /// throwaway op-cache. Most existing tests don't care about
     /// op-picker plumbing — this keeps their bodies short.
     fn drive_key(editor: &mut EditorState<'_>, k: KeyEvent) -> bool {
-        handle_auth_form_key(editor, k, fresh_op_cache())
+        handle_auth_form_key(editor, k, fresh_op_cache(), true)
     }
 
     /// Return the flat-row index for `WorkspaceMode { Claude }`.
@@ -669,8 +761,9 @@ mod tests {
     }
 
     /// Walking from the workspace × Claude row through the form:
-    /// Enter opens form, Space cycles mode to `api_key`, Enter into
-    /// credential, type literal, navigate to Save, Enter saves. The
+    /// Enter opens form, Space cycles mode to `api_key`, Tab moves to
+    /// credential, Enter picks source, type literal, Enter confirms,
+    /// Enter saves. The
     /// in-memory `pending.claude` and `pending.env` reflect the change.
     #[test]
     fn auth_form_save_persists_workspace_layer_into_pending() {
@@ -685,16 +778,13 @@ mod tests {
         // Cycle mode: None → first available (sync) → ApiKey is two cycles.
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
-        // Enter to advance to credential block.
-        drive_key(editor, key(KeyCode::Enter));
-        // Enter on cred radio → into LiteralValue.
-        drive_key(editor, key(KeyCode::Enter));
-        // Type "secret".
-        for c in "secret".chars() {
-            drive_key(editor, key(KeyCode::Char(c)));
-        }
-        // Tab to Save.
+        // Tab advances to credential row, then Enter opens the source picker.
         drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Enter));
+        assert!(matches!(editor.modal, Some(Modal::AuthSourcePicker { .. })));
+        apply_plain_source_picker_to_auth_form(editor);
+        assert!(matches!(editor.modal, Some(Modal::TextInput { .. })));
+        apply_plain_text_to_auth_form(editor, "secret");
         // Enter → save.
         let closed = drive_key(editor, key(KeyCode::Enter));
         assert!(closed, "save must close the modal");
@@ -733,10 +823,9 @@ mod tests {
         });
         open_auth_form_modal(editor);
         // Tab through to Reset and Enter.
-        // From Mode → Down → Cred → Down → Literal → Tab → Save → Tab → Cancel → Tab → Reset.
+        // From Mode → Down → Cred → Down → Save → Tab → Cancel → Tab → Reset.
         drive_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
-        drive_key(editor, key(KeyCode::Down)); // → LiteralValue
-        drive_key(editor, key(KeyCode::Tab)); // → Save
+        drive_key(editor, key(KeyCode::Down)); // → Save
         drive_key(editor, key(KeyCode::Tab)); // → Cancel
         drive_key(editor, key(KeyCode::Tab)); // → Reset
         let closed = drive_key(editor, key(KeyCode::Enter));
@@ -763,6 +852,60 @@ mod tests {
         assert!(
             editor.pending.claude.is_none(),
             "cancel must not write to pending"
+        );
+    }
+
+    #[test]
+    fn auth_form_enter_on_mode_does_not_navigate_tab_does() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+
+        drive_key(editor, key(KeyCode::Enter));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::Mode,
+            "Enter on mode must not move to the next actionable row"
+        );
+
+        drive_key(editor, key(KeyCode::Tab));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::CredentialSource,
+            "Tab on mode must move to the credential row"
+        );
+    }
+
+    #[test]
+    fn auth_form_typing_on_credential_row_does_not_set_plain_text() {
+        let (_cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor);
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Char('x')));
+
+        let Some(Modal::AuthForm { state, focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(*focus, AuthFormFocus::CredentialSource);
+        assert_eq!(
+            state.credential,
+            CredentialInput::None,
+            "typing on credential row must not bypass the source picker"
         );
     }
 
@@ -815,14 +958,14 @@ mod tests {
             }
         );
 
-        // Cycle sync to api_key, enter cred, type, tab to save, enter.
+        // Cycle sync to api_key, choose plain credential, type, tab to save, enter.
         drive_key(editor, key(KeyCode::Char(' ')));
-        drive_key(editor, key(KeyCode::Enter));
-        drive_key(editor, key(KeyCode::Enter));
-        for c in "abc".chars() {
-            drive_key(editor, key(KeyCode::Char(c)));
-        }
         drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Enter));
+        assert!(matches!(editor.modal, Some(Modal::AuthSourcePicker { .. })));
+        apply_plain_source_picker_to_auth_form(editor);
+        assert!(matches!(editor.modal, Some(Modal::TextInput { .. })));
+        apply_plain_text_to_auth_form(editor, "abc");
         let closed = drive_key(editor, key(KeyCode::Enter));
         assert!(closed);
 
@@ -846,10 +989,10 @@ mod tests {
         }
     }
 
-    /// Pressing Enter while focused on `OpRefValue` swaps the auth-form
-    /// modal for an `OpPicker` and stashes the form context in
-    /// `pending_auth_form_return`. Confirms the open path of the
-    /// picker round-trip wiring.
+    /// Choosing 1Password from the credential source picker swaps the
+    /// auth-form modal for an `OpPicker` and stashes the form context in
+    /// `pending_auth_form_return`. Confirms the open path of the picker
+    /// round-trip wiring.
     #[test]
     fn auth_form_op_ref_picker_invocation_opens_op_picker_modal() {
         let (_cfg, mut state) = build_state();
@@ -860,24 +1003,15 @@ mod tests {
         // Mode → ApiKey (two cycles past `None → sync`).
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
-        // Enter to advance to the credential block (CredentialSource).
-        drive_key(editor, key(KeyCode::Enter));
-        // Toggle credential source: Literal → OpRef. Now the cred-value
-        // focus resolves to OpRefValue.
-        drive_key(editor, key(KeyCode::Char(' ')));
-        // Down: CredentialSource → OpRefValue (focus_for_credential_value).
-        drive_key(editor, key(KeyCode::Down));
-        // Sanity-check we're on OpRefValue.
-        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
-            panic!("expected auth form still open before picker invocation")
-        };
-        assert_eq!(*focus, AuthFormFocus::OpRefValue);
-        // Enter on OpRefValue → swaps to OpPicker.
+        // Tab advances to the credential row, then Enter opens the source picker.
+        drive_key(editor, key(KeyCode::Tab));
         let closed = drive_key(editor, key(KeyCode::Enter));
-        assert!(closed, "transitioning to OpPicker must close auth form");
+        assert!(closed, "opening source picker must close auth form");
+        assert!(matches!(editor.modal, Some(Modal::AuthSourcePicker { .. })));
+        open_op_picker_from_auth_source(editor, fresh_op_cache());
         assert!(
             matches!(editor.modal, Some(Modal::OpPicker { .. })),
-            "auth form must hand off to OpPicker on Enter at OpRefValue"
+            "auth form must hand off to OpPicker from the source picker"
         );
         assert!(
             editor.pending_auth_form_return.is_some(),
@@ -903,15 +1037,14 @@ mod tests {
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        // Open the auth form on workspace × Claude and bring it to
-        // OpRefValue with mode = ApiKey.
+        // Open the auth form on workspace × Claude and choose
+        // 1Password from the source picker.
         open_auth_form_modal(editor);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Tab));
         drive_key(editor, key(KeyCode::Enter));
-        drive_key(editor, key(KeyCode::Char(' ')));
-        drive_key(editor, key(KeyCode::Down));
-        drive_key(editor, key(KeyCode::Enter));
+        open_op_picker_from_auth_source(editor, fresh_op_cache());
         assert!(matches!(editor.modal, Some(Modal::OpPicker { .. })));
 
         // Simulate the picker committing a valid OpRef. Bypass the
@@ -969,10 +1102,9 @@ mod tests {
         open_auth_form_modal(editor);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
+        drive_key(editor, key(KeyCode::Tab));
         drive_key(editor, key(KeyCode::Enter));
-        drive_key(editor, key(KeyCode::Char(' ')));
-        drive_key(editor, key(KeyCode::Down));
-        drive_key(editor, key(KeyCode::Enter));
+        open_op_picker_from_auth_source(editor, fresh_op_cache());
 
         let picked = OpRef {
             op: "op://uuid/missing".into(),
@@ -1045,13 +1177,17 @@ mod tests {
         let pending_before = editor.pending.clone();
         open_auth_form_modal(editor);
         // Build a form state with mode = ApiKey and credential = empty
-        // OpRef so `can_save` returns false. Cycle Mode (None → Sync →
-        // ApiKey), Enter into the credential block, Space to flip from
-        // Literal to (empty) OpRef, then Down to navigate to OpRefValue.
+        // OpRef so `can_save` returns false.
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
-        drive_key(editor, key(KeyCode::Enter));
-        drive_key(editor, key(KeyCode::Char(' ')));
+        if let Some(Modal::AuthForm { state, .. }) = editor.modal.as_mut() {
+            state.credential = CredentialInput::OpRef(OpRef {
+                op: String::new(),
+                path: String::new(),
+            });
+        } else {
+            panic!("auth form must still be open");
+        }
 
         // Confirm the form's credential is the empty OpRef and can_save
         // is false.

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -230,9 +230,8 @@ pub(super) fn handle_auth_form_key(
 /// Keystroke router for the `CredentialSource` row.
 ///
 /// - `Enter` → open the shared source picker (literal vs. 1Password).
-/// - `Down/j` → focus `Save`.
-/// - `Up/k` → focus `Mode`.
-/// - Anything else → no-op. Tab is reserved for row-level navigation.
+/// - `Down/j`/`Tab` → focus `Save` (forward through the cycle).
+/// - `Up/k`/`BackTab` → focus `Mode` (backward through the cycle).
 fn handle_credential_source_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
@@ -244,11 +243,11 @@ fn handle_credential_source_key(
 
     match key.code {
         KeyCode::Enter => open_auth_source_picker_from_form(editor, op_available),
-        KeyCode::Down | KeyCode::Char('j') => {
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
             *focus = AuthFormFocus::Save;
             false
         }
-        KeyCode::Up | KeyCode::Char('k') => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
             *focus = AuthFormFocus::Mode;
             false
         }
@@ -501,6 +500,10 @@ fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent
     match key.code {
         KeyCode::Char(' ') => cycle_mode(form),
         KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => *focus = next_focus_after_mode(form),
+        // BackTab wraps backward through the cycle to Reset (the last
+        // focusable control). Forward Tab from Reset wraps to Mode in
+        // `handle_reset_key`.
+        KeyCode::BackTab => *focus = AuthFormFocus::Reset,
         _ => {}
     }
 }
@@ -520,7 +523,9 @@ fn handle_save_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
             *focus = AuthFormFocus::Cancel;
             false
         }
-        KeyCode::Up => {
+        // BackTab walks backward through the cycle to the credential
+        // row (when shown) or Mode (otherwise); Up mirrors that.
+        KeyCode::Up | KeyCode::BackTab => {
             *focus = if state.shows_credential_block() {
                 AuthFormFocus::CredentialSource
             } else {
@@ -548,7 +553,7 @@ fn handle_cancel_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
         return false;
     };
     match key.code {
-        KeyCode::Left => {
+        KeyCode::Left | KeyCode::BackTab => {
             *focus = AuthFormFocus::Save;
             false
         }
@@ -569,8 +574,13 @@ fn handle_reset_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
         return false;
     };
     match key.code {
-        KeyCode::Left => {
+        KeyCode::Left | KeyCode::BackTab => {
             *focus = AuthFormFocus::Cancel;
+            false
+        }
+        // Tab from the last focusable control wraps to Mode (first).
+        KeyCode::Right | KeyCode::Tab => {
+            *focus = AuthFormFocus::Mode;
             false
         }
         KeyCode::Enter => {
@@ -879,6 +889,48 @@ mod tests {
             *focus,
             AuthFormFocus::CredentialSource,
             "Tab on mode must move to the credential row"
+        );
+    }
+
+    /// Tab from the last focusable control wraps back to the first.
+    /// Mirrors the convention used by every other modal in the TUI.
+    #[test]
+    fn auth_form_tab_wraps_around_at_reset() {
+        let (cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor, &cfg);
+        // Walk to Reset (last focusable):
+        // Mode → Tab → Save → Tab → Cancel → Tab → Reset.
+        drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Tab));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(*focus, AuthFormFocus::Reset);
+
+        // Tab from Reset wraps to Mode.
+        drive_key(editor, key(KeyCode::Tab));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::Mode,
+            "Tab on Reset must wrap to Mode"
+        );
+
+        // BackTab from Mode wraps to Reset (last).
+        drive_key(editor, key(KeyCode::BackTab));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::Reset,
+            "BackTab on Mode must wrap to Reset"
         );
     }
 

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -60,12 +60,18 @@ pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>) {
 /// duplicate the existing rows. Silent no-op when no candidates remain
 /// (the row is rendered dimmed in that state).
 pub(super) fn open_auth_role_picker(editor: &mut EditorState<'_>, config: &AppConfig) {
+    let Some(agent) = editor.auth_selected_agent else {
+        return;
+    };
     let eligible = super::super::render::editor::eligible_agents_for_override(editor, config);
     let already_overridden: std::collections::BTreeSet<String> = editor
         .pending
         .roles
         .iter()
-        .filter(|(_, ro)| ro.has_auth_override())
+        .filter(|(_, ro)| match agent {
+            Agent::Claude => ro.claude.is_some(),
+            Agent::Codex => ro.codex.is_some(),
+        })
         .map(|(name, _)| name.clone())
         .collect();
     let candidates: Vec<crate::selector::RoleSelector> = eligible
@@ -90,25 +96,29 @@ pub(super) fn toggle_role_expand(editor: &mut EditorState<'_>, role: String) {
 
 /// Handle `D`/`d` on the Auth tab.
 ///
-/// - `RoleHeader` → open a `Confirm` modal targeting `ClearAuthRoleOverride`.
-/// - `RoleAgentRow` → silently clear that single agent's override (no modal).
+/// - `RoleHeader` → clear the selected auth kind's role override.
+/// - `RoleMode` / `RoleSource` → silently clear that selected auth kind's override.
 /// - Anything else → no-op.
 pub(super) fn handle_d_on_auth_row(editor: &mut EditorState<'_>) {
     let FieldFocus::Row(n) = editor.active_field;
     let rows = super::super::render::editor::auth_flat_rows(editor);
     match rows.get(n).cloned() {
         Some(super::super::render::editor::AuthRow::RoleHeader { role, .. }) => {
-            editor.modal = Some(Modal::Confirm {
-                target: crate::console::manager::state::ConfirmTarget::ClearAuthRoleOverride {
-                    role: role.clone(),
-                },
-                state: crate::console::widgets::confirm::ConfirmState::new(format!(
-                    "Clear all auth overrides for '{role}'?"
-                )),
-            });
+            if let Some(agent) = editor.auth_selected_agent {
+                clear_role_agent(editor, &role, agent);
+            }
         }
-        Some(super::super::render::editor::AuthRow::RoleAgentRow { role, agent }) => {
+        Some(
+            super::super::render::editor::AuthRow::RoleMode { role, agent }
+            | super::super::render::editor::AuthRow::RoleSource { role, agent },
+        ) => {
             clear_role_agent(editor, &role, agent);
+        }
+        Some(
+            super::super::render::editor::AuthRow::WorkspaceMode { agent }
+            | super::super::render::editor::AuthRow::WorkspaceSource { agent },
+        ) => {
+            set_workspace_mode(&mut editor.pending, agent, None);
         }
         _ => {}
     }
@@ -605,7 +615,7 @@ mod tests {
         handle_auth_form_key(editor, k, fresh_op_cache())
     }
 
-    /// Return the flat-row index for `WorkspaceDefault { Claude }`.
+    /// Return the flat-row index for `WorkspaceMode { Claude }`.
     /// Panics if the row doesn't exist (which would indicate a broken
     /// fixture, not a test-under-test failure).
     fn workspace_claude_row_idx(editor: &EditorState<'_>) -> usize {
@@ -614,12 +624,12 @@ mod tests {
             .position(|r| {
                 matches!(
                     r,
-                    AuthRow::WorkspaceDefault {
+                    AuthRow::WorkspaceMode {
                         agent: Agent::Claude,
                     }
                 )
             })
-            .expect("WorkspaceDefault × Claude row must exist in auth_flat_rows")
+            .expect("WorkspaceMode × Claude row must exist in auth_flat_rows")
     }
 
     fn build_state() -> (AppConfig, ManagerState<'static>) {
@@ -651,6 +661,7 @@ mod tests {
         let ws = cfg.workspaces.get("proj").unwrap().clone();
         let mut editor = EditorState::new_edit("proj".into(), ws);
         editor.active_tab = crate::console::manager::state::EditorTab::Auth;
+        editor.auth_selected_agent = Some(Agent::Claude);
         let ws_claude_idx = workspace_claude_row_idx(&editor);
         editor.active_field = FieldFocus::Row(ws_claude_idx);
         state.stage = ManagerStage::Editor(editor);
@@ -765,24 +776,18 @@ mod tests {
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        // Insert an override entry for "smith" so it materialises as a
-        // RoleHeader in auth_flat_rows (the row only appears when
-        // claude.is_some() || codex.is_some()). We seed codex only so
-        // the claude field stays None — the auth form then opens fresh
-        // (None mode) and the two-Space cycle reaches ApiKey as the
-        // test expects.
+        // Insert a Claude override entry for "smith" so it materialises
+        // in the focused Claude auth view.
         editor.pending.roles.insert(
             "smith".into(),
             WorkspaceRoleOverride {
-                codex: Some(crate::config::CodexAuthConfig(
-                    crate::config::AgentAuthConfig {
-                        auth_forward: AuthForwardMode::Sync,
-                    },
-                )),
+                claude: Some(crate::config::AgentAuthConfig {
+                    auth_forward: AuthForwardMode::Sync,
+                }),
                 ..Default::default()
             },
         );
-        // Expand the role so the RoleAgentRow children are emitted.
+        // Expand the role so the RoleMode child is emitted.
         editor.auth_expanded.insert("smith".into());
         // Dynamically locate the smith × Claude agent row.
         let smith_claude_idx = auth_flat_rows(editor)
@@ -790,13 +795,13 @@ mod tests {
             .position(|r| {
                 matches!(
                     r,
-                    AuthRow::RoleAgentRow {
+                    AuthRow::RoleMode {
                         role,
                         agent: Agent::Claude,
                     } if role == "smith"
                 )
             })
-            .expect("RoleAgentRow smith × Claude must exist after override insertion");
+            .expect("RoleMode smith × Claude must exist after override insertion");
         editor.active_field = FieldFocus::Row(smith_claude_idx);
         open_auth_form_modal(editor);
         let Some(Modal::AuthForm { target, .. }) = &editor.modal else {
@@ -810,8 +815,7 @@ mod tests {
             }
         );
 
-        // Cycle to api_key, enter cred, type, tab to save, enter.
-        drive_key(editor, key(KeyCode::Char(' ')));
+        // Cycle sync to api_key, enter cred, type, tab to save, enter.
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Enter));
         drive_key(editor, key(KeyCode::Enter));

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -27,9 +27,9 @@ use crate::workspace::WorkspaceRoleOverride;
 /// cursor on the Auth tab. Pre-populates the form from the row's
 /// effective mode + credential so editing an existing entry shows
 /// what's there.
-pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>) {
+pub(super) fn open_auth_form_modal(editor: &mut EditorState<'_>, config: &AppConfig) {
     let FieldFocus::Row(n) = editor.active_field;
-    let Some(target) = resolve_auth_row_target(editor, n) else {
+    let Some(target) = resolve_auth_row_target(editor, config, n) else {
         return;
     };
     let agent = match &target {
@@ -99,11 +99,14 @@ pub(super) fn toggle_role_expand(editor: &mut EditorState<'_>, role: String) {
 /// Handle `D`/`d` on the Auth tab.
 ///
 /// - `RoleHeader` → clear the selected auth kind's role override.
-/// - `RoleMode` / `RoleSource` → silently clear that selected auth kind's override.
-/// - Anything else → no-op.
-pub(super) fn handle_d_on_auth_row(editor: &mut EditorState<'_>) {
+/// - `RoleMode` / `RoleSource` → silently clear the selected auth kind's
+///   role-level override.
+/// - `WorkspaceMode` / `WorkspaceSource` → clear the workspace-level
+///   override for the selected auth kind.
+/// - Anything else (`AuthKind`, `AddSentinel`, `Spacer`) → no-op.
+pub(super) fn handle_d_on_auth_row(editor: &mut EditorState<'_>, config: &AppConfig) {
     let FieldFocus::Row(n) = editor.active_field;
-    let rows = super::super::render::editor::auth_flat_rows(editor);
+    let rows = super::super::render::editor::auth_flat_rows(editor, config);
     match rows.get(n).cloned() {
         Some(super::super::render::editor::AuthRow::RoleHeader { role, .. }) => {
             if let Some(agent) = editor.auth_selected_agent {
@@ -167,17 +170,18 @@ fn current_mode_and_credential(
 
 /// Drive a single keystroke into an open `Modal::AuthForm`. Returns
 /// `true` when the modal was closed (committed, cancelled, or
-/// transitioned to `Modal::OpPicker` for credential selection).
+/// transitioned away from the form via `Modal::AuthSourcePicker`).
 ///
-/// `op_cache` is consumed when the operator chooses 1Password from the
-/// credential source picker; the auth-form's context is stashed in
-/// `editor.pending_auth_form_return` so the picker's commit handler in
-/// `editor.rs` can re-mount the form with the picked `OpRef` applied
-/// (or unchanged on cancel).
+/// `op_available` gates the 1Password choice rendered inside
+/// `Modal::AuthSourcePicker` — passed through from `EditorState` so
+/// the form doesn't reprobe the `op` binary on every keypress. The
+/// `OpPicker` itself is opened by `open_op_picker_from_auth_source`
+/// after the operator selects 1Password from the source picker; that
+/// helper takes its own `op_cache` so this entry point doesn't have
+/// to.
 pub(super) fn handle_auth_form_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
-    op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
     op_available: bool,
 ) -> bool {
     if !matches!(editor.modal, Some(Modal::AuthForm { .. })) {
@@ -203,30 +207,13 @@ pub(super) fn handle_auth_form_key(
         return handle_credential_source_key(editor, key, op_available);
     }
 
-    let Some(Modal::AuthForm {
-        state,
-        focus,
-        literal_buffer,
-        ..
-    }) = editor.modal.as_mut()
-    else {
+    let Some(Modal::AuthForm { state, focus, .. }) = editor.modal.as_mut() else {
         return false;
     };
 
     match current_focus {
         AuthFormFocus::Mode => handle_mode_key(focus, state.as_mut(), key),
         AuthFormFocus::CredentialSource => unreachable!("handled above"),
-        AuthFormFocus::LiteralValue => {
-            handle_literal_value_key(focus, state.as_mut(), literal_buffer, key);
-        }
-        AuthFormFocus::OpRefValue => match key.code {
-            KeyCode::Enter => {
-                return open_op_picker_from_auth_form(editor, op_cache);
-            }
-            KeyCode::Down | KeyCode::Tab => *focus = AuthFormFocus::Save,
-            KeyCode::Up => *focus = AuthFormFocus::CredentialSource,
-            _ => {}
-        },
         AuthFormFocus::Save => {
             return handle_save_key(editor, key);
         }
@@ -240,6 +227,14 @@ pub(super) fn handle_auth_form_key(
     false
 }
 
+/// Keystroke router for the `CredentialSource` row.
+///
+/// - `Enter` → open the shared source picker (literal vs. 1Password).
+/// - `Down/j` → focus `Save`.
+/// - `Up/k` → focus `Mode`.
+/// - Anything else → no-op (Tab is intentionally NOT handled here so
+///   future bindings can add Tab cycling without colliding with the
+///   row-level navigation rule).
 fn handle_credential_source_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
@@ -263,6 +258,15 @@ fn handle_credential_source_key(
     }
 }
 
+/// Detach the open `Modal::AuthForm` into `pending_auth_form_return`
+/// and mount a `Modal::AuthSourcePicker` for the form's required env
+/// var. Returns `true` when the swap happened (the picker took over).
+///
+/// Three early-returns put the form back unchanged when the swap
+/// can't proceed: no form open, mode not yet picked, or selected
+/// mode requires no credential. The form is restored verbatim so
+/// the operator's keypress on the credential row is a quiet no-op
+/// rather than a state desync.
 fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available: bool) -> bool {
     let Some(Modal::AuthForm {
         target,
@@ -308,6 +312,16 @@ fn open_auth_source_picker_from_form(editor: &mut EditorState<'_>, op_available:
     true
 }
 
+/// Commit branch for `Modal::AuthSourcePicker` when the operator picks
+/// the plain-text source. Re-stashes the auth form's context with the
+/// focus pinned to `CredentialSource`, then mounts a `Modal::TextInput`
+/// pre-filled from the round-trip's literal buffer.
+///
+/// If `pending_auth_form_return` is unexpectedly empty the round-trip
+/// can't continue — log loudly and leave `editor.modal` untouched so
+/// the next dispatch tick can reset cleanly. This shouldn't be
+/// reachable in practice (see `open_auth_source_picker_from_form`),
+/// hence the AUTH001 error code for grepping debug output.
 pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_>) {
     let Some(AuthFormReturnPath {
         target,
@@ -316,6 +330,10 @@ pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_
         ..
     }) = editor.pending_auth_form_return.take()
     else {
+        crate::debug_log!(
+            "auth",
+            "AUTH001 apply_plain_source_picker_to_auth_form: pending_auth_form_return missing"
+        );
         return;
     };
     editor.pending_auth_form_return = Some(AuthFormReturnPath {
@@ -330,11 +348,22 @@ pub(super) fn apply_plain_source_picker_to_auth_form(editor: &mut EditorState<'_
     });
 }
 
+/// Commit branch for the credential `Modal::TextInput`. Lifts the
+/// stashed auth form back, applies the typed value via `set_literal`,
+/// and re-mounts the form with focus on Save.
+///
+/// If `pending_auth_form_return` is empty the typed credential cannot
+/// be applied to the form — log AUTH002 with the reason rather than
+/// silently dropping the operator's input.
 pub(super) fn apply_plain_text_to_auth_form(editor: &mut EditorState<'_>, value: &str) {
     let Some(AuthFormReturnPath {
         target, mut state, ..
     }) = editor.pending_auth_form_return.take()
     else {
+        crate::debug_log!(
+            "auth",
+            "AUTH002 apply_plain_text_to_auth_form: pending_auth_form_return missing — typed credential dropped"
+        );
         return;
     };
     state.set_literal(value.to_string());
@@ -346,15 +375,33 @@ pub(super) fn apply_plain_text_to_auth_form(editor: &mut EditorState<'_>, value:
     });
 }
 
+/// Cancel branch for the credential `Modal::TextInput`. Restores the
+/// auth form unchanged from the stashed return path. Aliases
+/// [`restore_auth_form_after_op_picker_cancel`] because the recovery
+/// step is identical for the literal-text and 1Password legs of the
+/// source-picker round trip — separate names exist purely so each
+/// call site reads as its own intent.
 pub(super) fn restore_auth_form_after_plain_cancel(editor: &mut EditorState<'_>) {
     restore_auth_form_after_op_picker_cancel(editor);
 }
 
+/// Commit branch for `Modal::AuthSourcePicker` when the operator picks
+/// the 1Password source. Pins the stashed return-path focus to
+/// `CredentialSource` (so cancel/error paths land back on the source
+/// row) and mounts a fresh `Modal::OpPicker`.
+///
+/// If `pending_auth_form_return` is unexpectedly empty there is no
+/// form to return to — clear `editor.modal` and log AUTH003 so the
+/// state desync is visible in `--debug` output.
 pub(super) fn open_op_picker_from_auth_source(
     editor: &mut EditorState<'_>,
     op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
 ) {
     let Some(return_path) = editor.pending_auth_form_return.as_mut() else {
+        crate::debug_log!(
+            "auth",
+            "AUTH003 open_op_picker_from_auth_source: pending_auth_form_return missing — closing modal"
+        );
         editor.modal = None;
         return;
     };
@@ -362,38 +409,6 @@ pub(super) fn open_op_picker_from_auth_source(
     editor.modal = Some(Modal::OpPicker {
         state: Box::new(OpPickerState::new_with_cache(op_cache)),
     });
-}
-
-/// Detach the auth-form context into `editor.pending_auth_form_return`
-/// and replace `editor.modal` with a fresh `Modal::OpPicker`. The
-/// picker's commit handler (in `editor.rs`) is responsible for
-/// reading `pending_auth_form_return.take()` and re-mounting the form.
-///
-/// Returns `true` so the caller treats the auth-form modal as closed
-/// (it's been swapped out for the picker).
-fn open_op_picker_from_auth_form(
-    editor: &mut EditorState<'_>,
-    op_cache: std::rc::Rc<std::cell::RefCell<OpCache>>,
-) -> bool {
-    let Some(Modal::AuthForm {
-        target,
-        state,
-        focus,
-        literal_buffer,
-    }) = editor.modal.take()
-    else {
-        return false;
-    };
-    editor.pending_auth_form_return = Some(AuthFormReturnPath {
-        target,
-        state,
-        focus,
-        literal_buffer,
-    });
-    editor.modal = Some(Modal::OpPicker {
-        state: Box::new(OpPickerState::new_with_cache(op_cache)),
-    });
-    true
 }
 
 /// Re-mount the auth-form modal with a freshly-picked `OpRef` applied
@@ -417,6 +432,10 @@ pub(super) fn apply_op_picker_to_auth_form(
 /// Restore the auth-form modal unchanged after the operator cancels
 /// the `OpPicker`. Called from the `OpPicker` cancel branch in
 /// `editor.rs` when `pending_auth_form_return` was set.
+///
+/// Empty stash means the cancel handler fired without a paired open
+/// — log AUTH004 and leave the modal stack alone so the editor can
+/// recover on the next dispatch.
 pub(super) fn restore_auth_form_after_op_picker_cancel(editor: &mut EditorState<'_>) {
     let Some(AuthFormReturnPath {
         target,
@@ -425,6 +444,10 @@ pub(super) fn restore_auth_form_after_op_picker_cancel(editor: &mut EditorState<
         literal_buffer,
     }) = editor.pending_auth_form_return.take()
     else {
+        crate::debug_log!(
+            "auth",
+            "AUTH004 restore_auth_form_after_op_picker_cancel: pending_auth_form_return missing"
+        );
         return;
     };
     editor.modal = Some(Modal::AuthForm {
@@ -452,6 +475,10 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
         literal_buffer,
     }) = editor.pending_auth_form_return.take()
     else {
+        crate::debug_log!(
+            "auth",
+            "AUTH005 apply_op_picker_to_auth_form: pending_auth_form_return missing — OpRef commit dropped"
+        );
         return;
     };
     let read_result = state.try_commit_op_ref(runner, op_ref);
@@ -483,27 +510,6 @@ fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent
     match key.code {
         KeyCode::Char(' ') => cycle_mode(form),
         KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => *focus = next_focus_after_mode(form),
-        _ => {}
-    }
-}
-
-fn handle_literal_value_key(
-    focus: &mut AuthFormFocus,
-    form: &mut AuthForm,
-    literal_buffer: &mut String,
-    key: KeyEvent,
-) {
-    match key.code {
-        KeyCode::Char(c) => {
-            literal_buffer.push(c);
-            form.set_literal(literal_buffer.clone());
-        }
-        KeyCode::Backspace => {
-            literal_buffer.pop();
-            form.set_literal(literal_buffer.clone());
-        }
-        KeyCode::Down | KeyCode::Tab | KeyCode::Enter => *focus = AuthFormFocus::Save,
-        KeyCode::Up => *focus = AuthFormFocus::CredentialSource,
         _ => {}
     }
 }
@@ -700,18 +706,19 @@ mod tests {
         std::rc::Rc::new(std::cell::RefCell::new(OpCache::default()))
     }
 
-    /// Test wrapper around `handle_auth_form_key` that allocates a
-    /// throwaway op-cache. Most existing tests don't care about
-    /// op-picker plumbing — this keeps their bodies short.
+    /// Test wrapper around `handle_auth_form_key`. The form no longer
+    /// owns the op-cache (the `Modal::OpPicker` opens with its own,
+    /// supplied by the dispatcher) so this helper only needs the
+    /// `op_available` gate, which most tests want set to `true`.
     fn drive_key(editor: &mut EditorState<'_>, k: KeyEvent) -> bool {
-        handle_auth_form_key(editor, k, fresh_op_cache(), true)
+        handle_auth_form_key(editor, k, true)
     }
 
     /// Return the flat-row index for `WorkspaceMode { Claude }`.
     /// Panics if the row doesn't exist (which would indicate a broken
     /// fixture, not a test-under-test failure).
-    fn workspace_claude_row_idx(editor: &EditorState<'_>) -> usize {
-        auth_flat_rows(editor)
+    fn workspace_claude_row_idx(editor: &EditorState<'_>, config: &AppConfig) -> usize {
+        auth_flat_rows(editor, config)
             .iter()
             .position(|r| {
                 matches!(
@@ -754,7 +761,7 @@ mod tests {
         let mut editor = EditorState::new_edit("proj".into(), ws);
         editor.active_tab = crate::console::manager::state::EditorTab::Auth;
         editor.auth_selected_agent = Some(Agent::Claude);
-        let ws_claude_idx = workspace_claude_row_idx(&editor);
+        let ws_claude_idx = workspace_claude_row_idx(&editor, &cfg);
         editor.active_field = FieldFocus::Row(ws_claude_idx);
         state.stage = ManagerStage::Editor(editor);
         (cfg, state)
@@ -767,12 +774,12 @@ mod tests {
     /// in-memory `pending.claude` and `pending.env` reflect the change.
     #[test]
     fn auth_form_save_persists_workspace_layer_into_pending() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         // Open form (Enter) on row 0 → workspace × Claude.
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         assert!(matches!(editor.modal, Some(Modal::AuthForm { .. })));
 
         // Cycle mode: None → first available (sync) → ApiKey is two cycles.
@@ -814,14 +821,14 @@ mod tests {
     /// produces the "drop down to inherited" behavior.
     #[test]
     fn auth_form_reset_clears_workspace_layer_mode() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
         editor.pending.claude = Some(AgentAuthConfig {
             auth_forward: AuthForwardMode::ApiKey,
         });
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         // Tab through to Reset and Enter.
         // From Mode → Down → Cred → Down → Save → Tab → Cancel → Tab → Reset.
         drive_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
@@ -840,11 +847,11 @@ mod tests {
     /// stays untouched.
     #[test]
     fn auth_form_cancel_does_not_mutate_pending() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         drive_key(editor, key(KeyCode::Char(' '))); // cycle to sync
         // Esc cancels at any focus.
         let closed = drive_key(editor, key(KeyCode::Esc));
@@ -857,11 +864,11 @@ mod tests {
 
     #[test]
     fn auth_form_enter_on_mode_does_not_navigate_tab_does() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
 
@@ -888,11 +895,11 @@ mod tests {
 
     #[test]
     fn auth_form_typing_on_credential_row_does_not_set_plain_text() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Tab));
@@ -915,7 +922,7 @@ mod tests {
     /// `pending.roles[role].env`.
     #[test]
     fn auth_form_save_persists_role_layer_into_pending() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
@@ -933,7 +940,7 @@ mod tests {
         // Expand the role so the RoleMode child is emitted.
         editor.auth_expanded.insert("smith".into());
         // Dynamically locate the smith × Claude agent row.
-        let smith_claude_idx = auth_flat_rows(editor)
+        let smith_claude_idx = auth_flat_rows(editor, &cfg)
             .iter()
             .position(|r| {
                 matches!(
@@ -946,7 +953,7 @@ mod tests {
             })
             .expect("RoleMode smith × Claude must exist after override insertion");
         editor.active_field = FieldFocus::Row(smith_claude_idx);
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         let Some(Modal::AuthForm { target, .. }) = &editor.modal else {
             panic!("form must be open");
         };
@@ -995,11 +1002,11 @@ mod tests {
     /// round-trip wiring.
     #[test]
     fn auth_form_op_ref_picker_invocation_opens_op_picker_modal() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         // Mode → ApiKey (two cycles past `None → sync`).
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
@@ -1033,13 +1040,13 @@ mod tests {
             }
         }
 
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
         // Open the auth form on workspace × Claude and choose
         // 1Password from the source picker.
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Tab));
@@ -1095,11 +1102,11 @@ mod tests {
             }
         }
 
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Char(' ')));
         drive_key(editor, key(KeyCode::Tab));
@@ -1131,7 +1138,7 @@ mod tests {
     fn auth_form_esc_clears_pending_auth_form_return() {
         use crate::console::manager::state::AuthFormReturnPath;
 
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
@@ -1150,7 +1157,7 @@ mod tests {
         });
         // Open the auth form modal so handle_auth_form_key can be
         // entered.
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         assert!(matches!(editor.modal, Some(Modal::AuthForm { .. })));
 
         let closed = drive_key(editor, key(KeyCode::Esc));
@@ -1170,12 +1177,12 @@ mod tests {
     /// layer honours the guard rather than ignoring it.
     #[test]
     fn auth_form_save_disabled_blocks_enter() {
-        let (_cfg, mut state) = build_state();
+        let (cfg, mut state) = build_state();
         let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!()
         };
         let pending_before = editor.pending.clone();
-        open_auth_form_modal(editor);
+        open_auth_form_modal(editor, &cfg);
         // Build a form state with mode = ApiKey and credential = empty
         // OpRef so `can_save` returns false.
         drive_key(editor, key(KeyCode::Char(' ')));

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -409,10 +409,12 @@ pub(super) fn open_op_picker_from_auth_source(
 /// Secrets tab).
 ///
 /// On `try_commit_op_ref` failure (vault read error), the form is
-/// re-opened with the credential left unchanged and an `ErrorPopup`
-/// modal is layered on top so the operator sees what went wrong. The
-/// `read-then-commit` invariant from Task 18 guarantees a broken
-/// reference never lands in `editor.pending`.
+/// re-stashed into `pending_auth_form_return` and `Modal::ErrorPopup`
+/// is mounted; dismissing the popup invokes
+/// `restore_auth_form_after_op_picker_cancel` so the operator lands
+/// back on the form with the prior credential unchanged. The
+/// `read-then-commit` invariant on `try_commit_op_ref` guarantees a
+/// broken reference never lands in `editor.pending`.
 pub(super) fn apply_op_picker_to_auth_form(
     editor: &mut EditorState<'_>,
     op_ref: crate::operator_env::OpRef,
@@ -471,28 +473,31 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
         return;
     };
     let read_result = state.try_commit_op_ref(runner, op_ref);
-    let new_focus = if read_result.is_ok() {
-        // On success, drop the cursor onto Save so Enter commits.
-        AuthFormFocus::Save
-    } else {
-        // On failure, keep the cursor on the credential row so the
-        // operator can retry through the same source picker flow.
-        focus
-    };
-    editor.modal = Some(Modal::AuthForm {
-        target,
-        state,
-        focus: new_focus,
-        literal_buffer,
-    });
     if let Err(e) = read_result {
-        // Layer the error popup on top of the re-mounted auth form.
-        // The popup's commit closes only itself, returning the
-        // operator to the form with the credential field unchanged.
+        // Mount the error popup directly and re-stash the form into
+        // `pending_auth_form_return` so the popup's dismiss handler
+        // (in `editor.rs`'s `Modal::ErrorPopup` branch) can re-mount
+        // the auth form via `restore_auth_form_after_op_picker_cancel`.
+        // The credential is left unchanged because `try_commit_op_ref`
+        // mutates `state` only on Ok (read-then-commit invariant).
+        editor.pending_auth_form_return = Some(AuthFormReturnPath {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        });
         editor.modal = Some(Modal::ErrorPopup {
             state: ErrorPopupState::new("1Password read failed", e.to_string()),
         });
+        return;
     }
+    editor.modal = Some(Modal::AuthForm {
+        target,
+        state,
+        // Drop the cursor onto Save so Enter commits.
+        focus: AuthFormFocus::Save,
+        literal_buffer,
+    });
 }
 
 fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent) {
@@ -1076,10 +1081,10 @@ mod tests {
     }
 
     /// A failed vault read (e.g. biometric timeout) must NOT corrupt
-    /// the form's credential — the read-then-commit invariant from
-    /// Task 18 is what stops a broken reference reaching disk. The
-    /// form re-opens with the credential unchanged and an
-    /// `ErrorPopup` layered on top.
+    /// the form's credential — `try_commit_op_ref` only mutates state
+    /// on Ok. The form is re-stashed into `pending_auth_form_return`
+    /// and `Modal::ErrorPopup` is mounted; dismissing the popup must
+    /// restore the form with the prior credential intact.
     #[test]
     fn auth_form_op_ref_picker_failed_read_does_not_apply_op_ref() {
         struct FailRunner;
@@ -1106,14 +1111,26 @@ mod tests {
         };
         super::apply_op_picker_to_auth_form_with_runner(editor, picked, &FailRunner);
 
-        // Top modal must be the ErrorPopup; credential must remain
-        // the empty OpRef (or whatever the toggle seeded), NOT the
-        // attempted reference.
+        // ErrorPopup mounted; form re-stashed for the popup dismissal
+        // path to re-open via restore_auth_form_after_op_picker_cancel.
         assert!(
             matches!(editor.modal, Some(Modal::ErrorPopup { .. })),
             "failed vault read must surface an error popup"
         );
-        assert!(editor.pending_auth_form_return.is_none());
+        assert!(
+            editor.pending_auth_form_return.is_some(),
+            "form must be re-stashed so popup dismiss can restore it"
+        );
+
+        // Simulate ErrorPopup dismiss → form restored.
+        restore_auth_form_after_op_picker_cancel(editor);
+        let Some(Modal::AuthForm { state, .. }) = &editor.modal else {
+            panic!("popup dismiss must restore the auth form");
+        };
+        assert!(
+            !matches!(state.credential, CredentialInput::OpRef(ref r) if r.path == "Vault/Missing/field"),
+            "failed OpRef must not land in form credential"
+        );
     }
 
     /// Esc on an open auth form must drain `pending_auth_form_return`
@@ -1159,9 +1176,9 @@ mod tests {
 
     /// `Enter` on the Save focus when `can_save` is false (e.g. an
     /// `OpRef` credential with empty `op` and `path`) must NOT dismiss
-    /// the modal NOR mutate `editor.pending`. The Task 18 fixup made
-    /// `can_save` reject empty `OpRef`s; this test pins that the input
-    /// layer honours the guard rather than ignoring it.
+    /// the modal NOR mutate `editor.pending`. `can_save` rejects empty
+    /// `OpRef`s; this test pins that the input layer honours the guard
+    /// rather than ignoring it.
     #[test]
     fn auth_form_save_disabled_blocks_enter() {
         let (cfg, mut state) = build_state();

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -46,6 +46,14 @@ pub(super) fn handle_editor_key(
         }
         KeyCode::Esc => {
             if let ManagerStage::Editor(editor) = &state.stage {
+                // Auth tab two-screen navigation: Esc on the focused
+                // auth-kind view pops back to the kind picker WITHOUT
+                // routing through the dirty-modal flow. This is
+                // intentional — the pop is in-tab navigation, not an
+                // editor exit, and the operator's pending edits stay
+                // in `editor.pending`. A subsequent Esc with the
+                // editor still dirty will fall through to the dirty
+                // check below.
                 if editor.active_tab == EditorTab::Auth && editor.auth_selected_agent.is_some() {
                     if let ManagerStage::Editor(editor) = &mut state.stage {
                         editor.auth_selected_agent = None;
@@ -105,7 +113,7 @@ pub(super) fn handle_editor_key(
             }
             if key.code == KeyCode::Right && editor.active_tab == EditorTab::Auth {
                 let FieldFocus::Row(n) = editor.active_field;
-                let rows = super::super::render::editor::auth_flat_rows(editor);
+                let rows = super::super::render::editor::auth_flat_rows(editor, config);
                 if let Some(super::super::render::editor::AuthRow::RoleHeader { role, expanded }) =
                     rows.get(n).cloned()
                 {
@@ -146,7 +154,7 @@ pub(super) fn handle_editor_key(
             }
             if editor.active_tab == EditorTab::Auth {
                 let FieldFocus::Row(n) = editor.active_field;
-                let rows = super::super::render::editor::auth_flat_rows(editor);
+                let rows = super::super::render::editor::auth_flat_rows(editor, config);
                 if let Some(super::super::render::editor::AuthRow::RoleHeader { role, expanded }) =
                     rows.get(n).cloned()
                 {
@@ -181,7 +189,7 @@ pub(super) fn handle_editor_key(
                 let rows = secrets_flat_rows(editor);
                 step_secrets_cursor_up(&rows, candidate)
             } else if editor.active_tab == EditorTab::Auth {
-                let rows = super::super::render::editor::auth_flat_rows(editor);
+                let rows = super::super::render::editor::auth_flat_rows(editor, config);
                 step_auth_cursor_up(&rows, candidate)
             } else {
                 candidate
@@ -200,7 +208,7 @@ pub(super) fn handle_editor_key(
                 let max = max_row_for_tab(editor, config);
                 let candidate = (n + 1).min(max);
                 if editor.active_tab == EditorTab::Auth {
-                    let rows = super::super::render::editor::auth_flat_rows(editor);
+                    let rows = super::super::render::editor::auth_flat_rows(editor, config);
                     editor.active_field =
                         FieldFocus::Row(step_auth_cursor_down(&rows, candidate, max));
                 } else {
@@ -230,7 +238,7 @@ pub(super) fn handle_editor_key(
             }
             EditorTab::Auth => {
                 let FieldFocus::Row(n) = editor.active_field;
-                let rows = super::super::render::editor::auth_flat_rows(editor);
+                let rows = super::super::render::editor::auth_flat_rows(editor, config);
                 match rows.get(n) {
                     Some(super::super::render::editor::AuthRow::AuthKind { agent }) => {
                         editor.auth_selected_agent = Some(*agent);
@@ -248,7 +256,7 @@ pub(super) fn handle_editor_key(
                         | super::super::render::editor::AuthRow::RoleMode { .. }
                         | super::super::render::editor::AuthRow::RoleSource { .. },
                     ) => {
-                        super::auth::open_auth_form_modal(editor);
+                        super::auth::open_auth_form_modal(editor, config);
                     }
                     _ => {}
                 }
@@ -288,7 +296,7 @@ pub(super) fn handle_editor_key(
             remove_mount_at_cursor(editor);
         }
         KeyCode::Char('d' | 'D') if editor.active_tab == EditorTab::Auth => {
-            super::auth::handle_d_on_auth_row(editor);
+            super::auth::handle_d_on_auth_row(editor, config);
         }
         // M toggles per-row masking on the focused Secrets-tab key row.
         // Operator feedback (commit 32): the global mask flag was too
@@ -386,7 +394,9 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
         EditorTab::Secrets => 0,
-        EditorTab::Auth => super::super::render::editor::auth_row_count(editor).saturating_sub(1),
+        EditorTab::Auth => {
+            super::super::render::editor::auth_row_count(editor, config).saturating_sub(1)
+        }
     }
 }
 
@@ -1088,7 +1098,7 @@ pub(super) fn handle_editor_modal(
             }
         }
         Modal::AuthForm { .. } => {
-            super::auth::handle_auth_form_key(editor, key, op_cache, op_available);
+            super::auth::handle_auth_form_key(editor, key, op_available);
         }
         Modal::AuthRolePicker { state: picker } => match picker.handle_key(key) {
             ModalOutcome::Commit(role) => {
@@ -1113,29 +1123,6 @@ pub(super) fn handle_editor_modal(
             }
             ModalOutcome::Continue => {}
         },
-        Modal::AuthAgentPicker { role, state } => {
-            let outcome = state.handle_key(key);
-            match outcome {
-                ModalOutcome::Commit(agent) => {
-                    let role = role.clone();
-                    let target = crate::console::manager::state::AuthFormTarget::WorkspaceRole {
-                        role,
-                        agent,
-                    };
-                    let form = crate::console::widgets::auth_panel::AuthForm::new(agent);
-                    editor.modal = Some(Modal::AuthForm {
-                        target,
-                        state: Box::new(form),
-                        focus: crate::console::manager::state::AuthFormFocus::Mode,
-                        literal_buffer: String::new(),
-                    });
-                }
-                ModalOutcome::Cancel => {
-                    editor.modal = None;
-                }
-                ModalOutcome::Continue => {}
-            }
-        }
         Modal::OpPicker { state: picker } => {
             match picker.handle_key(key) {
                 ModalOutcome::Commit(op_ref) => {
@@ -1655,12 +1642,6 @@ fn apply_editor_confirm(
         // site because it consumes `plan` and routes through
         // `EditorSaveFlow::PendingCommit`. No-op here.
         ConfirmTarget::DeleteIsolatedAndSave { .. } => {}
-        ConfirmTarget::ClearAuthRoleOverride { role } => {
-            if let Some(ro) = editor.pending.roles.get_mut(role) {
-                ro.claude = None;
-                ro.codex = None;
-            }
-        }
     }
     Ok(())
 }
@@ -3718,5 +3699,88 @@ plugins = []
             !matches!(stored, crate::operator_env::EnvValue::OpRef(_)),
             "text entry must never produce EnvValue::OpRef"
         );
+    }
+}
+
+#[cfg(test)]
+mod auth_cursor_step_tests {
+    //! Spacer-skip tests for the Auth-tab cursor stepping helpers.
+    //! `Spacer` rows are intentionally non-selectable so the cursor
+    //! never lands on a blank line in the rendered list.
+    use super::super::super::render::editor::AuthRow;
+    use super::{step_auth_cursor_down, step_auth_cursor_up};
+    use crate::agent::Agent;
+
+    fn rows() -> Vec<AuthRow> {
+        // Mirrors the focused-mode shape: WorkspaceMode → Spacer →
+        // RoleHeader → Spacer → AddSentinel.
+        vec![
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude,
+            },
+            AuthRow::Spacer,
+            AuthRow::RoleHeader {
+                role: "smith".into(),
+                expanded: false,
+            },
+            AuthRow::Spacer,
+            AuthRow::AddSentinel { eligible: 1 },
+        ]
+    }
+
+    #[test]
+    fn down_skips_spacer_after_workspace_mode() {
+        // From WorkspaceMode (idx 0) the candidate becomes 1 = Spacer.
+        // Step must walk forward to the RoleHeader at idx 2.
+        let r = rows();
+        assert_eq!(step_auth_cursor_down(&r, 1, r.len() - 1), 2);
+    }
+
+    #[test]
+    fn down_skips_spacer_before_sentinel() {
+        // From RoleHeader (idx 2) candidate becomes 3 = Spacer; step
+        // must reach the AddSentinel at idx 4.
+        let r = rows();
+        assert_eq!(step_auth_cursor_down(&r, 3, r.len() - 1), 4);
+    }
+
+    #[test]
+    fn down_at_max_with_only_spacer_remaining_returns_candidate() {
+        // No non-spacer past the candidate: helper returns the
+        // candidate verbatim (caller already clamped to `max`).
+        let r = vec![
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude,
+            },
+            AuthRow::Spacer,
+        ];
+        assert_eq!(step_auth_cursor_down(&r, 1, 1), 1);
+    }
+
+    #[test]
+    fn up_skips_spacer_to_workspace_mode() {
+        let r = rows();
+        // candidate=1 = Spacer; step up returns 0 = WorkspaceMode.
+        assert_eq!(step_auth_cursor_up(&r, 1), 0);
+    }
+
+    #[test]
+    fn up_skips_spacer_to_role_header() {
+        let r = rows();
+        // candidate=3 = Spacer; step up returns 2 = RoleHeader.
+        assert_eq!(step_auth_cursor_up(&r, 3), 2);
+    }
+
+    #[test]
+    fn up_at_zero_spacer_clamps_to_zero() {
+        // First row a Spacer (degenerate fixture): step up clamps
+        // to idx 0 rather than wrapping.
+        let r = vec![
+            AuthRow::Spacer,
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude,
+            },
+        ];
+        assert_eq!(step_auth_cursor_up(&r, 0), 0);
     }
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -817,15 +817,21 @@ pub(super) fn handle_editor_modal(
                     }
                 }
                 ModalOutcome::Cancel => {
+                    let target = target.clone();
                     // Cancel of EnvKey/EnvValue must drop both the
                     // stashed key and any picker value — otherwise a
                     // later sentinel-picker commit silently applies
                     // the path to an unrelated key.
                     if let TextInputTarget::EnvKey { .. } | TextInputTarget::EnvValue { .. } =
-                        target
+                        &target
                     {
                         editor.pending_env_key = None;
                         editor.pending_picker_value = None;
+                    }
+                    if matches!(target, TextInputTarget::AuthCredential) {
+                        editor.modal = None;
+                        super::auth::restore_auth_form_after_plain_cancel(editor);
+                        return;
                     }
                     editor.modal = None;
                 }
@@ -1066,8 +1072,23 @@ pub(super) fn handle_editor_modal(
                 ModalOutcome::Continue => {}
             }
         }
+        Modal::AuthSourcePicker { state: source } => {
+            use crate::console::widgets::source_picker::SourceChoice;
+            match source.handle_key(key) {
+                ModalOutcome::Commit(SourceChoice::Plain) => {
+                    super::auth::apply_plain_source_picker_to_auth_form(editor);
+                }
+                ModalOutcome::Commit(SourceChoice::Op) => {
+                    super::auth::open_op_picker_from_auth_source(editor, op_cache);
+                }
+                ModalOutcome::Cancel => {
+                    super::auth::restore_auth_form_after_op_picker_cancel(editor);
+                }
+                ModalOutcome::Continue => {}
+            }
+        }
         Modal::AuthForm { .. } => {
-            super::auth::handle_auth_form_key(editor, key, op_cache);
+            super::auth::handle_auth_form_key(editor, key, op_cache, op_available);
         }
         Modal::AuthRolePicker { state: picker } => match picker.handle_key(key) {
             ModalOutcome::Commit(role) => {
@@ -1379,6 +1400,9 @@ pub(super) fn apply_text_input_to_pending(
         TextInputTarget::EnvValue { scope, key } => {
             set_pending_env_value(editor, scope, key, value);
             editor.pending_env_key = None;
+        }
+        TextInputTarget::AuthCredential => {
+            super::auth::apply_plain_text_to_auth_form(editor, value);
         }
     }
 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1001,6 +1001,15 @@ pub(super) fn handle_editor_modal(
             ModalOutcome::Cancel | ModalOutcome::Commit(()) => {
                 editor.modal = None;
                 editor.save_flow = EditorSaveFlow::Idle;
+                // If the popup was raised by a failed OpPicker commit
+                // for the auth form, the form's state was re-stashed
+                // into `pending_auth_form_return` instead of being
+                // re-mounted directly — restore it now so the operator
+                // lands back on the form with the prior credential
+                // unchanged, ready to retry through the source picker.
+                if editor.pending_auth_form_return.is_some() {
+                    super::auth::restore_auth_form_after_op_picker_cancel(editor);
+                }
             }
             ModalOutcome::Continue => {}
         },

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -3436,10 +3436,17 @@ plugins = []
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
         editor.secrets_expanded.insert("smith".into());
-        // Rows: WorkspaceKeyRow(0), WorkspaceAddSentinel(1),
-        // SectionSpacer(2), AgentHeader(3), AgentKeyRow(4),
-        // AgentAddSentinel(5). Focus the role key row.
-        editor.active_field = FieldFocus::Row(4);
+        let role_key_row = super::super::super::render::editor::secrets_flat_rows(&editor)
+            .iter()
+            .position(|row| {
+                matches!(
+                    row,
+                    super::super::super::render::editor::SecretsRow::RoleKeyRow { role, key }
+                        if role == "smith" && key == "API_TOKEN"
+                )
+            })
+            .expect("role API_TOKEN row");
+        editor.active_field = FieldFocus::Row(role_key_row);
         state.stage = ManagerStage::Editor(editor);
 
         handle_key(

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -46,6 +46,13 @@ pub(super) fn handle_editor_key(
         }
         KeyCode::Esc => {
             if let ManagerStage::Editor(editor) = &state.stage {
+                if editor.active_tab == EditorTab::Auth && editor.auth_selected_agent.is_some() {
+                    if let ManagerStage::Editor(editor) = &mut state.stage {
+                        editor.auth_selected_agent = None;
+                        editor.active_field = FieldFocus::Row(0);
+                    }
+                    return Ok(InputOutcome::Continue);
+                }
                 let dirty = editor.is_dirty();
                 if dirty {
                     if let ManagerStage::Editor(editor) = &mut state.stage {
@@ -117,6 +124,9 @@ pub(super) fn handle_editor_key(
                 EditorTab::Auth => EditorTab::General,
             };
             editor.active_field = FieldFocus::Row(0);
+            if editor.active_tab != EditorTab::Auth {
+                editor.auth_selected_agent = None;
+            }
             if was_secrets {
                 reset_secrets_view(editor);
             }
@@ -155,6 +165,9 @@ pub(super) fn handle_editor_key(
                 EditorTab::Auth => EditorTab::Secrets,
             };
             editor.active_field = FieldFocus::Row(0);
+            if editor.active_tab != EditorTab::Auth {
+                editor.auth_selected_agent = None;
+            }
             if was_secrets {
                 reset_secrets_view(editor);
             }
@@ -167,6 +180,9 @@ pub(super) fn handle_editor_key(
             let next = if editor.active_tab == EditorTab::Secrets {
                 let rows = secrets_flat_rows(editor);
                 step_secrets_cursor_up(&rows, candidate)
+            } else if editor.active_tab == EditorTab::Auth {
+                let rows = super::super::render::editor::auth_flat_rows(editor);
+                step_auth_cursor_up(&rows, candidate)
             } else {
                 candidate
             };
@@ -182,7 +198,14 @@ pub(super) fn handle_editor_key(
                     FieldFocus::Row(step_secrets_cursor_down(&rows, candidate, max));
             } else {
                 let max = max_row_for_tab(editor, config);
-                editor.active_field = FieldFocus::Row((n + 1).min(max));
+                let candidate = (n + 1).min(max);
+                if editor.active_tab == EditorTab::Auth {
+                    let rows = super::super::render::editor::auth_flat_rows(editor);
+                    editor.active_field =
+                        FieldFocus::Row(step_auth_cursor_down(&rows, candidate, max));
+                } else {
+                    editor.active_field = FieldFocus::Row(candidate);
+                }
             }
         }
         KeyCode::Enter => match editor.active_tab {
@@ -209,6 +232,10 @@ pub(super) fn handle_editor_key(
                 let FieldFocus::Row(n) = editor.active_field;
                 let rows = super::super::render::editor::auth_flat_rows(editor);
                 match rows.get(n) {
+                    Some(super::super::render::editor::AuthRow::AuthKind { agent }) => {
+                        editor.auth_selected_agent = Some(*agent);
+                        editor.active_field = FieldFocus::Row(0);
+                    }
                     Some(super::super::render::editor::AuthRow::AddSentinel { .. }) => {
                         super::auth::open_auth_role_picker(editor, config);
                     }
@@ -216,8 +243,10 @@ pub(super) fn handle_editor_key(
                         super::auth::toggle_role_expand(editor, role.clone());
                     }
                     Some(
-                        super::super::render::editor::AuthRow::WorkspaceDefault { .. }
-                        | super::super::render::editor::AuthRow::RoleAgentRow { .. },
+                        super::super::render::editor::AuthRow::WorkspaceMode { .. }
+                        | super::super::render::editor::AuthRow::WorkspaceSource { .. }
+                        | super::super::render::editor::AuthRow::RoleMode { .. }
+                        | super::super::render::editor::AuthRow::RoleSource { .. },
                     ) => {
                         super::auth::open_auth_form_modal(editor);
                     }
@@ -227,6 +256,11 @@ pub(super) fn handle_editor_key(
         },
         KeyCode::Char('a' | 'A') if editor.active_tab == EditorTab::Roles => {
             open_role_input(editor, config);
+        }
+        KeyCode::Char('a' | 'A')
+            if editor.active_tab == EditorTab::Auth && editor.auth_selected_agent.is_some() =>
+        {
+            super::auth::open_auth_role_picker(editor, config);
         }
         KeyCode::Char(' ') if editor.active_tab == EditorTab::Roles => {
             toggle_agent_allowed_at_cursor(editor, config);
@@ -352,9 +386,7 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
         EditorTab::Secrets => 0,
-        EditorTab::Auth => {
-            super::super::render::editor::auth_editable_row_count(editor).saturating_sub(1)
-        }
+        EditorTab::Auth => super::super::render::editor::auth_row_count(editor).saturating_sub(1),
     }
 }
 
@@ -386,6 +418,38 @@ fn step_secrets_cursor_up(
     loop {
         match rows.get(idx) {
             Some(SecretsRow::SectionSpacer) => {
+                if idx == 0 {
+                    return 0;
+                }
+                idx -= 1;
+            }
+            _ => return idx,
+        }
+    }
+}
+
+fn step_auth_cursor_down(
+    rows: &[super::super::render::editor::AuthRow],
+    candidate: usize,
+    max: usize,
+) -> usize {
+    use super::super::render::editor::AuthRow;
+    let mut idx = candidate;
+    while idx <= max {
+        match rows.get(idx) {
+            Some(AuthRow::Spacer) => idx += 1,
+            _ => return idx,
+        }
+    }
+    candidate
+}
+
+fn step_auth_cursor_up(rows: &[super::super::render::editor::AuthRow], candidate: usize) -> usize {
+    use super::super::render::editor::AuthRow;
+    let mut idx = candidate;
+    loop {
+        match rows.get(idx) {
+            Some(AuthRow::Spacer) => {
                 if idx == 0 {
                     return 0;
                 }
@@ -1007,10 +1071,21 @@ pub(super) fn handle_editor_modal(
         }
         Modal::AuthRolePicker { state: picker } => match picker.handle_key(key) {
             ModalOutcome::Commit(role) => {
-                editor.modal = Some(Modal::AuthAgentPicker {
-                    role: role.key(),
-                    state: crate::console::widgets::agent_choice::AgentChoiceState::new(),
-                });
+                if let Some(agent) = editor.auth_selected_agent {
+                    let target = crate::console::manager::state::AuthFormTarget::WorkspaceRole {
+                        role: role.key(),
+                        agent,
+                    };
+                    let form = crate::console::widgets::auth_panel::AuthForm::new(agent);
+                    editor.modal = Some(Modal::AuthForm {
+                        target,
+                        state: Box::new(form),
+                        focus: crate::console::manager::state::AuthFormFocus::Mode,
+                        literal_buffer: String::new(),
+                    });
+                } else {
+                    editor.modal = None;
+                }
             }
             ModalOutcome::Cancel => {
                 editor.modal = None;

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -46,14 +46,10 @@ pub(super) fn handle_editor_key(
         }
         KeyCode::Esc => {
             if let ManagerStage::Editor(editor) = &state.stage {
-                // Auth tab two-screen navigation: Esc on the focused
-                // auth-kind view pops back to the kind picker WITHOUT
-                // routing through the dirty-modal flow. This is
-                // intentional — the pop is in-tab navigation, not an
-                // editor exit, and the operator's pending edits stay
-                // in `editor.pending`. A subsequent Esc with the
-                // editor still dirty will fall through to the dirty
-                // check below.
+                // Auth-tab in-tab pop: clears the focused-kind
+                // selection without dirty check (see EditorState
+                // field doc). A subsequent Esc on the picker view
+                // falls through to the dirty branch below.
                 if editor.active_tab == EditorTab::Auth && editor.auth_selected_agent.is_some() {
                     if let ManagerStage::Editor(editor) = &mut state.stage {
                         editor.auth_selected_agent = None;
@@ -839,8 +835,10 @@ pub(super) fn handle_editor_modal(
                         editor.pending_picker_value = None;
                     }
                     if matches!(target, TextInputTarget::AuthCredential) {
+                        // Plain-text leg of the source-picker round trip
+                        // recovers identically to the OpPicker leg.
                         editor.modal = None;
-                        super::auth::restore_auth_form_after_plain_cancel(editor);
+                        super::auth::restore_auth_form_after_op_picker_cancel(editor);
                         return;
                     }
                     editor.modal = None;

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -164,10 +164,12 @@ fn list_content_row_index(
     if mouse.row < content_top || mouse.row >= content_bottom {
         return None;
     }
-    // Row index into the list: items start at y = content_top (the first
-    // row below the top border).
+    // Visual row index into the rendered list: items start at y = content_top
+    // (the first row below the top border). The rendered list may contain a
+    // blank spacer before "+ New workspace"; clicking that spacer selects
+    // nothing.
     let idx = usize::from(mouse.row - content_top);
-    state.row_at(idx)
+    state.row_at_visual_index(idx)
 }
 
 /// Compute the seam column (0-based) for a given split percentage and
@@ -574,7 +576,7 @@ mod mouse_drag_tests {
         }
     }
 
-    /// Build a list state with `n` saved workspaces (row 0 + n + sentinel).
+    /// Build a list state with `n` saved workspaces (row 0 + n + spacer + sentinel).
     fn list_state_with_saved(n: usize) -> ManagerState<'static> {
         let mut config = crate::config::AppConfig::default();
         for i in 0..n {
@@ -615,11 +617,20 @@ mod mouse_drag_tests {
         // 3 saved workspaces ⇒ rows are:
         //   y=4  → index 0 ("Current directory")
         //   y=5,6,7 → indices 1, 2, 3 (saved)
-        //   y=8  → index 4 (sentinel "+ New workspace")
+        //   y=8  → visual spacer
+        //   y=9  → visual index 5 (sentinel "+ New workspace")
         let mut state = list_state_with_saved(3);
         state.selected = 0;
-        handle_mouse(&mut state, mouse_at(10, 8), term(100));
+        handle_mouse(&mut state, mouse_at(10, 9), term(100));
         assert_eq!(state.selected, 4, "sentinel_idx = saved_count + 1 = 4");
+    }
+
+    #[test]
+    fn click_on_workspace_list_spacer_does_not_change_selected() {
+        let mut state = list_state_with_saved(3);
+        state.selected = 2;
+        handle_mouse(&mut state, mouse_at(10, 8), term(100));
+        assert_eq!(state.selected, 2);
     }
 
     #[test]

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1079,7 +1079,7 @@ fn render_auth_row(
     workspace_name: &str,
 ) -> ratatui::text::Line<'static> {
     use crate::config::resolve_mode;
-    use crate::console::widgets::auth_panel::{badge_for, mode_str};
+    use crate::console::widgets::auth_panel::mode_str;
 
     let bold_white = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
     let dim_green = Style::default().fg(PHOSPHOR_DIM);
@@ -1103,14 +1103,11 @@ fn render_auth_row(
             } else {
                 " (inherited)"
             };
-            let badge = badge_for(synthesized, workspace_name, "", *agent, mode);
             ratatui::text::Line::from(vec![
                 Span::raw("  "),
                 Span::styled(format!("{:<14}", "Mode"), bold_white),
                 Span::styled(mode_str(mode).to_string(), phosphor),
                 Span::styled(suffix.to_string(), dim_green),
-                Span::raw("  "),
-                badge_span(badge),
             ])
         }
         AuthRow::WorkspaceSource { agent } => {
@@ -1127,13 +1124,10 @@ fn render_auth_row(
         }
         AuthRow::RoleMode { role, agent } => {
             let mode = resolve_mode(synthesized, *agent, workspace_name, role);
-            let badge = badge_for(synthesized, workspace_name, role, *agent, mode);
             ratatui::text::Line::from(vec![
                 Span::raw("      "),
                 Span::styled(format!("{:<12}", "Mode"), bold_white),
                 Span::styled(mode_str(mode).to_string(), phosphor),
-                Span::raw("  "),
-                badge_span(badge),
             ])
         }
         AuthRow::RoleSource { role, agent } => {
@@ -1187,16 +1181,12 @@ fn render_auth_source_line(
 
     match value {
         Some(EnvValue::OpRef(r)) => {
-            spans.push(Span::styled(
-                "1Password  ",
-                Style::default().fg(PHOSPHOR_DIM),
-            ));
             push_op_breadcrumb_spans(&mut spans, &r.path);
         }
         Some(EnvValue::Plain(s)) if !s.is_empty() => {
             spans.push(Span::styled(
-                "literal  OK",
-                Style::default().fg(PHOSPHOR_GREEN),
+                "●".repeat(s.chars().count().clamp(1, 12)),
+                Style::default().fg(PHOSPHOR_DIM),
             ));
         }
         _ => {
@@ -1271,22 +1261,11 @@ fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
         spans.push(Span::styled(" / ", dim));
         spans.push(Span::styled(section, green));
     }
-    spans.push(Span::styled(" -> ", dim));
+    spans.push(Span::styled(" \u{2192} ", dim));
     spans.push(Span::styled(parts.field, green_bold));
     if let Some(query) = parts.attribute_query {
         spans.push(Span::raw(" "));
         spans.push(Span::styled(query, dim));
-    }
-}
-
-fn badge_span(
-    badge: crate::console::widgets::auth_panel::CredentialBadge,
-) -> ratatui::text::Span<'static> {
-    use crate::console::widgets::auth_panel::{CredentialBadge, DANGER_RED, PHOSPHOR_GREEN};
-    match badge {
-        CredentialBadge::Resolves => Span::styled("OK", Style::default().fg(PHOSPHOR_GREEN)),
-        CredentialBadge::Unset => Span::styled("! unset", Style::default().fg(DANGER_RED)),
-        CredentialBadge::NotApplicable => Span::raw(""),
     }
 }
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -25,6 +25,17 @@ use crate::operator_env::EnvValue;
 
 // ── Editor stage ────────────────────────────────────────────────────
 
+const ACTION_ACCENT: Color = Color::Rgb(180, 255, 180);
+
+fn action_row_style(selected: bool) -> Style {
+    let style = Style::default().fg(ACTION_ACCENT);
+    if selected {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
 pub fn render_editor(
     frame: &mut Frame,
     state: &EditorState<'_>,
@@ -436,8 +447,6 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
         .border_style(Style::default().fg(PHOSPHOR_DARK));
     let FieldFocus::Row(cursor) = state.active_field;
 
-    let white = WHITE;
-
     // Build aligned table rows for all mounts.
     let rows = format_mount_rows(&state.pending.mounts);
     let path_w = mount_path_width(&rows);
@@ -481,17 +490,12 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
     let sentinel_idx = state.pending.mounts.len();
     let sentinel_selected = cursor == sentinel_idx;
     let sentinel_prefix = if sentinel_selected { "▸ " } else { "  " };
-    let sentinel_style = if sentinel_selected {
-        Style::default().fg(white).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(white)
-    };
     if !state.pending.mounts.is_empty() {
         lines.push(Line::from(""));
     }
     lines.push(Line::from(Span::styled(
         format!("{sentinel_prefix}+ Add mount"),
-        sentinel_style,
+        action_row_style(sentinel_selected),
     )));
 
     frame.render_widget(Paragraph::new(lines).block(block), area);
@@ -566,17 +570,12 @@ fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, conf
     let sentinel_idx = config.roles.len();
     let sentinel_selected = cursor == sentinel_idx;
     let sentinel_prefix = if sentinel_selected { "▸ " } else { "  " };
-    let sentinel_style = if sentinel_selected {
-        Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(WHITE)
-    };
     if !config.roles.is_empty() {
         lines.push(Line::from(""));
     }
     lines.push(Line::from(Span::styled(
         format!("{sentinel_prefix}+ Add role"),
-        sentinel_style,
+        action_row_style(sentinel_selected),
     )));
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
@@ -797,24 +796,23 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 ));
             }
             SecretsRow::WorkspaceAddSentinel => {
-                let style = if selected {
-                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(WHITE)
-                };
                 lines.push(Line::from(Span::styled(
                     format!("{cursor_col}     + Add environment variable"),
-                    style,
+                    action_row_style(selected),
                 )));
             }
             SecretsRow::RoleHeader { role, expanded } => {
                 let arrow = if *expanded { "▼" } else { "▶" };
                 let in_registry = config.roles.contains_key(role);
                 let count = state.pending.roles.get(role).map_or(0, |o| o.env.len());
-                let mut spans = vec![Span::styled(
-                    format!("{cursor_col}     {arrow} Role: {role}  ({count} vars)"),
-                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-                )];
+                let mut spans = vec![
+                    Span::raw(format!("{cursor_col}     ")),
+                    Span::styled(arrow, Style::default().fg(PHOSPHOR_GREEN)),
+                    Span::styled(
+                        format!(" Role: {role}  ({count} vars)"),
+                        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+                    ),
+                ];
                 if !in_registry {
                     spans.push(Span::styled(
                         "  (not in registry)",
@@ -845,14 +843,9 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 ));
             }
             SecretsRow::RoleAddSentinel(role) => {
-                let style = if selected {
-                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(WHITE)
-                };
                 lines.push(Line::from(Span::styled(
                     format!("{cursor_col}     + Add {role} environment variable"),
-                    style,
+                    action_row_style(selected),
                 )));
             }
             SecretsRow::SectionSpacer => {
@@ -1068,7 +1061,15 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
 
     let items: Vec<ListItem> = rows
         .iter()
-        .map(|r| ListItem::new(render_auth_row(r, &synthesized, &workspace_name)))
+        .enumerate()
+        .map(|(i, r)| {
+            ListItem::new(render_auth_row(
+                i == selected,
+                r,
+                &synthesized,
+                &workspace_name,
+            ))
+        })
         .collect();
     let mut block = Block::default()
         .borders(Borders::ALL)
@@ -1087,6 +1088,7 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
 }
 
 fn render_auth_row(
+    selected: bool,
     row: &AuthRow,
     synthesized: &AppConfig,
     workspace_name: &str,
@@ -1127,12 +1129,11 @@ fn render_auth_row(
             render_auth_source_line("Source", synthesized, workspace_name, "", *agent, 2)
         }
         AuthRow::RoleHeader { role, expanded } => {
-            let glyph = if *expanded { "▾" } else { "▸" };
+            let glyph = if *expanded { "▼" } else { "▶" };
             ratatui::text::Line::from(vec![
-                Span::raw("  "),
+                Span::raw("     "),
                 Span::styled(glyph.to_string(), phosphor),
-                Span::raw(" "),
-                Span::styled(role.clone(), bold_white),
+                Span::styled(format!(" Role: {role}"), bold_white),
             ])
         }
         AuthRow::RoleMode { role, agent } => {
@@ -1150,7 +1151,7 @@ fn render_auth_row(
             let label_style = if *eligible == 0 {
                 dim_green
             } else {
-                Style::default().fg(WHITE)
+                action_row_style(selected)
             };
             let suffix = if *eligible == 0 {
                 "   (all roles overridden)".to_string()

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1161,10 +1161,11 @@ fn render_auth_source_line(
 
     let mode = crate::config::resolve_mode(synthesized, agent, workspace_name, role);
     let env_name = agent.required_env_var(mode);
+    let label_width = if indent == 2 { 14 } else { 12 };
     let mut spans = vec![
         Span::raw(" ".repeat(indent)),
         Span::styled(
-            format!("{label:<12}"),
+            format!("{label:<label_width$}"),
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ),
     ];

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1116,10 +1116,10 @@ fn render_auth_row(
     let phosphor = Style::default().fg(PHOSPHOR_GREEN);
 
     match row {
-        AuthRow::AuthKind { agent } => ratatui::text::Line::from(vec![
-            Span::raw("  "),
-            Span::styled(auth_kind_display(*agent).to_string(), bold_white),
-        ]),
+        AuthRow::AuthKind { agent } => ratatui::text::Line::from(Span::styled(
+            auth_kind_display(*agent).to_string(),
+            bold_white,
+        )),
         AuthRow::WorkspaceMode { agent } => {
             let ws = synthesized.workspaces.get(workspace_name);
             let explicit = ws.and_then(|ws| match agent {
@@ -1134,19 +1134,17 @@ fn render_auth_row(
                 " (inherited)"
             };
             ratatui::text::Line::from(vec![
-                Span::raw("  "),
                 Span::styled(format!("{:<14}", "Mode"), bold_white),
                 Span::styled(mode_str(mode).to_string(), phosphor),
                 Span::styled(suffix.to_string(), dim_green),
             ])
         }
         AuthRow::WorkspaceSource { agent } => {
-            render_auth_source_line("Source", synthesized, workspace_name, "", *agent, 2)
+            render_auth_source_line("Source", synthesized, workspace_name, "", *agent, 0)
         }
         AuthRow::RoleHeader { role, expanded } => {
             let glyph = if *expanded { "▼" } else { "▶" };
             ratatui::text::Line::from(vec![
-                Span::raw("  "),
                 Span::styled(glyph.to_string(), disclosure_style()),
                 Span::styled(format!(" Role: {role}"), disclosure_style()),
             ])
@@ -1174,7 +1172,7 @@ fn render_auth_row(
                 String::new()
             };
             ratatui::text::Line::from(vec![
-                Span::styled("  + Override for a role", label_style),
+                Span::styled("+ Override for a role", label_style),
                 Span::styled(suffix, dim_green),
             ])
         }
@@ -1194,7 +1192,7 @@ fn render_auth_source_line(
 
     let mode = crate::config::resolve_mode(synthesized, agent, workspace_name, role);
     let env_name = agent.required_env_var(mode);
-    let label_width = if indent == 2 { 14 } else { 12 };
+    let label_width = if indent == 0 { 14 } else { 12 };
     let mut spans = vec![
         Span::raw(" ".repeat(indent)),
         Span::styled(

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1182,6 +1182,7 @@ fn render_auth_source_line(
 
     match value {
         Some(EnvValue::OpRef(r)) => {
+            spans.push(Span::styled("[op] ", Style::default().fg(PHOSPHOR_DIM)));
             push_op_breadcrumb_spans(&mut spans, &r.path);
         }
         Some(EnvValue::Plain(s)) if !s.is_empty() => {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -486,6 +486,9 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
     } else {
         Style::default().fg(white)
     };
+    if !state.pending.mounts.is_empty() {
+        lines.push(Line::from(""));
+    }
     lines.push(Line::from(Span::styled(
         format!("{sentinel_prefix}+ Add mount"),
         sentinel_style,
@@ -568,6 +571,9 @@ fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, conf
     } else {
         Style::default().fg(WHITE)
     };
+    if !config.roles.is_empty() {
+        lines.push(Line::from(""));
+    }
     lines.push(Line::from(Span::styled(
         format!("{sentinel_prefix}+ Add role"),
         sentinel_style,
@@ -598,6 +604,9 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
     for key in editor.pending.env.keys() {
         rows.push(SecretsRow::WorkspaceKeyRow(key.clone()));
     }
+    if !editor.pending.env.is_empty() {
+        rows.push(SecretsRow::SectionSpacer);
+    }
     rows.push(SecretsRow::WorkspaceAddSentinel);
     for role in editor.pending.roles.keys() {
         rows.push(SecretsRow::SectionSpacer);
@@ -615,6 +624,7 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
                     });
                 }
             }
+            rows.push(SecretsRow::SectionSpacer);
             rows.push(SecretsRow::RoleAddSentinel(role.clone()));
         }
     }
@@ -705,6 +715,9 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
         .allowed_roles
         .len()
         .saturating_sub(override_roles.len());
+    if !override_roles.is_empty() {
+        rows.push(AuthRow::Spacer);
+    }
     rows.push(AuthRow::AddSentinel {
         eligible: eligible_remaining,
     });
@@ -1134,7 +1147,11 @@ fn render_auth_row(
             render_auth_source_line("Source", synthesized, workspace_name, role, *agent, 6)
         }
         AuthRow::AddSentinel { eligible } => {
-            let label_style = if *eligible == 0 { dim_green } else { phosphor };
+            let label_style = if *eligible == 0 {
+                dim_green
+            } else {
+                Style::default().fg(WHITE)
+            };
             let suffix = if *eligible == 0 {
                 "   (all roles overridden)".to_string()
             } else {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -874,11 +874,8 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
 
 /// Display-side breadcrumb parser for `OpRef.path`.
 /// Grammar: `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?<query>]`
-///
-/// Shared with the auth-form widget so all op-ref breadcrumbs render
-/// from the same parse tree.
 #[derive(Debug, PartialEq, Eq)]
-pub(in crate::console) struct PathBreadcrumb {
+pub(super) struct PathBreadcrumb {
     pub vault: String,
     pub item: String,
     pub item_subtitle: Option<String>,
@@ -888,7 +885,7 @@ pub(in crate::console) struct PathBreadcrumb {
 }
 
 /// Parse a snapshot breadcrumb. Returns `None` on empty input or non-3-/4-segment counts.
-pub(in crate::console) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
+pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
     if path.is_empty() {
         return None;
     }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -1138,7 +1138,7 @@ fn render_auth_row(
         AuthRow::RoleHeader { role, expanded } => {
             let glyph = if *expanded { "▼" } else { "▶" };
             ratatui::text::Line::from(vec![
-                Span::raw("     "),
+                Span::raw("  "),
                 Span::styled(glyph.to_string(), disclosure_style()),
                 Span::styled(format!(" Role: {role}"), disclosure_style()),
             ])

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -815,10 +815,7 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 let mut spans = vec![
                     Span::raw(format!("{cursor_col}     ")),
                     Span::styled(arrow, disclosure_style()),
-                    Span::styled(
-                        format!(" Role: {role}  ({count} vars)"),
-                        disclosure_style(),
-                    ),
+                    Span::styled(format!(" Role: {role}  ({count} vars)"), disclosure_style()),
                 ];
                 if !in_registry {
                     spans.push(Span::styled(
@@ -1897,28 +1894,32 @@ mod secrets_tab_render_tests {
         // Expected sequence:
         //  0  WorkspaceKeyRow("ALPHA")
         //  1  WorkspaceKeyRow("BETA")
-        //  2  WorkspaceAddSentinel
-        //  3  SectionSpacer
-        //  4  AgentHeader { role: "agent-a", expanded: true }
-        //  5  AgentKeyRow { role: "agent-a", key: "KEY" }
-        //  6  AgentAddSentinel("agent-a")
+        //  2  SectionSpacer
+        //  3  WorkspaceAddSentinel
+        //  4  SectionSpacer
+        //  5  AgentHeader { role: "agent-a", expanded: true }
+        //  6  AgentKeyRow { role: "agent-a", key: "KEY" }
         //  7  SectionSpacer
-        //  8  AgentHeader { role: "agent-b", expanded: false }
-        assert_eq!(rows.len(), 9, "unexpected row count: {rows:?}");
+        //  8  AgentAddSentinel("agent-a")
+        //  9  SectionSpacer
+        // 10  AgentHeader { role: "agent-b", expanded: false }
+        assert_eq!(rows.len(), 11, "unexpected row count: {rows:?}");
         assert!(matches!(&rows[0], super::SecretsRow::WorkspaceKeyRow(k) if k == "ALPHA"));
         assert!(matches!(&rows[1], super::SecretsRow::WorkspaceKeyRow(k) if k == "BETA"));
-        assert!(matches!(&rows[2], super::SecretsRow::WorkspaceAddSentinel));
-        assert!(matches!(&rows[3], super::SecretsRow::SectionSpacer));
+        assert!(matches!(&rows[2], super::SecretsRow::SectionSpacer));
+        assert!(matches!(&rows[3], super::SecretsRow::WorkspaceAddSentinel));
+        assert!(matches!(&rows[4], super::SecretsRow::SectionSpacer));
         assert!(
-            matches!(&rows[4], super::SecretsRow::RoleHeader { role, expanded: true } if role == "agent-a")
+            matches!(&rows[5], super::SecretsRow::RoleHeader { role, expanded: true } if role == "agent-a")
         );
         assert!(
-            matches!(&rows[5], super::SecretsRow::RoleKeyRow { role, key } if role == "agent-a" && key == "KEY")
+            matches!(&rows[6], super::SecretsRow::RoleKeyRow { role, key } if role == "agent-a" && key == "KEY")
         );
-        assert!(matches!(&rows[6], super::SecretsRow::RoleAddSentinel(a) if a == "agent-a"));
         assert!(matches!(&rows[7], super::SecretsRow::SectionSpacer));
+        assert!(matches!(&rows[8], super::SecretsRow::RoleAddSentinel(a) if a == "agent-a"));
+        assert!(matches!(&rows[9], super::SecretsRow::SectionSpacer));
         assert!(
-            matches!(&rows[8], super::SecretsRow::RoleHeader { role, expanded: false } if role == "agent-b")
+            matches!(&rows[10], super::SecretsRow::RoleHeader { role, expanded: false } if role == "agent-b")
         );
     }
 
@@ -2200,16 +2201,16 @@ mod secrets_tab_render_tests {
         let editor = EditorState::new_edit("ws".into(), ws);
         let rows = super::secrets_flat_rows(&editor);
         assert!(
-            matches!(rows.get(2), Some(super::SecretsRow::SectionSpacer)),
-            "row 2 must be a SectionSpacer between workspace section \
+            matches!(rows.get(3), Some(super::SecretsRow::SectionSpacer)),
+            "row 3 must be a SectionSpacer between workspace add row \
              and first role header; got {:?}",
-            rows.get(2)
+            rows.get(3)
         );
         assert!(
-            matches!(rows.get(3), Some(super::SecretsRow::RoleHeader { .. })),
-            "row 3 must be the role header right after the spacer; \
+            matches!(rows.get(4), Some(super::SecretsRow::RoleHeader { .. })),
+            "row 4 must be the role header right after the spacer; \
              got {:?}",
-            rows.get(3)
+            rows.get(4)
         );
     }
 
@@ -2736,8 +2737,9 @@ mod auth_flat_rows_tests {
             rows[header_idx],
             AuthRow::RoleHeader { ref role, expanded: false } if role == "the-architect"
         ));
+        assert!(matches!(rows[header_idx + 1], AuthRow::Spacer));
         assert!(matches!(
-            rows[header_idx + 1],
+            rows[header_idx + 2],
             AuthRow::AddSentinel { eligible: 1 }
         ));
     }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -286,43 +286,39 @@ fn contextual_row_items(
             }
         }
         EditorTab::Auth => {
-            // Auth tab rows are editable workspace + workspace × role
-            // entries; the global section is read-only.
-            let rows = auth_editable_row_count(state);
-            if rows == 0 {
-                Vec::new()
-            } else {
-                let mut items = vec![FooterItem::Key("Enter"), FooterItem::Text("edit auth")];
-                // When the cursor sits on a RoleAgentRow, append a provenance
-                // hint describing the resolved mode and which config layer
-                // supplied it (variant 2B: footer-only, no inline badge).
-                let flat = auth_flat_rows(state);
-                if let Some(AuthRow::RoleAgentRow { role, agent }) = flat.get(cursor) {
-                    let synthesized = synthesize_appconfig_for_auth(state, config);
-                    let ws_name = workspace_name_for_panel(state);
-                    let mode = crate::config::resolve_mode(&synthesized, *agent, &ws_name, role);
-                    let label = provenance_label(&synthesized, &ws_name, role, *agent);
-                    let agent_name = crate::console::widgets::auth_panel::agent_display(*agent);
-                    let hint = format!(
-                        "{role} / {agent_name} \u{b7} {mode} ({label})",
-                        mode = crate::console::widgets::auth_panel::mode_str(mode),
-                    );
-                    items.push(FooterItem::Sep);
-                    items.push(FooterItem::Dyn(hint));
+            let flat = auth_flat_rows(state);
+            match flat.get(cursor) {
+                Some(AuthRow::AuthKind { .. }) => {
+                    vec![FooterItem::Key("Enter"), FooterItem::Text("manage auth")]
                 }
-                items
+                Some(AuthRow::WorkspaceMode { .. } | AuthRow::RoleMode { .. }) => {
+                    vec![FooterItem::Key("Enter"), FooterItem::Text("edit mode")]
+                }
+                Some(AuthRow::RoleHeader { .. }) => vec![
+                    FooterItem::Key("Enter"),
+                    FooterItem::Text("expand"),
+                    FooterItem::Sep,
+                    FooterItem::Key("←/→"),
+                    FooterItem::Text("collapse/expand"),
+                    FooterItem::Sep,
+                    FooterItem::Key("D"),
+                    FooterItem::Text("reset"),
+                ],
+                Some(AuthRow::AddSentinel { .. }) => {
+                    vec![FooterItem::Key("Enter/A"), FooterItem::Text("add override")]
+                }
+                Some(AuthRow::WorkspaceSource { .. } | AuthRow::RoleSource { .. }) => {
+                    vec![FooterItem::Key("Enter"), FooterItem::Text("edit source")]
+                }
+                Some(AuthRow::OverridesHeader | AuthRow::Spacer) | None => Vec::new(),
             }
         }
     }
 }
 
 /// Number of rows in the auth panel that the operator can navigate / edit.
-/// Workspace rows (one per agent) plus role × agent rows. The global
-/// section is read-only and not part of the editable count.
-pub(in crate::console::manager) const fn auth_editable_row_count(state: &EditorState<'_>) -> usize {
-    // 2 agents (Claude + Codex) at the workspace layer; another 2 per role.
-    let agents = 2;
-    agents + state.pending.allowed_roles.len() * agents
+pub(in crate::console::manager) fn auth_row_count(state: &EditorState<'_>) -> usize {
+    auth_flat_rows(state).len()
 }
 
 fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
@@ -632,60 +628,62 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
 /// `Vec<AuthRow>` so cursor row numbers always agree with what's drawn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthRow {
-    /// Bold "Global defaults" caption (read-only).
-    GlobalHeader,
-    /// One row per agent under the Global header. Read-only.
-    GlobalDefault { agent: crate::agent::Agent },
-    /// Bold "Workspace defaults" caption.
-    WorkspaceHeader,
-    /// Editable workspace-level row, one per agent.
-    WorkspaceDefault { agent: crate::agent::Agent },
-    /// "Per-role overrides (N)" caption.
-    OverridesHeader { count: usize },
+    /// Root picker row: choose which auth kind to manage.
+    AuthKind { agent: crate::agent::Agent },
+    /// Selected auth kind's workspace-level mode row.
+    WorkspaceMode { agent: crate::agent::Agent },
+    /// Selected auth kind's workspace credential source row.
+    WorkspaceSource { agent: crate::agent::Agent },
+    /// "Role overrides" caption.
+    OverridesHeader,
     /// Collapsible role override block. `expanded` toggles the agent rows.
     RoleHeader { role: String, expanded: bool },
-    /// Agent row inside an expanded `RoleHeader`. Editable.
-    RoleAgentRow {
+    /// Mode row inside an expanded `RoleHeader`. Editable.
+    RoleMode {
         role: String,
         agent: crate::agent::Agent,
     },
-    /// `+ Add per-role override (N eligible)` sentinel — always last.
+    /// Credential source row inside an expanded `RoleHeader`.
+    RoleSource {
+        role: String,
+        agent: crate::agent::Agent,
+    },
+    /// `+ Override for a role` sentinel.
     AddSentinel { eligible: usize },
-    /// Visual divider between sections; not focusable.
-    Divider,
+    /// Visual spacer.
+    Spacer,
 }
 
 pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
     use crate::agent::Agent;
-    let mut rows = vec![
-        AuthRow::GlobalHeader,
-        AuthRow::GlobalDefault {
-            agent: Agent::Claude,
-        },
-        AuthRow::GlobalDefault {
-            agent: Agent::Codex,
-        },
-        AuthRow::Divider,
-        AuthRow::WorkspaceHeader,
-        AuthRow::WorkspaceDefault {
-            agent: Agent::Claude,
-        },
-        AuthRow::WorkspaceDefault {
-            agent: Agent::Codex,
-        },
-        AuthRow::Divider,
-    ];
+    let Some(agent) = editor.auth_selected_agent else {
+        return vec![
+            AuthRow::AuthKind {
+                agent: Agent::Claude,
+            },
+            AuthRow::AuthKind {
+                agent: Agent::Codex,
+            },
+        ];
+    };
 
     let override_roles: Vec<String> = editor
         .pending
         .roles
         .iter()
-        .filter(|(_, ro)| ro.has_auth_override())
+        .filter(|(_, ro)| match agent {
+            Agent::Claude => ro.claude.is_some(),
+            Agent::Codex => ro.codex.is_some(),
+        })
         .map(|(name, _)| name.clone())
         .collect();
-    rows.push(AuthRow::OverridesHeader {
-        count: override_roles.len(),
-    });
+
+    let mut rows = vec![AuthRow::WorkspaceMode { agent }];
+    if workspace_effective_mode_needs_credential(editor, agent) {
+        rows.push(AuthRow::WorkspaceSource { agent });
+    }
+    rows.push(AuthRow::Spacer);
+    rows.push(AuthRow::OverridesHeader);
     for role in &override_roles {
         let expanded = editor.auth_expanded.contains(role);
         rows.push(AuthRow::RoleHeader {
@@ -693,14 +691,16 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
             expanded,
         });
         if expanded {
-            rows.push(AuthRow::RoleAgentRow {
+            rows.push(AuthRow::RoleMode {
                 role: role.clone(),
-                agent: crate::agent::Agent::Claude,
+                agent,
             });
-            rows.push(AuthRow::RoleAgentRow {
-                role: role.clone(),
-                agent: crate::agent::Agent::Codex,
-            });
+            if role_effective_mode_needs_credential(editor, role, agent) {
+                rows.push(AuthRow::RoleSource {
+                    role: role.clone(),
+                    agent,
+                });
+            }
         }
     }
     let eligible_remaining = editor
@@ -712,6 +712,27 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
         eligible: eligible_remaining,
     });
     rows
+}
+
+fn workspace_effective_mode_needs_credential(
+    editor: &EditorState<'_>,
+    agent: crate::agent::Agent,
+) -> bool {
+    let synthesized = synthesize_appconfig_for_auth(editor, &AppConfig::default());
+    let ws = workspace_name_for_panel(editor);
+    let mode = crate::config::resolve_mode(&synthesized, agent, &ws, "");
+    agent.required_env_var(mode).is_some()
+}
+
+fn role_effective_mode_needs_credential(
+    editor: &EditorState<'_>,
+    role: &str,
+    agent: crate::agent::Agent,
+) -> bool {
+    let synthesized = synthesize_appconfig_for_auth(editor, &AppConfig::default());
+    let ws = workspace_name_for_panel(editor);
+    let mode = crate::config::resolve_mode(&synthesized, agent, &ws, role);
+    agent.required_env_var(mode).is_some()
 }
 
 /// Mirrors launch-time semantics from
@@ -1039,8 +1060,12 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
         .iter()
         .map(|r| ListItem::new(render_auth_row(r, &synthesized, &workspace_name)))
         .collect();
+    let title = state.auth_selected_agent.map_or_else(
+        || " Auth ".to_string(),
+        |agent| format!(" Auth / {} ", auth_kind_display(agent)),
+    );
     let title_span = Span::styled(
-        " Auth ",
+        title,
         Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
     );
     let block = Block::default()
@@ -1059,39 +1084,18 @@ fn render_auth_row(
     workspace_name: &str,
 ) -> ratatui::text::Line<'static> {
     use crate::config::resolve_mode;
-    use crate::console::widgets::auth_panel::{agent_display, badge_for, mode_str};
+    use crate::console::widgets::auth_panel::{badge_for, mode_str};
 
     let bold_white = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
     let dim_green = Style::default().fg(PHOSPHOR_DIM);
     let phosphor = Style::default().fg(PHOSPHOR_GREEN);
 
     match row {
-        AuthRow::GlobalHeader => {
-            ratatui::text::Line::from(Span::styled("Global defaults", bold_white))
-        }
-        AuthRow::GlobalDefault { agent } => {
-            let mode = match agent {
-                crate::agent::Agent::Claude => synthesized
-                    .claude
-                    .as_ref()
-                    .map(|c| c.auth_forward)
-                    .unwrap_or_default(),
-                crate::agent::Agent::Codex => synthesized
-                    .codex
-                    .as_ref()
-                    .map(|c| c.auth_forward)
-                    .unwrap_or_default(),
-            };
-            ratatui::text::Line::from(vec![
-                Span::raw("  "),
-                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
-                Span::styled(mode_str(mode).to_string(), phosphor),
-            ])
-        }
-        AuthRow::WorkspaceHeader => {
-            ratatui::text::Line::from(Span::styled("Workspace defaults", bold_white))
-        }
-        AuthRow::WorkspaceDefault { agent } => {
+        AuthRow::AuthKind { agent } => ratatui::text::Line::from(vec![
+            Span::raw("  "),
+            Span::styled(auth_kind_display(*agent).to_string(), bold_white),
+        ]),
+        AuthRow::WorkspaceMode { agent } => {
             let ws = synthesized.workspaces.get(workspace_name);
             let explicit = ws.and_then(|ws| match agent {
                 crate::agent::Agent::Claude => ws.claude.as_ref().map(|c| c.auth_forward),
@@ -1099,19 +1103,22 @@ fn render_auth_row(
             });
             let mode =
                 explicit.unwrap_or_else(|| resolve_mode(synthesized, *agent, workspace_name, ""));
+            let prefix = if explicit.is_some() { "" } else { "inherited " };
             let badge = badge_for(synthesized, workspace_name, "", *agent, mode);
             ratatui::text::Line::from(vec![
                 Span::raw("  "),
-                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
-                Span::styled(mode_str(mode).to_string(), phosphor),
+                Span::styled(format!("{:<14}", "Mode"), bold_white),
+                Span::styled(format!("{prefix}{}", mode_str(mode)), phosphor),
                 Span::raw("  "),
                 badge_span(badge),
             ])
         }
-        AuthRow::OverridesHeader { count } => ratatui::text::Line::from(vec![
-            Span::styled("Per-role overrides ", bold_white),
-            Span::styled(format!("({count})"), dim_green),
-        ]),
+        AuthRow::WorkspaceSource { agent } => {
+            render_auth_source_line("Source", synthesized, workspace_name, "", *agent, 2)
+        }
+        AuthRow::OverridesHeader => {
+            ratatui::text::Line::from(Span::styled("  Role overrides", bold_white))
+        }
         AuthRow::RoleHeader { role, expanded } => {
             let glyph = if *expanded { "▾" } else { "▸" };
             ratatui::text::Line::from(vec![
@@ -1121,33 +1128,157 @@ fn render_auth_row(
                 Span::styled(role.clone(), bold_white),
             ])
         }
-        AuthRow::RoleAgentRow { role, agent } => {
+        AuthRow::RoleMode { role, agent } => {
             let mode = resolve_mode(synthesized, *agent, workspace_name, role);
             let badge = badge_for(synthesized, workspace_name, role, *agent, mode);
             ratatui::text::Line::from(vec![
                 Span::raw("      "),
-                Span::styled(format!("{}: ", agent_display(*agent)), bold_white),
+                Span::styled(format!("{:<12}", "Mode"), bold_white),
                 Span::styled(mode_str(mode).to_string(), phosphor),
                 Span::raw("  "),
                 badge_span(badge),
             ])
+        }
+        AuthRow::RoleSource { role, agent } => {
+            render_auth_source_line("Source", synthesized, workspace_name, role, *agent, 6)
         }
         AuthRow::AddSentinel { eligible } => {
             let label_style = if *eligible == 0 { dim_green } else { phosphor };
             let suffix = if *eligible == 0 {
                 "   (all roles overridden)".to_string()
             } else {
-                format!("   ({eligible} eligible)")
+                String::new()
             };
             ratatui::text::Line::from(vec![
-                Span::styled("  + Add per-role override", label_style),
+                Span::styled("  + Override for a role", label_style),
                 Span::styled(suffix, dim_green),
             ])
         }
-        AuthRow::Divider => ratatui::text::Line::from(Span::styled(
-            "  ──────────────────────────────────────────",
-            dim_green,
-        )),
+        AuthRow::Spacer => ratatui::text::Line::from(""),
+    }
+}
+
+fn render_auth_source_line(
+    label: &str,
+    synthesized: &AppConfig,
+    workspace_name: &str,
+    role: &str,
+    agent: crate::agent::Agent,
+    indent: usize,
+) -> ratatui::text::Line<'static> {
+    use crate::console::widgets::auth_panel::mode_str;
+
+    let mode = crate::config::resolve_mode(synthesized, agent, workspace_name, role);
+    let env_name = agent.required_env_var(mode);
+    let mut spans = vec![
+        Span::raw(" ".repeat(indent)),
+        Span::styled(
+            format!("{label:<12}"),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ];
+
+    let Some(env_name) = env_name else {
+        spans.push(Span::styled(
+            "not required",
+            Style::default().fg(PHOSPHOR_DIM),
+        ));
+        return ratatui::text::Line::from(spans);
+    };
+
+    let value = auth_source_value(synthesized, workspace_name, role, env_name);
+
+    match value {
+        Some(EnvValue::OpRef(r)) => {
+            spans.push(Span::styled(
+                "1Password  ",
+                Style::default().fg(PHOSPHOR_DIM),
+            ));
+            push_op_breadcrumb_spans(&mut spans, &r.path);
+        }
+        Some(EnvValue::Plain(s)) if !s.is_empty() => {
+            spans.push(Span::styled(
+                "literal  OK",
+                Style::default().fg(PHOSPHOR_GREEN),
+            ));
+        }
+        _ => {
+            spans.push(Span::styled(
+                format!("unset  ({env_name} for {})", mode_str(mode)),
+                Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
+            ));
+        }
+    }
+    ratatui::text::Line::from(spans)
+}
+
+const fn auth_kind_display(agent: crate::agent::Agent) -> &'static str {
+    match agent {
+        crate::agent::Agent::Claude => "Claude Code",
+        crate::agent::Agent::Codex => "Codex",
+    }
+}
+
+fn auth_source_value<'a>(
+    synthesized: &'a AppConfig,
+    workspace_name: &str,
+    role: &str,
+    env_name: &str,
+) -> Option<&'a EnvValue> {
+    if !role.is_empty()
+        && let Some(value) = synthesized
+            .workspaces
+            .get(workspace_name)
+            .and_then(|ws| ws.roles.get(role))
+            .and_then(|ro| ro.env.get(env_name))
+    {
+        return Some(value);
+    }
+    if let Some(value) = synthesized
+        .workspaces
+        .get(workspace_name)
+        .and_then(|ws| ws.env.get(env_name))
+    {
+        return Some(value);
+    }
+    if !role.is_empty()
+        && let Some(value) = synthesized
+            .roles
+            .get(role)
+            .and_then(|r| r.env.get(env_name))
+    {
+        return Some(value);
+    }
+    synthesized.env.get(env_name)
+}
+
+fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
+    let dim = Style::default().fg(PHOSPHOR_DIM);
+    let white_style = Style::default().fg(WHITE);
+    let green = Style::default().fg(PHOSPHOR_GREEN);
+    let green_bold = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
+    let Some(parts) = parse_path_breadcrumb(path) else {
+        spans.push(Span::styled("<unparseable path - re-pick>", dim));
+        return;
+    };
+    spans.push(Span::styled(parts.vault, white_style));
+    spans.push(Span::styled(" / ", dim));
+    spans.push(Span::styled(parts.item, green));
+    if let Some(subtitle) = parts.item_subtitle {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(subtitle, dim));
+    }
+    if let Some(section) = parts.section {
+        spans.push(Span::styled(" / ", dim));
+        spans.push(Span::styled(section, green));
+    }
+    spans.push(Span::styled(" -> ", dim));
+    spans.push(Span::styled(parts.field, green_bold));
+    if let Some(query) = parts.attribute_query {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(query, dim));
     }
 }
 
@@ -1198,41 +1329,6 @@ pub(in crate::console::manager) fn workspace_name_for_panel(state: &EditorState<
     }
 }
 
-/// Return a short human-readable provenance label for the given
-/// (workspace, role, agent) triple.
-///
-/// Checks presence at each config layer and returns the most specific
-/// description: role-level override beats workspace default beats global.
-fn provenance_label(
-    synthesized: &crate::config::AppConfig,
-    workspace_name: &str,
-    role: &str,
-    agent: crate::agent::Agent,
-) -> &'static str {
-    let role_explicit = synthesized
-        .workspaces
-        .get(workspace_name)
-        .and_then(|ws| ws.roles.get(role))
-        .and_then(|ro| match agent {
-            crate::agent::Agent::Claude => ro.claude.as_ref().map(|_| ()),
-            crate::agent::Agent::Codex => ro.codex.as_ref().map(|_| ()),
-        });
-    let ws_explicit = synthesized
-        .workspaces
-        .get(workspace_name)
-        .and_then(|ws| match agent {
-            crate::agent::Agent::Claude => ws.claude.as_ref().map(|_| ()),
-            crate::agent::Agent::Codex => ws.codex.as_ref().map(|_| ()),
-        });
-    if role_explicit.is_some() {
-        "overrides workspace default"
-    } else if ws_explicit.is_some() {
-        "inherits workspace default"
-    } else {
-        "inherits global default"
-    }
-}
-
 /// Map a flattened editable row index (the cursor) into the
 /// `AuthFormTarget` the form modal should be opened against. Returns
 /// `None` for non-editable rows (headers, defaults, dividers, sentinel)
@@ -1244,11 +1340,15 @@ pub(in crate::console::manager) fn resolve_auth_row_target(
     use crate::console::manager::state::AuthFormTarget;
     let rows = auth_flat_rows(state);
     match rows.get(row)? {
-        AuthRow::WorkspaceDefault { agent } => Some(AuthFormTarget::Workspace { agent: *agent }),
-        AuthRow::RoleAgentRow { role, agent } => Some(AuthFormTarget::WorkspaceRole {
-            role: role.clone(),
-            agent: *agent,
-        }),
+        AuthRow::WorkspaceMode { agent } | AuthRow::WorkspaceSource { agent } => {
+            Some(AuthFormTarget::Workspace { agent: *agent })
+        }
+        AuthRow::RoleMode { role, agent } | AuthRow::RoleSource { role, agent } => {
+            Some(AuthFormTarget::WorkspaceRole {
+                role: role.clone(),
+                agent: *agent,
+            })
+        }
         _ => None,
     }
 }
@@ -2580,34 +2680,23 @@ mod parse_path_breadcrumb_tests {
 #[cfg(test)]
 mod auth_flat_rows_tests {
     use super::{AuthRow, auth_flat_rows};
+    use crate::agent::Agent;
     use crate::console::manager::state::EditorState;
     use crate::workspace::WorkspaceConfig;
 
     #[test]
-    fn empty_workspace_yields_defaults_overrides_header_and_sentinel() {
+    fn root_view_lists_auth_kinds_only() {
         let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         let rows = auth_flat_rows(&editor);
         assert_eq!(
             rows,
             vec![
-                AuthRow::GlobalHeader,
-                AuthRow::GlobalDefault {
-                    agent: crate::agent::Agent::Claude,
+                AuthRow::AuthKind {
+                    agent: Agent::Claude,
                 },
-                AuthRow::GlobalDefault {
-                    agent: crate::agent::Agent::Codex,
+                AuthRow::AuthKind {
+                    agent: Agent::Codex,
                 },
-                AuthRow::Divider,
-                AuthRow::WorkspaceHeader,
-                AuthRow::WorkspaceDefault {
-                    agent: crate::agent::Agent::Claude,
-                },
-                AuthRow::WorkspaceDefault {
-                    agent: crate::agent::Agent::Codex,
-                },
-                AuthRow::Divider,
-                AuthRow::OverridesHeader { count: 0 },
-                AuthRow::AddSentinel { eligible: 0 },
             ],
         );
     }
@@ -2624,13 +2713,14 @@ mod auth_flat_rows_tests {
         });
         ws.roles.insert("the-architect".into(), over);
 
-        let editor = EditorState::new_edit("ws".into(), ws);
+        let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.auth_selected_agent = Some(Agent::Claude);
         let rows = auth_flat_rows(&editor);
 
         let header_idx = rows
             .iter()
-            .position(|r| matches!(r, AuthRow::OverridesHeader { count: 1 }))
-            .expect("overrides header with count=1 expected");
+            .position(|r| matches!(r, AuthRow::OverridesHeader))
+            .expect("overrides header expected");
         assert!(matches!(
             rows[header_idx + 1],
             AuthRow::RoleHeader { ref role, expanded: false } if role == "the-architect"
@@ -2643,7 +2733,6 @@ mod auth_flat_rows_tests {
 
     #[test]
     fn role_with_override_when_expanded_emits_agent_rows() {
-        use crate::agent::Agent;
         use crate::config::{AgentAuthConfig, AuthForwardMode, CodexAuthConfig};
         use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
         let mut ws = WorkspaceConfig::default();
@@ -2658,6 +2747,7 @@ mod auth_flat_rows_tests {
         ws.roles.insert("the-architect".into(), over);
 
         let mut editor = EditorState::new_edit("ws".into(), ws);
+        editor.auth_selected_agent = Some(Agent::Claude);
         editor.auth_expanded.insert("the-architect".into());
         let rows = auth_flat_rows(&editor);
 
@@ -2667,28 +2757,24 @@ mod auth_flat_rows_tests {
             .expect("expanded role header missing");
         assert!(matches!(
             rows[header_pos + 1],
-            AuthRow::RoleAgentRow { ref role, agent: Agent::Claude } if role == "the-architect"
-        ));
-        assert!(matches!(
-            rows[header_pos + 2],
-            AuthRow::RoleAgentRow { ref role, agent: Agent::Codex } if role == "the-architect"
+            AuthRow::RoleMode { ref role, agent: Agent::Claude } if role == "the-architect"
         ));
     }
 
     #[test]
     fn resolve_auth_row_target_picks_workspace_default_for_workspacedefault_row() {
-        use crate::agent::Agent;
         use crate::console::manager::state::AuthFormTarget;
         use crate::workspace::WorkspaceConfig;
 
-        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        editor.auth_selected_agent = Some(Agent::Claude);
         let rows = auth_flat_rows(&editor);
         let workspace_claude_idx = rows
             .iter()
             .position(|r| {
                 matches!(
                     r,
-                    AuthRow::WorkspaceDefault {
+                    AuthRow::WorkspaceMode {
                         agent: Agent::Claude
                     }
                 )
@@ -2703,39 +2789,18 @@ mod auth_flat_rows_tests {
     }
 
     #[test]
-    fn provenance_label_picks_overrides_when_role_explicit() {
-        use crate::agent::Agent;
-        use crate::config::{AgentAuthConfig, AppConfig, AuthForwardMode};
-        use crate::workspace::{WorkspaceConfig, WorkspaceRoleOverride};
-
-        let mut cfg = AppConfig::default();
-        let mut ws = WorkspaceConfig::default();
-        let mut over = WorkspaceRoleOverride::default();
-        over.claude = Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::Ignore,
-        });
-        ws.roles.insert("the-architect".into(), over);
-        cfg.workspaces.insert("ws".into(), ws);
-
-        assert_eq!(
-            super::provenance_label(&cfg, "ws", "the-architect", Agent::Claude),
-            "overrides workspace default",
-        );
-    }
-
-    #[test]
-    fn resolve_auth_row_target_returns_none_for_global_or_header_or_sentinel() {
+    fn resolve_auth_row_target_returns_none_for_navigation_and_header_rows() {
         use crate::workspace::WorkspaceConfig;
-        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        editor.auth_selected_agent = Some(Agent::Claude);
         let rows = auth_flat_rows(&editor);
         for (idx, row) in rows.iter().enumerate() {
             match row {
-                AuthRow::GlobalHeader
-                | AuthRow::GlobalDefault { .. }
-                | AuthRow::WorkspaceHeader
-                | AuthRow::OverridesHeader { .. }
+                AuthRow::AuthKind { .. }
+                | AuthRow::OverridesHeader
                 | AuthRow::AddSentinel { .. }
-                | AuthRow::Divider => assert!(
+                | AuthRow::Spacer
+                | AuthRow::RoleHeader { .. } => assert!(
                     super::resolve_auth_row_target(&editor, idx).is_none(),
                     "row {idx} ({row:?}) must not resolve to an editable target"
                 ),

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -310,7 +310,7 @@ fn contextual_row_items(
                 Some(AuthRow::WorkspaceSource { .. } | AuthRow::RoleSource { .. }) => {
                     vec![FooterItem::Key("Enter"), FooterItem::Text("edit source")]
                 }
-                Some(AuthRow::OverridesHeader | AuthRow::Spacer) | None => Vec::new(),
+                Some(AuthRow::Spacer) | None => Vec::new(),
             }
         }
     }
@@ -634,8 +634,6 @@ pub enum AuthRow {
     WorkspaceMode { agent: crate::agent::Agent },
     /// Selected auth kind's workspace credential source row.
     WorkspaceSource { agent: crate::agent::Agent },
-    /// "Role overrides" caption.
-    OverridesHeader,
     /// Collapsible role override block. `expanded` toggles the agent rows.
     RoleHeader { role: String, expanded: bool },
     /// Mode row inside an expanded `RoleHeader`. Editable.
@@ -683,7 +681,6 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
         rows.push(AuthRow::WorkspaceSource { agent });
     }
     rows.push(AuthRow::Spacer);
-    rows.push(AuthRow::OverridesHeader);
     for role in &override_roles {
         let expanded = editor.auth_expanded.contains(role);
         rows.push(AuthRow::RoleHeader {
@@ -1060,18 +1057,16 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
         .iter()
         .map(|r| ListItem::new(render_auth_row(r, &synthesized, &workspace_name)))
         .collect();
-    let title = state.auth_selected_agent.map_or_else(
-        || " Auth ".to_string(),
-        |agent| format!(" Auth / {} ", auth_kind_display(agent)),
-    );
-    let title_span = Span::styled(
-        title,
-        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-    );
-    let block = Block::default()
+    let mut block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(title_span);
+        .border_style(Style::default().fg(PHOSPHOR_DARK));
+    if let Some(agent) = state.auth_selected_agent {
+        let title_span = Span::styled(
+            format!(" {} ", auth_kind_display(agent)),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        );
+        block = block.title(title_span);
+    }
     let list = List::new(items).block(block).highlight_symbol("▸ ");
     let mut list_state = ListState::default();
     list_state.select(Some(selected));
@@ -1103,21 +1098,23 @@ fn render_auth_row(
             });
             let mode =
                 explicit.unwrap_or_else(|| resolve_mode(synthesized, *agent, workspace_name, ""));
-            let prefix = if explicit.is_some() { "" } else { "inherited " };
+            let suffix = if explicit.is_some() {
+                ""
+            } else {
+                " (inherited)"
+            };
             let badge = badge_for(synthesized, workspace_name, "", *agent, mode);
             ratatui::text::Line::from(vec![
                 Span::raw("  "),
                 Span::styled(format!("{:<14}", "Mode"), bold_white),
-                Span::styled(format!("{prefix}{}", mode_str(mode)), phosphor),
+                Span::styled(mode_str(mode).to_string(), phosphor),
+                Span::styled(suffix.to_string(), dim_green),
                 Span::raw("  "),
                 badge_span(badge),
             ])
         }
         AuthRow::WorkspaceSource { agent } => {
             render_auth_source_line("Source", synthesized, workspace_name, "", *agent, 2)
-        }
-        AuthRow::OverridesHeader => {
-            ratatui::text::Line::from(Span::styled("  Role overrides", bold_white))
         }
         AuthRow::RoleHeader { role, expanded } => {
             let glyph = if *expanded { "▾" } else { "▸" };
@@ -2719,14 +2716,22 @@ mod auth_flat_rows_tests {
 
         let header_idx = rows
             .iter()
-            .position(|r| matches!(r, AuthRow::OverridesHeader))
-            .expect("overrides header expected");
+            .position(|r| {
+                matches!(
+                    r,
+                    AuthRow::RoleHeader {
+                        role,
+                        expanded: false
+                    } if role == "the-architect"
+                )
+            })
+            .expect("role override header expected");
         assert!(matches!(
-            rows[header_idx + 1],
+            rows[header_idx],
             AuthRow::RoleHeader { ref role, expanded: false } if role == "the-architect"
         ));
         assert!(matches!(
-            rows[header_idx + 2],
+            rows[header_idx + 1],
             AuthRow::AddSentinel { eligible: 1 }
         ));
     }
@@ -2797,7 +2802,6 @@ mod auth_flat_rows_tests {
         for (idx, row) in rows.iter().enumerate() {
             match row {
                 AuthRow::AuthKind { .. }
-                | AuthRow::OverridesHeader
                 | AuthRow::AddSentinel { .. }
                 | AuthRow::Spacer
                 | AuthRow::RoleHeader { .. } => assert!(

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -814,8 +814,13 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 ));
             }
             SecretsRow::WorkspaceAddSentinel => {
+                let marker_col = if state.pending.env.is_empty() {
+                    ""
+                } else {
+                    "     "
+                };
                 lines.push(Line::from(Span::styled(
-                    format!("{cursor_col}     + Add environment variable"),
+                    format!("{cursor_col}{marker_col}+ Add environment variable"),
                     action_row_style(selected),
                 )));
             }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -680,9 +680,10 @@ pub enum AuthRow {
 ///
 /// `config` provides the live `[claude]`/`[codex]` globals so the
 /// "does this mode need a credential?" check runs against the
-/// operator's actual configuration — using `AppConfig::default()` here
-/// would silently hide the workspace/role source rows whenever the
-/// effective mode came from a global (e.g. `claude.auth_forward = "api_key"`).
+/// operator's actual configuration. The synthesized config (workspace
+/// pending merged onto the live globals) is built once here and
+/// reused for every credential-row check, regardless of how many
+/// roles are expanded.
 pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthRow> {
     use crate::agent::Agent;
     let Some(agent) = editor.auth_selected_agent else {
@@ -707,8 +708,11 @@ pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthR
         .map(|(name, _)| name.clone())
         .collect();
 
+    let synthesized = synthesize_appconfig_for_auth(editor, config);
+    let ws_name = workspace_name_for_panel(editor);
+
     let mut rows = vec![AuthRow::WorkspaceMode { agent }];
-    if workspace_effective_mode_needs_credential(editor, config, agent) {
+    if effective_mode_needs_credential(&synthesized, &ws_name, "", agent) {
         rows.push(AuthRow::WorkspaceSource { agent });
     }
     rows.push(AuthRow::Spacer);
@@ -723,7 +727,7 @@ pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthR
                 role: role.clone(),
                 agent,
             });
-            if role_effective_mode_needs_credential(editor, config, role, agent) {
+            if effective_mode_needs_credential(&synthesized, &ws_name, role, agent) {
                 rows.push(AuthRow::RoleSource {
                     role: role.clone(),
                     agent,
@@ -745,26 +749,16 @@ pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthR
     rows
 }
 
-fn workspace_effective_mode_needs_credential(
-    editor: &EditorState<'_>,
-    config: &AppConfig,
-    agent: crate::agent::Agent,
-) -> bool {
-    let synthesized = synthesize_appconfig_for_auth(editor, config);
-    let ws = workspace_name_for_panel(editor);
-    let mode = crate::config::resolve_mode(&synthesized, agent, &ws, "");
-    agent.required_env_var(mode).is_some()
-}
-
-fn role_effective_mode_needs_credential(
-    editor: &EditorState<'_>,
-    config: &AppConfig,
+/// Whether the (workspace, role, agent) triple's effective mode (after
+/// merging globals + workspace + role overrides) requires a credential.
+/// `role = ""` checks the workspace-level effective mode.
+fn effective_mode_needs_credential(
+    synthesized: &AppConfig,
+    ws_name: &str,
     role: &str,
     agent: crate::agent::Agent,
 ) -> bool {
-    let synthesized = synthesize_appconfig_for_auth(editor, config);
-    let ws = workspace_name_for_panel(editor);
-    let mode = crate::config::resolve_mode(&synthesized, agent, &ws, role);
+    let mode = crate::config::resolve_mode(synthesized, agent, ws_name, role);
     agent.required_env_var(mode).is_some()
 }
 
@@ -881,10 +875,8 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
 /// Display-side breadcrumb parser for `OpRef.path`.
 /// Grammar: `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?<query>]`
 ///
-/// Visibility is `pub(in crate::console)` so the auth-form widget
-/// (`crate::console::widgets::auth_panel::render`) shares the parser
-/// — without it, that widget would carry its own ad-hoc `path.split('/')`
-/// fallback that drops `?attribute=...` queries and `[subtitle]` syntax.
+/// Shared with the auth-form widget so all op-ref breadcrumbs render
+/// from the same parse tree.
 #[derive(Debug, PartialEq, Eq)]
 pub(in crate::console) struct PathBreadcrumb {
     pub vault: String,
@@ -1285,7 +1277,10 @@ fn auth_source_value<'a>(
     synthesized.env.get(env_name)
 }
 
-fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
+/// Render an `OpRef.path` as a `vault / item [subtitle] / section → field ?query`
+/// breadcrumb. Shared between the Auth tab, the Secrets tab, and the
+/// auth-edit form so all three render the same path identically.
+pub(in crate::console) fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
     let dim = Style::default().fg(PHOSPHOR_DIM);
     let white_style = Style::default().fg(WHITE);
     let green = Style::default().fg(PHOSPHOR_GREEN);
@@ -2845,5 +2840,34 @@ mod auth_flat_rows_tests {
                 _ => {}
             }
         }
+    }
+
+    /// Globally configured `api_key` mode (in `[claude].auth_forward`)
+    /// must surface a `WorkspaceSource` row so the operator can set
+    /// the credential — even when the workspace has no explicit
+    /// `claude` block of its own.
+    #[test]
+    fn workspace_source_surfaces_when_global_requires_credential() {
+        use crate::config::{AgentAuthConfig, AuthForwardMode};
+        use crate::workspace::WorkspaceConfig;
+        let config = AppConfig {
+            claude: Some(AgentAuthConfig {
+                auth_forward: AuthForwardMode::ApiKey,
+            }),
+            ..AppConfig::default()
+        };
+        let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        editor.auth_selected_agent = Some(Agent::Claude);
+
+        let rows = auth_flat_rows(&editor, &config);
+        assert!(
+            rows.iter().any(|r| matches!(
+                r,
+                AuthRow::WorkspaceSource {
+                    agent: Agent::Claude
+                }
+            )),
+            "global claude.auth_forward = api_key must surface WorkspaceSource row; got {rows:?}"
+        );
     }
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -26,6 +26,7 @@ use crate::operator_env::EnvValue;
 // ── Editor stage ────────────────────────────────────────────────────
 
 const ACTION_ACCENT: Color = Color::Rgb(180, 255, 180);
+const DISCLOSURE_ACCENT: Color = Color::Rgb(255, 208, 102);
 
 fn action_row_style(selected: bool) -> Style {
     let style = Style::default().fg(ACTION_ACCENT);
@@ -34,6 +35,12 @@ fn action_row_style(selected: bool) -> Style {
     } else {
         style
     }
+}
+
+fn disclosure_style() -> Style {
+    Style::default()
+        .fg(DISCLOSURE_ACCENT)
+        .add_modifier(Modifier::BOLD)
 }
 
 pub fn render_editor(
@@ -807,10 +814,10 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 let count = state.pending.roles.get(role).map_or(0, |o| o.env.len());
                 let mut spans = vec![
                     Span::raw(format!("{cursor_col}     ")),
-                    Span::styled(arrow, Style::default().fg(PHOSPHOR_GREEN)),
+                    Span::styled(arrow, disclosure_style()),
                     Span::styled(
                         format!(" Role: {role}  ({count} vars)"),
-                        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+                        disclosure_style(),
                     ),
                 ];
                 if !in_registry {
@@ -1132,8 +1139,8 @@ fn render_auth_row(
             let glyph = if *expanded { "▼" } else { "▶" };
             ratatui::text::Line::from(vec![
                 Span::raw("     "),
-                Span::styled(glyph.to_string(), phosphor),
-                Span::styled(format!(" Role: {role}"), bold_white),
+                Span::styled(glyph.to_string(), disclosure_style()),
+                Span::styled(format!(" Role: {role}"), disclosure_style()),
             ])
         }
         AuthRow::RoleMode { role, agent } => {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -304,7 +304,7 @@ fn contextual_row_items(
             }
         }
         EditorTab::Auth => {
-            let flat = auth_flat_rows(state);
+            let flat = auth_flat_rows(state, config);
             match flat.get(cursor) {
                 Some(AuthRow::AuthKind { .. }) => {
                     vec![FooterItem::Key("Enter"), FooterItem::Text("manage auth")]
@@ -334,9 +334,15 @@ fn contextual_row_items(
     }
 }
 
-/// Number of rows in the auth panel that the operator can navigate / edit.
-pub(in crate::console::manager) fn auth_row_count(state: &EditorState<'_>) -> usize {
-    auth_flat_rows(state).len()
+/// Total number of rendered rows in the auth panel, including spacers.
+/// Cursor stepping in the input layer skips spacer rows; callers using
+/// this for `max_row_for_tab` should be aware the result includes
+/// non-selectable rows.
+pub(in crate::console::manager) fn auth_row_count(
+    state: &EditorState<'_>,
+    config: &AppConfig,
+) -> usize {
+    auth_flat_rows(state, config).len()
 }
 
 fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
@@ -640,8 +646,9 @@ pub(in crate::console::manager) fn secrets_flat_rows(editor: &EditorState<'_>) -
 /// Row-shape model for the Auth tab.
 ///
 /// `auth_flat_rows()` rebuilds this per frame from `editor.pending` +
-/// `editor.auth_expanded`. Rendering and input both index into the same
-/// `Vec<AuthRow>` so cursor row numbers always agree with what's drawn.
+/// `editor.auth_expanded` + the live `AppConfig`. Rendering and input
+/// both index into the same `Vec<AuthRow>` so cursor row numbers always
+/// agree with what's drawn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthRow {
     /// Root picker row: choose which auth kind to manage.
@@ -650,7 +657,8 @@ pub enum AuthRow {
     WorkspaceMode { agent: crate::agent::Agent },
     /// Selected auth kind's workspace credential source row.
     WorkspaceSource { agent: crate::agent::Agent },
-    /// Collapsible role override block. `expanded` toggles the agent rows.
+    /// Collapsible role override block. `expanded` toggles the mode (and
+    /// credential source, when required) for the selected auth kind.
     RoleHeader { role: String, expanded: bool },
     /// Mode row inside an expanded `RoleHeader`. Editable.
     RoleMode {
@@ -668,7 +676,14 @@ pub enum AuthRow {
     Spacer,
 }
 
-pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
+/// Build the row-shape vector for the Auth tab.
+///
+/// `config` provides the live `[claude]`/`[codex]` globals so the
+/// "does this mode need a credential?" check runs against the
+/// operator's actual configuration — using `AppConfig::default()` here
+/// would silently hide the workspace/role source rows whenever the
+/// effective mode came from a global (e.g. `claude.auth_forward = "api_key"`).
+pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthRow> {
     use crate::agent::Agent;
     let Some(agent) = editor.auth_selected_agent else {
         return vec![
@@ -693,7 +708,7 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
         .collect();
 
     let mut rows = vec![AuthRow::WorkspaceMode { agent }];
-    if workspace_effective_mode_needs_credential(editor, agent) {
+    if workspace_effective_mode_needs_credential(editor, config, agent) {
         rows.push(AuthRow::WorkspaceSource { agent });
     }
     rows.push(AuthRow::Spacer);
@@ -708,7 +723,7 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
                 role: role.clone(),
                 agent,
             });
-            if role_effective_mode_needs_credential(editor, role, agent) {
+            if role_effective_mode_needs_credential(editor, config, role, agent) {
                 rows.push(AuthRow::RoleSource {
                     role: role.clone(),
                     agent,
@@ -732,9 +747,10 @@ pub fn auth_flat_rows(editor: &EditorState<'_>) -> Vec<AuthRow> {
 
 fn workspace_effective_mode_needs_credential(
     editor: &EditorState<'_>,
+    config: &AppConfig,
     agent: crate::agent::Agent,
 ) -> bool {
-    let synthesized = synthesize_appconfig_for_auth(editor, &AppConfig::default());
+    let synthesized = synthesize_appconfig_for_auth(editor, config);
     let ws = workspace_name_for_panel(editor);
     let mode = crate::config::resolve_mode(&synthesized, agent, &ws, "");
     agent.required_env_var(mode).is_some()
@@ -742,10 +758,11 @@ fn workspace_effective_mode_needs_credential(
 
 fn role_effective_mode_needs_credential(
     editor: &EditorState<'_>,
+    config: &AppConfig,
     role: &str,
     agent: crate::agent::Agent,
 ) -> bool {
-    let synthesized = synthesize_appconfig_for_auth(editor, &AppConfig::default());
+    let synthesized = synthesize_appconfig_for_auth(editor, config);
     let ws = workspace_name_for_panel(editor);
     let mode = crate::config::resolve_mode(&synthesized, agent, &ws, role);
     agent.required_env_var(mode).is_some()
@@ -863,8 +880,13 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
 
 /// Display-side breadcrumb parser for `OpRef.path`.
 /// Grammar: `<Vault>/<Item>[<subtitle>?]/[<Section>/]<Field>[?<query>]`
+///
+/// Visibility is `pub(in crate::console)` so the auth-form widget
+/// (`crate::console::widgets::auth_panel::render`) shares the parser
+/// — without it, that widget would carry its own ad-hoc `path.split('/')`
+/// fallback that drops `?attribute=...` queries and `[subtitle]` syntax.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) struct PathBreadcrumb {
+pub(in crate::console) struct PathBreadcrumb {
     pub vault: String,
     pub item: String,
     pub item_subtitle: Option<String>,
@@ -874,7 +896,7 @@ pub(super) struct PathBreadcrumb {
 }
 
 /// Parse a snapshot breadcrumb. Returns `None` on empty input or non-3-/4-segment counts.
-pub(super) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
+pub(in crate::console) fn parse_path_breadcrumb(path: &str) -> Option<PathBreadcrumb> {
     if path.is_empty() {
         return None;
     }
@@ -1057,7 +1079,7 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
 
     let synthesized = synthesize_appconfig_for_auth(state, config);
     let workspace_name = workspace_name_for_panel(state);
-    let rows = auth_flat_rows(state);
+    let rows = auth_flat_rows(state, config);
 
     let FieldFocus::Row(cursor) = state.active_field;
     let max_idx = rows.len().saturating_sub(1);
@@ -1329,16 +1351,17 @@ pub(in crate::console::manager) fn workspace_name_for_panel(state: &EditorState<
     }
 }
 
-/// Map a flattened editable row index (the cursor) into the
+/// Map a flattened auth row index (the cursor) into the
 /// `AuthFormTarget` the form modal should be opened against. Returns
-/// `None` for non-editable rows (headers, defaults, dividers, sentinel)
-/// so callers can branch on it before opening the form.
+/// `None` for non-form rows (`AuthKind`, `RoleHeader`, `AddSentinel`,
+/// `Spacer`) so callers can dispatch them separately.
 pub(in crate::console::manager) fn resolve_auth_row_target(
     state: &EditorState<'_>,
+    config: &AppConfig,
     row: usize,
 ) -> Option<crate::console::manager::state::AuthFormTarget> {
     use crate::console::manager::state::AuthFormTarget;
-    let rows = auth_flat_rows(state);
+    let rows = auth_flat_rows(state, config);
     match rows.get(row)? {
         AuthRow::WorkspaceMode { agent } | AuthRow::WorkspaceSource { agent } => {
             Some(AuthFormTarget::Workspace { agent: *agent })
@@ -2685,13 +2708,14 @@ mod parse_path_breadcrumb_tests {
 mod auth_flat_rows_tests {
     use super::{AuthRow, auth_flat_rows};
     use crate::agent::Agent;
+    use crate::config::AppConfig;
     use crate::console::manager::state::EditorState;
     use crate::workspace::WorkspaceConfig;
 
     #[test]
     fn root_view_lists_auth_kinds_only() {
         let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
-        let rows = auth_flat_rows(&editor);
+        let rows = auth_flat_rows(&editor, &AppConfig::default());
         assert_eq!(
             rows,
             vec![
@@ -2719,7 +2743,7 @@ mod auth_flat_rows_tests {
 
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.auth_selected_agent = Some(Agent::Claude);
-        let rows = auth_flat_rows(&editor);
+        let rows = auth_flat_rows(&editor, &AppConfig::default());
 
         let header_idx = rows
             .iter()
@@ -2762,7 +2786,7 @@ mod auth_flat_rows_tests {
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.auth_selected_agent = Some(Agent::Claude);
         editor.auth_expanded.insert("the-architect".into());
-        let rows = auth_flat_rows(&editor);
+        let rows = auth_flat_rows(&editor, &AppConfig::default());
 
         let header_pos = rows
             .iter()
@@ -2781,7 +2805,8 @@ mod auth_flat_rows_tests {
 
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         editor.auth_selected_agent = Some(Agent::Claude);
-        let rows = auth_flat_rows(&editor);
+        let cfg = AppConfig::default();
+        let rows = auth_flat_rows(&editor, &cfg);
         let workspace_claude_idx = rows
             .iter()
             .position(|r| {
@@ -2794,7 +2819,7 @@ mod auth_flat_rows_tests {
             })
             .unwrap();
         assert_eq!(
-            super::resolve_auth_row_target(&editor, workspace_claude_idx),
+            super::resolve_auth_row_target(&editor, &cfg, workspace_claude_idx),
             Some(AuthFormTarget::Workspace {
                 agent: Agent::Claude
             }),
@@ -2806,14 +2831,15 @@ mod auth_flat_rows_tests {
         use crate::workspace::WorkspaceConfig;
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         editor.auth_selected_agent = Some(Agent::Claude);
-        let rows = auth_flat_rows(&editor);
+        let cfg = AppConfig::default();
+        let rows = auth_flat_rows(&editor, &cfg);
         for (idx, row) in rows.iter().enumerate() {
             match row {
                 AuthRow::AuthKind { .. }
                 | AuthRow::AddSentinel { .. }
                 | AuthRow::Spacer
                 | AuthRow::RoleHeader { .. } => assert!(
-                    super::resolve_auth_row_target(&editor, idx).is_none(),
+                    super::resolve_auth_row_target(&editor, &cfg, idx).is_none(),
                     "row {idx} ({row:?}) must not resolve to an editable target"
                 ),
                 _ => {}

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -55,10 +55,14 @@ pub(super) fn render_list_body(
         }
     }
 
-    // Left: [Current directory] + saved workspaces + [+ New workspace].
+    // Left: [Current directory] + saved workspaces + blank spacer +
+    // [+ New workspace]. The spacer is visual-only; state keeps logical row
+    // indices without it.
     // The cwd path itself is shown on the right-pane `workdir` line; keep the
     // list row label short to avoid duplicate visual load.
-    let mut items: Vec<ListItem> = Vec::with_capacity(saved_count + 2);
+    let has_saved_workspaces = saved_count > 0;
+    let mut items: Vec<ListItem> =
+        Vec::with_capacity(saved_count + 2 + usize::from(has_saved_workspaces));
     items.push(ListItem::new(Line::from(Span::styled(
         "Current directory",
         Style::default().fg(WHITE),
@@ -69,6 +73,9 @@ pub(super) fn render_list_body(
             .iter()
             .map(|w| ListItem::new(Line::from(w.name.as_str()))),
     );
+    if has_saved_workspaces {
+        items.push(ListItem::new(Line::from("")));
+    }
     items.push(ListItem::new(Line::from(Span::styled(
         "+ New workspace",
         Style::default().fg(WHITE),
@@ -85,7 +92,7 @@ pub(super) fn render_list_body(
         .highlight_symbol("▸ ");
 
     let mut ls = ListState::default();
-    ls.select(Some(state.selected));
+    ls.select(Some(state.visual_selected()));
     frame.render_stateful_widget(list, list_area, &mut ls);
 
     // Toast overlay — rendered last so it appears on top.

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -68,7 +68,7 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         | Modal::AuthSourcePicker { .. }
         | Modal::ScopePicker { .. }
         | Modal::AuthAgentPicker { .. } => (50, 7),
-        Modal::AuthForm { .. } => (60, 9),
+        Modal::AuthForm { .. } => (80, 9),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -64,10 +64,11 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
             let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
             (50, rows)
         }
-        Modal::SourcePicker { .. } | Modal::ScopePicker { .. } | Modal::AuthAgentPicker { .. } => {
-            (50, 7)
-        }
-        Modal::AuthForm { .. } => (70, 14),
+        Modal::SourcePicker { .. }
+        | Modal::AuthSourcePicker { .. }
+        | Modal::ScopePicker { .. }
+        | Modal::AuthAgentPicker { .. } => (50, 7),
+        Modal::AuthForm { .. } => (60, 9),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -98,15 +99,22 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
         | Modal::AuthRolePicker { state } => {
             role_picker::render(frame, modal_area, state);
         }
-        Modal::SourcePicker { state } => source_picker::render(frame, modal_area, state),
+        Modal::SourcePicker { state } | Modal::AuthSourcePicker { state } => {
+            source_picker::render(frame, modal_area, state);
+        }
         Modal::ScopePicker { state } => scope_picker::render(frame, modal_area, state),
-        Modal::AuthForm { target, state, .. } => {
+        Modal::AuthForm {
+            target,
+            state,
+            focus,
+            ..
+        } => {
             let (workspace, role) = match target {
                 AuthFormTarget::Workspace { .. } => ("(workspace)", "(workspace-default)"),
                 AuthFormTarget::WorkspaceRole { role, .. } => ("(workspace)", role.as_str()),
             };
             let ctx = auth_panel::FormContext { workspace, role };
-            auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx);
+            auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx, *focus);
         }
         Modal::AuthAgentPicker { state, .. } => {
             agent_choice::render(frame, modal_area, state);

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -5,9 +5,8 @@
 use ratatui::{Frame, layout::Rect};
 
 use super::super::super::widgets::{
-    agent_choice, auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker,
-    mount_dst_choice, op_picker, role_picker, save_discard, scope_picker, source_picker,
-    text_input, workdir_pick,
+    auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice,
+    op_picker, role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
 };
 use super::super::state::{AuthFormTarget, Modal};
 use super::centered_rect_fixed;
@@ -64,10 +63,9 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
             let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
             (50, rows)
         }
-        Modal::SourcePicker { .. }
-        | Modal::AuthSourcePicker { .. }
-        | Modal::ScopePicker { .. }
-        | Modal::AuthAgentPicker { .. } => (50, 7),
+        Modal::SourcePicker { .. } | Modal::AuthSourcePicker { .. } | Modal::ScopePicker { .. } => {
+            (50, 7)
+        }
         Modal::AuthForm { .. } => (80, 9),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
@@ -115,9 +113,6 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             };
             let ctx = auth_panel::FormContext { workspace, role };
             auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx, *focus);
-        }
-        Modal::AuthAgentPicker { state, .. } => {
-            agent_choice::render(frame, modal_area, state);
         }
     }
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -66,11 +66,10 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         Modal::SourcePicker { .. } | Modal::AuthSourcePicker { .. } | Modal::ScopePicker { .. } => {
             (50, 7)
         }
-        // 11 = 2 borders + 9 inner rows. Matches the credential-bearing
-        // form layout (mode + blank + cred row + blank + actions + blank
-        // + hint + 2 padding blanks). Modes that hide the credential
-        // row leave the bottom rows blank, which is fine.
-        Modal::AuthForm { .. } => (80, 11),
+        // Hug the content: hide the credential block when the mode
+        // doesn't need one so the dialog doesn't leave dead rows
+        // below the hint line.
+        Modal::AuthForm { state, .. } => (80, auth_panel::required_height(state.as_ref())),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -8,7 +8,7 @@ use super::super::super::widgets::{
     auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice,
     op_picker, role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
 };
-use super::super::state::{AuthFormTarget, Modal};
+use super::super::state::Modal;
 use super::centered_rect_fixed;
 
 // ── Modal dispatcher ────────────────────────────────────────────────
@@ -66,7 +66,11 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
         Modal::SourcePicker { .. } | Modal::AuthSourcePicker { .. } | Modal::ScopePicker { .. } => {
             (50, 7)
         }
-        Modal::AuthForm { .. } => (80, 9),
+        // 11 = 2 borders + 9 inner rows. Matches the credential-bearing
+        // form layout (mode + blank + cred row + blank + actions + blank
+        // + hint + 2 padding blanks). Modes that hide the credential
+        // row leave the bottom rows blank, which is fine.
+        Modal::AuthForm { .. } => (80, 11),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -101,18 +105,8 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             source_picker::render(frame, modal_area, state);
         }
         Modal::ScopePicker { state } => scope_picker::render(frame, modal_area, state),
-        Modal::AuthForm {
-            target,
-            state,
-            focus,
-            ..
-        } => {
-            let (workspace, role) = match target {
-                AuthFormTarget::Workspace { .. } => ("(workspace)", "(workspace-default)"),
-                AuthFormTarget::WorkspaceRole { role, .. } => ("(workspace)", role.as_str()),
-            };
-            let ctx = auth_panel::FormContext { workspace, role };
-            auth_panel::render_form(frame, modal_area, state.as_ref(), &ctx, *focus);
+        Modal::AuthForm { state, focus, .. } => {
+            auth_panel::render_form(frame, modal_area, state.as_ref(), *focus);
         }
     }
 }

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -133,9 +133,9 @@ pub struct EditorState<'a> {
     /// (wrapped as `EnvValue::OpRef`) until the operator names the key
     /// and the `EnvKey` modal commits both fields at once.
     pub pending_picker_value: Option<crate::operator_env::EnvValue>,
-    /// Stash for the auth-form → `OpPicker` → auth-form round trip.
-    /// Set when the operator presses Enter at `AuthFormFocus::OpRefValue`,
-    /// and consumed when `OpPicker` commits or cancels: on commit we
+    /// Stash for the auth-form → source picker / `OpPicker` → auth-form
+    /// round trip. Set when the operator presses Enter on the credential
+    /// row, and consumed when the picker commits or cancels: on commit we
     /// reconstruct the `Modal::AuthForm` with the picked `OpRef`
     /// applied; on cancel we reconstruct it pristine. Threading the
     /// auth-form context through this field (rather than via a
@@ -304,6 +304,9 @@ pub enum Modal<'a> {
     SourcePicker {
         state: SourcePickerState,
     },
+    AuthSourcePicker {
+        state: SourcePickerState,
+    },
     ScopePicker {
         state: ScopePickerState,
     },
@@ -326,15 +329,15 @@ pub enum Modal<'a> {
 /// Where in the auth-edit form the cursor currently sits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthFormFocus {
-    /// Mode picker line — Space/Tab cycles, Enter commits selection.
+    /// Mode picker line — Space cycles, Enter commits selection.
     Mode,
-    /// Credential source radio (Literal / 1Password) — Space toggles.
+    /// Required credential row — Enter opens the shared source picker.
     CredentialSource,
     /// Literal value text input — operator types into `literal_buffer`.
     LiteralValue,
     /// 1Password value display — Enter opens the `OpPicker`.
     OpRefValue,
-    /// `[ Save ]` action button.
+    /// Save action button.
     Save,
     /// `[ Cancel ]` action button.
     Cancel,
@@ -368,6 +371,7 @@ pub enum TextInputTarget {
     Role,
     EnvKey { scope: SecretsScopeTag },
     EnvValue { scope: SecretsScopeTag, key: String },
+    AuthCredential,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -357,11 +357,10 @@ pub enum Modal<'a> {
 
 /// Where in the auth-edit form the cursor currently sits.
 ///
-/// The credential value is no longer typed inline in the form — it is
-/// always collected via `Modal::AuthSourcePicker` → `Modal::TextInput`
-/// (literal) or `Modal::OpPicker` (1Password). The form therefore has
-/// only one credential-related focus (`CredentialSource`); the legacy
-/// `LiteralValue` / `OpRefValue` states were removed in PR #242.
+/// The credential value is collected through
+/// `Modal::AuthSourcePicker` → `Modal::TextInput` (literal) or
+/// `Modal::OpPicker` (1Password), so the form carries only one
+/// credential-related focus (`CredentialSource`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthFormFocus {
     /// Mode picker line — Space cycles, Enter commits selection.

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -363,7 +363,7 @@ pub enum Modal<'a> {
 /// credential-related focus (`CredentialSource`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthFormFocus {
-    /// Mode picker line — Space cycles, Enter commits selection.
+    /// Mode picker line — Space cycles modes; Tab/Down advances focus.
     Mode,
     /// Required credential row — Enter opens the shared source picker.
     CredentialSource,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -133,8 +133,13 @@ pub struct EditorState<'a> {
     pub unmasked_rows: BTreeSet<(SecretsScopeTag, String)>,
     pub secrets_expanded: BTreeSet<String>,
     pub auth_expanded: BTreeSet<String>,
-    /// Auth tab: `None` renders the auth-kind picker; `Some(agent)`
-    /// renders the focused editor for that auth kind.
+    /// Auth tab two-screen state: `None` renders the auth-kind
+    /// picker; `Some(agent)` renders the focused editor for that
+    /// auth kind. Cleared by Esc on the focused screen (see the Auth
+    /// branch in `input::editor::handle_editor_key`'s `KeyCode::Esc`
+    /// arm) and by Tab/BackTab leaving the Auth tab. The Esc-pop
+    /// is in-tab navigation and intentionally bypasses the
+    /// dirty-modal flow — pending edits stay in `editor.pending`.
     pub auth_selected_agent: Option<crate::agent::Agent>,
     /// Scratch for the two-step add flow: set on `EnvKey` commit,
     /// cleared on `EnvValue` commit/cancel.
@@ -148,22 +153,32 @@ pub struct EditorState<'a> {
     /// (wrapped as `EnvValue::OpRef`) until the operator names the key
     /// and the `EnvKey` modal commits both fields at once.
     pub pending_picker_value: Option<crate::operator_env::EnvValue>,
-    /// Stash for the auth-form → source picker / `OpPicker` → auth-form
-    /// round trip. Set when the operator presses Enter on the credential
-    /// row, and consumed when the picker commits or cancels: on commit we
-    /// reconstruct the `Modal::AuthForm` with the picked `OpRef`
-    /// applied; on cancel we reconstruct it pristine. Threading the
-    /// auth-form context through this field (rather than via a
-    /// payload on `Modal::OpPicker`) keeps the picker variant
-    /// orthogonal to its caller.
+    /// Stash for the auth-form ↔ side-modal round trips. Set when the
+    /// operator presses Enter on the credential row, and consumed when
+    /// the side modal commits or cancels:
+    ///
+    ///   - `AuthSourcePicker` (literal) → `TextInput` → `AuthForm`
+    ///   - `AuthSourcePicker` (1Password) → `OpPicker` → `AuthForm`
+    ///
+    /// On commit the form is reconstructed with the new credential
+    /// applied (literal text via `set_literal`, `OpRef` via
+    /// `try_commit_op_ref`); on cancel it's reconstructed pristine.
+    /// Threading the auth-form context through this single field
+    /// (rather than via a payload on each side variant) keeps the
+    /// picker/text-input variants orthogonal to their caller, at the
+    /// cost of an invariant that only the side-modal handlers
+    /// touch this slot — see `AUTH00x` debug tags in
+    /// `input::auth` for the recovery path on stash desync.
     pub pending_auth_form_return: Option<AuthFormReturnPath>,
 }
 
-/// Captured auth-form context to re-mount the form after the
-/// `OpPicker` commits or cancels.
+/// Captured auth-form context to re-mount the form after a side
+/// modal (`AuthSourcePicker`, `TextInput`, or `OpPicker`) commits or
+/// cancels.
 ///
 /// `state` and `literal_buffer` are stashed so a half-typed literal
-/// isn't lost when the operator detours into the picker.
+/// isn't lost when the operator detours through the source picker
+/// → text-input round trip and cancels back.
 #[derive(Debug)]
 pub struct AuthFormReturnPath {
     pub target: AuthFormTarget,
@@ -237,9 +252,12 @@ pub enum EditorTab {
     Mounts,
     Roles,
     Secrets,
-    /// Auth panel: workspace-level + per-(workspace × role) auth-forward
-    /// modes and credentials, with a global-defaults preview at the top.
-    /// Mounts the `auth_panel` widget (Tasks 15-18) inside the editor.
+    /// Auth panel: opens on a kind-first picker (`Claude Code` /
+    /// `Codex`); selecting a kind drops into a focused view with the
+    /// workspace-level mode + optional credential source plus
+    /// per-role overrides for that kind only. The form modal lives in
+    /// `auth_panel`; the row enumeration is `auth_flat_rows` in
+    /// `render::editor`.
     Auth,
 }
 
@@ -303,18 +321,12 @@ pub enum Modal<'a> {
     RoleOverridePicker {
         state: RolePickerState,
     },
-    /// Auth-tab role picker — the first step in the 3-step add flow
-    /// (sentinel → role → agent → `AuthForm`). Reuses the existing
-    /// `RolePickerState` widget; commit hands off to `AuthAgentPicker`.
+    /// Auth-tab role picker — opened from the `+ Override for a role`
+    /// sentinel when an auth kind is already focused. Commit reads
+    /// `editor.auth_selected_agent` to build the `AuthFormTarget`
+    /// directly, then hands off to `Modal::AuthForm`.
     AuthRolePicker {
         state: RolePickerState,
-    },
-    /// Auth-tab agent picker — second step. Carries the role chosen in
-    /// `AuthRolePicker` so commit can build the `AuthFormTarget`
-    /// directly without another round-trip.
-    AuthAgentPicker {
-        role: String,
-        state: crate::console::widgets::agent_choice::AgentChoiceState,
     },
     SourcePicker {
         state: SourcePickerState,
@@ -332,31 +344,35 @@ pub enum Modal<'a> {
     AuthForm {
         target: AuthFormTarget,
         state: Box<AuthForm>,
-        /// Active focus inside the form (mode picker / cred radio / cred value / buttons).
+        /// Active focus inside the form: mode picker, credential
+        /// source row, or one of the Save/Cancel/Reset buttons.
         focus: AuthFormFocus,
-        /// Scratch text-input buffer when the credential value is being
-        /// typed inline in the form. Cleared on Esc; committed to
-        /// `state.set_literal` on Enter.
+        /// Buffer used to round-trip a previously-typed literal
+        /// credential through the source-picker → text-input detour
+        /// so the value isn't lost on cancel and the text-input
+        /// modal can re-open pre-populated.
         literal_buffer: String,
     },
 }
 
 /// Where in the auth-edit form the cursor currently sits.
+///
+/// The credential value is no longer typed inline in the form — it is
+/// always collected via `Modal::AuthSourcePicker` → `Modal::TextInput`
+/// (literal) or `Modal::OpPicker` (1Password). The form therefore has
+/// only one credential-related focus (`CredentialSource`); the legacy
+/// `LiteralValue` / `OpRefValue` states were removed in PR #242.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthFormFocus {
     /// Mode picker line — Space cycles, Enter commits selection.
     Mode,
     /// Required credential row — Enter opens the shared source picker.
     CredentialSource,
-    /// Literal value text input — operator types into `literal_buffer`.
-    LiteralValue,
-    /// 1Password value display — Enter opens the `OpPicker`.
-    OpRefValue,
     /// Save action button.
     Save,
-    /// `[ Cancel ]` action button.
+    /// Cancel action button.
     Cancel,
-    /// `[ Reset ]` action button — clears the layer's mode/credential.
+    /// Reset action button — clears the layer's mode/credential.
     Reset,
 }
 
@@ -414,11 +430,6 @@ pub enum ConfirmTarget {
         plan: PendingSaveCommit,
         exit_on_success: bool,
         affected_containers: Vec<String>,
-    },
-    /// `D` on a `RoleHeader` on the Auth tab — clears both agent overrides
-    /// for `role` after the operator confirms in the Confirm modal.
-    ClearAuthRoleOverride {
-        role: String,
     },
 }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -118,6 +118,9 @@ pub struct EditorState<'a> {
     pub unmasked_rows: BTreeSet<(SecretsScopeTag, String)>,
     pub secrets_expanded: BTreeSet<String>,
     pub auth_expanded: BTreeSet<String>,
+    /// Auth tab: `None` renders the auth-kind picker; `Some(agent)`
+    /// renders the focused editor for that auth kind.
+    pub auth_selected_agent: Option<crate::agent::Agent>,
     /// Scratch for the two-step add flow: set on `EnvKey` commit,
     /// cleared on `EnvValue` commit/cancel.
     pub pending_env_key: Option<(SecretsScopeTag, String)>,
@@ -611,6 +614,7 @@ impl EditorState<'_> {
             unmasked_rows: BTreeSet::default(),
             secrets_expanded: BTreeSet::default(),
             auth_expanded: BTreeSet::default(),
+            auth_selected_agent: None,
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,
@@ -633,6 +637,7 @@ impl EditorState<'_> {
             unmasked_rows: BTreeSet::default(),
             secrets_expanded: BTreeSet::default(),
             auth_expanded: BTreeSet::default(),
+            auth_selected_agent: None,
             pending_env_key: None,
             pending_picker_target: None,
             pending_picker_value: None,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -35,6 +35,21 @@ impl ManagerListRow {
             Self::NewWorkspace => saved_count + 1,
         }
     }
+
+    #[must_use]
+    pub const fn to_visual_index(self, saved_count: usize) -> usize {
+        match self {
+            Self::CurrentDirectory => 0,
+            Self::SavedWorkspace(i) => i + 1,
+            Self::NewWorkspace => {
+                if saved_count > 0 {
+                    saved_count + 2
+                } else {
+                    saved_count + 1
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -554,6 +569,34 @@ impl ManagerState<'_> {
         } else {
             None
         }
+    }
+
+    /// Decode a visual list row into a logical row. The rendered list keeps a
+    /// blank spacer before "+ New workspace" when saved workspaces exist; that
+    /// spacer is intentionally not selectable.
+    #[must_use]
+    pub const fn row_at_visual_index(&self, idx: usize) -> Option<ManagerListRow> {
+        let saved_count = self.workspaces.len();
+        if idx == 0 {
+            Some(ManagerListRow::CurrentDirectory)
+        } else if idx <= saved_count {
+            Some(ManagerListRow::SavedWorkspace(idx - 1))
+        } else if idx == saved_count + 1 && saved_count > 0 {
+            None
+        } else if (saved_count > 0 && idx == saved_count + 2)
+            || (saved_count == 0 && idx == saved_count + 1)
+        {
+            Some(ManagerListRow::NewWorkspace)
+        } else {
+            None
+        }
+    }
+
+    /// Selected index in rendered-list coordinates. Differs from `selected`
+    /// only when the blank spacer before "+ New workspace" is present.
+    #[must_use]
+    pub fn visual_selected(&self) -> usize {
+        self.selected_row().to_visual_index(self.workspaces.len())
     }
 
     /// What the operator currently has highlighted.
@@ -1224,6 +1267,16 @@ mod tests {
             state.selected = idx;
             assert_eq!(state.selected_row(), row, "selected_row for idx={idx}");
         }
+
+        assert_eq!(
+            ManagerListRow::NewWorkspace.to_visual_index(saved_count),
+            saved_count + 2
+        );
+        assert_eq!(state.row_at_visual_index(saved_count + 1), None);
+        assert_eq!(
+            state.row_at_visual_index(saved_count + 2),
+            Some(ManagerListRow::NewWorkspace)
+        );
 
         // Out-of-range index returns None.
         assert_eq!(state.row_at(saved_count + 2), None);

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -165,6 +165,7 @@ const fn modal_debug_name(modal: &crate::console::manager::state::Modal<'_>) -> 
         Modal::RolePicker { .. } => "RolePicker",
         Modal::RoleOverridePicker { .. } => "RoleOverridePicker",
         Modal::SourcePicker { .. } => "SourcePicker",
+        Modal::AuthSourcePicker { .. } => "AuthSourcePicker",
         Modal::ScopePicker { .. } => "ScopePicker",
         Modal::AuthForm { .. } => "AuthForm",
         Modal::AuthRolePicker { .. } => "AuthRolePicker",

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -169,7 +169,6 @@ const fn modal_debug_name(modal: &crate::console::manager::state::Modal<'_>) -> 
         Modal::ScopePicker { .. } => "ScopePicker",
         Modal::AuthForm { .. } => "AuthForm",
         Modal::AuthRolePicker { .. } => "AuthRolePicker",
-        Modal::AuthAgentPicker { .. } => "AuthAgentPicker",
     }
 }
 

--- a/src/console/widgets/auth_panel/form.rs
+++ b/src/console/widgets/auth_panel/form.rs
@@ -1,7 +1,8 @@
 //! Auth-form state and save invariants.
 //!
-//! State-only — rendering and op-picker integration land in Task 18.
-//! The form is mounted by the workspace-manager TUI in Task 19.
+//! State for the workspace Auth-tab edit modal. Rendered by
+//! `super::render::render_form`; mounted and driven by
+//! `crate::console::manager::input::auth::handle_auth_form_key`.
 
 use crate::agent::Agent;
 use crate::config::AuthForwardMode;
@@ -103,7 +104,8 @@ impl AuthForm {
         matches!(self.mode, Some(m) if mode_requires_credential(self.agent, m))
     }
 
-    /// Modes the user can pick. Codex omits `OAuthToken` (parser-rejected by Task 6).
+    /// Modes the user can pick. Codex omits `OAuthToken`
+    /// (parser-rejected for that agent).
     pub const fn available_modes(&self) -> &'static [AuthForwardMode] {
         self.agent.supported_modes()
     }
@@ -117,12 +119,13 @@ impl AuthForm {
         match &self.credential {
             CredentialInput::None => false,
             CredentialInput::Literal(s) => !s.is_empty(),
-            // Both fields must be non-empty: the empty `OpRef { op: "",
-            // path: "" }` seeded by the credential-source toggle would
-            // otherwise pass the save gate and write a broken reference
-            // into `[workspaces.X.roles.Y.env]`. The launcher would then
-            // fail with "credential is unset" only after the operator
-            // had already committed the corrupt config to disk.
+            // Both fields must be non-empty: an empty `OpRef { op: "",
+            // path: "" }` reachable via partial picker round-trips or
+            // programmatic state injection would otherwise pass the
+            // save gate and write a broken reference into
+            // `[workspaces.X.roles.Y.env]`. The launcher would only
+            // surface "credential is unset" after the corrupt config
+            // had already landed on disk.
             CredentialInput::OpRef(r) => !r.op.is_empty() && !r.path.is_empty(),
         }
     }
@@ -222,7 +225,7 @@ mod tests {
     fn save_disabled_for_api_key_with_empty_op_ref() {
         let mut f = AuthForm::new(Agent::Claude);
         f.set_mode(AuthForwardMode::ApiKey);
-        // Both fields empty (the toggle-radio seed): rejected.
+        // Both fields empty: rejected.
         f.set_op_ref(OpRef {
             op: String::new(),
             path: String::new(),

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -14,5 +14,5 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub use render::render_form;
 pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, WHITE, mode_str};
+pub use render::{render_form, required_height};

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,7 +1,10 @@
 //! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
-//!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `mode_str`
-//!   - `form.rs`    : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
+//!   - `render.rs` : `render_form`, `FormContext`, colour constants, `mode_str`
+//!   - `form.rs`   : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
+//!   - `state.rs`  : test-only fixtures (`CredentialBadge` etc.); the
+//!     runtime no longer renders inline credential badges — the Auth
+//!     tab uses explicit `WorkspaceSource`/`RoleSource` rows instead.
 //!
 //! Flat-row Auth tab rendering lives in `src/console/manager/render/editor.rs`.
 

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,7 +1,7 @@
 //! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
 //!   - `state.rs`   : `CredentialBadge`, `badge_for`, `classify_env_value`
-//!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `agent_display`, `mode_str`
+//!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `mode_str`
 //!   - `form.rs`    : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
 //!
 //! Flat-row Auth tab rendering lives in `src/console/manager/render/editor.rs`.
@@ -11,9 +11,7 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub(crate) use render::{
-    DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, agent_display, mode_str,
-};
+pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, mode_str};
 pub use render::{FormContext, render_form};
 pub use state::CredentialBadge;
 pub(crate) use state::badge_for;

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -2,9 +2,9 @@
 //!
 //!   - `render.rs` : `render_form`, `FormContext`, colour constants, `mode_str`
 //!   - `form.rs`   : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
-//!   - `state.rs`  : test-only fixtures (`CredentialBadge` etc.); the
-//!     runtime no longer renders inline credential badges — the Auth
-//!     tab uses explicit `WorkspaceSource`/`RoleSource` rows instead.
+//!   - `state.rs`  : test-only fixtures (`CredentialBadge` etc.);
+//!     production rendering uses explicit `WorkspaceSource` /
+//!     `RoleSource` rows on the Auth tab.
 //!
 //! Flat-row Auth tab rendering lives in `src/console/manager/render/editor.rs`.
 

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,6 +1,5 @@
 //! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
-//!   - `state.rs`   : `CredentialBadge`, `badge_for`, `classify_env_value`
 //!   - `render.rs`  : `render_form`, `FormContext`, colour constants, `mode_str`
 //!   - `form.rs`    : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
 //!
@@ -8,10 +7,9 @@
 
 pub mod form;
 pub mod render;
+#[cfg(test)]
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE, mode_str};
+pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, WHITE, mode_str};
 pub use render::{FormContext, render_form};
-pub use state::CredentialBadge;
-pub(crate) use state::badge_for;

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -1,6 +1,6 @@
 //! Auth panel: edit-form and supporting data types for the Auth tab.
 //!
-//!   - `render.rs` : `render_form`, `FormContext`, colour constants, `mode_str`
+//!   - `render.rs` : `render_form`, colour constants, `mode_str`
 //!   - `form.rs`   : `AuthForm`, `AuthFormOutcome`, `CredentialInput`
 //!   - `state.rs`  : test-only fixtures (`CredentialBadge` etc.);
 //!     production rendering uses explicit `WorkspaceSource` /
@@ -14,5 +14,5 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
+pub use render::render_form;
 pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, WHITE, mode_str};
-pub use render::{FormContext, render_form};

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -162,12 +162,8 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     match cred {
         CredentialInput::None => {
             spans.push(Span::styled(
-                format!("{:<value_width$}", "required"),
+                "required".to_string(),
                 Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
-            ));
-            spans.push(Span::styled(
-                "Enter set".to_string(),
-                Style::default().fg(PHOSPHOR_DIM),
             ));
         }
         CredentialInput::Literal(s) => {

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -129,14 +129,14 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
         Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
     ])));
 
-    if form.shows_credential_block() {
-        if let Some(env_var) = form.mode.and_then(|mode| form.agent.required_env_var(mode)) {
-            lines.push(FormLine::left(credential_env_line(
-                env_var,
-                &form.credential,
-                matches!(focus, AuthFormFocus::CredentialSource),
-            )));
-        }
+    if form.shows_credential_block()
+        && let Some(env_var) = form.mode.and_then(|mode| form.agent.required_env_var(mode))
+    {
+        lines.push(FormLine::left(credential_env_line(
+            env_var,
+            &form.credential,
+            matches!(focus, AuthFormFocus::CredentialSource),
+        )));
     }
 
     lines.push(FormLine::left(Line::from("")));

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -111,6 +111,8 @@ impl FormLine {
 fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     let mut lines: Vec<FormLine> = Vec::new();
 
+    lines.push(FormLine::left(Line::from("")));
+
     // Mode picker line.
     let mode_text = form.mode.map_or("(unset)", mode_str);
     lines.push(FormLine::left(Line::from(vec![

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -21,7 +21,8 @@ pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
-const AUTH_FORM_LABEL_WIDTH: usize = 18;
+const AUTH_FORM_MODE_LABEL_WIDTH: usize = 12;
+const AUTH_FORM_CREDENTIAL_LABEL_WIDTH: usize = 22;
 
 pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
@@ -120,7 +121,10 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     let mode_text = form.mode.map_or("(unset)", mode_str);
     lines.push(FormLine::left(Line::from(vec![
         cursor_span(focus == AuthFormFocus::Mode),
-        Span::styled(format!("{:<AUTH_FORM_LABEL_WIDTH$}", "Mode"), label_style()),
+        Span::styled(
+            format!("{:<AUTH_FORM_MODE_LABEL_WIDTH$}", "Mode"),
+            label_style(),
+        ),
         Span::raw("  "),
         Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
     ])));
@@ -153,7 +157,10 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     };
     let mut spans = vec![
         cursor_span(selected),
-        Span::styled(format!("{env_var:<AUTH_FORM_LABEL_WIDTH$}"), label_style),
+        Span::styled(
+            format!("{env_var:<AUTH_FORM_CREDENTIAL_LABEL_WIDTH$}"),
+            label_style,
+        ),
         Span::raw("  "),
     ];
     match cred {

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -117,10 +117,6 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
         cursor_span(focus == AuthFormFocus::Mode),
         Span::styled("Mode: ", label_style()),
         Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
-        Span::styled(
-            "  (Space to cycle)".to_string(),
-            Style::default().fg(PHOSPHOR_DIM),
-        ),
     ])));
 
     if form.shows_credential_block() {

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -96,6 +96,20 @@ impl FormLine {
     }
 }
 
+/// Total rendered rows the auth-edit modal needs.
+///
+/// Inner content + 2 borders. Used by `render::modal` to size the
+/// modal so its vertical layout hugs the content rather than leaving
+/// dead space below the hint line.
+#[must_use]
+pub const fn required_height(form: &AuthForm) -> u16 {
+    // Layout (without credential block):
+    //   blank, Mode, blank, buttons, blank, hint = 6 inner rows
+    // With credential block, +2 (blank + cred row) = 8 inner rows.
+    let inner: u16 = if form.shows_credential_block() { 8 } else { 6 };
+    inner + 2
+}
+
 fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     let mut lines: Vec<FormLine> = Vec::new();
 

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -21,7 +21,7 @@ pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
-const AUTH_FORM_LABEL_WIDTH: usize = 22;
+const AUTH_FORM_LABEL_WIDTH: usize = 18;
 
 pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
@@ -106,8 +106,8 @@ impl FormLine {
 pub const fn required_height(form: &AuthForm) -> u16 {
     // Layout (without credential block):
     //   blank, Mode, blank, buttons, blank, hint = 6 inner rows
-    // With credential block, +2 (blank + cred row) = 8 inner rows.
-    let inner: u16 = if form.shows_credential_block() { 8 } else { 6 };
+    // With credential block, +1 (cred row) = 7 inner rows.
+    let inner: u16 = if form.shows_credential_block() { 7 } else { 6 };
     inner + 2
 }
 
@@ -126,7 +126,6 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     ])));
 
     if form.shows_credential_block() {
-        lines.push(FormLine::left(Line::from("")));
         if let Some(env_var) = form.mode.and_then(|mode| form.agent.required_env_var(mode)) {
             lines.push(FormLine::left(credential_env_line(
                 env_var,

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -183,24 +183,42 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
             } else {
                 Style::default().fg(PHOSPHOR_GREEN)
             };
-            spans.push(Span::styled(format!("{masked:<value_width$}"), style));
-            spans.push(Span::styled(
-                "plain text".to_string(),
-                Style::default().fg(PHOSPHOR_DIM),
-            ));
+            spans.push(Span::styled(masked, style));
         }
         CredentialInput::OpRef(r) => {
-            spans.push(Span::styled(
-                format!("{:<value_width$}", "1Password"),
-                Style::default().fg(PHOSPHOR_GREEN),
-            ));
-            spans.push(Span::styled(
-                r.path.clone(),
-                Style::default().fg(PHOSPHOR_DIM),
-            ));
+            push_op_breadcrumb_spans(&mut spans, &r.path);
         }
     }
     Line::from(spans)
+}
+
+fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
+    let dim = Style::default().fg(PHOSPHOR_DIM);
+    let white = Style::default().fg(WHITE);
+    let green = Style::default().fg(PHOSPHOR_GREEN);
+    let green_bold = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
+
+    let parts: Vec<&str> = path.split('/').collect();
+    let (vault, item, section, field) = match parts.as_slice() {
+        [vault, item, field] => (*vault, *item, None, *field),
+        [vault, item, section, field] => (*vault, *item, Some(*section), *field),
+        _ => {
+            spans.push(Span::styled("<unparseable path - re-pick>", dim));
+            return;
+        }
+    };
+
+    spans.push(Span::styled(vault.to_string(), white));
+    spans.push(Span::styled(" / ".to_string(), dim));
+    spans.push(Span::styled(item.to_string(), green));
+    if let Some(section) = section {
+        spans.push(Span::styled(" / ".to_string(), dim));
+        spans.push(Span::styled(section.to_string(), green));
+    }
+    spans.push(Span::styled(" \u{2192} ".to_string(), dim));
+    spans.push(Span::styled(field.to_string(), green_bold));
 }
 
 fn action_buttons_line(can_save: bool, focus: AuthFormFocus) -> Line<'static> {
@@ -385,8 +403,8 @@ mod form_render_tests {
             "literal credential should be masked; dump:\n{s}"
         );
         assert!(
-            s.contains("plain text"),
-            "missing plain text source label; dump:\n{s}"
+            !s.contains("plain text"),
+            "plain text source label should be omitted; dump:\n{s}"
         );
     }
 
@@ -400,12 +418,12 @@ mod form_render_tests {
         });
         let s = dump_form(&form, &ctx());
         assert!(
-            s.contains("1Password"),
-            "missing 1Password source label; dump:\n{s}"
+            !s.contains("1Password"),
+            "1Password source label should be omitted; dump:\n{s}"
         );
         assert!(
-            s.contains("Work/Anthropic/api-key"),
-            "missing op-ref path display; dump:\n{s}"
+            s.contains("Work / Anthropic → api-key"),
+            "missing op-ref breadcrumb display; dump:\n{s}"
         );
     }
 
@@ -419,8 +437,8 @@ mod form_render_tests {
         });
         let s = dump_form(&form, &ctx());
         assert!(
-            s.contains("CLAUDE_CODE_OAUTH_TOKEN  1Password"),
-            "env var and source label should not run together; dump:\n{s}"
+            s.contains("CLAUDE_CODE_OAUTH_TOKEN  Boris / Roblox → token"),
+            "env var and breadcrumb should have a visible gap; dump:\n{s}"
         );
     }
 }

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -159,6 +159,7 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     let mut spans = vec![
         cursor_span(selected),
         Span::styled(format!("{env_var:<22}"), label_style),
+        Span::raw("  "),
     ];
     match cred {
         CredentialInput::None => {
@@ -405,6 +406,21 @@ mod form_render_tests {
         assert!(
             s.contains("Work/Anthropic/api-key"),
             "missing op-ref path display; dump:\n{s}"
+        );
+    }
+
+    #[test]
+    fn long_credential_env_name_has_gap_before_source_label() {
+        let mut form = AuthForm::new(Agent::Claude);
+        form.set_mode(AuthForwardMode::OAuthToken);
+        form.set_op_ref(OpRef {
+            op: "op://uuid/oauth".into(),
+            path: "Boris/Roblox/token".into(),
+        });
+        let s = dump_form(&form, &ctx());
+        assert!(
+            s.contains("CLAUDE_CODE_OAUTH_TOKEN  1Password"),
+            "env var and source label should not run together; dump:\n{s}"
         );
     }
 }

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -153,7 +153,6 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     } else {
         Style::default().fg(WHITE)
     };
-    let value_width = 18;
     let mut spans = vec![
         cursor_span(selected),
         Span::styled(format!("{env_var:<22}"), label_style),

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -1,8 +1,7 @@
 //! Render helpers for the auth edit form.
 //!
-//! `render_form` renders the auth-edit modal for a single (workspace, role,
-//! agent) combination. The flat-row Auth tab rendering lives in
-//! `src/console/manager/render/editor.rs`.
+//! `render_form` renders the auth-edit modal. The flat-row Auth tab
+//! rendering lives in `src/console/manager/render/editor.rs`.
 
 use ratatui::{
     Frame,
@@ -32,13 +31,6 @@ pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     }
 }
 
-/// Identification context passed alongside the form's mutable state so the
-/// render can title the modal with the workspace and role being edited.
-pub struct FormContext<'a> {
-    pub workspace: &'a str,
-    pub role: &'a str,
-}
-
 /// Render the auth-edit modal for `form` into `area`.
 ///
 /// Lays out, top-to-bottom:
@@ -50,15 +42,7 @@ pub struct FormContext<'a> {
 ///
 /// Pure render — no input handling. Keystrokes are routed by
 /// `super::super::manager::input::auth::handle_auth_form_key`.
-///
-/// `_ctx` is currently unused.
-pub fn render_form(
-    frame: &mut Frame,
-    area: Rect,
-    form: &AuthForm,
-    _ctx: &FormContext,
-    focus: AuthFormFocus,
-) {
+pub fn render_form(frame: &mut Frame, area: Rect, form: &AuthForm, focus: AuthFormFocus) {
     frame.render_widget(ratatui::widgets::Clear, area);
     let title_span = Span::styled(
         " Edit auth ",
@@ -277,12 +261,12 @@ mod form_render_tests {
     use crate::operator_env::OpRef;
     use ratatui::{Terminal, backend::TestBackend};
 
-    fn dump_form(form: &AuthForm, ctx: &FormContext) -> String {
+    fn dump_form(form: &AuthForm) -> String {
         let backend = TestBackend::new(100, 20);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
             let area = f.area();
-            render_form(f, area, form, ctx, AuthFormFocus::Mode);
+            render_form(f, area, form, AuthFormFocus::Mode);
         })
         .unwrap();
         let buf = term.backend().buffer();
@@ -296,17 +280,10 @@ mod form_render_tests {
         s
     }
 
-    fn ctx() -> FormContext<'static> {
-        FormContext {
-            workspace: "proj",
-            role: "smith",
-        }
-    }
-
     #[test]
     fn form_header_is_short() {
         let form = AuthForm::new(Agent::Claude);
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(s.contains("Edit auth"), "missing header; dump:\n{s}");
         assert!(
             !s.contains("workspace"),
@@ -317,7 +294,7 @@ mod form_render_tests {
     #[test]
     fn form_with_unset_mode_hides_credential_block_and_dims_save() {
         let form = AuthForm::new(Agent::Claude);
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(s.contains("Mode:"), "missing mode line; dump:\n{s}");
         assert!(
             s.contains("(unset)"),
@@ -338,7 +315,7 @@ mod form_render_tests {
     fn form_with_sync_mode_hides_credential_block_and_enables_save() {
         let mut form = AuthForm::new(Agent::Claude);
         form.set_mode(AuthForwardMode::Sync);
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(s.contains("sync"), "missing sync mode label; dump:\n{s}");
         // Sync requires no credential.
         assert!(
@@ -353,7 +330,7 @@ mod form_render_tests {
         let mut form = AuthForm::new(Agent::Claude);
         form.set_mode(AuthForwardMode::ApiKey);
         form.set_literal("sk-ant-test".into());
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(s.contains("api_key"), "missing api_key mode; dump:\n{s}");
         assert!(
             s.contains("ANTHROPIC_API_KEY"),
@@ -377,7 +354,7 @@ mod form_render_tests {
             op: "op://uuid/anthropic".into(),
             path: "Work/Anthropic/api-key".into(),
         });
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(
             !s.contains("1Password"),
             "1Password source label should be omitted; dump:\n{s}"
@@ -396,7 +373,7 @@ mod form_render_tests {
             op: "op://uuid/oauth".into(),
             path: "Boris/Roblox/token".into(),
         });
-        let s = dump_form(&form, &ctx());
+        let s = dump_form(&form);
         assert!(
             s.contains("CLAUDE_CODE_OAUTH_TOKEN  Boris / Roblox → token"),
             "env var and breadcrumb should have a visible gap; dump:\n{s}"

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -21,6 +21,7 @@ pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
+const AUTH_FORM_LABEL_WIDTH: usize = 22;
 
 pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
@@ -119,7 +120,8 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     let mode_text = form.mode.map_or("(unset)", mode_str);
     lines.push(FormLine::left(Line::from(vec![
         cursor_span(focus == AuthFormFocus::Mode),
-        Span::styled("Mode: ", label_style()),
+        Span::styled(format!("{:<AUTH_FORM_LABEL_WIDTH$}", "Mode"), label_style()),
+        Span::raw("  "),
         Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
     ])));
 
@@ -152,7 +154,7 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     };
     let mut spans = vec![
         cursor_span(selected),
-        Span::styled(format!("{env_var:<22}"), label_style),
+        Span::styled(format!("{env_var:<AUTH_FORM_LABEL_WIDTH$}"), label_style),
         Span::raw("  "),
     ];
     match cred {
@@ -309,7 +311,11 @@ mod form_render_tests {
     fn form_with_unset_mode_hides_credential_block_and_dims_save() {
         let form = AuthForm::new(Agent::Claude);
         let s = dump_form(&form);
-        assert!(s.contains("Mode:"), "missing mode line; dump:\n{s}");
+        assert!(s.contains("Mode"), "missing mode line; dump:\n{s}");
+        assert!(
+            !s.contains("Mode:"),
+            "mode label should not use punctuation; dump:\n{s}"
+        );
         assert!(
             s.contains("(unset)"),
             "expected (unset) mode label; dump:\n{s}"

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -14,6 +14,7 @@ use ratatui::{
 
 use super::form::{AuthForm, CredentialInput};
 use crate::config::AuthForwardMode;
+use crate::console::manager::render::editor::push_op_breadcrumb_spans;
 use crate::console::manager::state::AuthFormFocus;
 
 pub(crate) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
@@ -50,9 +51,7 @@ pub struct FormContext<'a> {
 /// Pure render — no input handling. Keystrokes are routed by
 /// `super::super::manager::input::auth::handle_auth_form_key`.
 ///
-/// `_ctx` is currently unused; retained in the signature so a future
-/// header rev can re-introduce the workspace/role breadcrumb without
-/// a public-API change at every call site.
+/// `_ctx` is currently unused.
 pub fn render_form(
     frame: &mut Frame,
     area: Rect,
@@ -183,44 +182,6 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
         }
     }
     Line::from(spans)
-}
-
-/// Render an `OpRef.path` as a `vault / item [subtitle] / section → field ?query`
-/// breadcrumb. Delegates parsing to the shared
-/// [`parse_path_breadcrumb`](crate::console::manager::render::editor::parse_path_breadcrumb)
-/// so the auth form, the Auth tab, and the Secrets tab agree on what
-/// counts as a valid path — including optional `[subtitle]` annotations
-/// and `?attribute=...` queries.
-fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
-    let dim = Style::default().fg(PHOSPHOR_DIM);
-    let white = Style::default().fg(WHITE);
-    let green = Style::default().fg(PHOSPHOR_GREEN);
-    let green_bold = Style::default()
-        .fg(PHOSPHOR_GREEN)
-        .add_modifier(Modifier::BOLD);
-
-    let Some(parts) = crate::console::manager::render::editor::parse_path_breadcrumb(path) else {
-        spans.push(Span::styled("<unparseable path - re-pick>", dim));
-        return;
-    };
-
-    spans.push(Span::styled(parts.vault, white));
-    spans.push(Span::styled(" / ".to_string(), dim));
-    spans.push(Span::styled(parts.item, green));
-    if let Some(subtitle) = parts.item_subtitle {
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled(subtitle, dim));
-    }
-    if let Some(section) = parts.section {
-        spans.push(Span::styled(" / ".to_string(), dim));
-        spans.push(Span::styled(section, green));
-    }
-    spans.push(Span::styled(" \u{2192} ".to_string(), dim));
-    spans.push(Span::styled(parts.field, green_bold));
-    if let Some(query) = parts.attribute_query {
-        spans.push(Span::raw(" "));
-        spans.push(Span::styled(query, dim));
-    }
 }
 
 fn action_buttons_line(can_save: bool, focus: AuthFormFocus) -> Line<'static> {

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -47,7 +47,12 @@ pub struct FormContext<'a> {
 ///     - one required env-var row that opens the shared source picker
 ///   - action buttons and a compact key hint row
 ///
-/// Pure render — no input handling. Task 19 wires the keystroke router.
+/// Pure render — no input handling. Keystrokes are routed by
+/// `super::super::manager::input::auth::handle_auth_form_key`.
+///
+/// `_ctx` is currently unused; retained in the signature so a future
+/// header rev can re-introduce the workspace/role breadcrumb without
+/// a public-API change at every call site.
 pub fn render_form(
     frame: &mut Frame,
     area: Rect,
@@ -127,12 +132,7 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
             lines.push(FormLine::left(credential_env_line(
                 env_var,
                 &form.credential,
-                matches!(
-                    focus,
-                    AuthFormFocus::CredentialSource
-                        | AuthFormFocus::LiteralValue
-                        | AuthFormFocus::OpRefValue
-                ),
+                matches!(focus, AuthFormFocus::CredentialSource),
             )));
         }
     }
@@ -185,6 +185,12 @@ fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) ->
     Line::from(spans)
 }
 
+/// Render an `OpRef.path` as a `vault / item [subtitle] / section → field ?query`
+/// breadcrumb. Delegates parsing to the shared
+/// [`parse_path_breadcrumb`](crate::console::manager::render::editor::parse_path_breadcrumb)
+/// so the auth form, the Auth tab, and the Secrets tab agree on what
+/// counts as a valid path — including optional `[subtitle]` annotations
+/// and `?attribute=...` queries.
 fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
     let dim = Style::default().fg(PHOSPHOR_DIM);
     let white = Style::default().fg(WHITE);
@@ -193,25 +199,28 @@ fn push_op_breadcrumb_spans(spans: &mut Vec<Span<'static>>, path: &str) {
         .fg(PHOSPHOR_GREEN)
         .add_modifier(Modifier::BOLD);
 
-    let parts: Vec<&str> = path.split('/').collect();
-    let (vault, item, section, field) = match parts.as_slice() {
-        [vault, item, field] => (*vault, *item, None, *field),
-        [vault, item, section, field] => (*vault, *item, Some(*section), *field),
-        _ => {
-            spans.push(Span::styled("<unparseable path - re-pick>", dim));
-            return;
-        }
+    let Some(parts) = crate::console::manager::render::editor::parse_path_breadcrumb(path) else {
+        spans.push(Span::styled("<unparseable path - re-pick>", dim));
+        return;
     };
 
-    spans.push(Span::styled(vault.to_string(), white));
+    spans.push(Span::styled(parts.vault, white));
     spans.push(Span::styled(" / ".to_string(), dim));
-    spans.push(Span::styled(item.to_string(), green));
-    if let Some(section) = section {
+    spans.push(Span::styled(parts.item, green));
+    if let Some(subtitle) = parts.item_subtitle {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(subtitle, dim));
+    }
+    if let Some(section) = parts.section {
         spans.push(Span::styled(" / ".to_string(), dim));
-        spans.push(Span::styled(section.to_string(), green));
+        spans.push(Span::styled(section, green));
     }
     spans.push(Span::styled(" \u{2192} ".to_string(), dim));
-    spans.push(Span::styled(field.to_string(), green_bold));
+    spans.push(Span::styled(parts.field, green_bold));
+    if let Some(query) = parts.attribute_query {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(query, dim));
+    }
 }
 
 fn action_buttons_line(can_save: bool, focus: AuthFormFocus) -> Line<'static> {
@@ -257,9 +266,7 @@ fn form_hint_line(form: &AuthForm, focus: AuthFormFocus) -> Line<'static> {
             Span::styled("Space", key_style),
             Span::styled(" cycle mode", text_style),
         ],
-        AuthFormFocus::CredentialSource
-        | AuthFormFocus::LiteralValue
-        | AuthFormFocus::OpRefValue => vec![
+        AuthFormFocus::CredentialSource => vec![
             Span::styled("Enter", key_style),
             Span::styled(" set credential", text_style),
         ],

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -6,28 +6,21 @@
 
 use ratatui::{
     Frame,
-    layout::Rect,
+    layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
 
 use super::form::{AuthForm, CredentialInput};
-use crate::agent::Agent;
 use crate::config::AuthForwardMode;
+use crate::console::manager::state::AuthFormFocus;
 
 pub(crate) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
 pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
 pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
-
-pub(crate) const fn agent_display(agent: Agent) -> &'static str {
-    match agent {
-        Agent::Claude => "Claude",
-        Agent::Codex => "Codex",
-    }
-}
 
 pub(crate) const fn mode_str(m: AuthForwardMode) -> &'static str {
     match m {
@@ -48,25 +41,23 @@ pub struct FormContext<'a> {
 /// Render the auth-edit modal for `form` into `area`.
 ///
 /// Lays out, top-to-bottom:
-///   - title block: `Edit auth: workspace 'X' / role 'Y' / Agent`
-///   - mode picker line (current mode + cycle hint)
+///   - title block: `Edit auth`
+///   - mode picker row
 ///   - credential block (only when [`AuthForm::shows_credential_block`])
-///     - `Literal | 1Password` radio
-///     - text input or op-ref path display
-///     - resolves badge if a literal/op-ref is committed
-///   - action buttons: `Save` (DIM if `!form.can_save`) / `Cancel` / `Reset`
+///     - one required env-var row that opens the shared source picker
+///   - action buttons and a compact key hint row
 ///
 /// Pure render — no input handling. Task 19 wires the keystroke router.
-pub fn render_form(frame: &mut Frame, area: Rect, form: &AuthForm, ctx: &FormContext) {
+pub fn render_form(
+    frame: &mut Frame,
+    area: Rect,
+    form: &AuthForm,
+    _ctx: &FormContext,
+    focus: AuthFormFocus,
+) {
     frame.render_widget(ratatui::widgets::Clear, area);
-    let title = format!(
-        " Edit auth: workspace '{ws}' / role '{role}' / {agent} ",
-        ws = ctx.workspace,
-        role = ctx.role,
-        agent = agent_display(form.agent),
-    );
     let title_span = Span::styled(
-        title,
+        " Edit auth ",
         Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
     );
     let block = Block::default()
@@ -76,132 +67,142 @@ pub fn render_form(frame: &mut Frame, area: Rect, form: &AuthForm, ctx: &FormCon
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let lines = build_form_lines(form);
-    frame.render_widget(Paragraph::new(lines), inner);
+    for (idx, row) in build_form_lines(form, focus).into_iter().enumerate() {
+        let y = inner.y.saturating_add(idx as u16);
+        if y >= inner.y.saturating_add(inner.height) {
+            break;
+        }
+        let row_area = Rect {
+            x: inner.x,
+            y,
+            width: inner.width,
+            height: 1,
+        };
+        let alignment = if row.centered {
+            Alignment::Center
+        } else {
+            Alignment::Left
+        };
+        frame.render_widget(Paragraph::new(row.line).alignment(alignment), row_area);
+    }
 }
 
-fn build_form_lines(form: &AuthForm) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line<'static>> = Vec::new();
+struct FormLine {
+    line: Line<'static>,
+    centered: bool,
+}
+
+impl FormLine {
+    const fn left(line: Line<'static>) -> Self {
+        Self {
+            line,
+            centered: false,
+        }
+    }
+
+    const fn centered(line: Line<'static>) -> Self {
+        Self {
+            line,
+            centered: true,
+        }
+    }
+}
+
+fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
+    let mut lines: Vec<FormLine> = Vec::new();
 
     // Mode picker line.
     let mode_text = form.mode.map_or("(unset)", mode_str);
-    lines.push(Line::from(vec![
-        Span::styled(
-            "Mode: ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ),
+    lines.push(FormLine::left(Line::from(vec![
+        cursor_span(focus == AuthFormFocus::Mode),
+        Span::styled("Mode: ", label_style()),
         Span::styled(mode_text.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
         Span::styled(
-            "  (Tab/Space to cycle)".to_string(),
+            "  (Space to cycle)".to_string(),
             Style::default().fg(PHOSPHOR_DIM),
         ),
-    ]));
+    ])));
 
     if form.shows_credential_block() {
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "Credential",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        )));
-        lines.push(credential_radio_line(&form.credential));
-        lines.push(credential_value_line(&form.credential));
-        lines.push(credential_status_line(&form.credential));
+        lines.push(FormLine::left(Line::from("")));
+        if let Some(env_var) = form.mode.and_then(|mode| form.agent.required_env_var(mode)) {
+            lines.push(FormLine::left(credential_env_line(
+                env_var,
+                &form.credential,
+                matches!(
+                    focus,
+                    AuthFormFocus::CredentialSource
+                        | AuthFormFocus::LiteralValue
+                        | AuthFormFocus::OpRefValue
+                ),
+            )));
+        }
     }
 
-    lines.push(Line::from(""));
-    lines.push(action_buttons_line(form.can_save()));
+    lines.push(FormLine::left(Line::from("")));
+    lines.push(FormLine::centered(action_buttons_line(
+        form.can_save(),
+        focus,
+    )));
+    lines.push(FormLine::left(Line::from("")));
+    lines.push(FormLine::centered(form_hint_line(form, focus)));
     lines
 }
 
-fn credential_radio_line(cred: &CredentialInput) -> Line<'static> {
-    // Default selection when no credential committed yet is `Literal`.
-    let is_op_ref = matches!(cred, CredentialInput::OpRef(_));
-    let is_literal = !is_op_ref;
-
-    let literal_label = if is_literal {
-        "(*) Literal"
+fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) -> Line<'static> {
+    let label_style = if selected {
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
     } else {
-        "( ) Literal"
+        Style::default().fg(WHITE)
     };
-    let op_label = if is_op_ref {
-        "(*) 1Password"
-    } else {
-        "( ) 1Password"
-    };
-
-    let lit_style = if is_literal {
-        Style::default().fg(PHOSPHOR_GREEN)
-    } else {
-        Style::default().fg(PHOSPHOR_DIM)
-    };
-    let op_style = if is_op_ref {
-        Style::default().fg(PHOSPHOR_GREEN)
-    } else {
-        Style::default().fg(PHOSPHOR_DIM)
-    };
-
-    Line::from(vec![
-        Span::styled(literal_label.to_string(), lit_style),
-        Span::raw("    "),
-        Span::styled(op_label.to_string(), op_style),
-    ])
-}
-
-fn credential_value_line(cred: &CredentialInput) -> Line<'static> {
+    let value_width = 18;
+    let mut spans = vec![
+        cursor_span(selected),
+        Span::styled(format!("{env_var:<22}"), label_style),
+    ];
     match cred {
-        CredentialInput::None => Line::from(Span::styled(
-            "  (enter a literal value or pick from 1Password)".to_string(),
-            Style::default().fg(PHOSPHOR_DIM),
-        )),
-        CredentialInput::Literal(s) => {
-            // Mask the value for display — still need to show *something*
-            // so the operator knows there is content.
-            let masked = if s.is_empty() {
-                String::from("(empty)")
-            } else {
-                "*".repeat(s.chars().count().min(20))
-            };
-            Line::from(vec![
-                Span::styled(
-                    "  Value: ",
-                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(masked, Style::default().fg(WHITE)),
-            ])
+        CredentialInput::None => {
+            spans.push(Span::styled(
+                format!("{:<value_width$}", "required"),
+                Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::styled(
+                "Enter set".to_string(),
+                Style::default().fg(PHOSPHOR_DIM),
+            ));
         }
-        CredentialInput::OpRef(r) => Line::from(vec![
-            Span::styled(
-                "  Path:  ",
-                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(r.path.clone(), Style::default().fg(WHITE)),
-            Span::raw("  "),
-            Span::styled(
-                "[Pick from 1Password]".to_string(),
+        CredentialInput::Literal(s) => {
+            let masked = if s.is_empty() {
+                "required".to_string()
+            } else {
+                "●".repeat(s.chars().count().clamp(1, 12))
+            };
+            let style = if s.is_empty() {
+                Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(PHOSPHOR_GREEN)
+            };
+            spans.push(Span::styled(format!("{masked:<value_width$}"), style));
+            spans.push(Span::styled(
+                "plain text".to_string(),
+                Style::default().fg(PHOSPHOR_DIM),
+            ));
+        }
+        CredentialInput::OpRef(r) => {
+            spans.push(Span::styled(
+                format!("{:<value_width$}", "1Password"),
                 Style::default().fg(PHOSPHOR_GREEN),
-            ),
-        ]),
+            ));
+            spans.push(Span::styled(
+                r.path.clone(),
+                Style::default().fg(PHOSPHOR_DIM),
+            ));
+        }
     }
+    Line::from(spans)
 }
 
-fn credential_status_line(cred: &CredentialInput) -> Line<'static> {
-    match cred {
-        CredentialInput::None => Line::from(Span::styled(
-            "  Status: ! unset".to_string(),
-            Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
-        )),
-        CredentialInput::Literal(s) if s.is_empty() => Line::from(Span::styled(
-            "  Status: ! empty".to_string(),
-            Style::default().fg(DANGER_RED).add_modifier(Modifier::BOLD),
-        )),
-        CredentialInput::Literal(_) | CredentialInput::OpRef(_) => Line::from(Span::styled(
-            "  Status: OK resolves".to_string(),
-            Style::default().fg(PHOSPHOR_GREEN),
-        )),
-    }
-}
-
-fn action_buttons_line(can_save: bool) -> Line<'static> {
+fn action_buttons_line(can_save: bool, focus: AuthFormFocus) -> Line<'static> {
     let save_style = if can_save {
         Style::default()
             .fg(PHOSPHOR_GREEN)
@@ -212,23 +213,87 @@ fn action_buttons_line(can_save: bool) -> Line<'static> {
             .add_modifier(Modifier::DIM)
     };
     Line::from(vec![
-        Span::styled("[ Save ]".to_string(), save_style),
-        Span::raw("  "),
         Span::styled(
-            "[ Cancel ]".to_string(),
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+            "  Save  ".to_string(),
+            selected_button_style(focus == AuthFormFocus::Save, save_style),
         ),
-        Span::raw("  "),
+        Span::raw("    "),
         Span::styled(
-            "[ Reset ]".to_string(),
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+            "  Cancel  ".to_string(),
+            selected_button_style(
+                focus == AuthFormFocus::Cancel,
+                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ),
+        Span::raw("    "),
+        Span::styled(
+            "  Reset  ".to_string(),
+            selected_button_style(
+                focus == AuthFormFocus::Reset,
+                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+            ),
         ),
     ])
+}
+
+fn form_hint_line(form: &AuthForm, focus: AuthFormFocus) -> Line<'static> {
+    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let text_style = Style::default().fg(PHOSPHOR_GREEN);
+    let sep_style = Style::default().fg(PHOSPHOR_DARK);
+    let mut spans = match focus {
+        AuthFormFocus::Mode => vec![
+            Span::styled("Space", key_style),
+            Span::styled(" cycle mode", text_style),
+        ],
+        AuthFormFocus::CredentialSource
+        | AuthFormFocus::LiteralValue
+        | AuthFormFocus::OpRefValue => vec![
+            Span::styled("Enter", key_style),
+            Span::styled(" set credential", text_style),
+        ],
+        AuthFormFocus::Save | AuthFormFocus::Cancel | AuthFormFocus::Reset => vec![
+            Span::styled("Enter", key_style),
+            Span::styled(" select", text_style),
+        ],
+    };
+    if form.shows_credential_block() {
+        spans.push(Span::styled(" · ", sep_style));
+        spans.push(Span::styled("↑/↓", key_style));
+        spans.push(Span::styled(" navigate", text_style));
+    }
+    spans.push(Span::styled(" · ", sep_style));
+    spans.push(Span::styled("Esc", key_style));
+    spans.push(Span::styled(" cancel", text_style));
+    Line::from(spans)
+}
+
+fn cursor_span(selected: bool) -> Span<'static> {
+    if selected {
+        Span::styled(
+            "▸ ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        )
+    } else {
+        Span::raw("  ")
+    }
+}
+
+fn label_style() -> Style {
+    Style::default().fg(WHITE).add_modifier(Modifier::BOLD)
+}
+
+const fn selected_button_style(selected: bool, style: Style) -> Style {
+    if selected {
+        style.bg(WHITE).fg(Color::Black)
+    } else {
+        style
+    }
 }
 
 #[cfg(test)]
 mod form_render_tests {
     use super::*;
+    use crate::agent::Agent;
     use crate::operator_env::OpRef;
     use ratatui::{Terminal, backend::TestBackend};
 
@@ -237,7 +302,7 @@ mod form_render_tests {
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
             let area = f.area();
-            render_form(f, area, form, ctx);
+            render_form(f, area, form, ctx, AuthFormFocus::Mode);
         })
         .unwrap();
         let buf = term.backend().buffer();
@@ -259,13 +324,14 @@ mod form_render_tests {
     }
 
     #[test]
-    fn form_header_includes_workspace_role_and_agent() {
+    fn form_header_is_short() {
         let form = AuthForm::new(Agent::Claude);
         let s = dump_form(&form, &ctx());
-        assert!(s.contains("Edit auth:"), "missing header; dump:\n{s}");
-        assert!(s.contains("proj"), "missing workspace name; dump:\n{s}");
-        assert!(s.contains("smith"), "missing role name; dump:\n{s}");
-        assert!(s.contains("Claude"), "missing agent name; dump:\n{s}");
+        assert!(s.contains("Edit auth"), "missing header; dump:\n{s}");
+        assert!(
+            !s.contains("workspace"),
+            "header should not include verbose scope text; dump:\n{s}"
+        );
     }
 
     #[test]
@@ -277,10 +343,10 @@ mod form_render_tests {
             s.contains("(unset)"),
             "expected (unset) mode label; dump:\n{s}"
         );
-        // No credential block when mode is unset.
+        // No credential row when mode is unset.
         assert!(
-            !s.contains("Credential"),
-            "credential block must be hidden when mode unset; dump:\n{s}"
+            !s.contains("ANTHROPIC_API_KEY"),
+            "credential row must be hidden when mode unset; dump:\n{s}"
         );
         // Save still appears as a button label even when disabled.
         assert!(s.contains("Save"), "missing Save button; dump:\n{s}");
@@ -296,8 +362,8 @@ mod form_render_tests {
         assert!(s.contains("sync"), "missing sync mode label; dump:\n{s}");
         // Sync requires no credential.
         assert!(
-            !s.contains("Credential"),
-            "sync should hide credential block; dump:\n{s}"
+            !s.contains("ANTHROPIC_API_KEY"),
+            "sync should hide credential row; dump:\n{s}"
         );
         assert!(form.can_save());
     }
@@ -310,22 +376,16 @@ mod form_render_tests {
         let s = dump_form(&form, &ctx());
         assert!(s.contains("api_key"), "missing api_key mode; dump:\n{s}");
         assert!(
-            s.contains("Credential"),
-            "credential block must show for api_key; dump:\n{s}"
-        );
-        assert!(s.contains("Literal"), "missing Literal radio; dump:\n{s}");
-        assert!(
-            s.contains("1Password"),
-            "missing 1Password radio; dump:\n{s}"
-        );
-        // Active radio marker on the Literal side.
-        assert!(
-            s.contains("(*) Literal"),
-            "Literal radio not selected; dump:\n{s}"
+            s.contains("ANTHROPIC_API_KEY"),
+            "missing env var row; dump:\n{s}"
         );
         assert!(
-            s.contains("resolves"),
-            "missing resolves status badge; dump:\n{s}"
+            s.contains("●●●●●●●●●●●"),
+            "literal credential should be masked; dump:\n{s}"
+        );
+        assert!(
+            s.contains("plain text"),
+            "missing plain text source label; dump:\n{s}"
         );
     }
 
@@ -339,20 +399,12 @@ mod form_render_tests {
         });
         let s = dump_form(&form, &ctx());
         assert!(
-            s.contains("(*) 1Password"),
-            "1Password radio not selected; dump:\n{s}"
+            s.contains("1Password"),
+            "missing 1Password source label; dump:\n{s}"
         );
         assert!(
             s.contains("Work/Anthropic/api-key"),
             "missing op-ref path display; dump:\n{s}"
-        );
-        assert!(
-            s.contains("Pick from 1Password"),
-            "missing op-picker button; dump:\n{s}"
-        );
-        assert!(
-            s.contains("resolves"),
-            "missing resolves status badge for op-ref; dump:\n{s}"
         );
     }
 }

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -1,8 +1,12 @@
-//! Pure data types for the Auth panel.
+//! Pure data types for the Auth panel — test-only since PR #242.
 //!
 //! Provides [`CredentialBadge`], [`badge_for`], and
-//! [`classify_env_value`]. These are consumed by the flat-row renderer in
-//! `src/console/manager/render/editor.rs`.
+//! [`classify_env_value`]. The flat-row renderer no longer renders
+//! inline credential badges (the Auth tab moved to a kind-first
+//! picker with explicit `WorkspaceSource`/`RoleSource` rows), so the
+//! whole module is `#[cfg(test)]` and exists only to keep the
+//! parity-style unit tests around in case the badge model is
+//! revisited.
 
 use crate::agent::Agent;
 use crate::config::{AppConfig, AuthForwardMode};

--- a/src/console/widgets/auth_panel/state.rs
+++ b/src/console/widgets/auth_panel/state.rs
@@ -1,12 +1,10 @@
-//! Pure data types for the Auth panel — test-only since PR #242.
+//! Pure data types for the Auth panel; test-only fixtures.
 //!
 //! Provides [`CredentialBadge`], [`badge_for`], and
-//! [`classify_env_value`]. The flat-row renderer no longer renders
-//! inline credential badges (the Auth tab moved to a kind-first
-//! picker with explicit `WorkspaceSource`/`RoleSource` rows), so the
-//! whole module is `#[cfg(test)]` and exists only to keep the
-//! parity-style unit tests around in case the badge model is
-//! revisited.
+//! [`classify_env_value`]. The flat-row renderer uses explicit
+//! `WorkspaceSource`/`RoleSource` rows instead of inline credential
+//! badges, so this module is `#[cfg(test)]` and currently exists
+//! only to back the badge parity tests.
 
 use crate::agent::Agent;
 use crate::config::{AppConfig, AuthForwardMode};

--- a/src/console/widgets/confirm.rs
+++ b/src/console/widgets/confirm.rs
@@ -61,8 +61,12 @@ impl ConfirmState {
             // Direct shortcuts (case-insensitive).
             KeyCode::Char('y' | 'Y') => ModalOutcome::Commit(true),
             KeyCode::Char('n' | 'N') => ModalOutcome::Commit(false),
-            // Focus-based interaction — Tab/←→/h/l all toggle focus.
-            KeyCode::Tab | KeyCode::Right | KeyCode::Left | KeyCode::Char('l' | 'h') => {
+            // Focus-based interaction — Tab/BackTab/←→/h/l all toggle focus.
+            KeyCode::Tab
+            | KeyCode::BackTab
+            | KeyCode::Right
+            | KeyCode::Left
+            | KeyCode::Char('l' | 'h') => {
                 self.focus = match self.focus {
                     ConfirmFocus::Yes => ConfirmFocus::No,
                     ConfirmFocus::No => ConfirmFocus::Yes,

--- a/src/console/widgets/confirm_save.rs
+++ b/src/console/widgets/confirm_save.rs
@@ -72,9 +72,10 @@ impl ConfirmSaveState {
         match key.code {
             KeyCode::Char('s' | 'S') => ModalOutcome::Commit(SaveChoice::Save),
             KeyCode::Char('c' | 'C') | KeyCode::Esc => ModalOutcome::Cancel,
-            // Tab / Right / l-h / Left — only two buttons, so every
-            // "move focus" key just toggles between them.
+            // Tab / BackTab / Right / l-h / Left — only two buttons,
+            // so every "move focus" key just toggles between them.
             KeyCode::Tab
+            | KeyCode::BackTab
             | KeyCode::Right
             | KeyCode::Left
             | KeyCode::Char('l' | 'L' | 'h' | 'H') => {

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -109,7 +109,7 @@ impl FileBrowserState {
                 };
                 ModalOutcome::Continue
             }
-            KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h' | 'H') => {
                 self.pending_git_focus = match self.pending_git_focus {
                     GitPromptFocus::MountHere => GitPromptFocus::Cancel,
                     GitPromptFocus::EnterIn => GitPromptFocus::MountHere,

--- a/src/console/widgets/mount_dst_choice.rs
+++ b/src/console/widgets/mount_dst_choice.rs
@@ -66,7 +66,7 @@ impl MountDstChoiceState {
                 };
                 ModalOutcome::Continue
             }
-            KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h' | 'H') => {
                 self.focus = match self.focus {
                     MountDstFocus::SamePath => MountDstFocus::Cancel,
                     MountDstFocus::Edit => MountDstFocus::SamePath,

--- a/src/console/widgets/save_discard.rs
+++ b/src/console/widgets/save_discard.rs
@@ -45,7 +45,7 @@ impl SaveDiscardState {
                 };
                 ModalOutcome::Continue
             }
-            KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h' | 'H') => {
                 self.focus = match self.focus {
                     SaveDiscardFocus::Save => SaveDiscardFocus::Cancel,
                     SaveDiscardFocus::Discard => SaveDiscardFocus::Save,

--- a/src/console/widgets/scope_picker.rs
+++ b/src/console/widgets/scope_picker.rs
@@ -33,6 +33,7 @@ impl ScopePickerState {
         match key.code {
             KeyCode::Esc => ModalOutcome::Cancel,
             KeyCode::Tab
+            | KeyCode::BackTab
             | KeyCode::Right
             | KeyCode::Left
             | KeyCode::Char('l' | 'L' | 'h' | 'H') => {

--- a/src/console/widgets/source_picker.rs
+++ b/src/console/widgets/source_picker.rs
@@ -37,6 +37,7 @@ impl SourcePickerState {
             KeyCode::Char('p' | 'P') => ModalOutcome::Commit(SourceChoice::Plain),
             KeyCode::Char('o' | 'O') if self.op_available => ModalOutcome::Commit(SourceChoice::Op),
             KeyCode::Tab
+            | KeyCode::BackTab
             | KeyCode::Right
             | KeyCode::Left
             | KeyCode::Char('l' | 'L' | 'h' | 'H') => {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -139,17 +139,6 @@ pub struct WorkspaceRoleOverride {
     pub codex: Option<crate::config::CodexAuthConfig>,
 }
 
-impl WorkspaceRoleOverride {
-    /// Returns `true` when this role-override entry carries any
-    /// per-agent auth override (Claude or Codex). Used by the Auth-tab
-    /// renderer to decide whether to materialize a `RoleHeader` row,
-    /// and by the input dispatcher to filter out already-overridden
-    /// roles in the `+ Add` flow.
-    pub const fn has_auth_override(&self) -> bool {
-        self.claude.is_some() || self.codex.is_some()
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct WorkspaceEdit {
     pub workdir: Option<String>,

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2718,16 +2718,28 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         cwd,
         key(KeyCode::Char(' ')),
     )?;
-    // Enter advances to credential block (CredentialSource).
+    // Tab advances to credential row; Enter opens the source picker;
+    // Enter picks the default Plain text source.
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
-    // Enter again moves into LiteralValue (default credential is Literal).
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthSourcePicker { .. })),
+        "credential row Enter must open AuthSourcePicker; got {:?}",
+        editor(&state).modal
+    );
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::TextInput { .. })),
+        "Plain source must open credential text input; got {:?}",
+        editor(&state).modal
+    );
     // Type "sk-ant-test".
     for ch in "sk-ant-test".chars() {
         handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Char(ch)))?;
     }
-    // Tab to Save, Enter to commit the form.
-    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    // Enter confirms text input, returning to the auth form Save button.
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    // Enter commits the form.
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert!(
         editor(&state).modal.is_none(),
@@ -2797,6 +2809,68 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         toml.contains(r#"ANTHROPIC_API_KEY = "sk-ant-test""#),
         "raw TOML must carry the credential env var; got:\n{toml}"
     );
+    Ok(())
+}
+
+#[test]
+fn auth_credential_source_enter_opens_source_picker() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config
+        .workspaces
+        .get("big-monorepo")
+        .expect("seed must create big-monorepo")
+        .clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    let ws_claude_idx = auth_row_idx(&ed, |r| {
+        matches!(
+            r,
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(ws_claude_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+
+    let Some(Modal::AuthSourcePicker { state: picker }) = &editor(&state).modal else {
+        panic!(
+            "Enter on auth credential source must open AuthSourcePicker; got {:?}",
+            editor(&state).modal
+        );
+    };
+    assert_eq!(picker.key, "ANTHROPIC_API_KEY");
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Esc))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthForm { .. })),
+        "Esc from AuthSourcePicker must restore the auth form"
+    );
+
     Ok(())
 }
 

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -3223,3 +3223,130 @@ fn auth_workspace_source_d_clears_workspace_mode() -> Result<()> {
     );
     Ok(())
 }
+
+/// Cancelling the credential `Modal::TextInput` (the literal-text leg
+/// of the source-picker round trip) must restore `Modal::AuthForm` and
+/// drain `pending_auth_form_return` — not silently leave the operator
+/// on a blank Auth tab.
+#[test]
+fn auth_credential_text_input_cancel_restores_form() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
+        matches!(
+            r,
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(ws_claude_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    // Open form → cycle to api_key → Tab to credential row → Enter →
+    // SourcePicker → Enter (Plain) → TextInput → Esc.
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(matches!(
+        editor(&state).modal,
+        Some(Modal::AuthSourcePicker { .. })
+    ));
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    assert!(matches!(
+        editor(&state).modal,
+        Some(Modal::TextInput { .. })
+    ));
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Esc))?;
+    assert!(
+        matches!(editor(&state).modal, Some(Modal::AuthForm { .. })),
+        "TextInput cancel must restore AuthForm; got {:?}",
+        editor(&state).modal
+    );
+    assert!(
+        editor(&state).pending_auth_form_return.is_none(),
+        "TextInput cancel must drain pending_auth_form_return"
+    );
+    Ok(())
+}
+
+/// `op_available = false` must propagate through the auth-form ↔
+/// `AuthSourcePicker` handoff, so operators on hosts without `op` see
+/// the picker with the 1Password choice disabled.
+#[test]
+fn auth_source_picker_op_disabled_when_op_missing() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    state.op_available = false;
+    let ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
+        matches!(
+            r,
+            AuthRow::WorkspaceMode {
+                agent: Agent::Claude
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(ws_claude_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char(' ')),
+    )?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+
+    let Some(Modal::AuthSourcePicker { state: picker }) = &editor(&state).modal else {
+        panic!(
+            "Enter on credential source must open AuthSourcePicker; got {:?}",
+            editor(&state).modal
+        );
+    };
+    assert!(
+        !picker.op_available,
+        "op_available must propagate from ManagerState through to the picker"
+    );
+    Ok(())
+}

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2683,10 +2683,11 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
     let ws_claude_idx = auth_row_idx(&ed, |r| {
         matches!(
             r,
-            AuthRow::WorkspaceDefault {
+            AuthRow::WorkspaceMode {
                 agent: Agent::Claude
             }
         )
@@ -2698,7 +2699,7 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert!(
         matches!(editor(&state).modal, Some(Modal::AuthForm { .. })),
-        "Enter on WorkspaceDefault/Claude must open AuthForm; got {:?}",
+        "Enter on WorkspaceMode/Claude must open AuthForm; got {:?}",
         editor(&state).modal
     );
 
@@ -2800,7 +2801,7 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
 }
 
 #[test]
-fn auth_add_role_override_three_step_flow() -> Result<()> {
+fn auth_add_role_override_flow_uses_selected_auth_kind() -> Result<()> {
     let temp = tempdir()?;
     let paths = JackinPaths::for_tests(temp.path());
     let mut config = seed_config(&paths, temp.path())?;
@@ -2814,6 +2815,7 @@ fn auth_add_role_override_three_step_flow() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
 
     let sentinel_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::AddSentinel { .. }));
     ed.active_field = FieldFocus::Row(sentinel_idx);
@@ -2828,25 +2830,24 @@ fn auth_add_role_override_three_step_flow() -> Result<()> {
 
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
     assert!(
-        matches!(editor(&state).modal, Some(Modal::AuthAgentPicker { .. })),
-        "Enter on AuthRolePicker must open AuthAgentPicker; got {:?}",
+        match &editor(&state).modal {
+            Some(Modal::AuthForm {
+                target:
+                    jackin::console::manager::state::AuthFormTarget::WorkspaceRole { role, agent },
+                ..
+            }) => {
+                assert_eq!(*agent, Agent::Claude);
+                assert!(
+                    !role.is_empty(),
+                    "role must propagate from AuthRolePicker → AuthForm"
+                );
+                true
+            }
+            _ => false,
+        },
+        "Enter on AuthRolePicker must open AuthForm for selected auth kind; got {:?}",
         editor(&state).modal
     );
-
-    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
-    match &editor(&state).modal {
-        Some(Modal::AuthForm {
-            target: jackin::console::manager::state::AuthFormTarget::WorkspaceRole { role, agent },
-            ..
-        }) => {
-            assert_eq!(*agent, Agent::Claude);
-            assert!(
-                !role.is_empty(),
-                "role must propagate from AuthRolePicker → AuthAgentPicker → AuthForm"
-            );
-        }
-        other => panic!("expected AuthForm/WorkspaceRole, got {other:?}"),
-    }
     Ok(())
 }
 
@@ -2867,6 +2868,7 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
     let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
@@ -2879,7 +2881,7 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
 }
 
 #[test]
-fn auth_role_header_d_opens_confirm_then_clears_overrides() -> Result<()> {
+fn auth_role_header_d_clears_selected_auth_kind_override() -> Result<()> {
     let temp = tempdir()?;
     let paths = JackinPaths::for_tests(temp.path());
     let mut config = seed_config(&paths, temp.path())?;
@@ -2900,6 +2902,7 @@ fn auth_role_header_d_opens_confirm_then_clears_overrides() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
     let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
@@ -2911,29 +2914,20 @@ fn auth_role_header_d_opens_confirm_then_clears_overrides() -> Result<()> {
         cwd,
         key(KeyCode::Char('d')),
     )?;
-    assert!(matches!(
-        editor(&state).modal,
-        Some(Modal::Confirm {
-            target: jackin::console::manager::state::ConfirmTarget::ClearAuthRoleOverride { .. },
-            ..
-        })
-    ));
-
-    // Confirm with 'y' (default focus is No; Enter would dismiss without action).
-    handle_key(
-        &mut state,
-        &mut config,
-        &paths,
-        cwd,
-        key(KeyCode::Char('y')),
-    )?;
+    assert!(
+        editor(&state).modal.is_none(),
+        "selected auth-kind clear should not open a confirm modal"
+    );
     let role_over = editor(&state)
         .pending
         .roles
         .get("the-architect")
         .expect("override entry stays even after clear");
     assert!(role_over.claude.is_none());
-    assert!(role_over.codex.is_none());
+    assert!(
+        role_over.codex.is_some(),
+        "hidden Codex override must be untouched"
+    );
     Ok(())
 }
 
@@ -2959,11 +2953,12 @@ fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(jackin::agent::Agent::Claude);
     ed.auth_expanded.insert("the-architect".into());
     let claude_idx = auth_row_idx(&ed, |r| {
         matches!(
             r,
-            AuthRow::RoleAgentRow {
+            AuthRow::RoleMode {
                 agent: jackin::agent::Agent::Claude,
                 ..
             }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2644,8 +2644,12 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
 // ── Auth tab helpers ──────────────────────────────────────────────────
 
 /// Return the flat-row index of the first `AuthRow` that matches `pred`.
-fn auth_row_idx(ed: &EditorState<'_>, pred: impl Fn(&AuthRow) -> bool) -> usize {
-    auth_flat_rows(ed)
+fn auth_row_idx(
+    ed: &EditorState<'_>,
+    config: &AppConfig,
+    pred: impl Fn(&AuthRow) -> bool,
+) -> usize {
+    auth_flat_rows(ed, config)
         .iter()
         .position(pred)
         .expect("required auth row not found")
@@ -2684,7 +2688,7 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(Agent::Claude);
-    let ws_claude_idx = auth_row_idx(&ed, |r| {
+    let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
@@ -2828,7 +2832,7 @@ fn auth_credential_source_enter_opens_source_picker() -> Result<()> {
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(Agent::Claude);
-    let ws_claude_idx = auth_row_idx(&ed, |r| {
+    let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
@@ -2891,7 +2895,7 @@ fn auth_add_role_override_flow_uses_selected_auth_kind() -> Result<()> {
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(Agent::Claude);
 
-    let sentinel_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::AddSentinel { .. }));
+    let sentinel_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::AddSentinel { .. }));
     ed.active_field = FieldFocus::Row(sentinel_idx);
     state.stage = ManagerStage::Editor(ed);
 
@@ -2943,7 +2947,7 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(Agent::Claude);
-    let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
+    let header_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
 
@@ -2977,7 +2981,7 @@ fn auth_role_header_d_clears_selected_auth_kind_override() -> Result<()> {
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(Agent::Claude);
-    let header_idx = auth_row_idx(&ed, |r| matches!(r, AuthRow::RoleHeader { .. }));
+    let header_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
 
@@ -3029,7 +3033,7 @@ fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
     ed.active_tab = EditorTab::Auth;
     ed.auth_selected_agent = Some(jackin::agent::Agent::Claude);
     ed.auth_expanded.insert("the-architect".into());
-    let claude_idx = auth_row_idx(&ed, |r| {
+    let claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::RoleMode {
@@ -3056,4 +3060,198 @@ fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
     assert!(ro.claude.is_none());
     assert!(ro.codex.is_some(), "Codex override must be untouched");
     Ok(())
+}
+
+/// Pressing Enter on an `AuthKind` row sets `auth_selected_agent` and
+/// resets the cursor to row 0. Drives the kind picker → focused-view
+/// transition through the real keystroke dispatcher (every other auth
+/// integration test pre-seeds `auth_selected_agent`, which would mask
+/// a regression in the input-layer wiring).
+#[test]
+fn auth_enter_on_auth_kind_focuses_selected_agent() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    // No `auth_selected_agent` set — picker view.
+    let codex_kind_idx = auth_row_idx(&ed, &config, |r| {
+        matches!(
+            r,
+            AuthRow::AuthKind {
+                agent: Agent::Codex
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(codex_kind_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
+
+    let ed = editor(&state);
+    assert_eq!(ed.auth_selected_agent, Some(Agent::Codex));
+    assert!(
+        matches!(ed.active_field, FieldFocus::Row(0)),
+        "Enter on AuthKind must reset cursor to Row(0); got {:?}",
+        ed.active_field
+    );
+    Ok(())
+}
+
+/// Esc on the focused auth view pops back to the kind picker WITHOUT
+/// triggering the dirty-modal flow even when `editor.is_dirty()`.
+/// Pending edits stay in `editor.pending`; a subsequent Esc on the
+/// picker would fall through to the dirty check.
+#[test]
+fn auth_esc_from_focused_view_pops_to_picker_without_dirty_modal() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    // Mutate `pending` so `is_dirty()` is true — this is what would
+    // otherwise route Esc through `Modal::SaveDiscardCancel`.
+    ed.pending.git_pull_on_entry = !ed.pending.git_pull_on_entry;
+    ed.active_field = FieldFocus::Row(0);
+    state.stage = ManagerStage::Editor(ed);
+    assert!(editor(&state).is_dirty(), "fixture must be dirty");
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Esc))?;
+
+    let ed = editor(&state);
+    assert!(
+        ed.auth_selected_agent.is_none(),
+        "Esc on focused view must clear auth_selected_agent"
+    );
+    assert!(
+        ed.modal.is_none(),
+        "Esc must not open the dirty SaveDiscardCancel modal mid-tab"
+    );
+    assert!(
+        ed.is_dirty(),
+        "pending edits must survive the in-tab navigation pop"
+    );
+    Ok(())
+}
+
+/// Tab/BackTab leaving the Auth tab clears `auth_selected_agent` so
+/// re-entering the tab returns to the kind picker rather than a
+/// stale focused view.
+#[test]
+fn auth_tab_cycle_off_auth_clears_selected_agent() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
+    let ed = editor(&state);
+    assert_ne!(ed.active_tab, EditorTab::Auth);
+    assert!(
+        ed.auth_selected_agent.is_none(),
+        "leaving the Auth tab must drop the focused-kind selection"
+    );
+    Ok(())
+}
+
+/// Pressing D on a `WorkspaceSource` row clears the workspace-level
+/// auth-forward override for the focused kind. Mirrors the existing
+/// `RoleSource` clear test but for the workspace layer.
+#[test]
+fn auth_workspace_source_d_clears_workspace_mode() -> Result<()> {
+    let temp = tempdir()?;
+    let paths = JackinPaths::for_tests(temp.path());
+    let mut config = seed_config(&paths, temp.path())?;
+    let cwd = temp.path();
+
+    let mut ws = config.workspaces.get("big-monorepo").unwrap().clone();
+    ws.claude = Some(jackin::config::AgentAuthConfig {
+        auth_forward: jackin::config::AuthForwardMode::ApiKey,
+    });
+    ws.env.insert(
+        "ANTHROPIC_API_KEY".into(),
+        jackin::operator_env::EnvValue::Plain("k".into()),
+    );
+
+    let mut state = ManagerState::from_config(&config, cwd);
+    let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
+    ed.active_tab = EditorTab::Auth;
+    ed.auth_selected_agent = Some(Agent::Claude);
+    let source_idx = auth_row_idx(&ed, &config, |r| {
+        matches!(
+            r,
+            AuthRow::WorkspaceSource {
+                agent: Agent::Claude
+            }
+        )
+    });
+    ed.active_field = FieldFocus::Row(source_idx);
+    state.stage = ManagerStage::Editor(ed);
+
+    handle_key(
+        &mut state,
+        &mut config,
+        &paths,
+        cwd,
+        key(KeyCode::Char('d')),
+    )?;
+
+    let ed = editor(&state);
+    assert!(
+        ed.modal.is_none(),
+        "workspace source clear must be silent (no modal)"
+    );
+    assert!(
+        ed.pending.claude.is_none(),
+        "D on WorkspaceSource must drop the workspace-level claude override"
+    );
+    Ok(())
+}
+
+/// Globally configured `api_key` mode (in `[claude].auth_forward`)
+/// must surface a `WorkspaceSource` row in `auth_flat_rows` so the
+/// operator can set the credential. Guards the `AppConfig::default()`
+/// bug fixed in PR #242 — before the fix,
+/// `workspace_effective_mode_needs_credential` resolved against
+/// `AppConfig::default()` and silently dropped the row whenever the
+/// effective mode came from a global default.
+#[test]
+fn auth_flat_rows_surfaces_workspace_source_when_global_requires_credential() {
+    use jackin::config::{AgentAuthConfig, AuthForwardMode};
+    let config = AppConfig {
+        claude: Some(AgentAuthConfig {
+            auth_forward: AuthForwardMode::ApiKey,
+        }),
+        ..AppConfig::default()
+    };
+    let ws = jackin::workspace::WorkspaceConfig::default();
+    let mut ed = EditorState::new_edit("ws".into(), ws);
+    ed.auth_selected_agent = Some(Agent::Claude);
+
+    let rows = auth_flat_rows(&ed, &config);
+    assert!(
+        rows.iter().any(|r| matches!(
+            r,
+            AuthRow::WorkspaceSource {
+                agent: Agent::Claude
+            }
+        )),
+        "global claude.auth_forward = api_key must surface WorkspaceSource row; got {rows:?}"
+    );
 }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -3223,35 +3223,3 @@ fn auth_workspace_source_d_clears_workspace_mode() -> Result<()> {
     );
     Ok(())
 }
-
-/// Globally configured `api_key` mode (in `[claude].auth_forward`)
-/// must surface a `WorkspaceSource` row in `auth_flat_rows` so the
-/// operator can set the credential. Guards the `AppConfig::default()`
-/// bug fixed in PR #242 — before the fix,
-/// `workspace_effective_mode_needs_credential` resolved against
-/// `AppConfig::default()` and silently dropped the row whenever the
-/// effective mode came from a global default.
-#[test]
-fn auth_flat_rows_surfaces_workspace_source_when_global_requires_credential() {
-    use jackin::config::{AgentAuthConfig, AuthForwardMode};
-    let config = AppConfig {
-        claude: Some(AgentAuthConfig {
-            auth_forward: AuthForwardMode::ApiKey,
-        }),
-        ..AppConfig::default()
-    };
-    let ws = jackin::workspace::WorkspaceConfig::default();
-    let mut ed = EditorState::new_edit("ws".into(), ws);
-    ed.auth_selected_agent = Some(Agent::Claude);
-
-    let rows = auth_flat_rows(&ed, &config);
-    assert!(
-        rows.iter().any(|r| matches!(
-            r,
-            AuthRow::WorkspaceSource {
-                agent: Agent::Claude
-            }
-        )),
-        "global claude.auth_forward = api_key must surface WorkspaceSource row; got {rows:?}"
-    );
-}


### PR DESCRIPTION
## Summary

- Rework the workspace Auth tab into an auth-kind picker for Claude Code and Codex.
- Remove global defaults and extra Auth header chrome from the workspace editor Auth tab.
- Show focused mode/source rows and per-role overrides only for the selected auth kind.
- Use the selected app name as the focused Auth block title instead of an `Auth / ...` breadcrumb.
- Simplify role override rows by removing the empty `Role overrides` label row.
- Make inherited mode annotations dim secondary text, so the mode remains the primary value.
- Simplify the auth edit dialog to match the existing TUI dialog style: short title, centered action buttons/hints, no underlined labels, and one required credential row.
- Route credential setup through the shared SourcePicker and TextInput flows instead of the old Literal/1Password toggle row or direct typing inside the auth form.
- Make `Tab` move to the next actionable auth form control while `Enter` only acts on the focused control.
- Reuse 1Password breadcrumb rendering for auth credential sources.
- Align Auth, Environments, Mounts, Roles, and workspace-list spacer rows so add/override sentinels breathe consistently.
- Add distinct TUI colors for action rows and expandable role headers.
- Clarify agent PR guidance for console/TUI verification commands and open-PR feedback iteration.

## Verification

- `cargo fmt -- --check && cargo clippy -- -D warnings && cargo nextest run`

## Verify locally

#### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin feature/auth-tab-kind-picker:refs/remotes/origin/feature/auth-tab-kind-picker
git checkout -B feature/auth-tab-kind-picker refs/remotes/origin/feature/auth-tab-kind-picker
```

#### Static Checks

```sh
cargo fmt -- --check
cargo clippy -- -D warnings
```

#### Tests

```sh
cargo nextest run
```

#### User Smoke

```sh
cargo run --bin jackin -- console --debug
```

In the console, open any workspace editor and go to the **Auth** tab. Verify:

- The first Auth screen lists only `Claude Code` and `Codex`, with no `Auth` title on the box.
- `Enter` on either auth kind opens a focused detail view titled with only that app name.
- The detail view shows `Mode`, optional `Source`, existing role overrides, and `+ Override for a role`.
- Empty role overrides do not render a separate `Role overrides` label row.
- Inherited workspace mode renders as `sync (inherited)`, with `(inherited)` shown as secondary/dim text.
- `Esc` from the detail view returns to the auth-kind list.
- Adding a role override asks for the role only, not the auth kind/agent again.
- In the auth edit modal, `Space` cycles the mode; `Enter` on `Mode` does not move focus; `Tab` moves to the next actionable control.
- For credential modes, the modal shows the required env var row, such as `ANTHROPIC_API_KEY required`.
- Typing on the credential row does not set a value.
- `Enter` on the credential row opens the same `Source for ...` picker used by Environments/Secrets.
- Choosing Plain text opens the same text input dialog style used by environment values; confirming returns to the auth form Save button.
- The auth form action buttons and footer hint are centered in the dialog.
- Plain text credentials render masked; 1Password credential sources render as `[op] Vault / Item → field` breadcrumbs.
- `+ Add ...` and `+ Override for a role` rows use the shared action accent and have a blank row before them when following content.
- Auth and Environments expandable role headers use `▼`/`▶` and the shared disclosure accent.
- The workspace list has one blank row before `+ New workspace` when saved workspaces exist.
