### PR TITLE
docs(agents): use git fetch -f in PR verify recipe to survive force-pushes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,11 @@ fi
 
 cd jackin
 mise trust
-git fetch origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
+git fetch -f origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
 git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
 ```
+
+The `-f` (`--force`) on `git fetch` is required, not optional. Agent-authored PR branches are routinely force-pushed during iteration (review-fix amend, rebase onto fresh `main`, body-only fix-ups). Without `-f`, every force-push breaks the operator's verify recipe with `! [rejected] <branch> -> origin/<branch> (non-fast-forward)`, and the local `refs/remotes/origin/<branch>` stays pinned to the pre-force-push tip. The `git checkout -B` rewrites the local branch unconditionally, but only against whatever the remote-tracking ref points at — so the fetch must update that ref through force-pushes to be useful. Equivalent recipe: `git fetch origin '+<BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>'`. Prefer the `-f` form for readability.
 
 #### Static Checks
 


### PR DESCRIPTION
## Summary

Add `-f` to `git fetch` in the AGENTS.md "Verify locally" template + inline rationale so the operator's verify recipe survives force-pushes during PR iteration.

## Why

Today the template tells the operator:

```sh
git fetch origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
```

Agent-authored PR branches get force-pushed routinely during iteration (review fixes, rebase onto fresh `main`, body-only fix-ups). Without `-f`, every force-push breaks the recipe with `! [rejected] <branch> -> origin/<branch> (non-fast-forward)`, and the local `refs/remotes/origin/<branch>` stays pinned at the pre-force-push tip. The `git checkout -B` then "successfully" checks out the stale snapshot — the operator thinks they verified the latest PR but actually verified an older one.

Triggered by PR #244, where multiple force-pushes (body fixes, overview-sync rebase, deprecated-format fix, TUI walkthrough) broke the operator's verify run with that exact `[rejected]` line.

## Verify locally

#### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/agents-fetch-force-pushed-branches:refs/remotes/origin/docs/agents-fetch-force-pushed-branches
git checkout -B docs/agents-fetch-force-pushed-branches refs/remotes/origin/docs/agents-fetch-force-pushed-branches
```

This PR touches `AGENTS.md` only — no Astro site change. Review the diff against `AGENTS.md`:

```sh
git diff origin/main...HEAD -- AGENTS.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
