### PR TITLE
docs(agents): require literal Markdown in PR bodies + local-render verification for docs PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,22 @@ Every pull request created by an agent must include a copy-pasteable "Verify loc
 
 Use the real PR number, repository URL, branch name, and verification commands for the change. Start from a separate test directory so the operator can inspect the PR without disturbing their normal working tree. The clone step must be idempotent: reuse the folder if it already exists, otherwise clone it. Prefer the actual head branch name over GitHub's synthetic `pull/<PR_NUMBER>/head` ref for same-repository PRs; use the synthetic PR ref only when the branch cannot be fetched directly, such as a fork PR without an added fork remote.
 
-Split verification into named blocks only when each block contains meaningful commands. Always include checkout instructions. Add Static Checks only when there is a local check worth running beyond CI and GitHub's diff UI. Add Tests only when there is a relevant automated test command. Add User Smoke only when the operator can exercise changed behavior locally, such as CLI, runtime, workspace, Docker, TUI, or operator-flow changes. Do not add placeholder sections that say no test applies, and do not add commands that only print files for review. For documentation-only PRs where the meaningful review is reading the file diff, say to review the Files changed tab in GitHub instead of adding commands like `git diff origin/main...HEAD -- <file>`. For CLI/runtime smoke, run the local checkout's `jackin` binary and exercise the behavior touched by the PR. If the PR has no narrower manual path, use the console as the baseline smoke command: `cargo run --bin jackin -- console --debug`. For launch/runtime flows, prefer a command that hits the changed path, such as `cargo run --bin jackin -- load <role> <target> --debug`. For subcommands that do not support `--debug`, include the closest supported `jackin --debug` command in the same smoke block and explain the gap in one sentence.
+Split verification into named blocks only when each block contains meaningful commands. Always include checkout instructions. Add Static Checks only when there is a local check worth running beyond CI and GitHub's diff UI. Add Tests only when there is a relevant automated test command. Add User Smoke only when the operator can exercise changed behavior locally, such as CLI, runtime, workspace, Docker, TUI, or operator-flow changes. Do not add placeholder sections that say no test applies, and do not add commands that only print files for review. For CLI/runtime smoke, run the local checkout's `jackin` binary and exercise the behavior touched by the PR. If the PR has no narrower manual path, use the console as the baseline smoke command: `cargo run --bin jackin -- console --debug`. For launch/runtime flows, prefer a command that hits the changed path, such as `cargo run --bin jackin -- load <role> <target> --debug`. For subcommands that do not support `--debug`, include the closest supported `jackin --debug` command in the same smoke block and explain the gap in one sentence.
+
+#### Documentation-only PRs
+
+Documentation PRs (changes under `docs/**` only — `.mdx` files, `astro.config.ts` sidebar, theme/CSS) must verify by running the docs site **locally** in addition to checkout, not by pointing the operator at the GitHub Files-changed tab.
+
+The Files-changed tab shows raw MDX. It does not show how Starlight renders the page, whether `<RepoFile />` resolves, whether the sidebar entry lands in the right group, whether internal `[link](/path/)` references resolve, whether tables and Asides render correctly, or whether the page is even reachable through navigation. A docs PR that "looks right in the diff" can render visibly broken on the site.
+
+Required pattern for docs-only PRs:
+
+1. **Checkout block** — same as any other PR.
+2. **Run the docs site locally** — `cd docs && bun install --frozen-lockfile && bun run dev`. Astro serves at `http://localhost:4321/`.
+3. **Direct links to every changed page** — for each affected MDX file, include a localhost URL the operator can click straight into. Map `docs/src/content/docs/<path>.mdx` to `http://localhost:4321/<path>/`. For new pages, also tell the operator which sidebar group the entry should appear under, so they can confirm the navigation lands in the right place.
+4. **Sidebar audit** (when `astro.config.ts` or any roadmap MDX changed) — the diff command from `docs/AGENTS.md` → "Roadmap sidebar discipline".
+
+A `.mdx`-only PR that omits the local-render step is incomplete. The Files-changed tab is the operator's last-resort fallback, not the primary review surface.
 
 Template:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,26 @@ cargo run --bin jackin -- console --debug
 
 If the PR needs a different validation flow, replace the final example commands with the exact commands the operator should run. When those commands invoke `jackin`, include `--debug` as required by "Walking the operator through local validation".
 
+#### Author the PR body so it renders correctly on GitHub
+
+The PR body is Markdown — what the operator sees on GitHub is what matters. Two recurring failure modes when an agent constructs the body inside a shell command:
+
+1. **Do not escape backticks or `$`.** Triple-backtick fences must be literal `` ``` ``, not `\`\`\``. Variable references inside fenced code blocks (e.g. `$HOME`, `$PR_NUMBER`) must be literal `$`, not `\$`. Escaping them produces visibly broken output like `\`\`\`sh` and `\$HOME` in the rendered PR.
+2. **Use `gh pr create --body-file <file>` (not `--body "..."`)** when the body contains code fences, dollar signs, or anything else that interacts with shell quoting. Write the body to a temp file with a single-quoted `<<'EOF'` heredoc — single quotes already disable shell expansion and command substitution, so no manual escaping is needed inside the heredoc. The pattern is:
+
+   ~~~sh
+   cat > /tmp/pr-body.md <<'EOF'
+   ## Summary
+
+   ```sh
+   echo "$HOME"
+   ```
+   EOF
+   gh pr create --body-file /tmp/pr-body.md ...
+   ~~~
+
+   Then immediately verify the rendered body with `gh pr view <PR> --json body -q .body`. If you see `\`` or `\$` anywhere, the body is broken — fix it with `gh pr edit <PR> --body-file <file>` before moving on.
+
 For non-trivial code changes, structure the PR's "Verify locally" section by intent:
 
 - **Checkout** — copy-pasteable commands to fetch and check out the PR.


### PR DESCRIPTION
## Summary

Two new rules under AGENTS.md → "Include local checkout instructions in every PR":

1. **PR bodies must use literal Markdown — no defensive escaping.** Backticks (` ``` `) and `$` inside fenced code blocks must stay literal. Build the body via `gh pr create --body-file <file>` with a single-quoted `<<'EOF'` heredoc (which already suppresses shell expansion, so no escaping is needed). Always verify the rendered body with `gh pr view <PR> --json body -q .body` and fix any `\`` / `\$` artifacts before moving on.

2. **Docs-only PRs must verify against the local Astro site, not the Files-changed tab.** Required pattern: checkout block + `cd docs && bun install --frozen-lockfile && bun run dev` + a `http://localhost:4321/<path>/` link for every changed MDX page + sidebar group hint for new pages + sidebar audit when `astro.config.ts` or any roadmap MDX changed.

## Why

Both rules trigger from PR #244 going wrong:

- The PR body was authored with `\`\`\`sh` and `\$HOME` defensive escapes inside a single-quoted heredoc. Single quotes already suppress expansion, so the escapes survived to GitHub verbatim and rendered visibly broken (`\`\`\`sh` and `\$HOME` literal in the page).
- The original "Verify locally" section pointed the operator at the GitHub Files-changed tab. That works for prose tweaks but is wrong for a roadmap change that adds a new MDX page **and** a sidebar entry — exactly the case where Starlight rendering, sidebar placement, and link resolution all need eyeballs in a real browser.

## Verify locally

#### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch origin docs/agents-pr-body-no-escape:refs/remotes/origin/docs/agents-pr-body-no-escape
git checkout -B docs/agents-pr-body-no-escape refs/remotes/origin/docs/agents-pr-body-no-escape
```

This PR touches `AGENTS.md` only — no Astro site change. Review the diff against `AGENTS.md` directly:

```sh
git diff origin/main...HEAD -- AGENTS.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
