### PR TITLE
docs(roadmap): add GitHub CLI auth strategy + sync overview with directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,6 +109,7 @@ Docs rot silently. Every PR must include a one-pass verification that structure-
 - [ ] If the PR resolves or advances an item under `docs/src/content/docs/reference/roadmap/`, update that item's `Status` field (`Open | Deferred | Resolved`) and `Related Files` section in the same PR.
 - [ ] If the PR references `src/` paths that have since moved (e.g., a roadmap doc mentions `src/runtime.rs` which is now `src/runtime/`), fix those path references.
 - [ ] If the PR adds, renames, deletes, or moves a roadmap MDX file between status sections, update [`docs/astro.config.ts`](docs/astro.config.ts) so `Reference → Roadmap` (Open / Resolved / Codebase health) matches the directory. Run the audit command in `docs/AGENTS.md` → "Content Notes" → "Roadmap sidebar discipline" to confirm the diff is empty.
+- [ ] If the PR adds a new roadmap item, or changes any item's `**Status**` (e.g. Open → Resolved, Open → Deferred, Open → Partially implemented), update [`docs/src/content/docs/reference/roadmap.mdx`](docs/src/content/docs/reference/roadmap.mdx) so the item lands in the correct section (Completed / Partially implemented / Planned with the right `(status: …)` suffix). Run the overview audit command in `docs/AGENTS.md` → "Content Notes" → "Roadmap overview discipline" to confirm no items are missing.
 
 ### How to verify
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -153,6 +153,47 @@ bun install --frozen-lockfile
   ```
 
   The diff must be empty.
+- **Roadmap overview discipline.** `src/content/docs/reference/roadmap.mdx`
+  is the entry point operators land on when they want a single
+  picture of *what shipped, what is partial, what is planned, what
+  is deferred, and what is on hold*. The sidebar lists every item
+  alphabetically/by phase; the overview is what tells the reader
+  the **status story**. The two surfaces have different jobs and
+  must be maintained together, not folded into one.
+
+  Whenever you add, rename, delete, or change the `**Status**`
+  field of a roadmap item, also update `roadmap.mdx` so the item
+  lands in the section that matches its new status:
+
+  | `**Status**` value | Section in `roadmap.mdx` |
+  |---|---|
+  | `Resolved` / `Implemented in V1` | **Completed** |
+  | `Partially implemented` | **Partially implemented** |
+  | `Open` (active design / Phase work) | **Planned** (under the right subsection) |
+  | `Deferred` / `Proposed` / `Needs design` | **Planned** with a `(status: …)` suffix on the bullet |
+
+  An item that exists in `roadmap/` but is not reachable from
+  `roadmap.mdx` is half-hidden: an operator who only reads the
+  overview thinks the work does not exist, and an operator who
+  only browses the sidebar sees the title without status context.
+  Both must agree.
+
+  To audit which roadmap items are missing from the overview:
+
+  ```sh
+  ls docs/src/content/docs/reference/roadmap/*.mdx \
+    | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
+  grep -oE 'reference/roadmap/[a-z0-9-]+' docs/src/content/docs/reference/roadmap.mdx \
+    | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-overview
+  comm -23 /tmp/roadmap-files /tmp/roadmap-overview
+  ```
+
+  The output lists items present in the directory but missing from
+  the overview. It must be empty *unless* the missing items are
+  intentionally umbrella-covered by a parent program entry (e.g.
+  Universal Orchestrator Program leaves, Codebase readability
+  program leaves) — in which case the program entry itself must
+  appear in the overview and explicitly say it covers them.
 - Use Starlight components for callouts (`<Aside type="note|tip|caution">`),
   steps (`<Steps>` around an `<ol>`), and tabs (`<Tabs><TabItem>`). Import from
   `@astrojs/starlight/components`.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -205,6 +205,7 @@ export default defineConfig({
                       items: [
                         { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
                         { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
+                        { label: 'GitHub CLI authentication strategy', slug: 'reference/roadmap/github-cli-auth-strategy' },
                         { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
                       ],
                     },

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -59,6 +59,7 @@ The current implementation is Claude-specific end-to-end (manifest schema, deriv
 - **[Docker API migration](/reference/roadmap/bollard-migration/)** — incremental migration from CLI string-matching to the Bollard typed API client for more robust error handling
 - **[1Password integration](/reference/roadmap/onepassword-integration/)** — inject secrets from 1Password vaults without exposing them as files in the container
 - **[Reliable Claude authentication strategy](/reference/roadmap/claude-auth-strategy/)** — move beyond copied session auth toward clearer, more durable modes for long-lived and concurrent agent runtimes
+- **[GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/)** — extend the layered `auth_forward` model from agent runtimes to the GitHub CLI, so each (workspace × role) can use either the host login or a least-privilege token (e.g. a fine-grained PAT) instead of one broad `gh` identity for everything
 
 ### Workflow improvements
 

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -21,7 +21,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - State persistence across sessions
 - Agent identity (display names)
 - UID/GID host user mapping
-- GitHub CLI authentication passthrough
+- GitHub CLI authentication state persists across container restarts (forwarding host login on launch is tracked separately under [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/))
 - Homebrew installation
 - Namespaced roles (e.g., `chainargos/frontend-engineer`)
 - Last-agent memory per workspace
@@ -32,15 +32,24 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - [`JACKIN_DIND_HOSTNAME` environment variable](/reference/roadmap/dind-hostname-env-var/) for agents to discover the DinD sidecar hostname
 - [Agent source trust model](/reference/roadmap/agent-source-trust/) (trust-on-first-use verification for third-party role repos)
 - [DinD TLS authentication](/reference/roadmap/dind-tls/) with auto-generated certificates
+- [`JACKIN_DEBUG` environment variable](/reference/roadmap/jackin-debug-env-var/) — verbose tracing for shell commands and jackin internals
+- [MSRV toolchain pin](/reference/roadmap/msrv-toolchain/) — `rust-toolchain.toml` enforced in CI
+- [Worktree cleanup on container removal](/reference/roadmap/worktree-cleanup-assessment/) — orphaned host-side worktrees no longer accumulate
+- [Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/) — `shared | worktree | clone` modes implemented in V1
+
+## Partially implemented
+
+- [1Password integration](/reference/roadmap/onepassword-integration/) — workspace-managed `op://` env references shipped; file-mount generation (option 4) still deferred
+- [Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/) — Codex foundation slice shipped; Amp and full feature parity still in flight
 
 ## Planned
 
 ### Agent runtimes
 
 <Aside type="note">
-The current implementation is Claude-specific end-to-end (manifest schema, derived-image build, runtime entrypoint, persisted state, auth handling, and version probing all reference Claude Code directly). The linked roadmap item below tracks the concrete foundation work needed before Codex and Amp can be treated as first-class runtimes.
+The Codex foundation slice is in (see Partially implemented above). The remaining work to reach `claude` / `codex` / `amp` parity — runtime-specific auth, config, state, entrypoint behavior, and Amp itself — continues under the same roadmap item.
 </Aside>
-- **[Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/)** — introduce a small built-in runtime abstraction so one role can launch under `claude`, `codex`, or `amp`, with runtime-specific auth, config, state, and entrypoint behavior. Phase 1 focuses on secure local usability, not full Claude-feature parity.
+- **[Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/)** — finish the runtime abstraction so one role can launch under `claude`, `codex`, or `amp` interchangeably. Phase 1 focuses on secure local usability, not full Claude-feature parity.
 
 ### Platform expansion
 
@@ -50,24 +59,31 @@ The current implementation is Claude-specific end-to-end (manifest schema, deriv
 
 - **Network policy controls** — outbound domain filtering per role, similar to Docker Sandboxes' network policies. See [devcontainer parity](/reference/roadmap/devcontainer-parity/) for a comparison with the upstream `anthropics/claude-code` devcontainer's `iptables`/`ipset` egress-allowlist approach.
 - **Credential proxy** — proxy-based credential injection to avoid storing tokens inside containers
-- **[Agent version pinning](/reference/roadmap/reproducibility-pinning/)** — pin role repos to tagged versions for reproducible builds, with explicit `--update` to advance (design in progress)
-- **[Alternative isolation tiers](/reference/roadmap/selectable-sandbox-backends/)** — explore stronger backends beyond plain container isolation for users who need them, including [rootless DinD](/reference/roadmap/rootless-dind/) as a lighter-weight option
+- **[Agent version pinning](/reference/roadmap/reproducibility-pinning/)** — pin role repos to tagged versions for reproducible builds, with explicit `--update` to advance (status: needs design — brainstorming required before implementation)
+- **[GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/)** — extend the layered `auth_forward` model from agent runtimes to the GitHub CLI, so each (workspace × role) can use either the host login or a least-privilege token (e.g. a fine-grained PAT) instead of one broad `gh` identity for everything
+- **[Reliable Claude authentication strategy](/reference/roadmap/claude-auth-strategy/)** — move beyond copied session auth toward clearer, more durable modes for long-lived and concurrent agent runtimes (status: deferred — needs design work)
+- **[Alternative isolation tiers](/reference/roadmap/selectable-sandbox-backends/)** — explore stronger backends beyond plain container isolation for users who need them, including [rootless DinD](/reference/roadmap/rootless-dind/) as a lighter-weight option (status: deferred — requires a dedicated design pass)
+- **[Devcontainer parity](/reference/roadmap/devcontainer-parity/)** — comparison with the upstream `anthropics/claude-code` devcontainer setup; informs network policy + reproducibility decisions (status: proposed — research captured, no implementation committed)
 
 ### Infrastructure improvements
 
-- **[Construct user creation optimization](/reference/roadmap/construct-user-creation/)** — move user creation to the derived layer to eliminate UID/GID remapping
-- **[Docker API migration](/reference/roadmap/bollard-migration/)** — incremental migration from CLI string-matching to the Bollard typed API client for more robust error handling
-- **[1Password integration](/reference/roadmap/onepassword-integration/)** — inject secrets from 1Password vaults without exposing them as files in the container
-- **[Reliable Claude authentication strategy](/reference/roadmap/claude-auth-strategy/)** — move beyond copied session auth toward clearer, more durable modes for long-lived and concurrent agent runtimes
-- **[GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/)** — extend the layered `auth_forward` model from agent runtimes to the GitHub CLI, so each (workspace × role) can use either the host login or a least-privilege token (e.g. a fine-grained PAT) instead of one broad `gh` identity for everything
-
-### Workflow improvements
-
-- **[Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/)** — declarative `shared | worktree | clone` mode per mount so parallel agents stop sharing one working tree
+- **[Docker API migration](/reference/roadmap/bollard-migration/)** — incremental migration from CLI string-matching to the Bollard typed API client for more robust error handling (status: deferred — incremental migration is the pragmatic path)
+- **[Construct user creation optimization](/reference/roadmap/construct-user-creation/)** — move user creation to the derived layer to eliminate UID/GID remapping (status: deferred — needs design work)
 
 ### Operator surface and fleet operations
 
-- **[Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)** — phased program of 18 leaf items closing the gap between jackin's primitives and the operator surface that adjacent tools (notably [`multicode`](https://github.com/yawkat/multicode)) ship today. Covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts — the missing pieces that prevent jackin' from being the canonical orchestrator teams compose on instead of building their own.
+- **[Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)** — phased program of 18 leaf items closing the gap between jackin's primitives and the operator surface that adjacent tools (notably [`multicode`](https://github.com/yawkat/multicode)) ship today. Covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts — the missing pieces that prevent jackin' from being the canonical orchestrator teams compose on instead of building their own. The full list of 18 leaves lives in the program doc and the sidebar under **Reference → Roadmap → Active programs → Universal Orchestrator Program**.
+
+### Codebase health
+
+- **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
+- **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see [`AGENTS.md`](https://github.com/jackin-project/jackin/blob/main/AGENTS.md) → "Code review & automated scanning").
+
+### Documentation infrastructure
+
+- **[Greenfield workspace pattern](/reference/roadmap/greenfield-workspace/)** — workspace-onboarding pattern for empty projects (status: deferred to Phase 3 — trigger not yet met, but architecture is ready)
+- **[Markdown linting for docs](/reference/roadmap/docs-markdown-linting/)** — uniform Markdown lint pipeline for the docs site (status: proposed — design captured, no implementation committed)
+- **[Rustdoc → Starlight integration](/reference/roadmap/rustdoc-json-starlight/)** — surface rustdoc JSON inside the Starlight docs site (status: deferred — Phase 3)
 
 <Aside type="tip">
 Detailed design documents for individual TODO items are linked from the sidebar under **Roadmap → Open items** and **Roadmap → Resolved**. Each page is a self-contained proposal with problem statement, options, and related files.

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -3,6 +3,7 @@ title: Roadmap
 description: What's done and what's coming next
 ---
 import { Aside } from '@astrojs/starlight/components'
+import RepoFile from '../../../components/RepoFile.astro'
 
 
 ## Current status
@@ -77,7 +78,7 @@ The Codex foundation slice is in (see Partially implemented above). The remainin
 ### Codebase health
 
 - **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
-- **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see [`AGENTS.md`](https://github.com/jackin-project/jackin/blob/main/AGENTS.md) → "Code review & automated scanning").
+- **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see <RepoFile path="AGENTS.md" /> → "Code review & automated scanning").
 
 ### Documentation infrastructure
 

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -195,7 +195,7 @@ auth_forward = "ignore"
 ```
 
 <Aside type="caution">
-**Never use the bare-string `op://...` form for env values.** It has been deprecated since 2026-04-27 (see [`DEPRECATED.md`](https://github.com/jackin-project/jackin/blob/main/DEPRECATED.md) → "Bare `op://...` strings as env values"). Bare strings flow through as literals — `op read` is **not** invoked, so the container receives the unresolved URI rather than the secret. Always use the structured inline-table form `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }` shown above. The `op` field stores the UUID-form `op://` URI; `path` holds the human-readable Vault/Item/Field snapshot at pin time. Operator-facing entry points are `jackin workspace env set <NAME> "op://..."` (the CLI auto-resolves to the pinned UUID form) and the TUI 1Password picker.
+**Never use the bare-string `op://...` form for env values.** It has been deprecated since 2026-04-27 (see <RepoFile path="DEPRECATED.md" /> → "Bare `op://...` strings as env values"). Bare strings flow through as literals — `op read` is **not** invoked, so the container receives the unresolved URI rather than the secret. Always use the structured inline-table form `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }` shown above. The `op` field stores the UUID-form `op://` URI; `path` holds the human-readable Vault/Item/Field snapshot at pin time. Operator-facing entry points are `jackin workspace env set <NAME> "op://..."` (the CLI auto-resolves to the pinned UUID form) and the TUI 1Password picker.
 </Aside>
 
 ### Walkthrough — what wins?

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -1,0 +1,584 @@
+---
+title: "GitHub CLI Authentication Strategy"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+
+**Status**: Open — design proposal
+
+## Problem
+
+jackin' currently treats GitHub CLI auth as **state that persists**,
+not state that **flows from the host**.
+
+What that means in practice:
+
+- The first time an operator opens a (workspace × role), they have
+  to run `gh auth login` **inside** the container and click through
+  a browser device-code flow.
+- That login is bind-mounted at
+  `~/.jackin/data/<container>/.config/gh` so it survives restarts.
+- Every new (workspace × role) repeats the dance.
+
+This is the opposite of how Claude and Codex auth work in jackin'
+today. Those agent runtimes already have a layered `auth_forward`
+setting (`sync` / `api_key` / `oauth_token` / `ignore`) configurable
+at three levels: global, per-workspace, and per-(workspace × role).
+For `gh` no such setting exists.
+
+The proposal: give the GitHub CLI the same layered `auth_forward`
+treatment, with one important twist beyond convenience —
+**least-privilege scoping per role**.
+
+## Why It Matters
+
+The host's `gh` token is usually a broad PAT (or a `gh`-OAuth
+session) that can read and write every repo the operator owns.
+Handing that identity to every container is convenient but blurs
+exactly the boundary jackin' is built to enforce:
+
+- An operator with personal repos, an employer org, and two client
+  orgs has **one host `gh` identity** that touches all of them.
+  Whichever container is running gets the whole keyring.
+- A misbehaving agent that force-pushes to the wrong repo, rewrites
+  another team's branch, or deletes a release tag does damage at
+  host scope.
+- Junior or exploratory roles deserve narrower access than a
+  release-bot role. Today they all run as the same GitHub user.
+- **Audit trail granularity.** With one host token, every push
+  and every API call from any agent shows up under the same
+  GitHub identity. With per-(workspace × role) tokens, GitHub's
+  own audit log can attribute "agent-smith in customer-acme
+  pushed to prod at 2:14am" — recoverable from GitHub's side,
+  not only from jackin logs.
+
+GitHub already provides the answer on its side: fine-grained PATs,
+resource-scoped classic tokens, and per-host tokens for GHE. The
+missing piece is somewhere in jackin to say *"this role uses
+**this** token, not my host login."*
+
+## What Changes For Operators
+
+| Today | After this lands |
+|---|---|
+| First launch needs interactive `gh auth login` inside the container. | First launch reuses the host login automatically (`sync` default). |
+| Every (workspace × role) needs its own login the first time. | One host login covers them all by default. |
+| Every container shares the host's broad GitHub identity. | Workspaces and roles can opt into a scoped token instead. |
+| No way to point a role at a fine-grained PAT. | `auth_forward = "token"` + `GH_TOKEN` from operator-env (`op://`, host env, …). |
+| No way to deny `gh` to a specific role. | `auth_forward = "ignore"` wipes and refuses to forward. |
+| GitHub story disconnected from Claude / Codex auth UX. | Same modes, same layered config, same Auth tab in the console. |
+
+## Goals
+
+1. Keep the beginner-friendly path: when the operator is already
+   logged in to `gh` on the host, a freshly launched role works
+   without any in-container login step.
+2. Operators can override the default per workspace and per
+   (workspace × role) to bind a specific role to a specific
+   least-privilege token.
+3. The `gh` token source plugs into the same operator-env layer
+   already used for Claude/Codex auth (`op://`, host env, future
+   `keychain` and `command` sources from
+   [credential source pattern](/reference/roadmap/credential-source-pattern/)).
+4. The launch summary tells the operator unambiguously which `gh`
+   identity is active and where it came from.
+5. Switching modes (or roles) cleanly revokes any previously
+   forwarded `gh` credentials — no stale `hosts.yml` left behind in
+   role-state.
+
+## Non-Goals
+
+- Replacing the `gh` CLI's own auth model. jackin' provisions
+  state; `gh` keeps owning login, refresh, and `setup-git`.
+- Restricting *what* a token can do once active — that is the
+  token's scope on GitHub's side. jackin's job is making it easy to
+  pick the right token.
+- SSH-based git auth or commit signing — separate keys, separate
+  future design.
+- Inventing a jackin-specific PAT broker. The credential source is
+  whatever the operator already uses.
+
+## Modes
+
+Three modes, mirroring the agent-auth shape:
+
+| Mode | Behaviour |
+|---|---|
+| `sync` (default) | When the host has a usable `gh` token, materialize it into the role-state's `.config/gh/` on each launch. When the host is logged out, leave any existing container-side login alone. |
+| `token` | Provision empty `.config/gh/`; inject `GH_TOKEN` (and `GH_HOST` when non-default) into the container's process env from the operator-env layer. `gh` reads the token directly — perfect for fine-grained PATs scoped to one repo or org. |
+| `ignore` | Wipe any forwarded `gh` state and never forward host auth. The agent must `gh auth login` inside the container if it needs `gh`. |
+
+There is deliberately no `oauth_token` mode for GitHub. A `gh` PAT
+(classic or fine-grained) covers every flavor of token uniformly,
+so a separate variant would not buy operators anything.
+
+### How `sync` reads the host token
+
+Three sources, in priority order:
+
+1. `gh auth token --hostname <host>` on the host. Works when the
+   token lives in **macOS Keychain** (the default on macOS) and is
+   the most portable reader. Run once per launch.
+2. `~/.config/gh/hosts.yml` parsed directly. Falls back when `gh`
+   is not on the host but the file exists (e.g. CI image preparing
+   a workspace).
+3. If neither resolves, log a structured notice and leave the
+   container's existing `.config/gh/` untouched — the same
+   "host-logged-out preserves container" rule used by Claude `sync`.
+
+### What `token` mode does at launch
+
+- Pre-flight: launch aborts with a structured error when `GH_TOKEN`
+  is not present in the resolved operator-env for that
+  (workspace × role). Same shape as the existing
+  `CLAUDE_CODE_OAUTH_TOKEN` pre-flight check.
+- Any prior `hosts.yml` in `.config/gh/` is removed so a stale
+  file-based login cannot shadow the env token.
+- `gh` and `gh auth setup-git` both honor `GH_TOKEN` directly, so
+  in-container `gh` commands and git push/pull over HTTPS Just Work.
+
+### What `ignore` mode does at launch
+
+- Any previously forwarded `hosts.yml` is removed from role-state.
+- No `GH_TOKEN` is injected.
+- The agent sees an unauthenticated `gh`. If it needs `gh`, the
+  operator runs `gh auth login` inside the container.
+
+## Layered Configuration
+
+Three layers, most-specific wins, identical to agent `auth_forward`:
+
+1. **Global default** — set once in `~/.config/jackin/config.toml`.
+2. **Per workspace** — overrides the global for one workspace.
+3. **Per (workspace × role)** — overrides both for one role inside
+   one workspace.
+
+There is **no agent dimension** for `[github]`. The `.config/gh/`
+directory is shared by every agent in a container — `gh` is
+agent-neutral. Adding an agent split would only confuse operators
+without giving extra isolation.
+
+Resolution order: **(workspace × role) > workspace > global > `sync`**.
+
+Example:
+
+```toml
+# Global default — forward host login
+[github]
+auth_forward = "sync"
+
+# Workspace-wide — customer-facing repo, use a fine-grained PAT
+[workspaces.customer-acme.github]
+auth_forward = "token"
+
+[workspaces.customer-acme.github.env]
+GH_TOKEN = "op://Work/ACME/github-fine-grained-pat"
+
+# Per-role — release-bot in the same workspace, push-to-tags-only token
+[workspaces.customer-acme.roles.release-bot.github]
+auth_forward = "token"
+
+[workspaces.customer-acme.roles.release-bot.github.env]
+GH_TOKEN = "op://Work/ACME/github-release-pat"
+
+# Per-role — throwaway scratch role, no GitHub at all
+[workspaces.customer-acme.roles.scratch.github]
+auth_forward = "ignore"
+```
+
+### Walkthrough — what wins?
+
+For `customer-acme` workspace with the config above:
+
+- `engineer` role → no role override exists → falls back to
+  workspace `token` mode → `GH_TOKEN` resolves to the
+  fine-grained PAT.
+- `release-bot` role → role override exists → `token` mode with
+  the release PAT (overrides the workspace-level token).
+- `scratch` role → role override `ignore` → no `gh` access at all,
+  even though the workspace says `token`.
+- A different workspace `personal-blog` with no `[github]` block →
+  falls back to global `sync` → host login flows in.
+
+Tokens come from the same operator-env layers used everywhere else
+in jackin' (`op://...`, host env, future `keychain` / `command`
+sources from
+[credential source pattern](/reference/roadmap/credential-source-pattern/)).
+
+## Use Cases
+
+### Newcomer
+
+> "I want it to work like everything else."
+
+`auth_forward = "sync"` is the default. Host login → container.
+Same beginner experience Claude/Codex `sync` already ships.
+
+### Operator with multiple orgs
+
+> "When I open the customer-acme workspace I want a token that can
+> only touch acme repos."
+
+Workspace-level `token` mode + a fine-grained PAT scoped to acme.
+Other workspaces keep using the host login.
+
+### Risky vs safe roles in the same workspace
+
+> "My everyday `engineer` role has read + write on feature branches.
+> When I switch to `release-bot` to cut a tag, I want a separate
+> token with that exact privilege and nothing else."
+
+Per-(workspace × role) override. One workspace, two roles, two
+tokens.
+
+### Throwaway / offline role
+
+> "This role doesn't need GitHub at all."
+
+`auth_forward = "ignore"` for that role. No host token leaks in,
+no in-container login needed, no `.config/gh` written.
+
+### GHE (GitHub Enterprise) host
+
+> "My `acme` workspace targets `ghe.acme.com`, my personal stuff
+> targets `github.com`."
+
+Token mode with `GH_HOST = "ghe.acme.com"` set in
+`[workspaces.acme.github.env]`. The container's `gh` routes to the
+right host with the right token.
+
+## Console UX
+
+This builds on the kind-picker Auth tab introduced in
+[PR #242](https://github.com/jackin-project/jackin/pull/242).
+
+The Auth tab today has a two-level shape:
+
+1. **Root view** — pick which auth kind to manage. Today: **Claude
+   Code** and **Codex**.
+2. **Detail view** — for the picked kind, edit workspace mode +
+   credential source + per-role overrides.
+
+This roadmap item adds a third kind to the root picker:
+**GitHub CLI**. Selecting it opens the same detail-view shape:
+
+- Workspace-level mode: `sync` / `token` / `ignore`.
+- Credential source row, shown only when the resolved mode is
+  `token`. Same `SourcePicker` widget the existing Auth tab uses
+  for Claude/Codex (`op://`, host env, literal).
+- Per-role overrides list, same expand/collapse behaviour as
+  Claude/Codex.
+
+The same disabled-Save invariant the existing Auth-tab forms use
+applies: Save stays inert until `GH_TOKEN` resolves to a non-empty
+value when `token` is selected.
+
+Footer hints surface the resolved mode and where it came from
+(global / workspace / role override). Nothing new for operators
+to learn — GitHub CLI is one more entry in a picker they already
+know.
+
+## CLI
+
+Mirrors the existing per-agent shape:
+
+```bash
+jackin config auth set --target github sync
+jackin config auth set --target github token
+jackin config auth set --target github ignore
+```
+
+Per-workspace and per-role variants reuse the same flag layout the
+Claude/Codex commands already document.
+
+## Launch-Time Messaging
+
+Every launch already prints which Claude/Codex auth mode is active.
+A parallel line for `gh`:
+
+- `gh auth: forwarded host token (sync)`
+- `gh auth: scoped token from op://Work/ACME/github-fine-grained-pat (token)`
+- `gh auth: none (manual gh auth login required)` — for `ignore`
+
+When two or more containers share the same forwarded host token,
+the launch summary should call it out — same nudge planned for
+Claude `sync`.
+
+## Security Notes
+
+- `gh` tokens are redacted in launch summaries and command logs,
+  same as `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` are
+  today.
+- Forwarded `hosts.yml` is written `0600` and goes through the
+  symlink-refusing helper that already protects Claude / Codex
+  credential files.
+- Switching from `sync` / `token` to `ignore` actively removes any
+  previously forwarded `hosts.yml` from the role-state — no zombie
+  token left behind.
+- `[github]` is operator-only. Role manifests (`jackin.role.toml`)
+  cannot set or override it (same rule as agent `auth_forward`).
+- The token never lands in a derived image layer — only in the
+  role-state directory and the running container's process env.
+
+## What Needs To Happen
+
+High-level only — the implementing PR series will own the per-file
+detail.
+
+1. **Schema** — add a `[github]` peer block at the same three
+   layers where `[claude]` and `[codex]` already live (global,
+   workspace, workspace × role). Add a `token` value to the
+   `auth_forward` mode set, gated to GitHub.
+2. **Auth-tab kind axis** — generalize the post-#242 kind picker so
+   it can list a non-runtime kind. The runtime `Agent` enum stays
+   as it is — `Github` is not a runtime, it does not need an
+   install block or a launch entrypoint.
+3. **Provisioning** — `sync` writes `hosts.yml` from the host's
+   `gh auth token`; `token` empties the dir and injects `GH_TOKEN`;
+   `ignore` revokes.
+4. **Launch + messaging** — pre-flight check for missing `GH_TOKEN`
+   in `token` mode, summary line, shared-host-token warning.
+5. **CLI** — `jackin config auth set --target github …`.
+6. **Docs** — extend the authentication guide, the `config`
+   command reference, and the configuration schema page in
+   lockstep so the operator-facing story stays consistent.
+
+The PR series should land each layer separately so review stays
+small.
+
+## Documentation Drift To Repair Alongside This Work
+
+Three existing pages overstate today's `gh` story. The right time
+to fix them is the same PR series, so the operator narrative stays
+consistent:
+
+- <RepoFile path="docs/src/content/docs/reference/roadmap.mdx" /> —
+  the **Completed** entry "GitHub CLI authentication passthrough"
+  describes today's behaviour as forwarding. It is
+  *persistence-only* — the in-container login survives restarts
+  but no host login flows in. Either reword to "GitHub CLI auth
+  state persists across container restarts" or split into
+  "Have (persistence)" + "Coming (host forwarding)".
+- <RepoFile path="docs/src/content/docs/reference/roadmap/open-review-findings.mdx" />
+  finding 3 — claims runtime startup triggers `gh auth login`
+  automatically. The current
+  <RepoFile path="docker/runtime/entrypoint.sh" /> only runs
+  `gh auth setup-git` *after* a successful `gh auth status`; it
+  does not run `gh auth login`. Mark resolved or remove.
+- <RepoFile path="docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx" />
+  comparison row "GitHub CLI auth passthrough | Yes (read-only
+  mount) | Have" — same overstatement. Reword to persistence-only,
+  with this roadmap item as the planned forwarding work.
+
+## Known Gaps Worth Calling Out
+
+These are the corners that nearly slipped past the design but
+matter for the least-privilege goal. Each one needs an answer
+before the implementing PR series can land confidently.
+
+### 1. `git_pull_on_entry` runs host-side, before the container exists
+
+When a workspace has `git_pull_on_entry = true`, jackin' currently
+runs `git pull` on the host **before** the agent container starts.
+That pull uses the host's git credential helper, which on most
+machines is `gh auth setup-git` writing the host's broad token
+into git operations.
+
+If the operator's mental model is *"this workspace uses a scoped
+token via `auth_forward = "token"`"*, the pre-launch pull breaks
+that model: the scoped token never enters the picture for the
+clone/pull. The least-privilege story leaks.
+
+Same issue applies to the initial role-repo clone (the `git` URL
+in `[roles.<name>]`). That clone runs host-side too.
+
+Options:
+
+- **Document the limitation** loudly: `auth_forward` only governs
+  in-container `gh` and in-container `git`; the host-side pull and
+  initial clone still use host creds.
+- **Run the pull/clone inside a short-lived container** with the
+  resolved `GH_TOKEN` injected. More moving parts, but matches the
+  isolation promise.
+- **Push pulls into the runtime** so the container's git (now
+  authenticated under the role's token) does the fetch on first
+  start instead. Loses the "ready before launch" UX but preserves
+  the boundary.
+
+### 2. Token expiry mid-session
+
+Fine-grained PATs expire (default 30 days, max 1 year). Long-lived
+container sessions outlive the token they were launched with. When
+the token expires, in-container `gh` and `git push` start failing
+with 401s halfway through an agent run.
+
+`token` mode should at minimum:
+
+- Log the token's expiry on launch when GitHub returns one
+  (`gh auth status` exposes it).
+- Surface a clear "your `GH_TOKEN` expired at `<time>`; rerun the
+  agent after rotating" hint when 401s start, instead of letting
+  the agent retry blind.
+
+The fully reactive path — re-resolving `GH_TOKEN` from the operator
+env layer mid-session and re-injecting — is harder and should not
+block the first cut. Note it as a follow-up.
+
+### 3. `GH_TOKEN` vs `GITHUB_TOKEN` matters beyond `gh`
+
+The "canonical name" question in Open Questions is not just config
+hygiene. Several tools agents use today read different names:
+
+- `gh` CLI: prefers `GH_TOKEN`, falls back to `GITHUB_TOKEN`.
+- The official `github-mcp-server` and similar MCP integrations:
+  read `GITHUB_TOKEN`.
+- `gh auth setup-git` → git over HTTPS: works with whichever name
+  `gh` sees.
+- GitHub Actions-style scripts agents may run: expect `GITHUB_TOKEN`.
+
+Picking only `GH_TOKEN` cleanly breaks MCP servers; picking only
+`GITHUB_TOKEN` is non-canonical for `gh`. The pragmatic move is
+probably to **inject both** under the hood from one configured
+source — operator declares `GH_TOKEN` once, jackin' exports it
+under both names — but this needs an explicit decision so the
+schema doesn't accept conflicting values.
+
+### 4. GHE: `GH_HOST` is not enough
+
+For GitHub Enterprise hosts, `gh` honors a separate env name —
+`GH_ENTERPRISE_TOKEN` — when the active host is the enterprise
+one. Just exporting `GH_TOKEN` + `GH_HOST=ghe.acme.com` works for
+some `gh` versions but is brittle.
+
+The clean shape is:
+
+```toml
+[workspaces.acme.github.env]
+GH_HOST = "ghe.acme.com"
+GH_ENTERPRISE_TOKEN = "op://Work/ACME/ghe-pat"
+```
+
+Doc the GHE recipe explicitly so operators do not file
+"my GHE token doesn't work" issues.
+
+### 5. `sync` clobbers in-container token rotation
+
+`sync` re-copies host auth on every launch. If an operator (or an
+agent inside the container) ever runs `gh auth login` or `gh auth
+refresh` inside the container — adding a new host, switching
+account, refreshing scopes — that work is wiped on the next
+launch.
+
+This already applies to Claude `sync` and is documented there.
+Repeat the same warning for `gh` `sync`: in-container login
+changes are ephemeral; persistent changes belong on the host or
+in `token` mode pointing at the operator-env layer.
+
+### 6. Workspaces that should not see `gh` at all
+
+Default global `sync` forwards the host token to **every**
+workspace, including ones that have nothing to do with GitHub
+(local-only experiments, non-GitHub git hosts, fully offline
+roles). Today the only opt-out is setting `auth_forward = "ignore"`
+per role, which is verbose.
+
+Worth either:
+
+- A workspace-level shortcut: `auth_forward = "ignore"` at
+  `[workspaces.<ws>.github]` covers all roles in that workspace.
+  (Already supported by the layered design — verify the
+  walkthrough makes this obvious.)
+- A more global "default to `ignore` until I opt in" stance —
+  changes the beginner story, probably wrong default.
+
+The first is free; the doc should call it out as the recommended
+pattern for non-GitHub workspaces.
+
+### 7. Audit trail is a feature, not just a side effect
+
+Different tokens for different roles → GitHub audit log shows
+which token (and therefore which jackin role) made each API call
+or push. This is a real forensic benefit when something goes
+wrong: *"agent-smith in customer-acme pushed to prod at 2:14am"*
+is recoverable from GitHub's side, not just from jackin logs.
+
+Worth promoting from implicit to explicit in the **Why It
+Matters** section: audit-trail granularity is the third leg of
+the value proposition alongside scoped privileges and multi-org
+isolation.
+
+### 8. First-time PAT creation UX
+
+Operators new to fine-grained PATs will not know:
+
+- Where to create them (Settings → Developer settings → Fine-grained
+  tokens).
+- That they require the **target org's admin approval** for org
+  resources, which can take days.
+- That classic PATs (no admin approval needed) are an acceptable
+  fallback if fine-grained is blocked.
+
+The authentication guide should include a one-screenful "Create a
+scoped GitHub token" recipe with screenshots or a numbered list,
+linked from the `token` mode description. Without this, `token`
+mode is technically supported but practically unused.
+
+### 9. Migration for operators with existing in-container `gh` login
+
+Operators who have been using jackin' for a while have
+`~/.jackin/data/<container>/.config/gh` populated from earlier
+manual `gh auth login` runs. Once `sync` becomes the default
+behaviour, the next launch will overwrite that file with the host
+login.
+
+For most operators this is what they wanted; for some it is a
+silent identity switch. The first launch under the new default
+should print a one-line notice when an existing in-container login
+is being replaced, so the swap is not invisible.
+
+### 10. Scope of `.config/gh` actually forwarded
+
+`~/.config/gh/` on the host can contain more than `hosts.yml`:
+`config.yml` (preferences, default protocol), installed `gh
+extensions`, command aliases, OAuth client overrides.
+
+`sync` should copy only the **auth** state (`hosts.yml` and the
+keychain-resolved token), not the entire directory. Otherwise
+host-side gh extensions and aliases leak into containers in
+ways that will surprise operators (and may not even work in the
+container's gh version). Doc the boundary explicitly.
+
+## Open Questions
+
+1. Canonical name — `GH_TOKEN` or `GITHUB_TOKEN`? `gh` reads
+   either, but accepting both invites confusion. Pick one and
+   reject the other at parse time.
+2. Should `sync` mode warn the operator the first time it forwards
+   a token with admin scopes (`repo` + `delete_repo`, classic PATs
+   with `admin:org`)? `gh auth status` exposes the scope list — a
+   "broad token" hint would nudge operators toward `token` + a
+   fine-grained PAT.
+3. Multi-host: when `GH_HOST` is unset and the host's `hosts.yml`
+   has tokens for several hosts (github.com + a GHE), forward all
+   or just `github.com`? Default to `github.com` and require
+   explicit opt-in for GHE.
+4. Once
+   [credential source pattern](/reference/roadmap/credential-source-pattern/)
+   ships, `[github.env].GH_TOKEN = { command = "gh auth token --hostname …" }`
+   is a clean way to reuse the host's existing `gh` login as the
+   source for an alternate-host token without copying any file.
+5. Worth a `keychain` mode that reads the host keychain directly on
+   macOS, or better deferred to credential-source-pattern instead
+   of growing a fourth `auth_forward` mode?
+
+## Related Reading
+
+- [Reliable Claude authentication strategy](/reference/roadmap/claude-auth-strategy/)
+  — parallel design for agent auth, same layered shape
+- [Credential source pattern](/reference/roadmap/credential-source-pattern/)
+  — future unified credential resolver
+- [1Password integration](/reference/roadmap/onepassword-integration/)
+  — operator-env source for `GH_TOKEN`
+- [PR #242 — `feat(console): focus auth tab by kind`](https://github.com/jackin-project/jackin/pull/242)
+  — Auth-tab UX this item builds on
+- [`gh auth login` upstream manual](https://cli.github.com/manual/gh_auth_login)

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -1,6 +1,7 @@
 ---
 title: "GitHub CLI Authentication Strategy"
 ---
+import { Aside } from '@astrojs/starlight/components'
 import RepoFile from '../../../../components/RepoFile.astro'
 
 

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -263,37 +263,205 @@ right host with the right token.
 ## Console UX
 
 This builds on the kind-picker Auth tab introduced in
-[PR #242](https://github.com/jackin-project/jackin/pull/242).
+[PR #242](https://github.com/jackin-project/jackin/pull/242). The
+goal is **strict parity** with the Claude / Codex flow: same
+two-level shape, same edit modal, same keystrokes, same Save
+invariant. GitHub CLI is one more entry in a UI operators already
+know — there are no new screens, no new modes of interaction, no
+new mental model. What changes is small and entirely additive.
 
-The Auth tab today has a two-level shape:
+### Today's shape (Claude / Codex)
 
-1. **Root view** — pick which auth kind to manage. Today: **Claude
-   Code** and **Codex**.
-2. **Detail view** — for the picked kind, edit workspace mode +
-   credential source + per-role overrides.
+The Auth tab is two-level:
 
-This roadmap item adds a third kind to the root picker:
-**GitHub CLI**. Selecting it opens the same detail-view shape:
+1. **Root view** — a vertical list of auth kinds. Today: two rows,
+   `Claude Code` and `Codex`. The selected kind is highlighted
+   with the standard cursor symbol (`▸`). `Enter` enters the
+   detail view for that kind.
+2. **Detail view** — bordered panel titled with the kind name.
+   Rows, top to bottom:
+   - `Workspace mode: <mode>` — current effective mode for that
+     kind in the active workspace, with ` (inherited)` suffix when
+     no explicit workspace-level override exists.
+   - `Workspace source: …` — only when the resolved mode requires
+     a credential (Claude `api_key`/`oauth_token`, Codex
+     `api_key`). Renders the credential source: 1Password
+     breadcrumb, host-env reference, or literal indicator.
+   - Spacer + per-role override blocks. Each block is a
+     `RoleHeader` (collapsed by default); `→`/`←` expands or
+     collapses, revealing `RoleMode` and (if needed) `RoleSource`
+     rows.
+   - `+ Override for a role` sentinel at the bottom — opens the
+     `AuthRolePicker` modal that lists the eligible roles in the
+     workspace whose roster does **not** already carry an
+     override for the selected kind.
 
-- Workspace-level mode: `sync` / `token` / `ignore`.
-- Credential source row, shown only when the resolved mode is
-  `token`. Same `SourcePicker` widget the existing Auth tab uses
-  for Claude/Codex (1Password picker → structured
-  `EnvValue::OpRef`, host env passthrough, literal). The 1Password
-  picker writes the structured inline-table form by default; the
-  deprecated bare `op://...` string form is never produced by the
-  TUI.
-- Per-role overrides list, same expand/collapse behaviour as
-  Claude/Codex.
+`Enter` on `WorkspaceMode` / `WorkspaceSource` / `RoleMode` /
+`RoleSource` opens the **edit modal** (`AuthForm`):
 
-The same disabled-Save invariant the existing Auth-tab forms use
-applies: Save stays inert until `GH_TOKEN` resolves to a non-empty
-value when `token` is selected.
+- Title bar: `Edit auth`.
+- Mode picker row (label width 12 chars). Picks from the kind's
+  supported modes — Claude shows `sync` / `api_key` /
+  `oauth_token` / `ignore`, Codex omits `oauth_token`.
+- Credential block (label width 22 chars), only shown when the
+  picked mode requires one. One row that opens the shared
+  `SourcePicker` widget (1Password picker → structured
+  `EnvValue::OpRef`, host-env passthrough, literal).
+- `Save` / `Cancel` / `Reset` buttons. The **Save invariant**:
+  Save stays disabled (greyed out) until both `mode` is set
+  **and**, when the mode requires a credential, the credential is
+  non-empty. Both fields of an `EnvValue::OpRef` (`op` + `path`)
+  must be non-empty so a partial picker round-trip cannot land a
+  broken reference on disk.
 
-Footer hints surface the resolved mode and where it came from
-(global / workspace / role override). Nothing new for operators
-to learn — GitHub CLI is one more entry in a picker they already
-know.
+Outside the modal, `D` / `d` clears overrides at the row's level:
+on a `RoleHeader` it clears the role's override for the selected
+kind; on a `WorkspaceMode` / `WorkspaceSource` row it clears the
+workspace-level override and lets resolution fall through to the
+global default.
+
+### What changes for the GitHub kind
+
+Pure addition; no existing surface re-shapes. Specifically:
+
+1. **Root view grows by one row.** The kind list becomes
+   `Claude Code` / `Codex` / `GitHub CLI`, in that order. Same
+   row style, same cursor, same `Enter`-to-enter behaviour. No
+   tabs, no nesting, no visual weight beyond what Claude / Codex
+   already carry.
+2. **Detail view structure is identical.** Selecting `GitHub CLI`
+   opens a panel titled `GitHub CLI` with the same row sequence
+   as Claude / Codex: workspace mode → workspace source (when
+   mode is `token`) → spacer → role overrides → `+ Override for a
+   role`.
+3. **Mode picker shows three options:** `sync` / `token` /
+   `ignore`. There is no GitHub equivalent of `oauth_token` and
+   no `api_key` (`token` is the canonical name for `gh` PATs).
+4. **Credential block** appears only when `token` is picked. The
+   single row binds to `GH_TOKEN`. Same `SourcePicker` modal as
+   Claude / Codex — including the **1Password picker writes
+   structured `EnvValue::OpRef`, never the deprecated bare
+   `op://...` string** rule.
+5. **Save invariant unchanged.** Save stays disabled until
+   `mode` is set and, for `token`, until `GH_TOKEN` resolves to a
+   non-empty value (literal or both `op` + `path` populated).
+6. **Role-override picker** filters out roles that already carry
+   a `[workspaces.<ws>.roles.<role>.github]` override — the same
+   "no duplicate override" rule the existing picker applies for
+   `claude` / `codex`.
+7. **`D` / `d` semantics map directly:** clearing a `RoleHeader`
+   clears the role's `[…].github` override; clearing
+   `WorkspaceMode` / `WorkspaceSource` clears
+   `[workspaces.<ws>.github]`.
+8. **Footer hints** surface the resolved mode + provenance
+   (`global` / `workspace` / `role override`) for whichever row
+   is focused — same shape as today.
+
+### Wireframes
+
+Root view, after the change:
+
+```text
+┌──────────────────────────────────────────────┐
+│ Auth                                         │
+│                                              │
+│ ▸ Claude Code                                │
+│   Codex                                      │
+│   GitHub CLI                                 │  ← new
+│                                              │
+│ ↑/↓ select   Enter open   q back             │
+└──────────────────────────────────────────────┘
+```
+
+Detail view for `GitHub CLI` with `token` mode at the workspace
+level and a per-role `ignore` override on `scratch`:
+
+```text
+┌ GitHub CLI ──────────────────────────────────┐
+│                                              │
+│ ▸ Workspace mode:    token                   │
+│   Workspace source:  op  Work/ACME/gh-pat    │
+│                                              │
+│   ▾ scratch                                  │
+│       Mode:           ignore (role override) │
+│                                              │
+│   + Override for a role                      │
+│                                              │
+│ Resolved: token (workspace)   GH_TOKEN: set  │
+│ Enter edit   D clear   →/← expand   q back   │
+└──────────────────────────────────────────────┘
+```
+
+Edit modal for the workspace mode row above:
+
+```text
+┌ Edit auth ─────────────────────────────┐
+│                                        │
+│ Mode:        ( ) sync                  │
+│              (•) token                 │
+│              ( ) ignore                │
+│                                        │
+│ GH_TOKEN:    op  Work/ACME/gh-pat  […] │
+│                                        │
+│              [  Save  ] [Cancel] [Rst] │
+│                                        │
+│ Tab next   Enter act   Esc cancel      │
+└────────────────────────────────────────┘
+```
+
+`Save` is enabled here because `mode` is set **and** `GH_TOKEN`
+resolves to a non-empty `EnvValue::OpRef`. Switching to `sync` or
+`ignore` hides the credential row and keeps Save enabled
+(no credential needed). Switching to `token` while the row is
+empty disables Save until the operator picks a source.
+
+### Where the underlying types need to widen
+
+The detail-view machinery is keyed off the `Agent` enum today
+(`AuthRow::AuthKind { agent: Agent }`,
+`editor.auth_selected_agent: Option<Agent>`,
+`agent.required_env_var(mode)`, `agent.supported_modes()`,
+`pending.roles[*].claude` / `.codex` lookups).
+GitHub is **not** an agent — it has no install block, no launch
+entrypoint, no version probe. Adding `Agent::Github` would force
+fake arms across the runtime layer.
+
+The right move is to introduce an `AuthKind` enum at the
+auth-panel layer (variants `Claude`, `Codex`, `Github`) and
+rename the kind axis: `auth_selected_agent` →
+`auth_selected_kind`, `AuthRow::AuthKind { agent }` →
+`{ kind }`, and so on. `AuthKind::for_agent(Agent) -> AuthKind`
+keeps the runtime → kind mapping explicit. The `Agent` enum
+itself stays as it is.
+
+This is a mechanical rename across the auth panel + manager
+input/render layer, not a UX change.
+
+### Parity table
+
+What the operator sees today vs after this lands:
+
+| Surface | Claude / Codex (today) | GitHub CLI (after) |
+|---|---|---|
+| Root view row | ✓ | ✓ (third row) |
+| Detail view title bar | ` Claude Code ` / ` Codex ` | ` GitHub CLI ` |
+| Workspace mode row | ✓ | ✓ |
+| Workspace source row (when mode needs credential) | `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `OPENAI_API_KEY` | `GH_TOKEN` |
+| Per-role overrides (`RoleHeader` / `RoleMode` / `RoleSource`) | ✓ | ✓ |
+| `+ Override for a role` sentinel | ✓ | ✓ |
+| `→` / `←` expand/collapse role | ✓ | ✓ |
+| `Enter` opens edit modal | ✓ | ✓ |
+| `D` / `d` clears at row level | ✓ | ✓ |
+| Edit modal (`AuthForm`) | ✓ | ✓ (same widget) |
+| Mode picker contents | `sync` / `api_key` / `oauth_token` / `ignore` (Claude); `sync` / `api_key` / `ignore` (Codex) | `sync` / `token` / `ignore` |
+| Source picker (`SourcePicker`) | ✓ | ✓ (same widget; structured `EnvValue::OpRef`, never bare `op://...`) |
+| Save invariant | mode set + (no credential needed OR credential non-empty) | identical |
+| Footer hints | resolved mode + provenance | identical |
+| Color theme | `PHOSPHOR_GREEN` / `PHOSPHOR_DIM` / `WHITE` / `DANGER_RED` | identical |
+
+Nothing in the table is "different" for GitHub except the
+specific mode-picker contents and the env-var name. Everything
+else is reused as-is.
 
 ## CLI
 

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -61,7 +61,7 @@ missing piece is somewhere in jackin to say *"this role uses
 
 | Today | After this lands |
 |---|---|
-| First launch needs interactive `gh auth login` inside the container. | First launch reuses the host login automatically (`sync` default). |
+| First launch needs interactive `gh auth login` inside the container. | First launch reuses the host login automatically. `sync` is the default — same as Claude / Codex `sync` today, no extra setup required. |
 | Every (workspace × role) needs its own login the first time. | One host login covers them all by default. |
 | Every container shares the host's broad GitHub identity. | Workspaces and roles can opt into a scoped token instead. |
 | No way to point a role at a fine-grained PAT. | `auth_forward = "token"` + `GH_TOKEN` from operator-env (`op://`, host env, …). |
@@ -70,9 +70,14 @@ missing piece is somewhere in jackin to say *"this role uses
 
 ## Goals
 
-1. Keep the beginner-friendly path: when the operator is already
-   logged in to `gh` on the host, a freshly launched role works
-   without any in-container login step.
+1. **`sync` is the default — same parity Claude and Codex already
+   ship.** When the operator is already logged in to `gh` on the
+   host, every freshly launched role uses that login automatically,
+   with no in-container login step. This is non-negotiable: the
+   GitHub CLI must not regress the "host auth flows in by default"
+   experience that operators already expect from agent runtimes.
+   `token` and `ignore` are explicit opt-ins on top of that
+   default, not replacements for it.
 2. Operators can override the default per workspace and per
    (workspace × role) to bind a specific role to a specific
    least-privilege token.
@@ -104,7 +109,7 @@ Three modes, mirroring the agent-auth shape:
 
 | Mode | Behaviour |
 |---|---|
-| `sync` (default) | When the host has a usable `gh` token, materialize it into the role-state's `.config/gh/` on each launch. When the host is logged out, leave any existing container-side login alone. |
+| `sync` (**default — must stay default to match Claude / Codex parity**) | When the host has a usable `gh` token, materialize it into the role-state's `.config/gh/` on each launch. When the host is logged out, leave any existing container-side login alone. |
 | `token` | Provision empty `.config/gh/`; inject `GH_TOKEN` (and `GH_HOST` when non-default) into the container's process env from the operator-env layer. `gh` reads the token directly — perfect for fine-grained PATs scoped to one repo or org. |
 | `ignore` | Wipe any forwarded `gh` state and never forward host auth. The agent must `gh auth login` inside the container if it needs `gh`. |
 

--- a/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
+++ b/docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx
@@ -64,7 +64,7 @@ missing piece is somewhere in jackin to say *"this role uses
 | First launch needs interactive `gh auth login` inside the container. | First launch reuses the host login automatically. `sync` is the default — same as Claude / Codex `sync` today, no extra setup required. |
 | Every (workspace × role) needs its own login the first time. | One host login covers them all by default. |
 | Every container shares the host's broad GitHub identity. | Workspaces and roles can opt into a scoped token instead. |
-| No way to point a role at a fine-grained PAT. | `auth_forward = "token"` + `GH_TOKEN` from operator-env (`op://`, host env, …). |
+| No way to point a role at a fine-grained PAT. | `auth_forward = "token"` + `GH_TOKEN` from operator-env (structured `{ op = "op://uuid/...", path = "..." }` reference, host env, …). |
 | No way to deny `gh` to a specific role. | `auth_forward = "ignore"` wipes and refuses to forward. |
 | GitHub story disconnected from Claude / Codex auth UX. | Same modes, same layered config, same Auth tab in the console. |
 
@@ -82,8 +82,10 @@ missing piece is somewhere in jackin to say *"this role uses
    (workspace × role) to bind a specific role to a specific
    least-privilege token.
 3. The `gh` token source plugs into the same operator-env layer
-   already used for Claude/Codex auth (`op://`, host env, future
-   `keychain` and `command` sources from
+   already used for Claude/Codex auth (structured 1Password
+   `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }`
+   references, host env passthrough, future `keychain` and
+   `command` sources from
    [credential source pattern](/reference/roadmap/credential-source-pattern/)).
 4. The launch summary tells the operator unambiguously which `gh`
    identity is active and where it came from.
@@ -177,19 +179,23 @@ auth_forward = "sync"
 auth_forward = "token"
 
 [workspaces.customer-acme.github.env]
-GH_TOKEN = "op://Work/ACME/github-fine-grained-pat"
+GH_TOKEN = { op = "op://abc.../def.../fld...", path = "Work/ACME/github-fine-grained-pat" }
 
 # Per-role — release-bot in the same workspace, push-to-tags-only token
 [workspaces.customer-acme.roles.release-bot.github]
 auth_forward = "token"
 
 [workspaces.customer-acme.roles.release-bot.github.env]
-GH_TOKEN = "op://Work/ACME/github-release-pat"
+GH_TOKEN = { op = "op://abc.../def.../fld...", path = "Work/ACME/github-release-pat" }
 
 # Per-role — throwaway scratch role, no GitHub at all
 [workspaces.customer-acme.roles.scratch.github]
 auth_forward = "ignore"
 ```
+
+<Aside type="caution">
+**Never use the bare-string `op://...` form for env values.** It has been deprecated since 2026-04-27 (see [`DEPRECATED.md`](https://github.com/jackin-project/jackin/blob/main/DEPRECATED.md) → "Bare `op://...` strings as env values"). Bare strings flow through as literals — `op read` is **not** invoked, so the container receives the unresolved URI rather than the secret. Always use the structured inline-table form `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }` shown above. The `op` field stores the UUID-form `op://` URI; `path` holds the human-readable Vault/Item/Field snapshot at pin time. Operator-facing entry points are `jackin workspace env set <NAME> "op://..."` (the CLI auto-resolves to the pinned UUID form) and the TUI 1Password picker.
+</Aside>
 
 ### Walkthrough — what wins?
 
@@ -206,9 +212,11 @@ For `customer-acme` workspace with the config above:
   falls back to global `sync` → host login flows in.
 
 Tokens come from the same operator-env layers used everywhere else
-in jackin' (`op://...`, host env, future `keychain` / `command`
-sources from
-[credential source pattern](/reference/roadmap/credential-source-pattern/)).
+in jackin' — structured 1Password `EnvValue::OpRef` inline tables,
+host-env passthrough, and the future `keychain` / `command` sources
+from [credential source pattern](/reference/roadmap/credential-source-pattern/).
+Bare `op://...` strings are deprecated and resolve to literals — see
+the warning under the example above.
 
 ## Use Cases
 
@@ -270,7 +278,11 @@ This roadmap item adds a third kind to the root picker:
 - Workspace-level mode: `sync` / `token` / `ignore`.
 - Credential source row, shown only when the resolved mode is
   `token`. Same `SourcePicker` widget the existing Auth tab uses
-  for Claude/Codex (`op://`, host env, literal).
+  for Claude/Codex (1Password picker → structured
+  `EnvValue::OpRef`, host env passthrough, literal). The 1Password
+  picker writes the structured inline-table form by default; the
+  deprecated bare `op://...` string form is never produced by the
+  TUI.
 - Per-role overrides list, same expand/collapse behaviour as
   Claude/Codex.
 
@@ -302,7 +314,7 @@ Every launch already prints which Claude/Codex auth mode is active.
 A parallel line for `gh`:
 
 - `gh auth: forwarded host token (sync)`
-- `gh auth: scoped token from op://Work/ACME/github-fine-grained-pat (token)`
+- `gh auth: scoped token from Work/ACME/github-fine-grained-pat (token)` — the human-readable `path` field of the resolved `EnvValue::OpRef` is rendered, never the bare URI
 - `gh auth: none (manual gh auth login required)` — for `ignore`
 
 When two or more containers share the same forwarded host token,
@@ -460,7 +472,7 @@ The clean shape is:
 ```toml
 [workspaces.acme.github.env]
 GH_HOST = "ghe.acme.com"
-GH_ENTERPRISE_TOKEN = "op://Work/ACME/ghe-pat"
+GH_ENTERPRISE_TOKEN = { op = "op://abc.../def.../fld...", path = "Work/ACME/ghe-pat" }
 ```
 
 Doc the GHE recipe explicitly so operators do not file


### PR DESCRIPTION
## Summary

Two related streams of work, bundled because they belong to the same "roadmap hygiene" theme:

1. **New roadmap item — GitHub CLI authentication strategy.** Layered `auth_forward` (`sync` / `token` / `ignore`) for the GitHub CLI, mirroring the agent-auth design and the post-#242 kind-picker Auth tab. Headline use case is **least-privilege scoping per (workspace × role)** using fine-grained PATs, plus multi-org isolation and per-role audit-trail granularity. `sync` is pinned as the non-negotiable default — same parity Claude / Codex `sync` already ship.

2. **Roadmap overview sync + discipline rule.** The overview page (`reference/roadmap.mdx`) had drifted from the directory. Items resolved months ago were absent from Completed; partially implemented items hid under generic Planned bullets; whole programs (Codebase Readability, Open Review Findings) were not mentioned at all. Synced the page and added a `docs/AGENTS.md` rule + `TODO.md` checkbox so future PRs keep the overview honest.

## What lands

### New roadmap design doc

- `docs/src/content/docs/reference/roadmap/github-cli-auth-strategy.mdx` — full design proposal with operator-focused framing: problem / why-it-matters / before-and-after table for operators, three-mode design (`sync` / `token` / `ignore`) with `sync` pinned as the non-negotiable default, layered TOML example using the **structured `EnvValue::OpRef` form** (never bare `op://...` strings — see Aside below), GHE recipe with `GH_ENTERPRISE_TOKEN`, five worked use cases, security notes, and a "Known Gaps Worth Calling Out" section flagging ten non-obvious corners discovered during research. The Console UX section contains a research-backed walkthrough of the post-#242 kind-picker Auth tab, three ASCII wireframes (root view, GitHub CLI detail view, edit modal), and a 13-row parity table showing exactly what stays identical vs what changes for the new GitHub CLI kind.
- `docs/astro.config.ts` — sidebar entry under **Reference → Roadmap → Agent runtimes & authentication**, after the Claude auth strategy entry.

### Deprecated bare-string `op://` compliance

Every TOML example in the new roadmap doc uses the structured inline-table form `{ op = "op://uuid/uuid/uuid", path = "Vault/Item/Field" }` introduced by PR #193. A caution `<Aside>` under the layered-config example calls out that bare-string `op://...` env values were deprecated on 2026-04-27 (see [`DEPRECATED.md`](https://github.com/jackin-project/jackin/blob/main/DEPRECATED.md) → "Bare `op://...` strings as env values"), explains what they do today (literal pass-through, no `op read` resolution), and points operators at the right entry points (`jackin workspace env set` auto-resolution + the TUI 1Password picker, which writes the structured form by default).

### Roadmap overview page rewritten for accuracy

- Move `per-mount-isolation` from Planned to Completed (status is `Implemented in V1`).
- Add four missing Resolved entries: `jackin-debug-env-var`, `msrv-toolchain`, `worktree-cleanup-assessment`, `per-mount-isolation`.
- Reword the GitHub CLI Completed line to accurately describe today's persistence-only behavior, with a forward link to the new forwarding-strategy roadmap item.
- New **Partially implemented** section calling out `onepassword-integration` and `multi-runtime-support`.
- Add missing Planned entries with explicit `(status: …)` suffixes: `devcontainer-parity`, `claude-auth-strategy`, `selectable-sandbox-backends`, `bollard-migration`, `construct-user-creation`, `reproducibility-pinning`.
- New **Codebase health** section linking the `codebase-readability` program and the `open-review-findings` catalog.
- New **Documentation infrastructure** section linking `greenfield-workspace`, `docs-markdown-linting`, `rustdoc-json-starlight`.

### New discipline rules

- `docs/AGENTS.md` gains a **Roadmap overview discipline** entry next to the existing **Roadmap sidebar discipline**, with a `**Status**` → section mapping table and an audit command (`comm -23 …`). Output must be empty except for items intentionally umbrella-covered by a parent program entry that explicitly says so in the overview.
- `TODO.md` per-PR stale-docs checklist gains a new checkbox: any PR that adds a roadmap item or changes any `**Status**` must update the overview.

## Design highlights for the new roadmap item

- Three modes: `sync` (default, host-forward), `token` (scoped PAT via operator-env), `ignore` (no GitHub access).
- `sync` is pinned as the non-negotiable default — same parity Claude and Codex `sync` already ship.
- Three layers: global / per-workspace / per-(workspace × role). Most-specific wins.
- No agent dimension for `[github]` — `gh` is agent-neutral and the `.config/gh` mount is shared.
- Plugs into the post-#242 kind-picker Auth tab as a third entry alongside Claude Code and Codex.

## Known gaps the doc surfaces

A "Known Gaps Worth Calling Out" section flags non-obvious corners discovered during research, each with options for the implementing PR series:

1. **`git_pull_on_entry` runs host-side** before the container exists — bypasses the workspace-scoped token. Real isolation leak that needs a documented limitation or a containerized pull.
2. **Token expiry mid-session** — fine-grained PATs expire; long-running sessions hit silent 401s.
3. **`GH_TOKEN` vs `GITHUB_TOKEN`** beyond `gh` — MCP servers and Actions-style scripts read different names. Pragmatic fix: inject both from one source.
4. **GHE needs `GH_ENTERPRISE_TOKEN`** in addition to `GH_HOST`.
5. **`sync` clobbers in-container token rotation** every launch — same warning Claude `sync` carries.
6. **Workspaces that should not see `gh`** — workspace-level `ignore` covers all roles cleanly; doc the pattern.
7. **Audit-trail granularity** promoted to a featured value-prop bullet.
8. **First-time PAT creation friction** — fine-grained PATs require org-admin approval; auth guide needs a setup recipe.
9. **Migration for existing operators** with cached in-container `gh login` — silent identity swap risk.
10. **Scope of forwarded `~/.config/gh`** — auth state only, not extensions / aliases / preferences.

## Documentation drift the same PR series should repair

Three existing pages already overstate today's `gh` story:

- `roadmap.mdx` Completed line "GitHub CLI authentication passthrough" — already corrected in this PR (now reads "GitHub CLI authentication state persists across container restarts" with a forward link).
- `roadmap/open-review-findings.mdx` finding 3 — claims runtime startup triggers `gh auth login` automatically; current `entrypoint.sh` only runs `gh auth setup-git` after a successful `gh auth status`. Still needs fixing in the implementing PR series.
- `roadmap/multicode-inspired-features.mdx` comparison row "GitHub CLI auth passthrough | Yes (read-only mount) | Have" — same overstatement. Still needs fixing.

## Verify locally

#### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/github-cli-auth-strategy-roadmap:refs/remotes/origin/docs/github-cli-auth-strategy-roadmap
git checkout -B docs/github-cli-auth-strategy-roadmap refs/remotes/origin/docs/github-cli-auth-strategy-roadmap
```

#### Run the docs site locally and review the affected pages

```sh
cd docs
bun install --frozen-lockfile   # only needed first time / after lockfile changes
bun run dev
```

Astro serves at <http://localhost:4321/>. Open these pages to review the change in rendered form:

- **New roadmap page** — <http://localhost:4321/reference/roadmap/github-cli-auth-strategy/> — full design proposal. Check the use-case table, the layered TOML example, the "Known Gaps Worth Calling Out" section, and the "Documentation drift" callouts render correctly.
- **Roadmap overview** — <http://localhost:4321/reference/roadmap/> — confirm:
  - **Completed** now lists `JACKIN_DEBUG`, MSRV toolchain, worktree cleanup, per-mount isolation, and the corrected GitHub CLI line.
  - **Partially implemented** is a new section with 1Password and multi-runtime entries.
  - **Planned → Security improvements** includes the new GitHub CLI authentication strategy line and shows `(status: …)` suffixes on deferred / proposed items.
  - **Codebase health** and **Documentation infrastructure** are new sections, each linking the right program/items.
- **Sidebar** — open any page under **Reference → Roadmap** and confirm "GitHub CLI authentication strategy" appears in the **Agent runtimes & authentication** group, after "Reliable Claude authentication strategy".

#### Sidebar + overview audits

```sh
ls docs/src/content/docs/reference/roadmap/*.mdx | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
grep -oE 'reference/roadmap/[a-z0-9-]+' docs/astro.config.ts | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-sidebar
grep -oE 'reference/roadmap/[a-z0-9-]+' docs/src/content/docs/reference/roadmap.mdx | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-overview

echo "=== sidebar diff (must be empty) ==="
diff /tmp/roadmap-files /tmp/roadmap-sidebar
echo "=== overview missing (umbrella-covered items only) ==="
comm -23 /tmp/roadmap-files /tmp/roadmap-overview
```

The sidebar diff must be empty. The overview-missing list must contain only items intentionally umbrella-covered by parent program entries (Universal Orchestrator Program leaves and Codebase Readability program leaves, both of which the overview names explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


