### PR TITLE
docs(roadmap): correct stale gh CLI passthrough claims in two roadmap docs

### DIFF
--- a/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
+++ b/docs/src/content/docs/reference/roadmap/multicode-inspired-features.mdx
@@ -64,7 +64,7 @@ program.
 | Remote orchestration | Yes — `multicode-remote` SSH bridge + rsync | *Gap — see [jackin-remote](/reference/roadmap/jackin-remote/)* |
 | Workspace skills mount | Yes — `add-skills-from` mounts to `~/.config/<provider>/skills/` | *Gap — see [Workspace skills mount](/reference/roadmap/workspace-skills-mount/)* |
 | Credential source plurality | Three backends — `env`, `command`, keychain | Partial — `op://` and `${env.VAR}` shipped; *see [Credential source pattern](/reference/roadmap/credential-source-pattern/)* |
-| GitHub CLI auth passthrough | Yes (read-only mount) | Have |
+| GitHub CLI auth passthrough | Yes (read-only mount) | Partial — auth state persists across container restarts via the bind-mounted role-state `.config/gh`, but no host-to-container forwarding today; first launch needs in-container `gh auth login`. Layered host-forwarding + scoped tokens tracked under [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/) |
 | Operator console / TUI | Yes — ratatui, full-time | Have — `jackin console` (less feature-rich than CLI on purpose) |
 | Role repo contract | Implicit via `add-skills-from` | Have — `jackin.role.toml` + `Dockerfile` |
 | Sensitive mount warnings | No | Have |

--- a/docs/src/content/docs/reference/roadmap/open-review-findings.mdx
+++ b/docs/src/content/docs/reference/roadmap/open-review-findings.mdx
@@ -35,11 +35,18 @@ record of what was reviewed and when.
    behavior, config schema coverage, runtime behavior, and some
    security-model details.
 
-3. **Runtime startup still triggers `gh auth login` automatically.**
-   The runtime entrypoint starts a GitHub CLI login flow when `gh` is
-   present but unauthenticated. Public docs mostly frame GitHub
-   authentication as a persistence behavior after the operator chooses
-   to authenticate, not as a default startup interaction.
+3. **GitHub CLI auth is persistence-only — no host-to-container
+   forwarding.** The runtime entrypoint runs `gh auth setup-git`
+   only when `gh auth status` already succeeds inside the
+   container; it does **not** start a `gh auth login` flow. The
+   first time an operator opens a (workspace × role) they have
+   to run `gh auth login` manually inside the container. Public
+   docs and the roadmap overview historically described this as
+   "GitHub CLI authentication passthrough", which overstates the
+   behaviour. Layered host forwarding (`auth_forward = "sync"`),
+   least-privilege scoped tokens (`auth_forward = "token"`), and
+   the matching `[github]` config block are tracked under
+   [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/).
 
 4. **Command failures and debug logs can still leak secrets.**
    `ShellRunner` still logs and reports raw argv strings, while the


### PR DESCRIPTION
## Summary

Trivial follow-up to PR #244. Two roadmap docs overstated today's GitHub CLI behaviour; PR #244's "Documentation drift" section flagged both for repair. This is the repair.

## What changes

### `roadmap/open-review-findings.mdx` — finding 3

Old text claimed runtime startup triggers `gh auth login` automatically. The current `docker/runtime/entrypoint.sh` only runs `gh auth setup-git` after `gh auth status` already succeeds — it does **not** run `gh auth login`. Rewrite to describe the real behaviour (persistence-only, no host forwarding) and forward-link the layered host-forwarding + scoped-token work to `github-cli-auth-strategy`.

### `roadmap/multicode-inspired-features.mdx` — comparison row

Cell labelled "Have" for "GitHub CLI auth passthrough". Reword to "Partial" with the persistence-vs-forwarding distinction and the same forward link.

No code change. Operator-facing accuracy only.

## Verify locally

#### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/roadmap-stale-gh-passthrough-claims:refs/remotes/origin/docs/roadmap-stale-gh-passthrough-claims
git checkout -B docs/roadmap-stale-gh-passthrough-claims refs/remotes/origin/docs/roadmap-stale-gh-passthrough-claims
```

#### Run the docs site locally and review the affected pages

```sh
cd docs
bun install --frozen-lockfile   # only needed first time / after lockfile changes
bun run dev
```

Astro serves at <http://localhost:4321/>. Open these pages:

- **Open review findings** — <http://localhost:4321/reference/roadmap/open-review-findings/> — confirm finding 3 now reads "GitHub CLI auth is persistence-only" with a forward link to `github-cli-auth-strategy`.
- **Universal Orchestrator Program (multicode comparison)** — <http://localhost:4321/reference/roadmap/multicode-inspired-features/> — confirm the "GitHub CLI auth passthrough" row in the comparison table now reads "Partial — auth state persists across container restarts ... but no host-to-container forwarding today" with the same forward link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
