### PR TITLE
docs: split site into operator vs contributor audiences

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,154 +1,145 @@
 # Project Structure
 
-Quick navigation reference for AI agents working in this repository.
+Quick navigation for AI agents and human contributors working in this
+repository. **The canonical, detailed module map lives in the docs**
+([`reference/codebase-map`](https://jackin.tailrocks.com/reference/codebase-map/),
+served from `docs/src/content/docs/reference/codebase-map.mdx`). This
+file is the short pointer that agents land on first; it covers the
+**multi-repo ecosystem** and the per-PR **code ↔ docs contract**, and
+sends you to the docs for everything else.
 
-## Root Files
+## What this file is for
+
+- The **ecosystem table** below — which repository owns what.
+- The **code ↔ docs cross-reference** at the bottom — which docs page
+  must be touched when a given source area changes.
+- A short **map of root files** an agent might need to find quickly.
+
+For any deeper question — module layout, what each `src/` subdirectory
+owns, where to start when changing the runtime, the operator console,
+the configuration model, etc. — go to the docs:
+
+| Question | Page |
+|---|---|
+| "Where does the code for X live?" | [Codebase Map](https://jackin.tailrocks.com/reference/codebase-map/) (mirrored at `docs/src/content/docs/reference/codebase-map.mdx`) |
+| "How does jackin' orchestrate containers?" | [Architecture](https://jackin.tailrocks.com/reference/architecture/) |
+| "What does `~/.config/jackin/config.toml` look like?" | [Configuration File](https://jackin.tailrocks.com/reference/configuration/) |
+| "How are role repositories structured?" | [Role Repositories](https://jackin.tailrocks.com/guides/role-repos/) |
+| "What is on the roadmap?" | [Roadmap](https://jackin.tailrocks.com/reference/roadmap/) |
+
+The docs are deliberately the single source of truth for the *narrative*
+explanation of jackin's internals. This file stays terse on purpose —
+prose belongs on a docs page; here we point at it.
+
+## Ecosystem repositories
+
+jackin' is intentionally split across multiple GitHub repositories. This
+repo owns the CLI; sibling repos own roles, the construct image source,
+the Homebrew tap, and the docs site (today the docs site lives inside
+this repo — see roadmap item
+[Move documentation to a separate repository](https://jackin.tailrocks.com/reference/roadmap/docs-separate-repository/)
+for the discussion of moving it out).
+
+| Repository | Owns |
+|---|---|
+| [`jackin-project/jackin`](https://github.com/jackin-project/jackin) (this repo) | CLI source, the `construct` Dockerfile under `docker/construct/`, the docs site under `docs/`, CI workflows |
+| [`jackin-project/jackin-agent-smith`](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose role (`agent-smith`) |
+| [`jackin-project/jackin-the-architect`](https://github.com/jackin-project/jackin-the-architect) | Rust-development role (`the-architect`) used to develop jackin' itself |
+| [`jackin-project/homebrew-tap`](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for stable + preview channels |
+| [`jackin-project/jackin-marketplace`](https://github.com/jackin-project/jackin-marketplace) | Claude plugin marketplace consumed by role manifests |
+| [`jackin-project/validate-agent-action`](https://github.com/jackin-project/validate-agent-action) | GitHub Action that validates `jackin.role.toml` in role repos |
+| [`jackin-project/jackin-dev`](https://github.com/jackin-project/jackin-dev) | Internal development tooling and shared dotfiles |
+| [`jackin-project/jackin-github-terraform`](https://github.com/jackin-project/jackin-github-terraform) | Terraform that manages the `jackin-project` GitHub org |
+
+## Root files in this repo
+
+The CLI source lives under `src/`; supporting files at the repo root:
 
 | File | Purpose |
 |---|---|
-| `Cargo.toml` | Crate manifest — dependencies and lints |
+| `Cargo.toml` | Crate manifest — dependencies, lints, MSRV |
 | `Cargo.lock` | Locked dependency versions |
-| `AGENTS.md` | Shared instructions for all AI agents (testing, pre-commit, security) |
+| `AGENTS.md` | Shared instructions for all AI agents (testing, pre-commit, security, PR conventions) |
 | `CLAUDE.md` | Claude-specific pointer to `AGENTS.md` |
 | `RULES.md` | Project-wide conventions (docs go in `AGENTS.md`, not tool-specific files) |
-| `TODO.md` | Small follow-ups (especially upstream-dependency tracking), per-PR stale-docs checklist, and `TODO(<topic>)` marker convention. Larger feature work lives under `docs/src/content/docs/reference/roadmap/` |
+| `BRANCHING.md` | Branch naming + merge policy |
+| `COMMITS.md` | Conventional Commits format + DCO sign-off |
 | `TESTING.md` | Test runner setup, commands, and pre-commit requirements |
+| `CONTRIBUTING.md` | Contribution flow + DCO v1.1 text |
+| `DEPRECATED.md` | Ledger of deprecated APIs / CLIs / config values |
+| `TODO.md` | Small follow-ups and the per-PR stale-docs check |
 | `release.toml` | Release configuration |
-| `mise.toml` | Tool version management (bun) |
-| `Justfile` | Construct image build commands — contributor-facing `just` wrapper |
+| `mise.toml` | Tool version management (bun + just) |
+| `Justfile` | Construct image build commands |
 | `docker-bake.hcl` | Declarative Docker Bake build graph for the construct image |
-| `.gitignore` | Git ignore rules |
+| `rust-toolchain.toml` | Pinned Rust toolchain (CI-enforced MSRV) |
 
-## Roadmap — `docs/src/content/docs/reference/roadmap/`
+For the **Rust source tree** — `src/app/`, `src/cli/`, `src/runtime/`,
+`src/workspace/`, `src/console/`, etc., plus crate-root helpers like
+`src/derived_image.rs` and `src/env_model.rs` — see the
+[Codebase Map](https://jackin.tailrocks.com/reference/codebase-map/).
+That page is updated in the same PR as any module-level structural
+change, so it never falls behind.
 
-Self-contained design docs live alongside the rest of the Starlight
-docs site. Each page includes problem statement, options, and related
-source files. Browse via the sidebar (`Reference → Roadmap`) or on
-the deployed site at <https://jackin.tailrocks.com/reference/roadmap/>.
+## Documentation site (`docs/`)
 
-## Source Code — `src/`
+Astro Starlight site. **Lives alongside source code today** — update
+docs in the same commit as code changes (see roadmap item
+[Move documentation to a separate repository](https://jackin.tailrocks.com/reference/roadmap/docs-separate-repository/)
+for the longer-term discussion).
 
-Rust CLI binary. Every significant concern has its own directory;
-crate-root files are reserved for items that don't cluster into
-a domain group.
-
-### Crate root
-
-| File | Responsibility |
-|---|---|
-| `main.rs` | Entry point — constructs `Cli` and calls `jackin::run()` |
-| `lib.rs` | Thin crate root (~20 LOC) — module declarations + `pub use app::run` |
-| `bin/validate.rs` | Separate binary for validating agent manifests (`jackin-validate`) |
-
-### Module tree
-
-| Module | Owns |
-|---|---|
-| `app/` | `run()` command dispatch (`mod.rs`) and context helpers (`context.rs`): target classification, workspace-for-cwd, role-from-context, last-role persistence |
-| `cli/` | Clap schema split by topic: `root.rs` (`Cli` + `Command` enum), `role.rs` (Load/Hardline/Launch args, `--force`), `cleanup.rs` (Eject/Purge args), `workspace.rs` (`WorkspaceCommand`, `--mount-isolation`, `--delete-isolated-state`), `cd.rs` (`jackin cd <container> [dst]` — child shell into an isolated worktree), `config.rs` (`ConfigCommand` + sub-enums), `dispatch.rs` (bare-`jackin`/`console`/`launch` classification — `classify`, `is_tui_capable`, deprecation shims) |
-| `workspace/` | Workspace model and planning. `mod.rs` (types, re-exports), `paths.rs` (expand_tilde, resolve_path), `mounts.rs` (parse/validate), `planner.rs` (`plan_create`, `plan_edit`, `plan_collapse`), `resolve.rs` (runtime resolution), `sensitive.rs` (sensitive-mount detection) |
-| `config/` | TOML config model and persistence. `mod.rs` (types, `require_workspace` helper), `persist.rs` (load/save), `roles.rs` (builtin sync, trust, auth-forward), `mounts.rs` (global mount registry), `workspaces.rs` (workspace CRUD) |
-| `manifest/` | Role-manifest (`jackin.role.toml`) schema + validator. `mod.rs` (schema structs, `load`, `display_name`), `validate.rs` (`validate`, `is_valid_env_var_name`) |
-| `runtime/` | Container lifecycle. `mod.rs` (thin re-exports), `naming.rs` (labels, container/image naming, family matching), `identity.rs` (git/host identity), `repo_cache.rs` (repo lock + fetch), `image.rs` (docker build), `launch.rs` (`launch_role_runtime`, `load_role`, `load_role_with`, runs the foreground finalizer after attach returns), `attach.rs` (attach + hardline + DinD readiness — calls the same finalizer post-attach), `discovery.rs` (list managed roles), `cleanup.rs` (eject, purge, orphan GC), `caffeinate.rs` (macOS keep-awake reconciler — `reconcile`, lock-file + PID-comm-verified state converger over `jackin.keep_awake=true` containers), `test_support.rs` (shared `FakeRunner`) |
-| `isolation/` | Per-mount isolation. `mod.rs` (`MountIsolation` enum), `branch.rs` (scratch-branch naming), `materialize.rs` (worktree creation + `MaterializedWorkspace`), `state.rs` (`isolation.json` IO), `finalize.rs` (post-attach foreground finalizer — Preserved / Cleaned / ReturnToAgent decision), `cleanup.rs` (force/safe cleanup helpers shared by `purge` and the finalizer) |
-| `console/` | Interactive operator-console TUI. `mod.rs` (`run_console` entrypoint), `state.rs` (`ConsoleState`, `WorkspaceChoice`), `input.rs` (event handling), `preview.rs` (workspace preview + detail lines), `render.rs` (all drawing functions), `manager/` (workspace-manager TUI subsystem — `state.rs`, `input.rs`, `render.rs`, `create.rs`, `mount_info.rs`), `widgets/` (reusable modal/widget components — `file_browser`, `text_input`, `confirm`, `confirm_save`, `error_popup`, `mount_dst_choice`, `workdir_pick`, `github_picker`, `save_discard`, `panel_rain`) |
-| `instance/` | Per-container state preparation. `mod.rs` (`RoleState` + `AgentRuntimeState` enum, orchestration), `naming.rs` (container slug + clone naming + class-family matching), `auth.rs` (auth-forward modes + credential handling + symlink safety), `plugins.rs` (plugin-marketplace serialization) |
-| `agent/` | AI-agent dispatch (Claude / Codex). `mod.rs` (`Agent` enum + slug parsing + per-agent install block via `Agent::install_block`, consumed by `derived_image`) |
-| `tui/` | General terminal UI helpers (separate from the operator console). `mod.rs` (shared palette, `DEBUG_MODE`), `animation.rs` (intro/outro, digital rain), `output.rs` (tables, hints, fatal, logo, title), `prompt.rs` (`prompt_choice`, `spin_wait`, `require_interactive_stdin`) |
-
-### Flat helper files at crate root
-
-| File | Responsibility |
-|---|---|
-| `env_model.rs` | Single source of truth for env policy — reserved-runtime-env list, `is_reserved`, `extract_interpolation_refs`, `topological_env_order` (cycle detection) |
-| `env_resolver.rs` | Runtime env resolution — `resolve_env`, interpolation, interactive prompts |
-| `selector.rs` | Role selector parsing — `RoleSelector`, `Selector`, `TryFrom<&str>` impls |
-| `repo.rs` | Role repo validation — required files, path traversal checks |
-| `repo_contract.rs` | Enforces role `Dockerfile`s extend the `construct` base image |
-| `derived_image.rs` | Dockerfile generation for role images from the base construct |
-| `docker.rs` | Docker command builder — `CommandRunner` trait and `ShellRunner` |
-| `terminal_prompter.rs` | Interactive env-var prompting for manifest resolution |
-| `version_check.rs` | Claude CLI version detection for image cache-bust |
-| `paths.rs` | XDG-compliant data and config directory resolution (`JackinPaths`) |
-
-## Documentation — `docs/`
-
-Astro Starlight site. **Lives alongside source code intentionally** — update docs in the same commit as code changes.
-
-- Published at: https://jackin.tailrocks.com/
+- Published at: <https://jackin.tailrocks.com/>
 - Dev server: `cd docs && bun run dev`
 - Build: `cd docs && bun run build`
 - Package manager: **bun only** (not npm/pnpm/yarn)
 - Has its own `AGENTS.md` and `CLAUDE.md` at `docs/`
 
-### Docs Content — `docs/src/content/docs/`
+The site sidebar is split by **three audiences**:
 
-Maps 1:1 with the published site sidebar:
+- **Operator** (Getting Started, Operator Guide, Commands) — uses
+  jackin' as a product through CLI and TUI. Pages describe behaviour
+  through CLI/TUI flows — no TOML schemas, no on-disk paths, no Rust
+  internals.
+- **Role author** (Role Authoring) — *also a user-facing audience*,
+  but for users building their own role repos (`backend-engineer`,
+  `docs-writer`, `security-reviewer`, …). These pages explain how to
+  create a role from scratch, the manifest schema, and what tools
+  ship in the `construct`. They do not require any knowledge of how
+  jackin' is implemented.
+- **Contributor** (Behind jackin' — Internals) — works on jackin'
+  itself. Architecture, Configuration File schema, Codebase Map,
+  Roadmap. This is where on-disk layouts, internal mechanisms, and
+  Rust-level detail live.
 
-| Section | Files | Covers |
-|---|---|---|
-| Getting Started | `getting-started/why.mdx` | Why jackin' exists |
-| | `getting-started/installation.mdx` | Install methods + prerequisites |
-| | `getting-started/quickstart.mdx` | First-run walkthrough |
-| | `getting-started/concepts.mdx` | Operators, agents, constructs, workspaces |
-| Guides | `guides/workspaces.mdx` | Workspace configuration |
-| | `guides/mounts.mdx` | Mount specs and scoping |
-| | `guides/role-repos.mdx` | Agent repository structure |
-| | `guides/authentication.mdx` | Credential forwarding / in-container auth |
-| | `guides/security-model.mdx` | Isolation and permissions |
-| | `guides/comparison.mdx` | Comparison with alternatives |
-| Commands | `commands/load.mdx` | `jackin load` |
-| | `commands/console.mdx` | `jackin console` (bare `jackin` dispatches here) |
-| | `commands/cd.mdx` | `jackin cd` (open a child shell in an isolated worktree) |
-| | `commands/hardline.mdx` | `jackin hardline` |
-| | `commands/eject.mdx` | `jackin eject` |
-| | `commands/exile.mdx` | `jackin exile` |
-| | `commands/purge.mdx` | `jackin purge` |
-| | `commands/workspace.mdx` | `jackin workspace` |
-| | `commands/config.mdx` | `jackin config` |
-| Developing Agents | `developing/creating-roles.mdx` | How to build role repos |
-| | `developing/construct-image.mdx` | Base Docker image contents |
-| | `developing/role-manifest.mdx` | `jackin.role.toml` reference |
-| Reference | `reference/configuration.mdx` | Config file format |
-| | `reference/architecture.mdx` | Container orchestration internals |
-| | `reference/roadmap.mdx` | Planned features |
+Slugs are stable across the audience split — the audience
+distinction is enforced in `docs/astro.config.ts`, not in URLs.
 
-### Docs Config
-
-| File | Purpose |
-|---|---|
-| `docs/astro.config.ts` | Sidebar structure, site metadata, edit links, component overrides (TypeScript — all config is TS, no `.mjs`) |
-| `docs/package.json` | Bun dependencies |
-| `docs/bun.lock` | Locked deps |
-| `docs/src/styles/fonts.css` | Self-hosted fontsource imports + `Inter Black` `@font-face` for the wordmark |
-| `docs/src/styles/docs-theme.css` | Starlight chrome → brand tokens mapping |
-| `docs/src/styles/global.css` | Tailwind v4 entry + landing utility tokens |
-| `docs/src/content.config.ts` | Astro content collection config (Content Layer API via `docsLoader()`) |
-| `docs/src/components/overrides/` | Starlight component overrides (Head, SiteTitle, ThemeSelect, PageSidebar, SocialIcons) |
-| `docs/src/components/landing/` | React islands + standalone CSS for the landing route |
-| `docs/src/pages/index.astro` | Landing route — plain Astro page, NOT a Starlight content entry |
-| `docs/src/pages/og/[...slug].png.ts` | Per-page OG card generator (astro-og-canvas + local fontsource files) |
-
-## Docker — `docker/`
+## Docker (`docker/`)
 
 | Path | Purpose |
 |---|---|
-| `docker/construct/Dockerfile` | Shared base image all agents extend |
-| `docker/construct/README.md` | Construct image documentation |
+| `docker/construct/Dockerfile` | Shared base image all roles extend |
+| `docker/construct/README.md` | `construct` image documentation |
 | `docker/construct/zshrc` | Shell config injected into containers |
-| `docker/runtime/entrypoint.sh` | Container entrypoint at runtime — git identity setup, `gh auth setup-git` when gh is already authenticated (never performs login itself), MCP server registration, pre-launch hook, then `exec claude` or `exec codex`. UID/GID remapping and Claude plugin installation happen during the derived-image build (`src/derived_image.rs`), not here. |
+| `docker/runtime/entrypoint.sh` | Container entrypoint at runtime |
 
-## CI/CD — `.github/workflows/`
+For what each piece does at runtime, see
+[The Construct Image](https://jackin.tailrocks.com/developing/construct-image/)
+and [Architecture](https://jackin.tailrocks.com/reference/architecture/).
+
+## CI/CD (`.github/workflows/`)
 
 | Workflow | Triggers |
 |---|---|
-| `construct.yml` | Builds and publishes the construct base Docker image |
+| `construct.yml` | Builds and publishes the `construct` base Docker image |
 | `docs.yml` | Builds and deploys the documentation site |
 | `release.yml` | Creates release artifacts |
 
-## Code ↔ Docs Cross-Reference
+## Code ↔ docs cross-reference
 
-When changing behavior, update both sides:
+When changing behaviour, update both sides in the same PR. This table
+is the **per-PR contract** every agent should consult before opening a
+PR for the listed area:
 
 | Code change in | Update docs in |
 |---|---|
@@ -157,18 +148,21 @@ When changing behavior, update both sides:
 | `src/config/**` (config format) | `docs/.../reference/configuration.mdx` |
 | `src/runtime/**` (container lifecycle) | `docs/.../reference/architecture.mdx` |
 | `src/runtime/caffeinate.rs` (keep_awake reconciler) | `docs/.../guides/workspaces.mdx` (keep_awake section) |
-| `src/isolation/**` (per-mount isolation, materialization, finalizer) | `docs/.../guides/workspaces.mdx` (per-mount isolation section), `docs/.../guides/mounts.mdx` (isolation field), `docs/.../reference/configuration.mdx` (`MountConfig.isolation`), `docs/.../reference/architecture.mdx` (materialization + finalizer), `docs/.../commands/load.mdx` (`--force`), `docs/.../commands/workspace.mdx` (`--mount-isolation`, Isolation column), `docs/.../commands/cd.mdx`, `docs/.../commands/purge.mdx` (running-agent guard + isolated cleanup) |
+| `src/isolation/**` (per-mount isolation, materialization, finalizer) | `docs/.../guides/workspaces.mdx` (per-mount isolation section), `docs/.../guides/mounts.mdx` (isolation field), `docs/.../reference/configuration.mdx` (`MountConfig.isolation`), `docs/.../reference/architecture.mdx` (materialization + finalizer), `docs/.../commands/load.mdx` (`--force`), `docs/.../commands/workspace.mdx` (`--mount-isolation`, Isolation column), `docs/.../commands/purge.mdx` (running-agent guard + isolated cleanup) |
 | `src/manifest/**` (`jackin.role.toml` schema or validation) | `docs/.../developing/role-manifest.mdx` |
 | `src/instance/auth.rs` (auth-forward, credential handling) | `docs/.../guides/authentication.mdx`, `docs/.../guides/security-model.mdx` |
-| `src/env_model.rs`, `src/env_resolver.rs` (env policy) | `docs/.../developing/role-manifest.mdx` (env section) |
+| `src/env_model.rs`, `src/env_resolver.rs` (env policy) | `docs/.../developing/role-manifest.mdx` (env section), `docs/.../guides/environment-variables.mdx` (reserved-name list) |
 | `src/derived_image.rs` (Dockerfile gen) | `docs/.../developing/construct-image.mdx` |
 | `src/repo.rs` / `src/repo_contract.rs` | `docs/.../guides/role-repos.mdx` |
 | `docker/construct/Dockerfile` | `docs/.../developing/construct-image.mdx` |
+| Module structure in `src/**` (added/split/renamed module) | `docs/.../reference/codebase-map.mdx` |
 
-## Keeping this file fresh
+## Keeping the docs fresh
 
-If a PR changes module boundaries — adds a new module directory,
-splits a file into a subdirectory, introduces a new cross-cutting
-helper — **update the module tree above in the same PR**. See
-[`TODO.md`](TODO.md) for the stale-docs check every structural PR
-should run.
+The Codebase Map and the cross-reference table above are the two
+places where structural changes show up first. If your PR adds a new
+module directory, splits a file into a subdirectory, introduces a new
+cross-cutting helper, or renames a public surface — **update
+`docs/.../reference/codebase-map.mdx` and (if relevant) the
+cross-reference table above in the same PR**. See `TODO.md` for the
+stale-docs check every structural PR should run.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Jack your AI coding agents in. Isolated worlds, scoped access, full autonomy. You're the Operator. They're already inside.
 
+jackin' is the **ecosystem layer around** AI coding agents — not another agent itself. It runs many agents in parallel, each in its own container, with its own file access, tool profile, and credentials. Every agent runtime ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) `--dangerously-skip-permissions`, [Codex](https://github.com/openai/codex) YOLO, [Amp](https://ampcode.com), and the next ones to come) is most productive at full speed — and full speed against your host machine is risky. jackin' moves the boundary off the host, so the runtime can stay fast.
+
 Documentation: <https://jackin.tailrocks.com/>
 
-> **Current status:** jackin' is built as a proof of concept around [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as its first and only supported agent runtime. Support for additional runtimes is [on the roadmap](https://jackin.tailrocks.com/reference/roadmap/).
+> **Current status:** jackin' is a proof of concept. [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://github.com/openai/codex) ship today as fully integrated agent runtimes. [Amp](https://ampcode.com) is under active development and will join them; full feature parity across all three is tracked on the [roadmap](https://jackin.tailrocks.com/reference/roadmap/). The isolation model is runtime-agnostic — adding another runtime is a matter of installing and starting it inside the container, not changing the boundary.
 
 ## Install
 
@@ -22,25 +24,31 @@ Or [build from source](https://jackin.tailrocks.com/getting-started/installation
 
 ## Quick Start
 
-```sh
-# Load an agent into your current project directory
-jackin load agent-smith
+The simplest way to use jackin' is the **operator console** — an interactive TUI that picks workspaces, roles, and agents for you:
 
-# Or open the interactive operator console
+```sh
 jackin
 ```
 
-That's it. jackin' pulls the base image, builds the agent container, mounts your project, and drops you into Claude Code — fully autonomous inside an isolated environment.
+(Or `jackin console` to be explicit.) The console is the daily driver and covers the common cases of every other command.
 
-See the [Quick Start guide](https://jackin.tailrocks.com/getting-started/quickstart/) for common workflows and next steps.
+If you'd rather see the isolation model in action with a single one-shot command, `jackin load` is the **scriptable CLI** equivalent:
+
+```sh
+jackin load agent-smith
+```
+
+That pulls the base image, builds the agent container, mounts your project, and drops you into the agent runtime — fully autonomous inside an isolated environment.
+
+See the [Quick Start guide](https://jackin.tailrocks.com/getting-started/quickstart/) for the full walkthrough, and [`jackin console`](https://jackin.tailrocks.com/commands/console/) for the TUI reference.
 
 ## What It Does
 
 - **Isolates each agent** in its own Docker container with Docker-in-Docker enabled
-- **Gives agents full autonomy** inside the container boundary (`--dangerously-skip-permissions`)
+- **Gives agents full autonomy** inside the container boundary (whatever full-speed mode the runtime ships — Claude's `--dangerously-skip-permissions`, Codex's YOLO, etc.)
 - **Separates tooling from file access** — roles define the environment, workspaces define which files are visible
 - **Supports multiple agents simultaneously** — different tool profiles against the same or different projects
-- **Persists agent state** between sessions (Claude history, GitHub CLI auth, plugins)
+- **Persists agent state** between sessions (conversation history, GitHub CLI auth, plugins)
 
 Learn more: [Why jackin'?](https://jackin.tailrocks.com/getting-started/why/) · [Core Concepts](https://jackin.tailrocks.com/getting-started/concepts/) · [Security Model](https://jackin.tailrocks.com/guides/security-model/) · [Comparison with Alternatives](https://jackin.tailrocks.com/guides/comparison/)
 
@@ -49,24 +57,27 @@ Learn more: [Why jackin'?](https://jackin.tailrocks.com/getting-started/why/) ·
 | Repository | Description |
 |---|---|
 | [jackin](https://github.com/jackin-project/jackin) | CLI source code (this repo) |
-| [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose agent |
-| [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) | Rust development agent (used for jackin' development) |
-| [construct image source](https://github.com/jackin-project/jackin/tree/main/docker/construct) | Shared base Docker image for all agents |
+| [jackin-agent-smith](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose role |
+| [jackin-the-architect](https://github.com/jackin-project/jackin-the-architect) | Rust development role (used for jackin' development) |
+| [construct image source](https://github.com/jackin-project/jackin/tree/main/docker/construct) | Shared base Docker image for all roles |
 
 ## Documentation
 
-The full documentation lives at **<https://jackin.tailrocks.com/>** and covers:
+This README is a first impression. The full documentation at **<https://jackin.tailrocks.com/>** is where every detail lives:
 
-- [Installation](https://jackin.tailrocks.com/getting-started/installation/) — all install methods and prerequisites
-- [Core Concepts](https://jackin.tailrocks.com/getting-started/concepts/) — operators, agents, constructs, and workspaces
-- [Commands](https://jackin.tailrocks.com/commands/load/) — complete CLI reference
-- [Creating Agents](https://jackin.tailrocks.com/developing/creating-agents/) — build your own role repos
-- [The Construct Image](https://jackin.tailrocks.com/developing/construct-image/) — what's inside the shared base image and how it is built
-- [Architecture](https://jackin.tailrocks.com/reference/architecture/) — how jackin' orchestrates containers and networks
+- [Why jackin'?](https://jackin.tailrocks.com/getting-started/why/) — the problem and the ecosystem framing
+- [Installation](https://jackin.tailrocks.com/getting-started/installation/) — install methods and prerequisites
+- [Quick Start](https://jackin.tailrocks.com/getting-started/quickstart/) — first-run walkthrough, console + CLI side by side
+- [Core Concepts](https://jackin.tailrocks.com/getting-started/concepts/) — operators, agents, roles, constructs, workspaces
+- [`jackin console`](https://jackin.tailrocks.com/commands/console/) — the daily-driver TUI
+- [Commands](https://jackin.tailrocks.com/commands/console/) — full reference (TUI first, then CLI)
+- [Security Model](https://jackin.tailrocks.com/guides/security-model/) — what the boundary protects and what it doesn't
+- [Comparison with Alternatives](https://jackin.tailrocks.com/guides/comparison/) — honest snapshot vs. Docker Sandboxes and others
+- Behind jackin' (Internals) — [Architecture](https://jackin.tailrocks.com/reference/architecture/), [Codebase Map](https://jackin.tailrocks.com/reference/codebase-map/), [Roadmap](https://jackin.tailrocks.com/reference/roadmap/)
 
 ## Development
 
-To develop jackin' itself, use [The Architect](https://github.com/jackin-project/jackin-the-architect) — a dedicated agent with the full Rust toolchain:
+To develop jackin' itself, use [The Architect](https://github.com/jackin-project/jackin-the-architect) — a dedicated role with the full Rust toolchain:
 
 ```sh
 jackin load the-architect

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -132,14 +132,17 @@ bun install --frozen-lockfile
 - Sidebar and top-nav are configured in `astro.config.ts`.
 - **Roadmap sidebar discipline.** Every MDX file under
   `src/content/docs/reference/roadmap/` must have a matching entry in
-  the sidebar in `astro.config.ts` (under `Reference → Roadmap → Open
-  items`, `Resolved`, or `Codebase health` as appropriate for its
-  `**Status**` field). Whenever you add, rename, delete, or change the
-  status of a roadmap item — or restructure the directory — verify
-  the sidebar still matches the directory contents in the same PR.
-  Operators rely on the sidebar (not the overview prose) to discover
-  open work, so an item reachable only via direct URL or the
-  overview page is effectively hidden. To audit:
+  the sidebar in `astro.config.ts` under one of the open-work
+  categories (`Universal Orchestrator Program`, `Codebase health`,
+  `Agent runtimes & authentication`, `Isolation & security`,
+  `Infrastructure`, `Documentation tooling`,
+  `Configuration ergonomics`) or under `Resolved`, as appropriate for
+  the page's `**Status**` field. Whenever you add, rename, delete, or
+  change the status of a roadmap item — or restructure the directory
+  — verify the sidebar still matches the directory contents in the
+  same PR. Operators rely on the sidebar (not the overview prose) to
+  discover open work, so an item reachable only via direct URL or
+  the overview page is effectively hidden. To audit:
 
   ```sh
   ls docs/src/content/docs/reference/roadmap/*.mdx \
@@ -197,6 +200,111 @@ bun install --frozen-lockfile
 - Every page requires a `title:` field in its frontmatter.
 - Self-hosted fonts via fontsource (`src/styles/fonts.css`) — no third-party font CDN.
 - Keep docs and code behavior aligned; when they differ, code is the source of truth.
+- **Never reference open pull requests in published documentation.** Any
+  link of the form `https://github.com/jackin-project/<repo>/pull/<N>`
+  or prose like "PR #123" / "in flight in #123" must not appear in
+  `src/content/docs/**.mdx`. Open PRs are ephemeral — they may be
+  closed, rebased, force-pushed, retitled, split, or replaced — so
+  pointing operators or roadmap readers at one bakes a transient URL
+  into a long-lived page. When a feature is *under development*,
+  describe its **state** ("under active development", "in flight",
+  "design in progress") without naming the PR. The PR that lands the
+  feature is the right place to update the documentation to say it
+  has landed; until then, the docs describe the steady-state user-
+  visible reality, not the in-progress engineering. Closed/merged
+  PRs and issues may still appear when they are the canonical record
+  of a *resolved* design discussion or a known limitation — that is
+  the existing pattern in `reference/roadmap/*.mdx` and is fine.
+  This rule applies equally to the README, AGENTS files outside
+  `docs/`, and any other published artefact.
+- **The site has three audiences, not two.** Always classify a docs
+  change against this list before writing it:
+  1. **Operator** (sidebar groups: *Getting Started*, *Operator
+     Guide*, *Commands*) — uses jackin' as a product through CLI and
+     TUI. Never asked to know on-disk paths, TOML schemas, or
+     internals.
+  2. **Role author** (sidebar group: *Role Authoring* — pages under
+     `guides/role-repos.mdx` and `developing/*`) — **also user-facing**.
+     Builds their own role repos with their preferred toolchain and
+     plugins. Does not need to know how jackin' is implemented to
+     follow these pages. The only concession is that
+     `developing/construct-image.mdx` has a contributor lower half
+     for `just construct-build` / CI workflow.
+  3. **Contributor** (sidebar group: *Behind jackin' — Internals* —
+     `reference/*`, including `roadmap/*.mdx`) — works on jackin'
+     itself. Architecture, configuration-file schema, codebase map,
+     roadmap design proposals. This is where on-disk layouts,
+     internal mechanisms, and Rust-level details live.
+
+  When you add or rewrite a page, decide which of the three audiences
+  it serves and put it under the matching sidebar group. Never mix
+  audiences inside the same page beyond the explicit
+  `developing/construct-image.mdx` exception. Pages on the
+  user-facing surfaces (Operator and Role Authoring) link out to the
+  Internals surface when a contributor reader would want the deeper
+  detail; they do not inline it.
+
+- **Never leak technical-implementation details into user-facing
+  pages.** "User-facing" here covers **both** the Operator surface
+  (Getting Started, Operator Guide, Commands) **and** the Role
+  Authoring surface (the *Role Authoring* sidebar group). On either
+  surface, do not mention:
+  - on-disk paths the operator never edits — `~/.config/jackin/`,
+    `~/.jackin/`, `~/.jackin/data/<…>/`, `~/.jackin/roles/<…>/`,
+    `~/.jackin/cache/`, the per-container state directory layout,
+    `isolation.json`, the `git/worktree/repo/<dst>/<container>/`
+    materialised path, the role-repo branch cache directory, or any
+    other internal storage location;
+  - TOML schema fragments — `[workspaces.<name>]`,
+    `[workspaces.<name>.env]`, `[workspaces.<name>.roles.<role>.env]`,
+    `[claude]`, `[codex]`, `[roles."org/agent"]`, `[docker.mounts]`,
+    `[[mounts]]`, etc.;
+  - field-level keys readers would only know from reading the
+    config file — `auth_forward = "sync"`, `trusted = true`,
+    `last_role`, `git_pull_on_entry`, `published_image`, `data_dir`,
+    `keep_awake.enabled`, etc. Describe the **operator-visible
+    behaviour** instead;
+  - Rust struct, enum, function, or module names — `RoleManifest`,
+    `MountIsolation`, `ConfigEditor`, `MaterializedWorkspace`,
+    `RUNTIME_OWNED_ENV_VARS`, etc.;
+  - internal-implementation footnotes — "this is technical debt and
+    is on the roadmap to simplify", "the current implementation does
+    X then Y in the derived image", or any other "we plan to refactor
+    this" admission. Those belong to the internals pages or to a
+    roadmap item, not to the operator surface.
+
+  Where each kind of detail belongs:
+
+  - **Contributor-only internals** (jackin's on-disk layout under
+    `~/.config/jackin/` and `~/.jackin/`, the schema of jackin's own
+    `config.toml`, `isolation.json`, the per-container state-directory
+    layout, internal Rust struct/enum/function names, and any
+    "this is technical debt" admission) belong on pages under
+    `reference/` and `reference/roadmap/`. They must **not** appear
+    on the Operator or Role Authoring surfaces.
+  - **Role-author surface schema** is different from jackin's
+    internals and *is* allowed on the Role Authoring pages: the
+    schema of the role's own `jackin.role.toml` (`[claude]`,
+    `[codex]`, `[hooks]`, `[identity]`, `[env.<NAME>]`, etc.) lives
+    in `developing/role-manifest.mdx` because that file is the
+    role author's own surface — they author it. Likewise the role
+    repo's own `Dockerfile` shape lives in `developing/creating-roles.mdx`
+    and `guides/role-repos.mdx`. These are the role's artefacts, not
+    jackin's storage.
+  - **The contributor section of `developing/construct-image.mdx`**
+    (its lower half — `just construct-build`, CI workflow, advanced
+    publish rehearsal) is the documented exception where one page
+    serves two audiences. Its top-of-page Aside calls this out
+    explicitly.
+
+  Whenever a user-facing page needs to refer to internal layout
+  for context, link to the matching internals page
+  (`/reference/configuration/`, `/reference/architecture/`,
+  `/reference/codebase-map/`) instead of inlining the detail. When
+  in doubt, ask: "could a reader follow this
+  page using only the CLI/TUI?" If the answer is no because the page
+  describes a TOML key or an on-disk path, move that detail to
+  internals.
 
 ## Landing Page
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
 import react from '@astrojs/react'
 import rehypeExternalLinks from 'rehype-external-links'
+import rehypeJk from './scripts/rehype-jk'
 
 export default defineConfig({
   site: 'https://jackin.tailrocks.com',
@@ -17,6 +18,10 @@ export default defineConfig({
           protocols: ['http', 'https'],
         },
       ],
+      // Wrap every prose mention of `jackin'` (the project name) with
+      // a brand-styled span so the name picks up `--jk-brand` in both
+      // light and dark modes. Skips code blocks and command lines.
+      rehypeJk,
     ],
   },
   integrations: [
@@ -36,6 +41,19 @@ export default defineConfig({
       editLink: {
         baseUrl: 'https://github.com/jackin-project/jackin/edit/main/docs/',
       },
+      // Audience-split sidebar.
+      //
+      // The first three groups (Getting Started, Operator Guide,
+      // Commands) are written for **operators** — people who use
+      // jackin' to run agents. Those pages describe behaviour,
+      // CLI/TUI flows, and operator-level concepts. They never tell
+      // the reader to hand-edit `~/.config/jackin/config.toml`.
+      //
+      // The "Behind jackin'" group is written for **contributors and
+      // role authors** — people who want to understand how jackin' is
+      // built, hand-edit a config file for debugging, author a role
+      // repository, or work on jackin' itself. Internals, schema
+      // references, and the development roadmap live there.
       sidebar: [
         {
           label: 'Getting Started',
@@ -47,22 +65,28 @@ export default defineConfig({
           ],
         },
         {
-          label: 'Guides',
+          label: 'Operator Guide',
           items: [
             { label: 'Workspaces', slug: 'guides/workspaces' },
             { label: 'Mounts', slug: 'guides/mounts' },
             { label: 'Environment Variables', slug: 'guides/environment-variables' },
             { label: 'Authentication', slug: 'guides/authentication' },
-            { label: 'Role Repos', slug: 'guides/role-repos' },
             { label: 'Security Model', slug: 'guides/security-model' },
             { label: 'Comparison', slug: 'guides/comparison' },
           ],
         },
         {
+          // Commands are ordered by the operator's day-to-day flow, not
+          // alphabetically. `console` (the TUI) leads because it is the
+          // simplest, most convenient surface and the one most people
+          // use most of the time. `load` and the rest of the CLI follow
+          // — they are the more advanced, scriptable surface, where
+          // niche flags land first and there is deliberately no feature
+          // parity with the console.
           label: 'Commands',
           items: [
+            { label: 'console (TUI)', slug: 'commands/console' },
             { label: 'load', slug: 'commands/load' },
-            { label: 'console', slug: 'commands/console' },
             { label: 'hardline', slug: 'commands/hardline' },
             { label: 'eject', slug: 'commands/eject' },
             { label: 'exile', slug: 'commands/exile' },
@@ -72,168 +96,184 @@ export default defineConfig({
           ],
         },
         {
-          label: 'Developing Roles',
+          // Role authoring is a *user-facing* activity — a normal
+          // jackin' user creating a backend-engineer / docs-writer /
+          // security-reviewer role with their preferred toolchain
+          // and plugins. It is NOT a contributor activity, so it
+          // gets its own top-level group separate from the
+          // contributor-facing Internals group below. Pages are
+          // ordered by gradually increasing complexity: what a role
+          // is → how to create one → the manifest schema → the base
+          // image every role extends.
+          label: 'Role Authoring',
           items: [
-            { label: 'Creating Roles', slug: 'developing/creating-roles' },
-            { label: 'Construct Image', slug: 'developing/construct-image' },
+            { label: 'Role Repositories', slug: 'guides/role-repos' },
+            { label: 'Creating a Role', slug: 'developing/creating-roles' },
             { label: 'Role Manifest', slug: 'developing/role-manifest' },
+            { label: 'Construct Image', slug: 'developing/construct-image' },
           ],
         },
         {
-          label: 'Reference',
+          label: "Behind jackin' — Internals",
           items: [
-            { label: 'Configuration', slug: 'reference/configuration' },
             { label: 'Architecture', slug: 'reference/architecture' },
+            { label: 'Configuration File', slug: 'reference/configuration' },
+            { label: 'Codebase Map', slug: 'reference/codebase-map' },
             {
+              // Roadmap groups are flat — every group below is open
+              // work. Some groups happen to be phased programs that
+              // should be read together (Universal Orchestrator
+              // Program, Codebase health); others are loose
+              // categories of standalone items. The shape difference
+              // is informational, not a separate "active programs" /
+              // "open items" distinction. The only real status axis
+              // here is open vs. resolved, which is why "Resolved"
+              // stays its own bottom group.
               label: 'Roadmap',
               collapsed: false,
               items: [
                 { label: 'Overview', slug: 'reference/roadmap' },
                 {
-                  label: 'Active programs',
-                  collapsed: false,
+                  label: 'Universal Orchestrator Program',
+                  collapsed: true,
                   items: [
+                    { label: 'Overview', slug: 'reference/roadmap/multicode-inspired-features' },
                     {
-                      label: 'Universal Orchestrator Program',
+                      label: 'Phase 1 — Foundation gaps',
                       collapsed: true,
                       items: [
-                        { label: 'Overview', slug: 'reference/roadmap/multicode-inspired-features' },
-                        {
-                          label: 'Phase 1 — Foundation gaps',
-                          collapsed: true,
-                          items: [
-                            { label: 'Workspace description', slug: 'reference/roadmap/workspace-description' },
-                            { label: 'Operator handler system', slug: 'reference/roadmap/operator-handler-system' },
-                            { label: 'Workspace archive', slug: 'reference/roadmap/workspace-archive' },
-                            { label: 'Declarative resource limits', slug: 'reference/roadmap/declarative-resource-limits' },
-                            { label: 'Ephemeral mount modes', slug: 'reference/roadmap/ephemeral-mount-modes' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 2 — Live operator surface',
-                          collapsed: true,
-                          items: [
-                            { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
-                            { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
-                            { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
-                            { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
-                            { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 3 — Persistence & telemetry',
-                          collapsed: true,
-                          items: [
-                            { label: 'Persistent storage layer', slug: 'reference/roadmap/persistent-storage-layer' },
-                            { label: 'Token & cost telemetry', slug: 'reference/roadmap/token-cost-telemetry' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 4 — Fleet operations',
-                          collapsed: true,
-                          items: [
-                            { label: 'Task source abstraction', slug: 'reference/roadmap/task-source-abstraction' },
-                            { label: 'Autonomous task queue', slug: 'reference/roadmap/autonomous-task-queue' },
-                            { label: 'Idle runtime cleanup', slug: 'reference/roadmap/idle-runtime-cleanup' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 5 — Distributed & extensibility',
-                          collapsed: true,
-                          items: [
-                            { label: 'jackin-remote', slug: 'reference/roadmap/jackin-remote' },
-                            { label: 'Credential source pattern', slug: 'reference/roadmap/credential-source-pattern' },
-                            { label: 'Workspace skills mount', slug: 'reference/roadmap/workspace-skills-mount' },
-                          ],
-                        },
+                        { label: 'Workspace description', slug: 'reference/roadmap/workspace-description' },
+                        { label: 'Operator handler system', slug: 'reference/roadmap/operator-handler-system' },
+                        { label: 'Workspace archive', slug: 'reference/roadmap/workspace-archive' },
+                        { label: 'Declarative resource limits', slug: 'reference/roadmap/declarative-resource-limits' },
+                        { label: 'Ephemeral mount modes', slug: 'reference/roadmap/ephemeral-mount-modes' },
                       ],
                     },
                     {
-                      label: 'Codebase health',
+                      label: 'Phase 2 — Live operator surface',
                       collapsed: true,
                       items: [
-                        { label: 'Overview', slug: 'reference/roadmap/codebase-readability' },
-                        {
-                          label: 'Phase 1 — Documentation & setup',
-                          collapsed: true,
-                          items: [
-                            { label: 'Module contracts', slug: 'reference/roadmap/module-contracts' },
-                            { label: 'Behavioral spec: launch.rs', slug: 'reference/roadmap/behavioral-spec-launch' },
-                            { label: 'Behavioral spec: op_picker', slug: 'reference/roadmap/behavioral-spec-op-picker' },
-                            { label: 'Per-directory README + AGENTS.md', slug: 'reference/roadmap/per-directory-readme' },
-                            { label: 'Developer Reference setup', slug: 'reference/roadmap/developer-reference-setup' },
-                            { label: 'Update PROJECT_STRUCTURE.md', slug: 'reference/roadmap/project-structure-update' },
-                            { label: 'CI gate: PROJECT_STRUCTURE.md', slug: 'reference/roadmap/ci-project-structure-gate' },
-                            { label: 'pub(crate) visibility', slug: 'reference/roadmap/pub-crate-visibility' },
-                            { label: 'MSRV & toolchain', slug: 'reference/roadmap/msrv-toolchain' },
-                            { label: 'Architecture Decision Records', slug: 'reference/roadmap/architecture-decision-records' },
-                            { label: 'Snapshot tests for TUI', slug: 'reference/roadmap/snapshot-tests-tui' },
-                            { label: 'Agent workflow: cc-sdd', slug: 'reference/roadmap/agent-workflow-cc-sdd' },
-                            { label: 'Move CONTRIBUTING + TESTING', slug: 'reference/roadmap/move-contributing-testing' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 2 — File splits',
-                          collapsed: true,
-                          items: [
-                            { label: 'Split input/editor.rs', slug: 'reference/roadmap/split-input-editor' },
-                            { label: 'Split app/mod.rs', slug: 'reference/roadmap/split-app-mod' },
-                            { label: 'Split operator_env.rs', slug: 'reference/roadmap/split-operator-env' },
-                            { label: 'Split runtime/launch.rs', slug: 'reference/roadmap/split-runtime-launch' },
-                          ],
-                        },
-                        {
-                          label: 'Phase 3 — Future',
-                          collapsed: true,
-                          items: [
-                            { label: 'Greenfield workspace split', slug: 'reference/roadmap/greenfield-workspace' },
-                            { label: 'rustdoc JSON → Starlight', slug: 'reference/roadmap/rustdoc-json-starlight' },
-                          ],
-                        },
+                        { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
+                        { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
+                        { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
+                        { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
+                        { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 3 — Persistence & telemetry',
+                      collapsed: true,
+                      items: [
+                        { label: 'Persistent storage layer', slug: 'reference/roadmap/persistent-storage-layer' },
+                        { label: 'Token & cost telemetry', slug: 'reference/roadmap/token-cost-telemetry' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 4 — Fleet operations',
+                      collapsed: true,
+                      items: [
+                        { label: 'Task source abstraction', slug: 'reference/roadmap/task-source-abstraction' },
+                        { label: 'Autonomous task queue', slug: 'reference/roadmap/autonomous-task-queue' },
+                        { label: 'Idle runtime cleanup', slug: 'reference/roadmap/idle-runtime-cleanup' },
+                      ],
+                    },
+                    {
+                      label: 'Phase 5 — Distributed & extensibility',
+                      collapsed: true,
+                      items: [
+                        { label: 'jackin-remote', slug: 'reference/roadmap/jackin-remote' },
+                        { label: 'Credential source pattern', slug: 'reference/roadmap/credential-source-pattern' },
+                        { label: 'Workspace skills mount', slug: 'reference/roadmap/workspace-skills-mount' },
                       ],
                     },
                   ],
                 },
                 {
-                  label: 'Open items',
-                  collapsed: false,
+                  label: 'Codebase health',
+                  collapsed: true,
                   items: [
+                    { label: 'Overview', slug: 'reference/roadmap/codebase-readability' },
                     {
-                      label: 'Agent runtimes & authentication',
+                      label: 'Phase 1 — Documentation & setup',
                       collapsed: true,
                       items: [
-                        { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
-                        { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
-                        { label: 'GitHub CLI authentication strategy', slug: 'reference/roadmap/github-cli-auth-strategy' },
-                        { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
+                        { label: 'Module contracts', slug: 'reference/roadmap/module-contracts' },
+                        { label: 'Behavioral spec: launch.rs', slug: 'reference/roadmap/behavioral-spec-launch' },
+                        { label: 'Behavioral spec: op_picker', slug: 'reference/roadmap/behavioral-spec-op-picker' },
+                        { label: 'Per-directory README + AGENTS.md', slug: 'reference/roadmap/per-directory-readme' },
+                        { label: 'Developer Reference setup', slug: 'reference/roadmap/developer-reference-setup' },
+                        { label: 'Update PROJECT_STRUCTURE.md', slug: 'reference/roadmap/project-structure-update' },
+                        { label: 'CI gate: PROJECT_STRUCTURE.md', slug: 'reference/roadmap/ci-project-structure-gate' },
+                        { label: 'pub(crate) visibility', slug: 'reference/roadmap/pub-crate-visibility' },
+                        { label: 'MSRV & toolchain', slug: 'reference/roadmap/msrv-toolchain' },
+                        { label: 'Architecture Decision Records', slug: 'reference/roadmap/architecture-decision-records' },
+                        { label: 'Snapshot tests for TUI', slug: 'reference/roadmap/snapshot-tests-tui' },
+                        { label: 'Agent workflow: cc-sdd', slug: 'reference/roadmap/agent-workflow-cc-sdd' },
+                        { label: 'Move CONTRIBUTING + TESTING', slug: 'reference/roadmap/move-contributing-testing' },
                       ],
                     },
                     {
-                      label: 'Isolation & security',
+                      label: 'Phase 2 — File splits',
                       collapsed: true,
                       items: [
-                        { label: 'Rootless DinD', slug: 'reference/roadmap/rootless-dind' },
-                        { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },
-                        { label: 'Reproducibility & provenance pinning', slug: 'reference/roadmap/reproducibility-pinning' },
-                        { label: 'Devcontainer parity', slug: 'reference/roadmap/devcontainer-parity' },
-                        { label: 'Open review findings', slug: 'reference/roadmap/open-review-findings' },
+                        { label: 'Split input/editor.rs', slug: 'reference/roadmap/split-input-editor' },
+                        { label: 'Split app/mod.rs', slug: 'reference/roadmap/split-app-mod' },
+                        { label: 'Split operator_env.rs', slug: 'reference/roadmap/split-operator-env' },
+                        { label: 'Split runtime/launch.rs', slug: 'reference/roadmap/split-runtime-launch' },
                       ],
                     },
                     {
-                      label: 'Infrastructure',
+                      label: 'Phase 3 — Future',
                       collapsed: true,
                       items: [
-                        { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
-                        { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
+                        { label: 'Greenfield workspace split', slug: 'reference/roadmap/greenfield-workspace' },
+                        { label: 'rustdoc JSON → Starlight', slug: 'reference/roadmap/rustdoc-json-starlight' },
                       ],
                     },
-                    {
-                      label: 'Documentation tooling',
-                      collapsed: true,
-                      items: [
-                        { label: 'Docs markdown linting', slug: 'reference/roadmap/docs-markdown-linting' },
-                      ],
-                    },
+                  ],
+                },
+                {
+                  label: 'Agent runtimes & authentication',
+                  collapsed: true,
+                  items: [
+                    { label: 'Multi-runtime support (Codex & Amp)', slug: 'reference/roadmap/multi-runtime-support' },
+                    { label: 'Reliable Claude authentication strategy', slug: 'reference/roadmap/claude-auth-strategy' },
+                    { label: 'GitHub CLI authentication strategy', slug: 'reference/roadmap/github-cli-auth-strategy' },
+                    { label: '1Password integration', slug: 'reference/roadmap/onepassword-integration' },
+                  ],
+                },
+                {
+                  label: 'Isolation & security',
+                  collapsed: true,
+                  items: [
+                    { label: 'Rootless DinD', slug: 'reference/roadmap/rootless-dind' },
+                    { label: 'Selectable sandbox backends', slug: 'reference/roadmap/selectable-sandbox-backends' },
+                    { label: 'Reproducibility & provenance pinning', slug: 'reference/roadmap/reproducibility-pinning' },
+                    { label: 'Devcontainer parity', slug: 'reference/roadmap/devcontainer-parity' },
+                    { label: 'Open review findings', slug: 'reference/roadmap/open-review-findings' },
+                  ],
+                },
+                {
+                  label: 'Infrastructure',
+                  collapsed: true,
+                  items: [
+                    { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
+                    { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
+                  ],
+                },
+                {
+                  label: 'Documentation tooling',
+                  collapsed: true,
+                  items: [
+                    { label: 'Docs markdown linting', slug: 'reference/roadmap/docs-markdown-linting' },
+                    { label: 'Move documentation to a separate repository', slug: 'reference/roadmap/docs-separate-repository' },
+                  ],
+                },
+                {
+                  label: 'Configuration ergonomics',
+                  collapsed: true,
+                  items: [
+                    { label: 'Split config.toml into per-workspace files', slug: 'reference/roadmap/split-workspace-config-files' },
                   ],
                 },
                 {

--- a/docs/scripts/rehype-jk.ts
+++ b/docs/scripts/rehype-jk.ts
@@ -1,0 +1,57 @@
+import { visit, SKIP } from 'unist-util-visit'
+import type { Element, Root, Text } from 'hast'
+
+// Tag every prose mention of the jackin' project name (and the
+// possessive form) with a brand-styled span so the name picks up
+// --jk-brand in both light and dark modes. Styling lives in
+// src/styles/docs-theme.css under the .jk-name selector.
+//
+// SmartyPants in the markdown pipeline rewrites the straight ASCII
+// apostrophe (U+0027) into the typographic right single quotation
+// mark (U+2019) before the rehype stage runs, so the regex has to
+// accept both forms. The trailing `s` is optional to cover the
+// possessive `jackin's`.
+//
+// Skip inside <code> and <pre>: command lines and code blocks
+// already render in monospace and shouldn't double up. Stay out
+// of <style> and <script> for safety.
+const NAME_PATTERN = /jackin['’](?:s)?/g
+const SKIPPED_TAGS = new Set(['code', 'pre', 'style', 'script'])
+
+export default function rehypeJk() {
+  return (tree: Root) => {
+    visit(tree, 'text', (node: Text, index, parent) => {
+      if (index === undefined || !parent || parent.type !== 'element') return
+      const parentEl = parent as Element
+      if (SKIPPED_TAGS.has(parentEl.tagName)) return
+
+      const value = node.value
+      if (!value) return
+      if (!value.includes("jackin'") && !value.includes('jackin’')) return
+
+      const parts: Array<Text | Element> = []
+      let last = 0
+      NAME_PATTERN.lastIndex = 0
+      let match: RegExpExecArray | null
+      while ((match = NAME_PATTERN.exec(value)) !== null) {
+        if (match.index > last) {
+          parts.push({ type: 'text', value: value.slice(last, match.index) })
+        }
+        parts.push({
+          type: 'element',
+          tagName: 'span',
+          properties: { className: ['jk-name'] },
+          children: [{ type: 'text', value: match[0] }],
+        })
+        last = match.index + match[0].length
+      }
+      if (parts.length === 0) return
+      if (last < value.length) {
+        parts.push({ type: 'text', value: value.slice(last) })
+      }
+
+      parentEl.children.splice(index, 1, ...parts)
+      return [SKIP, index + parts.length]
+    })
+  }
+}

--- a/docs/src/content/docs/commands/config.mdx
+++ b/docs/src/content/docs/commands/config.mdx
@@ -88,13 +88,13 @@ workspace editor (or by hand-editing TOML).
 jackin config auth set <MODE>
 ```
 
-Set the global Claude auth-forwarding mode (`[claude].auth_forward`).
+Set the global Claude auth-forwarding mode (the default mode for every `Claude Code` launch unless a workspace or per-role override changes it).
 
 | Mode | Description |
 |---|---|
 | `sync` | Overwrite from host on each launch when host auth exists; preserve container auth when absent (default) |
-| `api_key` | Inject `ANTHROPIC_API_KEY` from the operator-env layer |
-| `oauth_token` | Inject `CLAUDE_CODE_OAUTH_TOKEN` from the operator-env layer |
+| `api_key` | Inject `ANTHROPIC_API_KEY` from your operator env vars |
+| `oauth_token` | Inject `CLAUDE_CODE_OAUTH_TOKEN` from your operator env vars |
 | `ignore` | Never forward; revoke any previously forwarded credentials |
 
 ```bash
@@ -120,9 +120,9 @@ jackin config auth show
 
 Manage operator env vars at global and per-role scope.
 
-Values are stored verbatim — whatever you type is what goes into the TOML. No editor-side validation of key names or value shape. jackin' resolves values at launch time through the operator-env layer, so `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work.
+Values are stored verbatim — whatever you type is what jackin' resolves at launch time. No editor-side validation of key names or value shape. `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work.
 
-Without `--role`, writes and reads target the global `[env]` table. With `--role <SELECTOR>`, they target `[roles.<SELECTOR>.env]`. The role selector is not pre-validated — the table path is written even if the role is not registered.
+Without `--role`, writes and reads target the **global** scope (applies to every agent launch). With `--role <SELECTOR>`, they target the **per-role** scope (applies only when that role is loaded). The role selector is not pre-validated — the value is recorded even if the role is not registered.
 
 ### `config env set`
 
@@ -134,8 +134,8 @@ Set or overwrite an env var at the chosen scope.
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | Apply to `[roles.<SELECTOR>.env]` instead of the global `[env]` |
-| `--comment <TEXT>` | Write a TOML line comment directly above the key |
+| `--role <SELECTOR>` | Apply to the per-role scope instead of the global scope |
+| `--comment <TEXT>` | Attach an inline comment to the key |
 
 ```bash
 # Global scope — 1Password reference
@@ -154,11 +154,11 @@ jackin config env set OPENAI_KEY "op://Work/OpenAI/key" --comment "rotate quarte
 jackin config env unset <KEY> [OPTIONS]
 ```
 
-Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without modifying the config file.
+Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without changing anything.
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | Unset from `[roles.<SELECTOR>.env]` instead of the global `[env]` |
+| `--role <SELECTOR>` | Unset from the per-role scope instead of the global scope |
 
 ```bash
 jackin config env unset API_TOKEN
@@ -175,7 +175,7 @@ Show the env vars registered at the chosen scope as a table with `Key` and `Valu
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | List vars from `[roles.<SELECTOR>.env]` instead of the global `[env]` |
+| `--role <SELECTOR>` | List vars from the per-role scope instead of the global scope |
 
 ```bash
 jackin config env list

--- a/docs/src/content/docs/commands/console.mdx
+++ b/docs/src/content/docs/commands/console.mdx
@@ -4,6 +4,25 @@ description: "Interactive operator console"
 ---
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="tip">
+The operator console is the **simplest and most convenient way to use
+jackin'** day-to-day, and the surface most operators stay on. The CLI
+is for the **advanced and very specific cases**: scripted one-liners,
+niche flags, automation, and behaviours the console deliberately does
+not expose.
+
+Today the console covers launching agents (the `load` flow),
+managing workspaces (`workspace`), and editing the per-workspace
+auth and env tables (`config` for those scopes). The remaining CLI
+subcommands — `hardline`, `eject`, `exile`, `purge`, global mounts
+and global env, multi-session preview — are **not in the console
+yet** and live on the CLI for now; they will land in the console as
+the TUI grows feature by feature. There is no feature parity by
+design: niche flags continue to land on the CLI first.
+
+The expectation is **most people use the TUI, and reach for the CLI
+only when they need it.**
+</Aside>
 
 ## Synopsis
 
@@ -42,7 +61,7 @@ agent-selection screen.
 The manager list shows two kinds of rows:
 
 - **Current directory** — a synthetic row that mounts your `cwd` at the same path inside the container
-- **Saved workspaces** — named definitions from `~/.config/jackin/config.toml`
+- **Saved workspaces** — named definitions you have created with `jackin workspace create` or in the workspace manager
 
 If your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths, that workspace is preselected.
 
@@ -134,13 +153,13 @@ The Environments tab in the `jackin console` workspace editor manages
 environment variables at two scopes:
 
 - **Workspace environment** — applies to every role launch in this
-  workspace, stored under `[workspaces.<name>.env]`.
-- **Per-role overrides** — apply only when a specific role is launched in
-  this workspace, stored under `[workspaces.<name>.roles.<role>.env]`.
+  workspace.
+- **Per-role overrides** — apply only when a specific role is launched
+  in this workspace.
 
-Values are stored as-typed. Use `op://...` for 1Password references, `$VAR`
-or `${VAR}` for shell-variable substitution, or a literal string.
-jackin' resolves them at launch via `operator_env`.
+Values are stored as-typed. Use `op://...` for 1Password references,
+`$VAR` or `${VAR}` for shell-variable substitution, or a literal
+string. jackin' resolves them at launch.
 
 | Key | Action |
 |---|---|

--- a/docs/src/content/docs/commands/eject.mdx
+++ b/docs/src/content/docs/commands/eject.mdx
@@ -48,4 +48,4 @@ When you eject an agent:
 - The per-agent Docker network is removed
 
 When you add `--purge`:
-- All of the above, plus persisted state at `~/.jackin/data/<container-name>/` is deleted
+- All of the above, plus the agent's persisted state (conversation history, forwarded credentials, `gh` state, plugins) is deleted

--- a/docs/src/content/docs/commands/load.mdx
+++ b/docs/src/content/docs/commands/load.mdx
@@ -4,6 +4,12 @@ description: "Jack an agent into an isolated container"
 ---
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="note">
+`jackin load` is the **CLI** entry point. For most day-to-day work,
+[`jackin console`](/commands/console/) is simpler and faster. Use
+`jackin load` when you want a scriptable one-liner, want to skip the
+TUI entirely, or want a flag the console does not expose.
+</Aside>
 
 ## Synopsis
 
@@ -11,7 +17,7 @@ import { Aside } from '@astrojs/starlight/components'
 jackin load [SELECTOR] [TARGET] [OPTIONS]
 ```
 
-Load an agent into an isolated Docker container. This is the primary command for starting an agent session.
+Load an agent into an isolated `Docker` container directly from the command line.
 
 `SELECTOR` chooses the **role** (tool profile). `TARGET` chooses the **workspace or path** (file access boundary).
 
@@ -106,16 +112,15 @@ jackin load the-architect --role-branch feat/caveman-all-install
 
 | Behaviour | Default | With `--role-branch` |
 |---|---|---|
-| Role repo cache path | `~/.jackin/roles/<name>/` | `~/.jackin/roles/<name>/branches/<branch>/` |
-| Image tag | `jackin-<name>` | `jackin-<name>-<branch-slug>` |
-| Uses `published_image` | Yes (if declared in manifest) | No — always builds from the branch Dockerfile |
-| Docker layer cache | Used | Used (no forced rebuild unless `--rebuild` is also passed) |
-| Repo lock file | Shared with default-branch loads | Separate — branch builds never block default-branch loads |
+| Branch cached and reused | Default branch | The named branch — repeat loads of the same branch reuse the cached checkout |
+| Image | Stable per-role image | Branch-specific image, fully isolated from the stable image |
+| Concurrency with default-branch loads | Same role's default-branch load may be blocked while the cache refreshes | Branch builds never block default-branch loads, and vice versa |
 | Trust confirmation | First-use only | **Always** — regardless of the role's trusted status |
+| Forced rebuild | Pass `--rebuild` to refresh layers | Same — pass `--rebuild` to refresh layers |
 
-The branch cache (`branches/<branch>/`) is completely separate from the default-branch cache. Running `jackin load the-architect` after a branch build still uses the unchanged default-branch image.
+The branch image is completely separate from the default-branch image. Running `jackin load the-architect` after a branch build still uses the unchanged default-branch image.
 
-Branch names with slashes are preserved as nested directories on disk (`feat/my-pr` → `branches/feat/my-pr/`), so a branch named `feat/my-pr` and one named `feat-my-pr` are always stored at distinct paths and use distinct lock files.
+Branch names with slashes (`feat/my-pr`) and dashes (`feat-my-pr`) are kept distinct, so loading both never reuses the same image or cache slot by mistake.
 
 ### Branch trust gate
 

--- a/docs/src/content/docs/commands/purge.mdx
+++ b/docs/src/content/docs/commands/purge.mdx
@@ -38,23 +38,23 @@ jackin purge chainargos/backend-engineer
 
 ## What gets deleted
 
-Persisted state at `~/.jackin/data/<container-name>/`:
+The agent's persisted state:
 
-- `.claude/` — Claude Code session history and configuration
-- `.claude.json` — Claude settings
-- `.config/gh/` — GitHub CLI authentication and settings
+- `Claude Code` session history and runtime settings
+- `GitHub CLI` authentication and settings
+- forwarded auth credentials (when `auth_forward = "sync"` was used)
+- any plugins the role installed into per-agent state
 
-For workspaces with isolated mounts, `purge` also force-removes:
+For workspaces with isolated mounts (`worktree` or `clone`), `purge` also force-removes:
 
-- every isolated worktree recorded in `<data_dir>/jackin-<container>/.jackin/isolation.json` (`git worktree remove --force`)
-- the corresponding `git/` subtree (the materialized worktree under `git/worktree/repo/<dst>/<container>/` and the jackin-owned override files under `git/overrides/<dst>/`)
-- the recorded local scratch branch (`jackin/scratch/<container>` by default)
+- every per-container isolated worktree or clone the workspace materialized
+- the matching local scratch branch jackin' created for that container
 
 There is no unpushed-commit guard, no `--delete-branches` flag, and no interactive prompt — once the operator runs `purge`, the recovery state is gone. If you may still need an isolated branch, push it (or rename it) before purging.
 
-If the host repo recorded in `isolation.json` has been deleted or moved between `load` and `purge`, jackin' tolerates the missing parent: it best-effort attempts `git worktree remove --force` and then `rm -rf` the per-container `git/` tree. Purge does not fail just because the host repo is gone.
+If the host repo backing an isolated mount has been deleted or moved between `load` and `purge`, jackin' tolerates the missing parent and best-effort cleans up what remains. Purge does not fail just because the host repo is gone.
 
-The Docker image and cached role repo are **not** affected. Use `--rebuild` on the next `jackin load` to force a full image rebuild.
+The `Docker` image and the cached role repository are **not** affected. Use `--rebuild` on the next `jackin load` to force a full image rebuild.
 
 ## Running-agent guard
 

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -169,15 +169,15 @@ jackin workspace prune my-app        # interactive
 jackin workspace prune my-app --yes  # non-interactive
 ```
 
-Under rule C, a mount is redundant when another mount in the same workspace strictly covers it at the same container location — same host-to-container offset. See [Redundant-mount invariant](/guides/mounts/#redundant-mount-invariant) in the mounts guide.
+A mount is redundant when another mount in the same workspace strictly covers it at the same container location — same host-to-container offset. See [Redundant mounts](/guides/mounts/#redundant-mounts) in the mounts guide.
 
 ## `workspace env`
 
 Manage operator env vars at workspace and workspace-role scope.
 
-Values are stored verbatim — `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work. jackin' resolves values at launch time through the operator-env layer; there is no editor-side validation of key names or value shape.
+Values are stored verbatim — `op://...` 1Password references, `$VAR` / `${VAR}` shell-style interpolations, and literal strings all work. jackin' resolves values at launch time; there is no editor-side validation of key names or value shape.
 
-Without `--role`, writes and reads target `[workspaces.<WORKSPACE>.env]`. With `--role <SELECTOR>`, they target `[workspaces.<WORKSPACE>.roles.<SELECTOR>.env]`. The workspace must already exist — unknown workspaces fail fast with a non-zero exit. The role selector is not pre-validated.
+Without `--role`, writes and reads target the **workspace-wide** scope (applies to every role launch in this workspace). With `--role <SELECTOR>`, they target the **per-(workspace × role)** scope (applies only when that role is launched in this workspace). The workspace must already exist — unknown workspaces fail fast with a non-zero exit. The role selector is not pre-validated.
 
 ### `workspace env set`
 
@@ -189,8 +189,8 @@ Set or overwrite an env var at the chosen scope.
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | Apply to `[workspaces.<WORKSPACE>.roles.<SELECTOR>.env]` instead of the workspace-wide table |
-| `--comment <TEXT>` | Write a TOML line comment directly above the key |
+| `--role <SELECTOR>` | Apply to the per-(workspace × role) scope instead of the workspace-wide one |
+| `--comment <TEXT>` | Attach an inline comment to the key |
 
 ```bash
 # Workspace scope
@@ -209,11 +209,11 @@ jackin workspace env set prod DEBUG "1" --comment "temporary; remove after Q2"
 jackin workspace env unset <WORKSPACE> <KEY> [OPTIONS]
 ```
 
-Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without modifying the config file. Fails fast if `<WORKSPACE>` does not exist.
+Remove an env var from the chosen scope. Idempotent: if the key is not present, prints `<KEY> not set.` and exits 0 without modifying anything. Fails fast if `<WORKSPACE>` does not exist.
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | Unset from `[workspaces.<WORKSPACE>.roles.<SELECTOR>.env]` instead of the workspace-wide table |
+| `--role <SELECTOR>` | Unset from the per-(workspace × role) scope instead of the workspace-wide one |
 
 ```bash
 jackin workspace env unset prod DB_URL
@@ -230,7 +230,7 @@ Show the env vars registered at the chosen scope as a table with `Key` and `Valu
 
 | Option | Description |
 |---|---|
-| `--role <SELECTOR>` | List vars from `[workspaces.<WORKSPACE>.roles.<SELECTOR>.env]` instead of the workspace-wide table |
+| `--role <SELECTOR>` | List vars from the per-(workspace × role) scope instead of the workspace-wide one |
 
 ```bash
 jackin workspace env list prod

--- a/docs/src/content/docs/developing/construct-image.mdx
+++ b/docs/src/content/docs/developing/construct-image.mdx
@@ -5,6 +5,16 @@ description: What's inside the shared base image that every agent starts from
 import RepoFile from '../../../components/RepoFile.astro'
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="note">
+This page has two readers. **Role authors** (user-facing) read the
+top half — *what is in the `construct`*, *what tools come for free*,
+*how to extend it from a role's `Dockerfile`*. **Contributors**
+(internals-facing) read the lower half — *how to build, validate,
+and publish the `construct` image itself* (`just construct-build`,
+CI workflow, advanced publish rehearsal). Operators using jackin'
+as a product do not need to read either half; `jackin load` pulls
+and updates the `construct` automatically.
+</Aside>
 
 ## What is the construct?
 

--- a/docs/src/content/docs/developing/creating-roles.mdx
+++ b/docs/src/content/docs/developing/creating-roles.mdx
@@ -1,9 +1,18 @@
 ---
-title: Creating an Agent
+title: Creating a Role
 description: Build your own role repo with a custom toolchain
 ---
 import { Aside, Steps } from '@astrojs/starlight/components'
 
+<Aside type="note">
+This page is **for role authors** — a step-by-step walkthrough of
+creating your own role repository. Role authoring is a normal
+user-facing activity (a developer building a backend-engineer,
+docs-writer, or security-reviewer role with their preferred
+toolchain and plugins) — you do not need to know how jackin' is
+implemented to follow it. If you only want to *load* existing
+roles, see the [Operator Guide](/guides/workspaces/) instead.
+</Aside>
 
 ## Overview
 
@@ -185,6 +194,8 @@ jackin load my-agent my-app --agent claude
 
 ## Testing your agent
 
+### Testing the default branch
+
 The fastest way to test is to load it:
 
 ```bash
@@ -198,6 +209,70 @@ Use `--debug` to see raw Docker output if something goes wrong:
 ```bash
 jackin load your-agent-name --rebuild --debug
 ```
+
+### Testing a branch (your own work or someone else's PR)
+
+When you have changes that are **not yet on the default branch** — your
+own feature branch, a fork's branch you want to try, or a contributor's
+pull request you want to verify before approving — pass `--role-branch`
+to load that branch instead of the role repo's default:
+
+```bash
+# Test your own branch on a role you own
+jackin load your-agent-name --role-branch feat/some-change --rebuild
+
+# Test someone else's PR branch (their fork must be the role's
+# configured remote, or you opened the PR against your fork)
+jackin load your-agent-name --role-branch their-feature --rebuild
+```
+
+`--role-branch` always triggers an interactive **branch trust gate**,
+even when the role itself is already trusted (`trusted = true` in
+your config). The reason is in [Security Model →
+Branch trust gate](/guides/security-model/#branch-trust-gate): a
+`trusted = true` flag records that you reviewed the role's *default*
+branch, and an unmerged branch may contain a Dockerfile or scripts
+that would run during the image build but were never reviewed. The
+prompt asks you to confirm you have read the diff before continuing,
+and it cannot be skipped — there is no `--force-branch` and
+non-interactive shells fail rather than defaulting to yes.
+
+The recommended flow when reviewing someone else's role-repo PR:
+
+1. Fetch the PR branch into a checkout of the role repo and read the
+   diff yourself, especially `Dockerfile`, any pre-launch hook, and
+   the `jackin.role.toml` manifest.
+2. Run the load command above with `--role-branch <PR-branch-name>`
+   and `--rebuild`.
+3. When the trust prompt appears, confirm only after the diff review
+   is complete.
+4. Inside the container, exercise the change — install the toolchain
+   the PR claims to add, run a representative project, etc.
+5. `jackin eject your-agent-name` when finished. The branch's cached
+   checkout is kept around so the next `--role-branch` load of the
+   same branch is fast; `jackin purge` for that container clears it.
+
+### Testing your changes from a fork
+
+If you do not have write access to the upstream role repo, the
+standard fork-and-PR flow works without any extra jackin' configuration.
+On your **own** fork:
+
+1. Push the branch to your fork.
+2. Point jackin' at your fork as the role's source. The cleanest way
+   is to give the role a namespaced selector that matches your fork
+   (for example `your-org/your-role` resolving to
+   `https://github.com/your-org/jackin-your-role.git`); jackin'
+   resolves the source from the selector. If you want the role's
+   short name (`your-role`) to load from your fork instead of the
+   upstream, use `jackin config trust grant <selector>` and any
+   selector-source helpers your jackin' release exposes — see the
+   [Configuration File](/reference/configuration/) internals
+   reference if you need the on-disk schema.
+3. Run `jackin load <role> --role-branch <branch> --rebuild`.
+4. When the change is ready, open a PR against the upstream role
+   repo from the same fork branch. Reviewers can then verify it
+   against their own checkout using the same `--role-branch` flow.
 
 ## Example agents
 

--- a/docs/src/content/docs/developing/role-manifest.mdx
+++ b/docs/src/content/docs/developing/role-manifest.mdx
@@ -4,6 +4,13 @@ description: "The jackin.role.toml file that defines a role"
 ---
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="note">
+This page is **for role authors** — it documents the schema of the
+`jackin.role.toml` file inside a role repository. Role authoring is
+a user-facing activity: you do not need to know how jackin' is
+implemented to use this page. Operators who only *load* existing
+roles never edit this file.
+</Aside>
 
 ## Overview
 
@@ -218,16 +225,12 @@ Declare environment variables that the agent needs at runtime. Each variable is 
 - `depends_on` entries must use the `env.` prefix (e.g., `"env.PROJECT"`)
 - `depends_on` must reference variables declared in the same manifest
 - `${env.*}` references in `prompt` and `default` must point to declared variables that are listed in `depends_on`
-- `JACKIN` is reserved for jackin and cannot be declared in `[env]`
-- `JACKIN_DIND_HOSTNAME` is reserved for jackin and cannot be declared in `[env]`
+- Reserved runtime names (see [Reserved names](/guides/environment-variables/#reserved-names) for the canonical list) cannot be declared in `[env]`
 - Circular dependencies are rejected
 
 ### Runtime-managed variables
 
-jackin sets these variables automatically inside the container. Do not declare either of them in `[env]`.
-
-- `JACKIN=1` marks that the process is running inside a jackin-managed runtime.
-- `JACKIN_DIND_HOSTNAME` is the hostname agents should use to reach published services started via the Docker-in-Docker daemon.
+jackin' sets a small set of variables automatically inside the container — most notably `JACKIN=1` (which marks that the process is running inside a jackin-managed runtime) and `JACKIN_DIND_HOSTNAME` (which agents use to reach published services started via the Docker-in-Docker daemon). The full set of reserved runtime names is documented under [Reserved names](/guides/environment-variables/#reserved-names) and must not be declared in `[env]`.
 
 ### Interactive text input
 

--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: The mental model behind jackin' — operators, agents, constructs, and workspaces
+description: The mental model behind jackin' — operators, agents, roles, constructs, and workspaces
 ---
 import { Aside } from '@astrojs/starlight/components'
 
@@ -14,25 +14,25 @@ import { Aside } from '@astrojs/starlight/components'
 - Which workspace configuration to use
 - When to eject (stop) an agent
 
-The operator never enters the container. You interact with jackin's CLI and TUI from your host machine.
+The operator never enters the container. You drive jackin' from your host machine through two surfaces: the **operator console** (`jackin console`) — an interactive TUI that is the simplest and most-used way to work day-to-day — and the **CLI** (`jackin load`, `jackin workspace`, …) for advanced, scripted, or non-interactive flows.
 
 ## Agents
 
-An **agent** is an AI coding runtime (like Claude Code) running inside an isolated Docker container. Each agent:
+An **agent** is an AI coding runtime (`Claude Code` and `Codex` today; `Amp` under active development) running inside an isolated `Docker` container. Each agent:
 
 - Has its own filesystem, network, and process space
-- Runs with full permissions inside the container (`--dangerously-skip-permissions`)
+- Runs at full speed inside the container — whatever "no permission prompts" mode the runtime ships (`Claude Code`'s `--dangerously-skip-permissions`, `Codex`'s YOLO, etc.) — because the boundary is the container, not the prompts
 - Can only access directories you explicitly mount
-- Has Docker-in-Docker (DinD) enabled, so it can build and run Docker containers inside its own container
-- Persists its state between sessions (Claude history, settings, GitHub CLI auth/config, plugins)
+- Can build and run its own containers (`Docker-in-Docker`), without touching your host's `Docker` daemon
+- Persists its state between sessions (conversation history, runtime settings, `GitHub CLI` auth/config, plugins)
 
 ### Roles
 
-An agent **class** is a reusable tool profile for creating agent containers. It's defined by a GitHub repository that contains a Dockerfile and a manifest file (`jackin.role.toml`). For example:
+An agent **role** is a reusable tool profile for creating agent containers. It's defined by a `GitHub` repository that contains a `Dockerfile` and a manifest file. For example:
 
 - `agent-smith` — the default role
 - `the-architect` — an agent with the full Rust toolchain (used for jackin' development)
-- `chainargos/backend-engineer` — a namespaced agent for backend work in the chainargos organization
+- `chainargos/backend-engineer` — a namespaced role for backend work in the chainargos organization
 
 The name `agent-smith` is just a project-specific example. In practice, role names can reflect the job they are designed for:
 
@@ -42,16 +42,16 @@ The name `agent-smith` is just a project-specific example. In practice, role nam
 - `docs-writer`
 - `security-reviewer`
 
-When you run `jackin load agent-smith`, jackin' clones the `jackin-agent-smith` repository, builds a Docker image from it, and launches a container.
+When you run `jackin load agent-smith`, jackin' clones the `jackin-agent-smith` repository, builds a `Docker` image from it, and launches a container.
 
-Think of an role as answering: "What kind of agent is this?"
+Think of a role as answering: "What kind of agent is this?"
 
 - Which language toolchains are installed?
 - Which shell setup or helper scripts are present?
-- Which Claude plugins are installed?
+- Which `Claude Code` plugins (or equivalent extensions for other runtimes) are installed?
 - Which defaults should this agent start with?
 
-One project may intentionally use several roles. That is not redundancy. It is how you keep the agent's world focused. A frontend-oriented class can carry UI tooling and plugins, while a backend-oriented class can carry server tooling and database clients, even if both point at the same workspace. The smaller and more relevant that environment is, the less out-of-scope context the agent has to inspect.
+One project may intentionally use several roles. That is not redundancy. It is how you keep the agent's world focused. A frontend-oriented role can carry UI tooling and plugins, while a backend-oriented role can carry server tooling and database clients, even if both point at the same workspace. The smaller and more relevant that environment is, the less out-of-scope context the agent has to inspect.
 
 ### Agent instances
 
@@ -59,40 +59,24 @@ A single role can have multiple running **instances**. Each instance is a separa
 
 ## The construct
 
-The **construct** in jackin' is the shared base Docker image that every agent starts from — the empty foundation that gets layered with agent-specific tools at load time:
+The **`construct`** is the shared base `Docker` image that every agent starts from. It carries the operating system and the tools every agent is expected to have on day one — `Debian`, the `Docker` CLI, `git`, `GitHub CLI`, `mise`, `ripgrep`, `fd`, `fzf`, `zsh` with `Oh My Zsh`, and the `Starship` prompt.
 
-```
-projectjackin/construct:trixie
-```
+Role repos extend the `construct` with their own tools. For example, a role for Rust development would add the Rust toolchain on top of the `construct`.
 
-The construct provides:
-
-| Component | Purpose |
-|---|---|
-| **Debian Trixie** | Stable base OS |
-| **Docker CLI + Compose** | So agents can build/run containers (via DinD) |
-| **Git + Git LFS** | Source control |
-| **GitHub CLI** | Repository and PR operations |
-| **mise** | Language version management (Node, Python, Go, etc.) |
-| **ripgrep, fd, fzf** | Fast search tools |
-| **zsh + Oh My Zsh** | Shell environment with autosuggestions |
-| **Starship prompt** | Informative terminal prompt |
-
-Role repos extend the construct with their own tools. For example, an agent for Rust development would add the Rust toolchain on top of the construct.
-
-## Docker-in-Docker (DinD)
-
-Each agent gets its own Docker daemon via a **DinD sidecar container**. This means agents can:
-
-- Build Docker images (`docker build`)
-- Run containers (`docker run`)
-- Use Docker Compose (`docker compose up`)
-
-All within their own isolated Docker environment. The agent's Docker daemon is completely separate from your host's Docker daemon.
+You don't pull or maintain the `construct` yourself — `jackin load` does it for you the first time it is needed.
 
 <Aside type="note">
-The DinD sidecar runs on a per-agent Docker network (`jackin-{agent}-net`). The agent container connects to the DinD daemon via TCP.
+If you want to know exactly what the `construct` contains and how it
+is built, see [The Construct Image](/developing/construct-image/) in
+the internals section. Operators rarely need that level of detail.
 </Aside>
+
+## Docker-in-Docker
+
+Each agent gets its own private `Docker` daemon. From the agent's point of view that means it can run `docker build`, `docker run`, and `docker compose` inside its own container, without ever talking to your host `Docker` daemon.
+
+The practical consequence: an agent can build and run containers as part of its work, but those containers cannot escape into your host's `Docker` engine.
+
 ## Workspaces
 
 A **workspace** defines how your project directories are mounted into an agent container. It specifies:
@@ -122,58 +106,34 @@ Workspaces can be:
 
 1. **Current-directory workspace** — the current directory, mounted at the same path. This is what you get with `jackin load agent-smith` from any directory.
 
-2. **Saved** — named configurations stored in `~/.config/jackin/config.toml`. Saved workspaces are useful when you want to reuse the same project boundary across sessions, launch from anywhere, preserve a multi-mount layout, or keep a preferred/default agent attached to that project.
+2. **Saved** — named configurations you create in the operator console (or with `jackin workspace create` from the CLI). Saved workspaces are useful when you want to reuse the same project boundary across sessions, launch from anywhere, preserve a multi-mount layout, or keep a preferred/default agent attached to that project.
 
-## Derived images
-
-When you load an agent, jackin' doesn't use the construct image directly. Instead, it generates a **derived Dockerfile** that:
-
-1. Starts from the agent's Dockerfile (which itself starts from the construct)
-2. Remaps the container user to match your host UID/GID
-3. Installs Claude Code — the current implementation targets Claude specifically; supporting other agent runtimes is on the roadmap but not in the build path today
-4. Injects the runtime entrypoint script
-5. Copies in Claude plugins if declared in the manifest
-
-Every load re-runs `docker build` on the derived Dockerfile, but Docker's layer cache makes unchanged layers instant — the first load pays the full build cost, subsequent loads typically only rebuild what changed. Passing `--rebuild` additionally invalidates the Claude installation layer so the next build picks up a newer Claude version.
+<Aside type="tip">
+Saved workspaces are managed exclusively through `jackin workspace …`
+commands or the operator console — there is no need to hand-edit any
+configuration file. Every operator-level setting has a CLI flow; the
+common ones (workspace mounts, workspace env, per-(workspace × role)
+auth) additionally have a TUI flow in the operator console. Global
+mounts, global env, and a few advanced flags are CLI-only today.
+</Aside>
 
 ## State persistence
 
-Agent state is persisted between sessions at `~/.jackin/data/<container-name>/`. This includes:
+Each agent keeps its own session state — conversation history, login state for tools you authenticated inside the container (such as `gh`), and any plugins the role installed. When you stop and restart an agent, it picks up where it left off.
 
-- `.claude/` — Claude Code session history and configuration
-- `.claude.json` — Claude settings
-- `.config/gh/` — GitHub CLI authentication and settings when you authenticate inside the container
-
-When you stop and restart an agent, it picks up where it left off. Use `jackin purge` to delete persisted state and start fresh.
+To wipe an agent's persisted state and start fresh, run `jackin purge <role>`.
 
 ## Putting it all together
 
-Here's what happens when you run `jackin load agent-smith ~/Projects/my-app`:
+When you run `jackin load agent-smith ~/Projects/my-app`, jackin' takes care of every step needed to launch a usable agent — from your point of view, that looks like:
 
-```
-1. Resolve role "agent-smith"
-   └─ Clone/update github.com/jackin-project/jackin-agent-smith
+1. **Pick the role** — fetch and validate the role repo.
+2. **Build the agent image** — extending the `construct` with the role's tools and the agent runtime. Subsequent loads reuse `Docker`'s layer cache.
+3. **Mount your project files** — at the path the workspace says.
+4. **Start the container in isolation** — on its own `Docker` network, with its own private `Docker` daemon for any containers the agent itself needs to build.
+5. **Drop you inside** — `Claude Code` (or another supported runtime) starts with full permissions inside that boundary.
 
-2. Validate role repo contract
-   └─ Check jackin.role.toml and Dockerfile
-
-3. Generate derived Dockerfile
-   └─ Construct base → Agent layer → Claude install → Entrypoint
-
-4. Build derived Docker image (cached if unchanged)
-
-5. Create per-agent Docker network
-   └─ jackin-agent-smith-net
-
-6. Launch DinD sidecar container
-   └─ jackin-agent-smith-dind on jackin-agent-smith-net
-
-7. Launch agent container
-   ├─ Mount ~/Projects/my-app at the same path
-   ├─ Mount persisted state from ~/.jackin/data/
-   ├─ Connect to jackin-agent-smith-net
-   ├─ Set DOCKER_HOST to DinD sidecar
-   └─ Run Claude Code with --dangerously-skip-permissions
-
-8. You're inside — Claude Code is ready
-```
+That whole sequence is one command. If you want to read the full,
+under-the-hood account — derived `Dockerfile`s, networking, isolated
+worktrees, the post-attach finalizer — see
+[Architecture](/reference/architecture/) in the internals section.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -64,12 +64,12 @@ On macOS, [OrbStack](https://orbstack.dev/) is a lightweight alternative to Dock
 
 jackin' itself is a single binary. When you first load an agent, jackin' will:
 
-1. **Pull the construct image** (`projectjackin/construct:trixie`) — a Debian-based image with system tools, Docker CLI, git, and more
-2. **Clone the role repo** — cached at `~/.jackin/roles/`
-3. **Build a derived image** — layers the agent's tools and Claude Code on top of the construct
-4. **Create a Docker network** — per-agent isolation
+1. **Pull the `construct` image** — the shared Debian-based base image every agent extends
+2. **Fetch the role repository** — cached locally so subsequent loads of the same role do not re-clone
+3. **Build a derived image** — layers the role's tools and the agent runtime on top of the `construct`
+4. **Create a per-agent `Docker` network** — for isolation between agents
 
-Subsequent loads re-run `docker build` but reuse Docker's layer cache where nothing upstream changed, so repeated loads of the same agent are typically fast. The role repo cache at `~/.jackin/roles/` is also reused. Passing `--rebuild` additionally invalidates the Claude installation layer so a newer Claude version is picked up.
+Subsequent loads of the same role are typically fast: `Docker`'s layer cache is reused, the role-repo cache is reused, and only changed layers rebuild. Pass `--rebuild` when you want jackin' to refresh the agent-runtime install layer (for example, to pick up a newer agent release).
 
 ## Next steps
 

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -5,9 +5,20 @@ description: Load your first agent in under a minute
 import { Aside, Steps, TabItem, Tabs } from '@astrojs/starlight/components'
 
 
-## Load your first agent
+## Two ways to drive jackin'
 
-In jackin', the first thing you choose is usually an **role**. That is the tool profile you want to run. `agent-smith` is the default starter class included by this project.
+jackin' has **two surfaces** and you'll use both — but very differently:
+
+- **`jackin console`** — the interactive operator console (TUI). The simplest and most convenient surface, and the one most operators stay on day-to-day. Today it covers launching agents (the `load` flow), managing workspaces (`workspace`), and editing the per-workspace auth and env tables (`config` for those scopes). The remaining CLI subcommands — `hardline`, `eject`, `exile`, `purge`, global mounts and global env, multi-session preview — are **not in the console yet** and live on the CLI for now; they will land in the console as the TUI grows feature by feature.
+- **`jackin load` and the rest of the CLI** — the advanced, scriptable surface. Use it when you want a saved one-liner, an automation script, a specific niche flag the console doesn't expose, or a feature the console doesn't yet have. There is **no feature parity** between the two on purpose: new flags land on the CLI first.
+
+The expectation is **most people use the TUI, and reach for the CLI only when they need it.**
+
+The walkthrough below starts with `jackin load` because it is the **shortest one-shot demonstration of jackin's isolation model** — install, load, see for yourself that the agent is now running in an isolated world it can't escape. Once that shape clicks, the operator console is where you stay for daily work.
+
+## Load your first agent (CLI)
+
+In jackin', the first thing you choose is usually a **role**. That is the tool profile you want to run. `agent-smith` is the default starter role included by this project.
 
 <Steps>
 1. **Navigate to your project directory**
@@ -23,25 +34,25 @@ In jackin', the first thing you choose is usually an **role**. That is the tool 
    ```
 
    The first time you run this, jackin' will:
-   - Pull the construct base image
-   - Clone the agent-smith repository
-   - Build a derived Docker image with Claude Code installed
-   - Create an isolated Docker network
+   - Pull the `construct` base image
+   - Clone the `agent-smith` role repository
+   - Build a derived `Docker` image with `Claude Code` installed
+   - Create an isolated `Docker` network
    - Launch the container with your current directory mounted
 
 3. **You're inside**
 
-   Claude Code starts automatically with full permissions inside the container. Your project directory is mounted at the same path, so the agent sees the same file layout you do.
+   `Claude Code` starts automatically with full permissions inside the container. Your project directory is mounted at the same path, so the agent sees the same file layout you do.
 
 4. **Exit when done**
 
-   Press `Ctrl+C` or type `/exit` in Claude Code to leave. The container stops, but its state is persisted for next time.
+   Press `Ctrl+C` or type `/exit` in `Claude Code` to leave. The container stops, but its state is persisted for next time.
 </Steps>
 If you already know you want a more specialized role, swap `agent-smith` for something else such as `the-architect`.
 
-## Use the interactive console
+## Move to the operator console for daily use
 
-If you prefer a visual interface:
+Once you've seen `jackin load` work end-to-end, switch to the console for everyday work:
 
 ```bash
 jackin console
@@ -49,15 +60,20 @@ jackin console
 
 This opens the operator console — a TUI where you can:
 - Pick from saved workspaces or use the current directory
-- Preview the final directory mounts for the highlighted agent before loading it
-- Choose which agent to load
+- Preview the final directory mounts for the highlighted role before loading it
+- Choose which role and agent to load
+- Manage saved workspaces, env vars, and auth without remembering flag syntax
+
+<Aside type="tip">
+The console is the **default daily driver**. It covers the common
+cases of every CLI subcommand. Reach for the CLI when you want a
+scripted one-liner, a non-interactive run (CI, automation), or a
+specific advanced flag — `jackin load --rebuild`, `jackin workspace
+edit … --mount-isolation …`, that kind of thing.
+</Aside>
 
 See [`jackin console`](/commands/console/) for the full reference, including the bare-`jackin` shortcut.
 
-<Aside type="tip">
-The operator console is the human-first flow — visual and interactive.
-`load` is the terminal-first flow — explicit and scriptable.
-</Aside>
 ## Reconnect to a running agent
 
 If you close your terminal but the agent is still running:
@@ -66,7 +82,7 @@ If you close your terminal but the agent is still running:
 jackin hardline agent-smith
 ```
 
-This reattaches your terminal to the running container's session.
+This reattaches your terminal to the running container's session. `hardline` is a CLI-only flow today.
 
 ## Stop an agent
 
@@ -81,7 +97,21 @@ jackin exile
 ## Common workflows
 
 <Tabs>
-<TabItem label="Daily development">
+<TabItem label="Daily development (console)">
+
+```bash
+# Open the console once
+jackin console
+
+# Pick a workspace, pick a role, press Enter — you're inside.
+# Eject from the same console row when you're done.
+```
+
+The console is the default surface for this flow. The CLI tabs below show the equivalent one-liners for scripts and automation.
+
+</TabItem>
+
+<TabItem label="Daily development (CLI)">
 
 ```bash
 # Start of day — load agent into your project
@@ -106,12 +136,14 @@ jackin workspace create backend --workdir ~/Projects/backend --mount ~/Projects/
 jackin load agent-smith frontend
 jackin load agent-smith backend
 
-# Both agents run simultaneously in isolated containers
+# Both agents run simultaneously in isolated containers.
+# In the console, those workspaces appear in the manager list and you
+# launch them by selecting a row.
 ```
 
 </TabItem>
 
-<TabItem label="One workspace, different agents">
+<TabItem label="One workspace, different roles">
 
 ```bash
 # Same project access boundary, different tool profiles
@@ -120,7 +152,8 @@ jackin workspace create monorepo --workdir ~/Projects/monorepo --mount ~/Project
 jackin load agent-smith monorepo
 jackin load the-architect monorepo
 
-# Same files, different environment and plugins
+# Same files, different environment and plugins.
+# In the console, switch the role from the same workspace row.
 ```
 
 </TabItem>
@@ -137,6 +170,7 @@ jackin load agent-smith ~/Projects/my-app \
 </Tabs>
 ## Next steps
 
-- Learn the [Core Concepts](/getting-started/concepts) behind jackin's architecture
-- Set up [Workspaces](/guides/workspaces) for your projects
-- Understand the [Security Model](/guides/security-model)
+- Learn the [Core Concepts](/getting-started/concepts/) behind jackin's architecture
+- Try the [`jackin console`](/commands/console/) reference — the daily-driver TUI
+- Set up [Workspaces](/guides/workspaces/) for your projects
+- Understand the [Security Model](/guides/security-model/)

--- a/docs/src/content/docs/getting-started/why.mdx
+++ b/docs/src/content/docs/getting-started/why.mdx
@@ -9,16 +9,20 @@ import { Aside, Steps } from '@astrojs/starlight/components'
 
 AI coding agents are transforming software development. Tools like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), and [Amp Code](https://ampcode.com) can read your codebase, write code, run tests, install dependencies, and execute arbitrary shell commands — all autonomously.
 
-But there's a catch: **these agents are most productive when they run without guardrails.**
+But there's a catch: **every modern agent runtime is most productive when it runs without guardrails.**
 
-Claude Code has a mode called `--dangerously-skip-permissions` that removes all confirmation prompts. No "are you sure?" dialogs. No permission gates. The agent just *does things*. And that's exactly what you want when you're trying to get work done — an agent that can move fast without waiting for you to click "Allow" every ten seconds.
+- **`Claude Code`** has a mode called `--dangerously-skip-permissions` that removes every confirmation prompt. No "are you sure?" dialogs. No permission gates. The agent just *does things*.
+- **`Codex`** ships a sandbox plus an approval policy that, in their default `workspace-write` + `on-request` configuration, contain dangerous commands behind a prompt. The same CLI also exposes `--dangerously-bypass-approvals-and-sandbox` (aliased `--yolo`), which turns *both* off — Codex's direct equivalent of `Claude Code`'s `--dangerously-skip-permissions`. Operators reach for YOLO for the same reason they reach for `--dangerously-skip-permissions`: permission and sandbox prompts kill agent throughput.
+- **`Amp`**, and every other emerging agent runtime, carries its own equivalent of full-speed mode. Permission prompts in front of every shell command kill agent throughput, so every runtime eventually grows a flag that turns them off.
 
-**The problem is what "doing things" means on your host machine:**
+That speed is exactly what you want when an agent is actually getting work done — nobody wants to click "Allow" every ten seconds. And the more capable the model, the more painful permission prompts become *and* the larger the blast radius if something goes wrong. AI models are only going to get more powerful. **Running any of them at full speed against your host machine will always be a substantial risk.**
+
+**What "doing things" actually means on your host:**
 
 - The agent can read **every file** on your filesystem — your SSH keys, your `.env` files, your browser cookies
 - It can run **any command** — `rm -rf /`, `curl` data to external servers, modify system configs
 - It can install **any package** — potentially pulling in malicious dependencies
-- It has your **credentials** — Docker Hub tokens, AWS keys, GitHub tokens, anything in your shell environment
+- It has your **credentials** — `Docker Hub` tokens, AWS keys, `GitHub` tokens, anything in your shell environment
 
 Running an unrestricted AI agent directly on your host is like inviting a brilliant but unpredictable contractor into your home and saying "do whatever you want." They might build something amazing — or they might accidentally (or intentionally) cause damage you never anticipated.
 
@@ -26,7 +30,7 @@ Running an unrestricted AI agent directly on your host is like inviting a brilli
 
 **jackin' gives each agent its own isolated world to operate in.**
 
-Instead of running on your host, each agent runs inside a Docker container with Docker-in-Docker (DinD) enabled. From the agent's perspective, it has full autonomy — it can execute commands, install packages, build Docker images, run tests. But from *your* perspective as the operator, you've defined exactly what the agent can see and touch.
+Instead of running on your host, each agent runs inside a `Docker` container with `Docker-in-Docker` (`DinD`) enabled. From the agent's perspective, it has full autonomy — it can execute commands, install packages, build `Docker` images, run tests. But from *your* perspective as the operator, you've defined exactly what the agent can see and touch.
 
 <Steps>
 1. **You define the boundaries**
@@ -35,7 +39,7 @@ Instead of running on your host, each agent runs inside a Docker container with 
 
 2. **The agent runs freely inside those boundaries**
 
-   No permission prompts, no restrictions, full `--dangerously-skip-permissions` mode
+   No permission prompts. No "are you sure?" interruptions. The runtime's full-speed mode (`Claude Code`'s `--dangerously-skip-permissions`, `Codex`'s YOLO, whatever the runtime calls it) is exactly what you want — *because the boundary is somewhere else.*
 
 3. **Your host system stays untouched**
 
@@ -43,7 +47,17 @@ Instead of running on your host, each agent runs inside a Docker container with 
 </Steps>
 Think of it this way: you're not restricting the agent's *capabilities*. You're restricting its *blast radius*.
 
-jackin' also helps you restrict the agent's *context*. You are not forced to put every language toolchain, helper script, and Claude plugin into one universal environment. You can build smaller roles for specific kinds of work and point them at the same workspace when needed.
+jackin' also helps you restrict the agent's *context*. You are not forced to put every language toolchain, helper script, and runtime plugin into one universal environment. You can build smaller roles for specific kinds of work and point them at the same workspace when needed.
+
+## jackin' is an ecosystem, not an agent
+
+There are already excellent products focused on the **agent itself** — better runtimes, better prompts, better tool integrations, more capable models. **jackin' is not one of them.**
+
+jackin' is the layer **around** those agents. It lets you run *many* of them in parallel, each with its own isolation boundary, its own file access rules, its own tool profile, and its own credentials — without designing those rules from scratch every time. One agent for frontend work, another for backend, another for security review, all on the same laptop, all isolated from each other and from your host.
+
+That ecosystem framing is why every UX choice in jackin' — the CLI, the operator console, workspaces, roles, mounts, env scopes, auth forwarding — exists to make isolation *easy and convenient*. The harder isolation is to set up, the more often someone skips it. The faster jackin' makes it, the more often it actually gets used.
+
+The agent runtime stays the agent runtime. jackin' is the part that decides where each agent lives, what each one can touch, and how many of them you can have running at once.
 
 ## What jackin' optimizes for
 
@@ -73,7 +87,7 @@ Second, it keeps the agent's working environment focused. The role decides which
 
 Imagine one company with a shared monorepo:
 
-- the frontend team uses a `chainargos/frontend-engineer` role with Node, Playwright, design-system utilities, and UI-oriented Claude plugins
+- the frontend team uses a `chainargos/frontend-engineer` role with Node, Playwright, design-system utilities, and UI-oriented agent plugins
 - the backend team uses a `chainargos/backend-engineer` role with Rust or Go toolchains, database clients, and API-oriented plugins
 - both teams can still point those roles at the same monorepo workspace when needed
 
@@ -81,32 +95,32 @@ That split keeps the visible project files and the installed toolchain independe
 
 In practice, this often produces better results than one kitchen-sink agent image. A narrower environment gives the agent fewer irrelevant cues and makes it more likely that the tools and plugins it discovers actually match the task.
 
-It also helps with Claude Code plugins. A tool like Superpowers can be extremely useful, but it brings hooks and behavior that you may not want in every task. The most reliable way to keep it out of scope is not to "mostly disable" it, but to use a different role where it simply is not installed.
+It also helps with runtime-specific plugins. A `Claude Code` tool like Superpowers (or any other agent's equivalent extension) can be extremely useful, but it brings hooks and behavior that you may not want in every task. The most reliable way to keep it out of scope is not to "mostly disable" it, but to use a different role where it simply is not installed.
 
 ## The cyberpunk analogy
 
-The name "jackin'" borrows the cyberpunk verb *jacking in* — a cultural idiom for connecting into a simulated environment. The imagery is the classic cyberpunk one: an operator loads a person into a constructed environment where they can train, build, and operate with capabilities they wouldn't have outside it. The real world stays untouched — the operator controls what the construct contains.
+The name "jackin'" borrows the cyberpunk verb *jacking in* — a cultural idiom for connecting into a simulated environment. The imagery is the classic cyberpunk one: an operator loads a person into a constructed environment where they can train, build, and operate with capabilities they wouldn't have outside it. The real world stays untouched — the operator controls what the `construct` contains.
 
 That's exactly what jackin' does:
 
 | Cyberpunk concept | jackin' |
 |---|---|
 | **Operator** | You — the developer running jackin' |
-| **The Construct** | The base Docker image with system tools |
+| **The `Construct`** | The base `Docker` image with system tools |
 | **Jacking in** | `jackin load agent-smith` |
-| **The agent inside** | Claude Code running with full permissions |
+| **The agent inside** | Whatever runtime you load (`Claude Code` and `Codex` today; `Amp` under active development), running at full speed |
 | **The real world** | Your host machine, untouched |
 | **Hardline** | `jackin hardline` — reconnecting to a running agent |
 | **Pulling out** | `jackin eject` — stopping an agent |
 | **Exile** | `jackin exile` — pulling everyone out at once |
 
-Every command in jackin' maps to a cyberpunk-operator concept. This isn't just for fun — it makes the mental model intuitive. When you "load" an agent, you're loading it into a construct. When you "eject" it, you're pulling it out. The vocabulary reinforces what's actually happening.
+Every command in jackin' maps to a cyberpunk-operator concept. This isn't just for fun — it makes the mental model intuitive. When you "load" an agent, you're loading it into a `construct`. When you "eject" it, you're pulling it out. The vocabulary reinforces what's actually happening.
 
 ## Why not just use Docker Sandboxes?
 
 Because the problem is not only isolation.
 
-Products like [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) are strong at what they are designed for: quick-start agent sandboxes with a microVM boundary, a private Docker daemon, credential proxying for supported flows, and outbound network policy controls.
+Products like [`Docker Sandboxes`](https://docs.docker.com/ai/sandboxes/) are strong at what they are designed for: quick-start agent sandboxes with a microVM boundary, a private `Docker` daemon, credential proxying for supported flows, and outbound network policy controls.
 
 jackin' exists because many operators also want:
 
@@ -117,7 +131,7 @@ jackin' exists because many operators also want:
 
 So the honest comparison is this:
 
-- if you want the **strongest local isolation boundary**, Docker Sandboxes is ahead
+- if you want the **strongest local isolation boundary**, `Docker Sandboxes` is ahead
 - if you want **open, local-first agent orchestration**, jackin' is the better fit
 
 For a deeper comparison, including adjacent approaches and where jackin' is weaker today, see [Comparison with Alternatives](/guides/comparison).
@@ -127,15 +141,15 @@ For a deeper comparison, including adjacent approaches and where jackin' is weak
 <Aside type="caution">
 jackin' is not a general-purpose container orchestrator. It's specifically designed for AI coding agents.
 </Aside>
-- **Not a VM** — agents share the host kernel via Docker. The isolation is at the container level, not the hypervisor level. If you need hypervisor-level isolation, use a microVM-based approach instead.
-- **Not a sandbox for untrusted code execution** — it's for running *trusted agent runtimes* (Claude Code, Codex) in a controlled environment. The agent binary itself is trusted; it's the agent's *actions* you want to contain.
-- **Not Kubernetes** — jackin' runs on a single machine with Docker. Kubernetes support is on the roadmap for teams that need multi-node orchestration.
+- **Not a microVM today** — the current proof-of-concept boundary is the `Docker` container, not a hypervisor. If you need hypervisor-level isolation right now, use a microVM-based product such as `Docker Sandboxes`. Stronger boundaries — microVMs, alternative sandbox backends — are research items on the [Roadmap](/reference/roadmap/); the long-term plan is to make the boundary configurable per workspace, not to force a single approach on everyone.
+- **Not a sandbox for untrusted code execution** — it's for running *trusted agent runtimes* (`Claude Code`, `Codex`) in a controlled environment. The agent binary itself is trusted; it's the agent's *actions* you want to contain.
+- **Not Kubernetes** — jackin' runs on a single machine with `Docker`. Kubernetes support is on the roadmap for teams that need multi-node orchestration.
 
-That last point is deliberate. jackin' starts with local Docker because that is the shortest path to a useful operator experience. Over time, the same model can grow toward Kubernetes-backed workflows for production debug containers and team-scale orchestration, but local development is the first job.
+Both "not yet" points above are deliberate. jackin' starts with local `Docker` because that is the shortest path to an operator experience the team can iterate on. Over time, the same operator and workspace model can grow toward stronger sandbox backends and Kubernetes-backed debug workflows, but local development with the boundary we know best is the first job.
 
 ## Who is it for?
 
-**Individual developers** who want to run AI agents at full speed without risking their host machine. You can give Claude Code complete autonomy inside a container, knowing it can't accidentally delete your SSH keys or push to production. If you work on multiple projects or branches simultaneously, jackin' lets you run separate agents in parallel without resource pressure.
+**Individual developers** who want to run AI agents at full speed without risking their host machine. You can give any supported runtime complete autonomy inside a container, knowing it can't accidentally delete your SSH keys or push to production. If you work on multiple projects or branches simultaneously, jackin' lets you run separate agents in parallel without resource pressure.
 
 **Teams** that want to standardize how AI agents are deployed. Define role repos with the tools each project needs, save workspace configurations, and every developer gets the same isolated environment. Roles are git repos — version them, review them in PRs, share them across the organization.
 
@@ -156,8 +170,18 @@ jackin' is built in Rust for three reasons:
 ## Current status
 
 <Aside type="note">
-jackin' is currently a proof of concept with Claude Code as its only supported agent runtime. Support for Codex and Amp Code is planned.
+jackin' is currently a proof of concept. `Claude Code` and `Codex` ship today as fully integrated agent runtimes. `Amp` is under active development and will join them; full feature parity across all three is tracked on the [Roadmap](/reference/roadmap/). The isolation model is runtime-agnostic by design — adding a new runtime is a matter of teaching jackin' how to install and start it inside the `construct`, not redesigning the boundary.
 </Aside>
 The core isolation model works, workspaces and mounts are configurable, the interactive operator console is functional, and the role system supports namespaced, team-shareable environments. It's licensed under Apache 2.0.
 
-The vision is local-first development with excellent tooling and UX, eventually expanding to deployment ecosystems — Kubernetes support is planned for using jackin' as a debug container in production environments to safely explore issues with AI agent assistance.
+## Vision
+
+jackin' is designed as a **local-first development tool** focused on excellent UX and practical isolation. The near-term goal is to be the best way to run AI coding agents in parallel on a local machine — lightweight, composable, and open source. Every feature decision is weighed against that: does it make running many agents *on your laptop* more deliberate, more reusable, and more pleasant?
+
+The longer-term vision extends to deployment ecosystems. **Kubernetes support** will let jackin' run as a debug-container platform — loading an agent into a production pod to safely investigate issues, with the same workspace and mount controls that make local use safe. The same operator and workspace primitives generalise from one laptop to one cluster; the boundary moves, the model stays the same.
+
+Stronger isolation boundaries are an explicit research direction. Today the boundary is the `Docker` container. The roadmap tracks **selectable sandbox backends** (microVM, alternative sandbox engines), **rootless `DinD`** for a smaller privileged surface, and **reproducibility/provenance pinning** so what runs is what was reviewed. The plan is to keep iterating on UX and ergonomics until jackin' is no longer in the *experimenting* phase, and then add stronger boundaries as a configurable option per workspace — never as a single forced choice.
+
+This vision is meant to be visible. Whether you arrived as an operator who wants to run their first agent, a role author building a `backend-engineer` role for your team, or a contributor deciding whether to send a PR — knowing where the project is going is part of the contract. The full design proposals, status, and order of operations live in the [Roadmap](/reference/roadmap/).
+
+If jackin' almost works for what you need but is missing something, the project welcomes suggestions and contributions: [open an issue](https://github.com/jackin-project/jackin/issues) or submit a pull request.

--- a/docs/src/content/docs/guides/authentication.mdx
+++ b/docs/src/content/docs/guides/authentication.mdx
@@ -5,14 +5,19 @@ description: Forward or provide agent credentials for agent containers
 import { Aside } from '@astrojs/starlight/components'
 
 
-jackin' provisions agent containers with credentials drawn from the host
-or from the operator-env layer, so agents start pre-authenticated
+jackin' provisions agent containers with credentials drawn from your
+host (or from operator env vars) so agents start pre-authenticated
 without an interactive `/login` step inside the container.
 
-The shape of that provisioning is described by an `auth_forward` mode,
-configured per agent (`claude`, `codex`) at three layers: a global
-default, a per-workspace override, and a per (workspace × role × agent)
-override.
+That behaviour is controlled by an `auth_forward` mode, configured per
+agent (`claude`, `codex`) at three scopes: a global default, a
+per-workspace override, and a per (workspace × role × agent) override.
+
+<Aside type="tip">
+Auth forwarding is managed through `jackin config auth …` and the
+**Auth** tab of `jackin console`'s workspace editor. You should not
+need to hand-edit any configuration file.
+</Aside>
 
 ## How it works
 
@@ -24,20 +29,15 @@ Each agent has its own credential model:
 | Claude (Linux) | `~/.claude/.credentials.json` + `~/.claude.json` |
 | Codex | `~/.codex/auth.json` (written by `codex login`) |
 
-When jackin' creates or launches an agent container, it consults the
-resolved `auth_forward` mode for that (workspace × role × agent) and
-either:
+When jackin' launches an agent container, it consults the resolved
+`auth_forward` mode for that (workspace × role × agent) and either:
 
-- copies the host credential file into the role-state directory
+- copies the host credential file into the container's per-agent state
   (`sync`), or
-- injects an env var resolved from the operator-env layer
+- injects an env var resolved from your operator env vars
   (`api_key`, `oauth_token`), or
 - provisions an empty state and lets the agent authenticate inside the
   container (`ignore`).
-
-The role-state directory at `~/.jackin/data/<container-name>/` is
-bind-mounted into the container, so the agent picks up forwarded
-credentials immediately.
 
 ## Modes
 
@@ -45,56 +45,34 @@ jackin' supports four modes:
 
 | Mode | Behavior |
 |---|---|
-| `sync` (default) | When host auth exists, copy it into the container's role-state on each launch. When host auth is absent, preserve any existing container auth. |
-| `api_key` | Inject the agent's API-key env var (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex), resolved from the operator-env layer. No credential files are written. |
-| `oauth_token` | **Claude only.** Inject `CLAUDE_CODE_OAUTH_TOKEN` from the operator-env layer. Codex rejects this mode at config-parse time. |
+| `sync` (default) | When host auth exists, copy it into the container on each launch. When host auth is absent, preserve any existing container auth. |
+| `api_key` | Inject the agent's API-key env var (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex) from your operator env vars. No credential files are written. |
+| `oauth_token` | **Claude only.** Inject `CLAUDE_CODE_OAUTH_TOKEN` from your operator env vars. Codex rejects this mode. |
 | `ignore` | Never forward host auth. Revoke any previously forwarded credentials. The agent authenticates itself inside the container. |
 
 ### sync
 
-`sync` re-copies host credentials on every launch. Use this when you
-want agents to always reflect the host's current account — for example,
-if you rotate credentials frequently or switch between organizations.
+`sync` re-copies host credentials on every launch. Use this when you want agents to always reflect the host's current account — for example, if you rotate credentials frequently or switch between organizations.
 
-When the host's credentials are missing (e.g. you logged out), `sync`
-preserves the container's existing auth rather than wiping it. This
-prevents accidental de-authentication from a missing file.
+When the host's credentials are missing (e.g. you logged out), `sync` preserves the container's existing auth rather than wiping it. This prevents accidental de-authentication from a missing file.
 
 ### api_key
 
-`api_key` provisions the agent with an empty state and exports the
-agent's API key into the container's process env. Claude Code reads
-`ANTHROPIC_API_KEY`; Codex CLI reads `OPENAI_API_KEY`. No file-based
-credentials are written into the role-state.
+`api_key` provisions the agent with an empty state and exports the agent's API key into the container's process env. Claude Code reads `ANTHROPIC_API_KEY`; Codex CLI reads `OPENAI_API_KEY`. No file-based credentials are written.
 
 Setup:
 
-1. Add the API-key entry to any of the four operator-env layers.
-   For example, in the workspace's `[env]` block referencing 1Password:
+1. Set the API-key env var at the scope you want (see [Environment Variables](/guides/environment-variables/)):
 
-   ```toml
-   [workspaces.my-app.env]
-   ANTHROPIC_API_KEY = "op://Personal/Anthropic/key"
+   ```bash
+   jackin workspace env set my-app ANTHROPIC_API_KEY "op://Personal/Anthropic/key"
    ```
 
-   Or forwarding from the host shell:
-
-   ```toml
-   [env]
-   OPENAI_API_KEY = "$OPENAI_API_KEY"
-   ```
-
-2. Set the `auth_forward` mode at the layer that should pick this up
-   (see [Layered configuration](#layered-configuration) below).
+2. Set the `auth_forward` mode for that scope (see below).
 
 ### oauth_token (Claude only)
 
-`oauth_token` is designed for long-lived and concurrent jackin' sessions
-on Claude. Instead of bind-mounting a copy of the host's `/login`
-session state, jackin' injects a long-lived OAuth token
-(`CLAUDE_CODE_OAUTH_TOKEN`) into the container's process env. Claude
-Code inside the container reads the token directly, bypassing the
-file-based credential store.
+`oauth_token` is designed for long-lived and concurrent jackin' sessions on Claude. Instead of bind-mounting a copy of the host's `/login` session state, jackin' injects a long-lived OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) into the container's process env. Claude Code inside the container reads the token directly, bypassing the file-based credential store.
 
 Setup:
 
@@ -104,99 +82,54 @@ Setup:
    claude setup-token
    ```
 
-2. Tell jackin' where to find it by adding a line to one of the
-   operator-env layers. For example, referencing 1Password:
+2. Tell jackin' where to find it by setting `CLAUDE_CODE_OAUTH_TOKEN` at one of the env scopes — for example, referencing 1Password:
 
-   ```toml
-   [claude.env]
-   CLAUDE_CODE_OAUTH_TOKEN = "op://Personal/Claude/token"
+   ```bash
+   jackin config env set CLAUDE_CODE_OAUTH_TOKEN "op://Personal/Claude/token"
    ```
 
-   or forwarding from the host shell:
+3. Set `auth_forward = oauth_token` for Claude at the matching scope (see below).
 
-   ```toml
-   [env]
-   CLAUDE_CODE_OAUTH_TOKEN = "$CLAUDE_CODE_OAUTH_TOKEN"
-   ```
-
-3. Set `auth_forward = "oauth_token"` for `[claude]` at the appropriate
-   layer.
-
-If `CLAUDE_CODE_OAUTH_TOKEN` is not present in the resolved env when
-`oauth_token` mode is active, jackin' aborts the launch with a
-structured error (see [Launch-time validation](#launch-time-validation)).
+If `CLAUDE_CODE_OAUTH_TOKEN` is not present in the resolved env when `oauth_token` mode is active, jackin' aborts the launch with a clear error pointing at the missing key.
 
 <Aside type="caution">
 Codex has no OAuth-token analog of Claude's `CLAUDE_CODE_OAUTH_TOKEN`.
-Setting `auth_forward = "oauth_token"` under any `[codex]` block is
-rejected at config-parse time with an "unknown variant" error. Use
+Setting `auth_forward = "oauth_token"` for Codex is rejected. Use
 `api_key` (with `OPENAI_API_KEY`) or `sync` for Codex.
 </Aside>
 
 ### ignore
 
-`ignore` provisions the container with an empty state — no
-credential file is written, and any previously forwarded credentials
-in the role-state are deleted. The agent must authenticate itself
-inside the container the next time it runs.
+`ignore` provisions the container with an empty state — no credential file is written, and any previously forwarded credentials are deleted. The agent must authenticate itself inside the container the next time it runs.
 
-Switching an agent from `sync`, `api_key`, or `oauth_token` to `ignore`
-actively revokes any previously forwarded credentials.
+Switching an agent from `sync`, `api_key`, or `oauth_token` to `ignore` actively revokes any previously forwarded credentials.
 
-## Layered configuration
+## Setting modes
 
-`auth_forward` is configured per agent (`claude`, `codex`) at three
-layers, with most-specific wins:
+`auth_forward` is configured per agent at three scopes:
 
-1. **Global default** — `[claude].auth_forward` and
-   `[codex].auth_forward` in `~/.config/jackin/config.toml`.
-2. **Per workspace** — `[workspaces.<ws>.claude].auth_forward` and
-   `[workspaces.<ws>.codex].auth_forward`.
-3. **Per (workspace × role)** — `[workspaces.<ws>.roles.<role>.claude].auth_forward`
-   and `[workspaces.<ws>.roles.<role>.codex].auth_forward`.
+1. **Global default** — applies to every agent launch.
+2. **Per workspace** — applies to every launch in this workspace.
+3. **Per (workspace × role × agent)** — applies only for this specific cell.
 
-Resolution order: **per-(workspace × role) > per-workspace > global > `sync`**.
+Resolution order: **per-(workspace × role × agent) > per-workspace > global > `sync`**.
 
-Example `config.toml`:
+### Global default
 
-```toml
-# Layer 1 — global defaults
-[claude]
-auth_forward = "sync"
+Use the CLI:
 
-[codex]
-auth_forward = "sync"
-
-# Layer 2 — workspace-wide overrides
-[workspaces.my-app.claude]
-auth_forward = "oauth_token"
-
-# Layer 3 — most-specific override for one (workspace, role) cell
-[workspaces.my-app.roles.agent-smith.claude]
-auth_forward = "ignore"
-
-[workspaces.my-app.roles.agent-smith.codex]
-auth_forward = "api_key"
+```bash
+jackin config auth set sync
+jackin config auth set ignore
+jackin config auth set oauth_token
+jackin config auth set api_key
 ```
 
-Credentials referenced by `api_key` and `oauth_token` modes live in
-ordinary `[*.env]` blocks under the well-known names
-(`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`) and
-follow the same four-layer env merge as every other variable. See
-[Environment Variables](/guides/environment-variables) for the layer
-order.
+`jackin config auth show` prints the current global mode.
 
-<Aside type="note">
-Auth forwarding is an operator-level setting. Agent manifests
-(`jackin.role.toml`) cannot set or override this — it is always the
-operator's decision.
-</Aside>
+### Per workspace and per (workspace × role × agent)
 
-## Auth tab in the operator console
-
-The `jackin console` workspace editor exposes auth forwarding through a
-dedicated **Auth** tab, peer to the existing **Secrets** tab. To open
-it:
+Use the **Auth** tab of the operator console:
 
 1. Run `jackin console`.
 2. Select the workspace.
@@ -204,85 +137,41 @@ it:
 
 The Auth tab presents three sections, top to bottom:
 
-1. **Global defaults** (read-only) — what `[claude]` / `[codex]` resolve
-   to at the global layer. These rows reflect `~/.config/jackin/config.toml`
-   and cannot be edited from within a workspace.
-2. **Workspace defaults** — `[workspaces.<ws>.claude]` and
-   `[workspaces.<ws>.codex]` rows. Press `Enter` on a row to open the
-   auth-edit form for that agent.
-3. **Per-role overrides** — collapsible role headers. The list starts
-   empty; press `Enter` on the `+ Add per-role override` entry to step
-   through a three-step flow: choose the **role**, choose the **agent**
-   (`claude` or `codex`), then fill in the **auth-edit form**.
-   Press `→` / `←` to expand or collapse a role header. Press `D` on a
-   role header to open a confirmation dialog that clears both agents'
-   overrides for that role; press `D` on a single agent row to clear
-   only that agent's override.
+1. **Global defaults** (read-only) — what the **Claude** and **Codex** rows resolve to at the global layer. These rows reflect your global setting and cannot be edited from inside a workspace.
+2. **Workspace defaults** — workspace-wide rows for Claude and Codex. Press `Enter` on a row to open the auth-edit form for that agent.
+3. **Per-role overrides** — collapsible role headers. The list starts empty; press `Enter` on the `+ Add per-role override` entry to step through a three-step flow: choose the **role**, choose the **agent** (`claude` or `codex`), then fill in the **auth-edit form**. Press `→` / `←` to expand or collapse a role header. Press `D` on a role header to clear both agents' overrides for that role; press `D` on a single agent row to clear only that agent's override.
 
-Footer hints surface the resolved mode and its provenance for whichever
-override row is currently focused.
+Footer hints surface the resolved mode and its provenance for whichever override row is currently focused.
 
 ### The edit form
 
-Pressing `Enter` on a workspace-defaults row or completing the
-role-add flow opens an edit form with three blocks:
+The auth-edit form has three blocks:
 
-1. **Mode picker.** `sync`, `api_key`, `oauth_token` (Claude only),
-   `ignore`. Codex cells omit `oauth_token`.
-2. **Credential block** (only shown for modes that need a credential —
-   `api_key` and `oauth_token`). Pick the credential source: a
-   1Password reference (`op://...`), a host-env passthrough
-   (`$VAR` / `${VAR}`), or a literal value.
-3. **Save / Cancel / Reset.** Save commits the change to disk; Cancel
-   reverts the form; Reset clears the override at this layer (so the
-   cell falls through to the next layer up).
+1. **Mode picker** — `sync`, `api_key`, `oauth_token` (Claude only), `ignore`. Codex cells omit `oauth_token`.
+2. **Credential block** — only shown for modes that need a credential (`api_key` and `oauth_token`). Pick the credential source: a 1Password reference (`op://...`), a host-env passthrough (`$VAR` / `${VAR}`), or a literal value.
+3. **Save / Cancel / Reset** — Save commits the change. Cancel reverts the form. Reset clears the override at this scope so the cell falls through to the next-level-up default.
 
 #### Save invariant
 
 The **Save** button stays disabled until both:
 
 - a mode is selected, and
-- if the mode requires a credential (`api_key` or `oauth_token`),
-  the credential block has a committed value.
+- if the mode requires a credential (`api_key` or `oauth_token`), the credential block has a committed value.
 
-This makes it impossible to leave the workspace in a state where
-`auth_forward` says "use a credential" but no credential resolves.
+This makes it impossible to leave the workspace in a state where `auth_forward` says "use a credential" but no credential resolves.
 
 #### 1Password picker integration
 
-When the credential source is set to a 1Password reference, the form
-opens the standard 1Password picker (the same component used by the
-Secrets tab). Picking a reference triggers an `op read` validation
-**before** the value is committed to the form — broken or
-unauthorized references never reach the form, and never reach disk.
+When the credential source is set to a 1Password reference, the form opens the standard 1Password picker (the same component used by the env vars editor). Picking a reference triggers an `op read` validation **before** the value is committed to the form — broken or unauthorized references never reach the form, and never reach disk.
 
 ## Launch-time validation
 
-When jackin' resolves `auth_forward` for a launch, it verifies that
-modes requiring a credential have one set in the operator-env layer.
-If the credential is missing, the launch fails with a structured
-`LaunchError::AuthCredentialMissing` error containing:
+When jackin' resolves `auth_forward` for a launch, it verifies that any mode requiring a credential has one available in your env vars. If the credential is missing, the launch fails with an error that:
 
-- The fully-resolved mode trace (which layer chose which mode for
-  Claude and Codex).
-- The state of the relevant env var across all four env layers, so the
-  operator can see exactly which layer was supposed to provide the
-  value.
+- shows which scope chose which mode for Claude and Codex, and
+- shows which scopes were checked for the missing env var.
 
-A typical message looks like:
-
-```
-error: auth credential missing for claude (mode = oauth_token)
-  required env var: CLAUDE_CODE_OAUTH_TOKEN
-  mode resolved at: workspaces.my-app.claude
-  env layer state:
-    [env]                                     : (unset)
-    [claude.env]                              : (unset)
-    [workspaces.my-app.env]                   : (unset)
-    [workspaces.my-app.roles.smith.env]       : (unset)
-  fix: set CLAUDE_CODE_OAUTH_TOKEN in any of the four env layers above,
-       or change auth_forward to "sync" / "ignore".
-```
+That makes it obvious whether the right mode is in effect and whether the credential is missing entirely or just set at the wrong scope.
 
 ## What gets forwarded under `sync`
 
@@ -293,40 +182,19 @@ For Claude, two pieces of data are forwarded from the host:
 | `.claude.json` | Account metadata, preferences (email, org, billing type, startup config) |
 | `.claude/.credentials.json` | OAuth tokens (access token, refresh token, scopes, subscription type) |
 
-Both files are written with `0600` permissions (owner-only read/write).
-If an older agent state directory has a pre-existing `.claude.json`
-with permissive permissions (e.g. `0644`), the permissions are
-tightened on the next write.
+Both files are written with owner-only (`0600`) permissions.
 
-For Codex, the host's `~/.codex/auth.json` is copied into
-`~/.jackin/data/<container>/codex/auth.json` with `0600` permissions
-and bind-mounted at `/jackin/codex/auth.json`. The runtime entrypoint
-copies the file into `~/.codex/auth.json` inside the container before
-launching the agent. Token refreshes performed inside the container
-stay in the container's writable layer (lost on `docker rm`); they
-are not propagated back to the host.
+For Codex, the host's `~/.codex/auth.json` is copied with `0600` permissions and made available inside the container before Codex starts. Token refreshes performed inside the container stay in the container's writable layer (lost on `docker rm`); they are not propagated back to the host.
 
-When the host has no Codex auth.json (and `OPENAI_API_KEY` is not set
-via `api_key` mode), jackin' still starts the container — Codex CLI
-prompts for ChatGPT login on first invocation. jackin' emits a
-`codex auth: none — Codex CLI will prompt for ChatGPT login` notice at
-launch so the fallback is explicit, not silent.
+When the host has no Codex auth.json (and `OPENAI_API_KEY` is not set via `api_key` mode), jackin' still starts the container — Codex CLI prompts for ChatGPT login on first invocation. jackin' emits a `codex auth: none — Codex CLI will prompt for ChatGPT login` notice at launch so the fallback is explicit, not silent.
 
 ## Security considerations
 
-- Forwarded credentials give the agent the same agent access as your
-  host account (same model tier, same organization, same billing).
-- Under `sync`, credentials are stored on disk in the agent's
-  state directory (`~/.jackin/data/<container-name>/`). Use
-  `jackin purge <agent>` to delete all persisted state including
-  credentials.
-- Switching to `ignore` mode actively revokes forwarded credentials —
-  it does not just stop future forwarding.
-- The agent manifest cannot control auth forwarding. An untrusted
-  agent cannot force any mode against the operator's wishes.
-- `api_key` and `oauth_token` modes never write the credential to disk
-  in the role-state — the value is exported into the container's
-  process env at launch only.
+- Forwarded credentials give the agent the same agent access as your host account (same model tier, same organization, same billing).
+- Under `sync`, credentials live inside the agent's persisted state. Use `jackin purge <role>` to delete all persisted state including credentials.
+- Switching to `ignore` mode actively revokes forwarded credentials — it does not just stop future forwarding.
+- Role manifests cannot control auth forwarding. An untrusted role cannot force any mode against the operator's wishes.
+- `api_key` and `oauth_token` modes never write the credential to disk in the agent state — the value is exported into the container's process env at launch only.
 
 <Aside type="caution">
 Under `sync`, OAuth tokens are copied to the container's filesystem.
@@ -340,29 +208,15 @@ difference is that forwarding happens automatically.
 
 ### Agent shows "Not logged in" after forwarding
 
-If the agent shows "Not logged in" or falls back to a different model
-tier (e.g. Sonnet instead of Opus), the credentials may not have been
-forwarded. Check:
+If the agent shows "Not logged in" or falls back to a different model tier (e.g. Sonnet instead of Opus), the credentials may not have been forwarded. Check:
 
-1. **What mode is effective?** Open the **Auth** tab in
-   `jackin console` for that workspace, and look at the effective mode
-   for the (role × agent) cell.
-2. **Does the host have credentials?** For Claude on macOS, check
-   `security find-generic-password -s "Claude Code-credentials" -w`.
-   On Linux, check `~/.claude/.credentials.json`. For Codex, check
-   `~/.codex/auth.json`.
-3. **Is this a pre-existing container?** In `sync` mode, host
-   credentials are forwarded on every launch — but if the host has no
-   credentials, the container's existing auth is preserved. If the
-   container has stale auth and the host has fresh auth, restart the
-   container (`jackin eject <agent> && jackin load <agent>`) or purge
-   state (`jackin purge <agent>`) to force a fresh sync.
+1. **What mode is effective?** Open the **Auth** tab in `jackin console` for that workspace, and look at the effective mode for the (role × agent) cell.
+2. **Does the host have credentials?** For Claude on macOS, check `security find-generic-password -s "Claude Code-credentials" -w`. On Linux, check `~/.claude/.credentials.json`. For Codex, check `~/.codex/auth.json`.
+3. **Is this a pre-existing container?** In `sync` mode, host credentials are forwarded on every launch — but if the host has no credentials, the container's existing auth is preserved. If the container has stale auth and the host has fresh auth, restart the container (`jackin eject <role> && jackin load <role>`) or purge state (`jackin purge <role>`) to force a fresh sync.
 
 ### Revoking forwarded credentials
 
-To stop forwarding and clear existing credentials, set the (workspace
-× role × agent) cell to `ignore` in the **Auth** tab and reload the
-agent:
+To stop forwarding and clear existing credentials, set the (workspace × role × agent) cell to `ignore` in the **Auth** tab and reload the agent:
 
 ```bash
 jackin load <role>  # next launch will reset to {}
@@ -371,14 +225,10 @@ jackin load <role>  # next launch will reset to {}
 Or purge all state:
 
 ```bash
-jackin purge <agent>
+jackin purge <role>
 ```
 
 ## See also
 
-- [Environment Variables](/guides/environment-variables) — the
-  four-layer operator-env model that supplies credentials for
-  `api_key` and `oauth_token` modes, and forwards arbitrary
-  operator-owned secrets into the agent container.
-- [Configuration File](/reference/configuration) — the full
-  `config.toml` schema, including the layered `auth_forward` shape.
+- [Environment Variables](/guides/environment-variables/) — how the four-scope operator-env model supplies credentials for `api_key` and `oauth_token` modes.
+- [Configuration File](/reference/configuration/) — the on-disk schema, for contributors who want to inspect the config file directly while debugging.

--- a/docs/src/content/docs/guides/comparison.mdx
+++ b/docs/src/content/docs/guides/comparison.mdx
@@ -263,3 +263,16 @@ Choose **jackin'** when:
 - you regularly run several agents in parallel and care about footprint
 
 Use both when appropriate. They sit at different points on the security-versus-flexibility curve, and there is no rule saying one team must standardize on only one of them.
+
+## Spotted something we missed?
+
+This page is a snapshot, not a verdict. We do not believe jackin' has the final answer on agent isolation — quite the opposite. jackin' was built to scratch our own itch while running other projects, and every design decision in it reflects principles **we** currently agree with. Other projects make different trade-offs we genuinely admire, and we take those as reference material.
+
+If any of the following is true, please tell us:
+
+- a feature on a comparable product that solves something jackin' currently doesn't
+- a project that belongs on this comparison page but isn't here
+- an inaccurate claim above (about jackin' or about another product)
+- a design idea worth borrowing — even from a tool we already mention
+
+Open an issue or start a discussion on [GitHub](https://github.com/jackin-project/jackin) and we will read it. We actively want critique, recommendations, and pointers to prior art — that is how this project gets better and how the comparison stays honest.

--- a/docs/src/content/docs/guides/environment-variables.mdx
+++ b/docs/src/content/docs/guides/environment-variables.mdx
@@ -4,60 +4,67 @@ description: Operator-controlled env layers, 1Password integration, and host-env
 ---
 import { Aside } from '@astrojs/starlight/components'
 
-jackin' lets operators declare environment variables in four config layers that are merged at launch and injected into the agent container via `docker run -e`. Values can be literal strings, references to host env vars, or references to 1Password items resolved through the `op` CLI.
+jackin' lets you set environment variables for agent containers at four scopes — global, per role, per workspace, and per (workspace × role). Values can be literal strings, references to host env vars, or references to 1Password items resolved through the `op` CLI.
+
+<Aside type="tip">
+Operator env vars are managed through `jackin config env`,
+`jackin workspace env`, or the **Environments** tab in the
+operator console's workspace editor (workspace and per-(workspace ×
+role) scopes). You should not need to hand-edit any configuration
+file — the global scope is CLI-only today; the workspace scopes
+are reachable from both the CLI and the console.
+</Aside>
 
 ## Why operator env
 
-Role manifests (`jackin.role.toml`) declare the env *shape* — what keys a role expects, what's interactive, what has a default. Operator env layers declare the *values* for a specific operator on a specific workspace with a specific role. Keeping shape and values in different places means:
+Role manifests declare the env *shape* — what keys a role expects, what's interactive, what has a default. Operator env scopes declare the *values* for a specific operator on a specific workspace with a specific role. Keeping shape and values in different places means:
 
 - Third-party roles never see your secrets in their git history.
 - The same role can run with different credentials in different workspaces (personal laptop vs company monorepo).
-- You can override a manifest default from `config.toml` without forking the role.
+- You can override a manifest default without forking the role.
 
-## Layers
+## Scopes
 
-Four layers are merged with later-wins semantics:
+Four scopes are merged with later-wins semantics — most-specific values take priority:
 
-1. **Global** — `[env]` at the top of `~/.config/jackin/config.toml`.
-2. **Role** — `[roles.<selector>.env]`.
-3. **Workspace** — `[workspaces.<name>.env]`.
-4. **Workspace × Role** — `[workspaces.<name>.roles.<selector>.env]`.
+1. **Global** — applies to every agent launch.
+2. **Role** — applies whenever this role is loaded.
+3. **Workspace** — applies whenever this workspace is loaded.
+4. **Workspace × Role** — applies only for this specific (workspace, role) cell.
 
-Keys present in multiple layers take the value from the highest-priority layer (layer 4 > layer 3 > layer 2 > layer 1). Keys unique to any layer are preserved.
+Keys present in multiple scopes take the value from the highest-priority scope (4 > 3 > 2 > 1). Keys unique to any scope are preserved.
+
+## Setting values from the CLI
+
+Use `jackin config env` for global and per-role values, and `jackin workspace env` for per-workspace and per (workspace × role) values:
+
+```bash
+# Global — applies to every agent launch
+jackin config env set OPERATOR_ORG "acme-corp"
+
+# Role scope — only when loading agent-smith
+jackin config env set API_TOKEN "op://Personal/acme-api/token" --role agent-smith
+
+# Workspace scope — only when launching in big-monorepo
+jackin workspace env set big-monorepo ARTIFACT_REGISTRY '${COMPANY_REGISTRY_URL}'
+
+# Workspace × Role — most specific, wins on conflict
+jackin workspace env set big-monorepo API_TOKEN "op://Work/shared-smith/token" --role agent-smith
+```
+
+Values are stored verbatim — whatever you pass is what jackin' resolves at launch time. List or remove values with `jackin config env list` / `jackin config env unset` (and the matching `jackin workspace env` subcommands).
 
 ## Value syntax
 
-Each value in an env map is one of:
+Each value is one of:
 
 | Syntax | Resolution |
 |---|---|
 | `op://VAULT/ITEM/FIELD` | Resolved via the [1Password CLI](https://developer.1password.com/docs/cli/) (`op read "<ref>"`). Requires `op` on `PATH` and an authenticated session. |
-| `$NAME` or `${NAME}` | Read from the host's environment at launch time (`std::env::var(NAME)`). Errors if the host var is unset. |
+| `$NAME` or `${NAME}` | Read from the host's environment at launch time. Errors if the host var is unset. |
 | Anything else | Literal string. |
 
-## Example
-
-```toml
-# ~/.config/jackin/config.toml
-
-# Global — applies to every agent launch
-[env]
-OPERATOR_ORG = "acme-corp"
-
-# Role layer — only when loading agent-smith
-[roles.agent-smith.env]
-API_TOKEN = "op://Personal/acme-api/token"
-
-# Workspace layer — only when launching in "big-monorepo"
-[workspaces.big-monorepo.env]
-ARTIFACT_REGISTRY = "${COMPANY_REGISTRY_URL}"
-
-# Workspace × Role — most specific, wins on conflict
-[workspaces.big-monorepo.roles.agent-smith.env]
-API_TOKEN = "op://Work/shared-smith/token"
-```
-
-When `jackin load agent-smith` is invoked in `big-monorepo`:
+When you load an agent with the example above in `big-monorepo`:
 
 - `OPERATOR_ORG = "acme-corp"` (literal; from global)
 - `API_TOKEN = <resolved via op read "op://Work/shared-smith/token">` (workspace × role wins over role layer)
@@ -65,47 +72,42 @@ When `jackin load agent-smith` is invoked in `big-monorepo`:
 
 ## Reserved names
 
-Five runtime-owned names are reserved and rejected at config load. Declaring them at any layer is a hard error:
+A small set of names is owned by the jackin' runtime and cannot be set from any scope:
 
 - `JACKIN`
 - `JACKIN_DIND_HOSTNAME`
+- `JACKIN_AGENT`
+- `JACKIN_ROLE`
 - `DOCKER_HOST`
 - `DOCKER_TLS_VERIFY`
 - `DOCKER_CERT_PATH`
 
-<Aside type="note">
-Reserved-name enforcement runs at config LOAD, not at launch. If your `config.toml` declares a reserved name, any `jackin` subcommand (including `config show`) will fail with a message pointing at the offending layer.
-</Aside>
+Trying to set one of these is rejected before the agent launches.
 
 ## 1Password CLI setup
 
 1. Install the [1Password CLI](https://developer.1password.com/docs/cli/get-started/).
 2. Sign in: `eval $(op signin)` (or unlock the desktop-app integration).
-3. Declare `op://...` references in your config.
+3. Set values with `op://...` references — for example:
 
-Each `jackin load` that touches `op://...` values shells out to `op read <ref>` per key. `op` failures (missing item, expired session, binary not on PATH) surface as aggregated resolution errors — all failing keys are reported in a single message. `op` subprocesses have a 30-second timeout per call, and stderr is truncated at 4 KiB in error messages.
+   ```bash
+   jackin config env set ANTHROPIC_API_KEY "op://Personal/Anthropic/key"
+   ```
+
+Each `jackin load` that references `op://...` values shells out to `op read <ref>` per key. `op` failures (missing item, expired session, binary not on PATH) are reported in a single message that names every failing key. Each `op` invocation has a 30-second timeout.
 
 ## Launch diagnostic
 
-jackin' prints a compact diagnostic line on launch when operator env is non-empty:
+jackin' prints a compact diagnostic line on launch when operator env is non-empty, so you can confirm at a glance which keys flowed into the container:
 
 ```
 [jackin] operator env: 3 resolved (2 op://, 1 host ref, 0 literal)
 ```
 
-In `--debug` mode the diagnostic expands to per-key reference strings and layer attribution:
-
-```
-[jackin] operator env:
-  API_TOKEN      op://Work/shared-smith/token  (workspace "big-monorepo" → role "agent-smith" [env])
-  OPERATOR_ORG   literal                        (global [env])
-  REGISTRY       ${COMPANY_REGISTRY_URL}        (workspace "big-monorepo" [env])
-```
-
-Resolved values are never printed — only `op://` references (which are not secret themselves), host-var references, or the label `"literal"`.
+In `--debug` mode, the diagnostic expands to per-key reference strings and scope attribution. Resolved secret values are never printed.
 
 ## Interaction with manifest env
 
-Manifest-declared env (`jackin.role.toml`'s `[env]` table) is resolved first (with interactive prompts as needed). Operator env is resolved second and overlaid on top: **operator wins on key conflict**. This lets operators pin a value that the manifest would otherwise prompt for, or swap a manifest default for a workspace-specific secret.
+A role's manifest can declare env vars the role expects — including interactive prompts. Manifest-declared env is resolved first (running any prompts the role asks for); operator env is resolved second and overlaid on top: **operator wins on key conflict.** This lets you pin a value that the manifest would otherwise prompt for, or swap a manifest default for a workspace-specific secret.
 
-See [Authentication Forwarding](/guides/authentication) for the companion mechanism that forwards Claude Code credentials from host to container. Env layers and auth forwarding are orthogonal — use both.
+See [Authentication Forwarding](/guides/authentication/) for the companion mechanism that forwards Claude Code credentials from host to container. Env scopes and auth forwarding are orthogonal — use both.

--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -11,6 +11,14 @@ Mounts are the primary mechanism for giving agents access to your files. When yo
 
 This is the core of jackin's security model: **agents can only access what you explicitly mount.**
 
+<Aside type="tip">
+Workspace mounts are managed through `jackin workspace …` flags or
+the operator console's workspace editor. **Global mounts** (the
+`jackin config mount` family) are CLI-only today and are not yet
+reachable from the console. Either way, you should not need to
+hand-edit a configuration file to add, remove, or change a mount.
+</Aside>
+
 ## Mount spec format
 
 The `--mount` flag accepts two formats:
@@ -89,10 +97,10 @@ jackin config mount add gradle-cache \
 
 ### Scoped global mounts
 
-Scope a global mount to specific agents:
+Scope a global mount to specific roles:
 
 ```bash
-# Only mount secrets for chainargos agents
+# Only mount secrets for chainargos roles
 jackin config mount add secrets \
   --src ~/.chainargos/secrets \
   --dst /secrets \
@@ -101,8 +109,8 @@ jackin config mount add secrets \
 ```
 
 The `--scope` flag supports glob patterns:
-- `"chainargos/*"` — matches all agents in the chainargos namespace
-- `"chainargos/backend-engineer"` — matches only a specific agent
+- `"chainargos/*"` — matches all roles in the chainargos namespace
+- `"chainargos/backend-engineer"` — matches only a specific role
 
 ### Managing global mounts
 
@@ -126,61 +134,35 @@ When multiple mount sources are resolved, jackin' combines them in this order:
 If two mounts target the same container destination, jackin' stops with an error. It does not silently let the later mount win. This is deliberate because mounts are part of the security boundary.
 </Aside>
 
-## Redundant-mount invariant
+## Redundant mounts
 
-A saved workspace never contains two mounts where one strictly covers the other at the same container location. The rule: mount **P** covers mount **C** iff:
+A saved workspace never contains two mounts where one already exposes the other's host subtree at the same container location. If you add a mount that strictly covers an existing one, jackin' detects the redundancy:
 
-1. `P.src` is an ancestor of `C.src`, AND
-2. the suffix from `P.src` to `C.src` equals the suffix from `P.dst` to `C.dst`.
+- `jackin workspace create` automatically removes the redundant mount and prints a summary.
+- `jackin workspace edit` prompts before collapsing — see the [`workspace edit` docs](/commands/workspace/#mount-collapse) for the prompt and the `--yes` / `--prune` flags.
 
-In that case `C` projects the same host subtree to the same container path that `P` already exposes it at — making `C` strictly redundant.
+Identity mounts (same source AND same destination) are not redundant — they are simply replaced in place.
 
-jackin enforces this on write: `workspace create` auto-removes redundants (with a stderr summary), and `workspace edit` prompts before collapsing (see [mount collapse](/commands/workspace/#mount-collapse)). Identity mounts (same `src` AND same `dst`) are not covered by this rule — they're handled by upsert-by-destination semantics.
-
-Ad-hoc `-v` mounts passed on the command line at launch time are not collapsed; they stay literal.
+Ad-hoc `--mount` flags passed at launch time are kept literal and are not collapsed against workspace mounts.
 
 ## Mount isolation
 
-Workspace mounts accept an `isolation` field that controls whether the host path is bind-mounted as-is or materialized into a per-container git checkout first.
+Workspace mounts can be marked **isolated** so that each container gets its own per-container git checkout instead of sharing the host directory directly. This is what lets you run multiple agents against the same project at the same time without them stepping on each other.
 
-| Value | Default | Behavior |
-|---|---|---|
-| `shared` | yes | Host path bind-mounted as-is. |
-| `worktree` | no | jackin' runs `git worktree add` on the host repo and bind-mounts the worktree. Each container gets its own checkout and scratch branch, while refs remain shared with the host repo. |
-| `clone` | no | jackin' runs `git clone --local` into the per-container state dir and bind-mounts the clone. Each container gets its own `.git/` and independent refs. |
+| Value | Behavior |
+|---|---|
+| `shared` (default) | Host path bind-mounted as-is. |
+| `worktree` | jackin' creates a per-container `git worktree` from the host repo. The container sees its own checkout and scratch branch; refs are shared with the host repo. |
+| `clone` | jackin' creates a per-container `git clone --local`. The container has its own `.git/` and independent refs. |
 
-```toml
-[[workspaces.my-app.mounts]]
-src = "~/projects/my-app"
-dst = "/workspace/my-app"
-isolation = "worktree"
-```
-
-Omitting the field is equivalent to `isolation = "shared"`. On save, jackin' always writes the field explicitly — even when it's `shared` — so the stored TOML names the isolation level for every mount. Old configs that predate the field are migrated to the explicit form on first save.
+Set isolation per mount with `--mount-isolation <dst>=<type>` on `jackin workspace create` and `jackin workspace edit`. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation) in the workspaces guide for the full validation rules and recommended patterns.
 
 <Aside type="note">
-Isolation is a workspace-mount concept only. Global mounts (`[[mounts]]` and `jackin config mount add`) reject the `isolation` field at parse time — global mounts are typically non-repo system paths where `shared` is the only sensible answer.
+Isolation is a workspace-mount concept only. Global mounts (added with
+`jackin config mount add`) are typically non-repo system paths, so
+`shared` is always the answer there — passing isolation flags to
+global mounts is rejected.
 </Aside>
-
-### Isolated source with a shared cache
-
-A common composition: keep source isolated per agent, but mount a shared host cache directory back in as an explicit `shared` child so build artifacts persist across agents and containers.
-
-```toml
-[[workspaces.jackin.mounts]]
-src = "~/projects/jackin"
-dst = "/workspace/jackin"
-isolation = "worktree"
-
-[[workspaces.jackin.mounts]]
-src = "~/.cache/jackin/target"
-dst = "/workspace/jackin/target"
-isolation = "shared"
-```
-
-The agent sees an isolated checkout at `/workspace/jackin` while `target/` is backed by a shared host cache directory. jackin' emits parent mounts before children so the cache mount overlays the corresponding path inside the isolated worktree. This is intentional, not a redundant mount to collapse.
-
-See the [workspaces guide](/guides/workspaces/#per-mount-isolation) for the full validation rules and dirty-host caveats.
 
 ## Sensitive path warnings
 
@@ -198,6 +180,7 @@ When a sensitive path is detected, you'll see a warning explaining the risk and 
 <Aside type="caution">
 The warning defaults to "no". If stdin is not a terminal (e.g. in a script), jackin' aborts rather than silently mounting sensitive paths.
 </Aside>
+
 ## Best practices
 
 - **Mount only what the agent needs.** Don't mount your entire home directory. Be specific about which project directories the agent should access.

--- a/docs/src/content/docs/guides/role-repos.mdx
+++ b/docs/src/content/docs/guides/role-repos.mdx
@@ -1,9 +1,19 @@
 ---
-title: Role Repos
+title: Role Repositories
 description: How role repositories work and how they're discovered
 ---
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="note">
+This page is **for role authors** — anyone creating their own
+role repository (`backend-engineer`, `docs-writer`,
+`security-reviewer`, …) for themselves or for a team. Role
+authoring is a normal user-facing activity, not a contributor
+activity: you do not need to know how jackin' is implemented to
+read this page. Operators who only *load* existing roles only need
+the role's selector name (e.g. `agent-smith`) and can skip this
+section.
+</Aside>
 
 ## What is a role repo?
 
@@ -72,14 +82,14 @@ This name appears in jackin's TUI and output. When omitted, the role selector na
 
 ## Caching
 
-Role repos are cloned under `~/.jackin/roles/` on first load. The default branch checkout lives at `~/.jackin/roles/<role>/default`, and branch-specific checkouts live under `~/.jackin/roles/<role>/branches/<branch>`. Subsequent loads use the cached checkout. jackin' updates the repo on each load to keep the cache current.
+jackin' caches each role's repository on first load and reuses the cached checkout on every subsequent load — there is no manual cache to manage. Branches loaded with `--role-branch` are cached separately from the default branch, so you can flip between them without re-cloning either side. jackin' updates the cache on each load to keep it in sync with the configured source.
 
 jackin' is intentionally strict about that cache:
 
 - if the cached repo's `origin` no longer matches the configured source, load fails
 - if the cached repo contains local changes or extra files, load fails
 
-This avoids silently building from a tampered or stale cache. If you intentionally edited the cached repo, remove it and let jackin' clone again.
+This avoids silently building from a tampered or stale cache. If you intentionally need a clean cache, run `jackin purge <role>` to drop it and let the next load clone fresh.
 
 <Aside type="tip">
 Pass `--rebuild` to force jackin' to rebuild the Docker image from scratch. This is useful when the construct base image or agent Dockerfile has changed.

--- a/docs/src/content/docs/guides/security-model.mdx
+++ b/docs/src/content/docs/guides/security-model.mdx
@@ -7,13 +7,25 @@ import { Aside } from '@astrojs/starlight/components'
 
 ## Honest boundary statement
 
-jackin' provides a **container boundary**, not a **microVM boundary**.
+jackin' provides a **container boundary** today. That is a deliberate proof-of-concept choice, not the long-term ceiling.
 
-That distinction matters.
+Containers are where jackin' starts because the team building it has years of operational experience with `Docker`, the mental model is widely understood, and a container boundary is the shortest path to a useful product the operator can actually feel — workspaces, mounts, isolated worktrees, parallel agents, all running locally without an additional virtualization layer to debug. The current version is mostly designed around that boundary because it is what we know how to make ergonomic *now*.
 
-jackin' is useful when you trust the agent runtime itself but want to limit what it can touch on your machine. It is not the right tool to claim hypervisor-level isolation or to contain a fully hostile workload.
+That doesn't mean jackin' has to stop there. Stronger boundaries — microVMs, hypervisor-backed sandboxes, and selectable backends — are explicit research items on the roadmap:
 
-If you need the hardest local isolation boundary available today, a microVM-based tool such as Docker Sandboxes is stronger by design.
+- [Selectable sandbox backends](/reference/roadmap/selectable-sandbox-backends/) — let the operator pick `Docker`, microVM, or another backend per workspace, instead of forcing one for everyone. Not every workload needs a microVM, and forcing one would cost startup time, build cache, and parallelism.
+- [Rootless `DinD`](/reference/roadmap/rootless-dind/) — shrink the privileged surface inside the current container model.
+- [Reproducibility & provenance pinning](/reference/roadmap/reproducibility-pinning/) — tighten what gets into the image to begin with.
+
+The plan is to keep iterating on UX, ergonomics, and operator workflows until jackin' is no longer in the *experimenting and figuring it out* phase, and then research and add stronger isolation boundaries as a configurable option. We constantly look at adjacent projects (microVM-based agent sandboxes, devcontainer setups, remote sandbox products) and borrow good ideas — see [Comparison with Alternatives](/guides/comparison/) for a current snapshot.
+
+So the honest framing today is:
+
+- jackin' is useful when you trust the agent runtime itself but want to limit what it can touch on your machine.
+- It is not the right tool to claim hypervisor-level isolation or to contain a fully hostile workload **right now**.
+- If you need the hardest local isolation boundary available today, a microVM-based tool such as `Docker Sandboxes` is stronger by design — and we treat those tools as references for what jackin' should eventually offer as one of the selectable backends.
+
+For the latest plan and current research items, the [Roadmap](/reference/roadmap/) is the source of truth.
 
 ## Isolation layers
 
@@ -64,7 +76,7 @@ Built-in agents (`agent-smith`, `the-architect`) are always trusted. When you lo
     - The agent will have access to your mounted workspace files
 ```
 
-Once you confirm, the trust decision is saved to `~/.config/jackin/config.toml` and subsequent loads proceed without prompting.
+Once you confirm, jackin' remembers the decision and subsequent loads of the same role proceed without prompting.
 
 You can also manage trust from the command line:
 
@@ -79,13 +91,7 @@ jackin config trust revoke chainargos/the-architect
 jackin config trust list
 ```
 
-For non-interactive environments (CI, automation), pre-trust an agent by adding `trusted = true` to its config entry:
-
-```toml
-[roles."org/agent-name"]
-git = "https://github.com/org/jackin-agent-name.git"
-trusted = true
-```
+For non-interactive environments (CI, automation), use `jackin config trust grant <selector>` ahead of the first load — that records the trust decision the same way the interactive prompt would.
 
 <Aside type="note">
 Trust is tied to the agent selector (e.g., `org/agent-name`), not the git URL. If an agent's cached repo URL no longer matches the configured source, jackin' rejects it with a separate remote-mismatch error regardless of trust status.
@@ -94,7 +100,7 @@ Trust is tied to the agent selector (e.g., `org/agent-name`), not the git URL. I
 
 Loading a role from an unmerged branch (`--role-branch`) triggers a separate, always-on confirmation prompt — even if the role is already trusted.
 
-The reason: `trusted = true` in your config records that you reviewed the role's **default branch**. An external contributor can open a pull request on that same role repository with a modified Dockerfile that runs arbitrary commands during the image build. If you loaded the branch without a prompt, you could unknowingly execute code you never reviewed, in a context where you expected the behaviour of the trusted default branch.
+The reason: trusting a role records that you reviewed the role's **default branch**. An external contributor can open a pull request on that same role repository with a modified Dockerfile that runs arbitrary commands during the image build. If you loaded the branch without a prompt, you could unknowingly execute code you never reviewed, in a context where you expected the behaviour of the trusted default branch.
 
 The branch trust gate shows the role, source repository, and branch name, then asks you to confirm that you have reviewed the diff:
 
@@ -153,26 +159,17 @@ jackin' remaps the container user to your host UID and GID. That means:
 - you avoid common permission conflicts after the agent edits files
 - the main runtime process does not run as root
 
-<Aside type="note">
-The current implementation creates the user in the construct image and then remaps it in the derived image. This is known technical debt and is on the roadmap to simplify.
-</Aside>
 ## What persists and what does not
 
-jackin' persists state at `~/.jackin/data/<container-name>/`. Today that includes:
+Each agent keeps its own session state — conversation history, OAuth credentials forwarded from your host, account metadata, and any tool logins (such as `gh`) you performed inside the container. That state survives stop/restart, so reconnecting to the same role picks up where it left off.
 
-- `.claude/` (session history, and `.credentials.json` with OAuth tokens)
-- `.claude.json` (account metadata and preferences)
-- `.config/gh/`
-
-That means Claude conversation state, authentication, and `gh` state can survive across sessions.
-
-But several important things do **not** persist:
+Several important things do **not** persist:
 
 - the mutable root filesystem of the runtime container
 - packages installed interactively into the running container
-- DinD images and containers created during that session
+- containers and images the agent built inside its own private `Docker` daemon during the session
 
-This is a deliberate trade-off. jackin' is biased toward reproducible agent images and explicit workspace mounts, not long-lived mutable sandboxes.
+This is a deliberate trade-off. jackin' is biased toward reproducible agent images and explicit workspace mounts, not long-lived mutable sandboxes. Use `jackin purge <role>` to wipe all of an agent's persisted state and start fresh.
 
 ## Current implementation constraints
 
@@ -196,9 +193,9 @@ Mounted files are live host files. If the agent edits a mounted path, the host f
 
 ### Authentication forwarding
 
-By default, jackin' forwards the host's Claude Code OAuth credentials into new agent containers (`auth_forward = "sync"`). This means agents start pre-authenticated but also means OAuth tokens are stored on disk in the agent state directory with `0600` permissions.
+By default, jackin' forwards the host's Claude Code OAuth credentials into new agent containers (the `sync` auth-forward mode). This means agents start pre-authenticated, but it also means OAuth tokens land on disk inside the agent's persisted state with owner-only file permissions.
 
-You can control this behavior at three layers (global, per workspace, and per workspace × role × agent) — see [Authentication Forwarding](/guides/authentication). Setting `auth_forward = "ignore"` revokes any previously forwarded credentials and returns to the legacy behavior of manual in-container login. The `api_key` and `oauth_token` modes inject the credential into the container's process env at launch only — no credential is written to disk in the role-state directory.
+You can control this behaviour at three scopes (global, per workspace, and per workspace × role × agent) — see [Authentication Forwarding](/guides/authentication/). Setting the mode to `ignore` revokes any previously forwarded credentials and falls back to manual in-container login. The `api_key` and `oauth_token` modes inject the credential into the container's process env at launch only — no credential is written to disk inside the agent's persisted state.
 
 ### Credentials obtained inside the runtime remain inside the runtime
 

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -9,7 +9,7 @@ import { Aside } from '@astrojs/starlight/components'
 
 A workspace is a saved configuration that tells jackin' how to mount your project directories into an agent container. Instead of typing long mount paths every time, you save a project boundary once and reference it by name.
 
-A workspace is **not** the same thing as an role:
+A workspace is **not** the same thing as a role:
 
 - **workspace** = which project files are available
 - **role** = which tools, plugins, and defaults are installed
@@ -17,6 +17,12 @@ A workspace is **not** the same thing as an role:
 That means one workspace can be reused with multiple roles when the file access should stay the same but the runtime profile should differ.
 
 In practice, that is one of the main reasons workspaces exist. They let you preserve the same file boundary while swapping in the role that best matches the work.
+
+<Aside type="tip">
+Every workspace setting on this page is managed through `jackin workspace …`
+commands or the operator console (`jackin console`). You should never
+need to hand-edit a configuration file to manage workspaces.
+</Aside>
 
 ## The current directory workspace
 
@@ -75,6 +81,7 @@ The `--workdir` path sets the container's `cwd` when the agent starts. It does n
 <Aside type="tip">
 Use `--mount ~/Projects/my-app` when you want the host and container paths to stay identical. Keeping the paths the same avoids confusion when the agent references files.
 </Aside>
+
 ### Adding extra mounts
 
 Workspaces can include additional directories beyond the workdir:
@@ -103,56 +110,57 @@ Here, `/workspace` is the container start path and `~/src:/workspace` is the exp
 
 By default, every workspace mount is `shared` — the host directory is bind-mounted as-is, and any agent that loads the workspace edits the same files you do on the host. That is the right default for most workflows, but it stops working as soon as you want two agents to work on the same project at the same time without stepping on each other.
 
-Setting `isolation = "worktree"` on a source mount tells jackin' to materialize a per-container `git worktree add` of the host repo and bind-mount that worktree into the container instead of the original `src`. Each container gets its own checkout, its own scratch branch (`jackin/scratch/<container>` — full container name verbatim), and its own working tree — so concurrent agents no longer share a `.git` directory.
+Setting a mount's isolation to `worktree` tells jackin' to create a per-container `git worktree` of the host repo and mount that instead of the original directory. Each container gets its own checkout, its own scratch branch, and its own working tree — so concurrent agents no longer share a `.git` directory.
 
 ### Modes
 
-| Mode | Status | Behavior |
-|---|---|---|
-| `shared` | Default | Host path bind-mounted as-is. Today's behavior. |
-| `worktree` | Available | Materialize a `git worktree` per container; bind-mount the worktree path. Branch defaults to `jackin/scratch/<container>`, base is host `HEAD`. Refs are shared with the host repo. |
-| `clone` | Available | Materialize a per-container `git clone --local`; bind-mount the clone path. The clone has its own `.git/` and independent refs; branches appear on the host only after an explicit push. |
+| Mode | Behavior |
+|---|---|
+| `shared` (default) | Host path bind-mounted as-is. |
+| `worktree` | A per-container `git worktree` is created from the host repo. The container sees its own checkout on a scratch branch; refs are still shared with the host repo, so branches the agent creates are visible to you immediately. |
+| `clone` | A per-container `git clone --local` is created. The container has its own `.git/` and independent refs; branches appear on your host only after an explicit push. |
 
-Use `worktree` when immediate host-side branch visibility is useful and the agent is trusted with the host repo's `.git/`. Use `clone` when ref isolation is more important than immediate host visibility.
+Use `worktree` when you want immediate host-side branch visibility and you trust the agent with the host repo's `.git/`. Use `clone` when ref isolation matters more than immediate host visibility.
+
+### Setting isolation from the CLI
+
+The `--mount-isolation <dst>=<type>` flag (repeatable) on `jackin workspace create` and `jackin workspace edit` sets isolation per mount destination:
+
+```bash
+jackin workspace create jackin \
+  --workdir /workspace/jackin \
+  --mount ~/projects/jackin:/workspace/jackin \
+  --mount ~/.cache/jackin/target:/workspace/jackin/target \
+  --mount-isolation /workspace/jackin=worktree
+```
+
+The agent sees an isolated checkout at `/workspace/jackin` while `target/` is backed by a shared host cache. jackin' arranges the mounts so the cache mount overlays the corresponding path inside the isolated worktree — the cache then survives across agents even when each agent has its own checkout.
 
 ### Validation
 
 `worktree` and `clone` mounts have a few preconditions enforced before materialization:
 
-- `src` must be a git repository **root** (not a subdirectory).
+- The mount source must be a git repository **root** (not a subdirectory).
 - The host repo must not be mid-rebase, mid-merge, or mid-cherry-pick.
-- `readonly` is not allowed — a forked working copy must be writable.
-- Sensitive mount paths (`~/.ssh`, `~/.aws`, etc.) are rejected.
-- Two isolated mounts whose `dst` paths nest (one inside the other) are rejected — the inner worktree's `.git` would land inside the outer worktree's tree, which is unsafe regardless of mode.
+- Read-only is not allowed for an isolated mount — a forked working copy must be writable.
+- Sensitive paths (`~/.ssh`, `~/.aws`, etc.) are rejected.
+- Two isolated mounts whose destinations nest (one inside the other) are rejected.
+
+If a precondition is not met, the command fails with a clear error pointing at the offending mount.
 
 <Aside type="caution">
-The worktree branches from your host repo's current `HEAD`. If your host tree has uncommitted changes, those edits stay on the host — they do not travel into the agent's worktree. Pass `jackin load --force` (non-interactive) or confirm in the TUI to acknowledge that WIP stays behind.
+The worktree branches from your host repo's current `HEAD`. If your
+host tree has uncommitted changes, those edits stay on the host —
+they do not travel into the agent's worktree. Pass
+`jackin load --force` (non-interactive) or confirm in the TUI to
+acknowledge that work-in-progress stays behind.
 </Aside>
 
-### Isolated source with a shared cache
-
-The recommended pattern for expensive build artifacts: keep source isolated and mount cache directories back in as explicit `shared` children.
-
-```toml
-[workspaces.jackin]
-workdir = "/workspace/jackin"
-
-[[workspaces.jackin.mounts]]
-src = "~/projects/jackin"
-dst = "/workspace/jackin"
-isolation = "worktree"
-
-[[workspaces.jackin.mounts]]
-src = "~/.cache/jackin/target"
-dst = "/workspace/jackin/target"
-isolation = "shared"
-```
-
-The agent sees an isolated checkout at `/workspace/jackin` while `target/` is backed by a shared host cache. jackin' emits parent mounts before children so the cache mount overlays the corresponding path inside the isolated worktree.
-
-### Setting isolation from the CLI
-
-You don't need to hand-edit TOML to opt in. The `--mount-isolation <dst>=<type>` flag (repeatable) on `jackin workspace create` and `jackin workspace edit` sets isolation per mount destination — see the [`workspace`](/commands/workspace/) command reference. To inspect what's been materialized for a container, look up the worktree path under `<data_dir>/jackin-<container>/git/worktree/repo/<dst>/<container>/` (or use `git worktree list` on the host repo) and `cd` to it directly.
+To inspect what's been materialized for a container, use
+`jackin workspace show <name>` (the **Isolation** column shows the
+effective mode for every mount) or `git worktree list` on the host
+repo. If you need the on-disk layout details, see
+[Architecture](/reference/architecture/) in the internals section.
 
 ## Managing workspaces
 
@@ -187,9 +195,9 @@ jackin workspace edit my-app --remove-destination /old-mount
 jackin workspace remove my-app
 ```
 
-## Restricting agents
+## Restricting roles
 
-You can limit which agents are allowed to use a workspace:
+You can limit which roles are allowed to use a workspace:
 
 ```bash
 jackin workspace create secure-api \
@@ -198,16 +206,16 @@ jackin workspace create secure-api \
   --default-role agent-smith
 ```
 
-- `--allowed-role` — only these agents can load this workspace (repeatable)
+- `--allowed-role` — only these roles can load this workspace (repeatable)
 - `--default-role` — auto-selected role when you open this workspace in the operator console
 - `--default-agent` — default agent used by `jackin load` unless `--agent` is passed for that launch
 
-This is especially useful when one workspace should only be used with a very specific tool profile, such as a production-infra agent or a security-review agent.
+This is especially useful when one workspace should only be used with a very specific tool profile, such as a production-infra role or a security-review role.
 
-### Editing agent restrictions
+### Editing role restrictions
 
 ```bash
-# Grant access to another agent
+# Grant access to another role
 jackin workspace edit secure-api --allowed-role the-architect
 
 # Revoke access
@@ -230,24 +238,20 @@ jackin workspace edit secure-api --clear-default-agent
 
 Long-running agent work — large builds, test suites, dataset pulls — can outlast your screen-saver and the host's idle-sleep timer. macOS will then suspend the machine and the agent stops making progress until you wake it up.
 
-Workspaces can opt in to a per-workspace keep-awake reconciler that prevents this:
-
-```toml
-[workspaces.my-app.keep_awake]
-enabled = true
-```
-
-When the flag is set, `jackin` keeps a single `caffeinate -imsu` process alive for as long as **any** agent in **any** keep-awake workspace is running. The reconciler runs at every command boundary (`load`, `console`, `hardline`, `eject`, `exile`), so the assertion turns on the moment a keep-awake agent starts and turns off the moment the last keep-awake agent stops.
+Workspaces can opt in to a per-workspace keep-awake reconciler that prevents this. While any agent in any keep-awake workspace is running, jackin' keeps a single `caffeinate -imsu` process alive in the background; when the last keep-awake agent stops, jackin' releases it.
 
 <Aside type="caution">
-This feature is **macOS-only** today. On Linux and Windows the flag is silently ignored — there is no equivalent system-wake assertion wired up yet. If you need it on another platform, please open an issue.
+Keep-awake is **macOS-only** today. On Linux and Windows the flag is
+silently accepted but has no effect — useful when sharing settings
+across machines, but the host will still sleep. If you need it on
+another platform, please open an issue.
 </Aside>
 
 Other workspaces (those without the flag) are unaffected: their containers do not contribute to the keep-awake count, and the host is free to sleep if no opted-in agent is running.
 
 ### Setting keep-awake
 
-You can opt in (or out) from the CLI or the operator console — no need to hand-edit `config.toml`.
+You can opt in (or out) from the CLI or the operator console.
 
 **CLI** — paired flags on `workspace create` and `workspace edit`:
 
@@ -270,20 +274,12 @@ jackin workspace edit my-app --no-keep-awake
 
 When you open a workspace, your local branches may have drifted behind their remotes. The git-pull-on-entry toggle runs `git pull` on every mounted git repository from the **host** before the agent container starts — so the agent always sees the latest committed code without you needing to remember a manual pull first.
 
-```toml
-[workspaces.my-app]
-workdir = "/workspace/my-app"
-git_pull_on_entry = true
-
-[[workspaces.my-app.mounts]]
-src = "~/Projects/my-app"
-dst = "/workspace/my-app"
-```
-
-Failures are **non-fatal**: if a pull fails (offline, uncommitted changes, protected branch, etc.) jackin prints a warning and continues the launch. The workspace remains fully usable — the toggle is a convenience, not a gate.
+Failures are **non-fatal**: if a pull fails (offline, uncommitted changes, protected branch, etc.) jackin' prints a warning and continues the launch. The workspace remains fully usable — the toggle is a convenience, not a gate.
 
 <Aside type="caution">
-`git pull` is run on the **host** directory, not inside the container. Any uncommitted local changes or an active rebase will cause the pull to fail; jackin will warn and proceed.
+`git pull` is run on the **host** directory, not inside the container.
+Any uncommitted local changes or an active rebase will cause the pull
+to fail; jackin' will warn and proceed.
 </Aside>
 
 ### Setting git pull on entry
@@ -305,14 +301,6 @@ jackin workspace edit my-app --no-git-pull
 
 `jackin workspace show <name>` surfaces a `Git Pull: on entry` row when the flag is on.
 
-## Jackin development workspace
-
-When the saved workspace is named `jackin`, jackin automatically injects `MISE_TRUSTED_CONFIG_PATHS` into the role container. The value covers the workspace `workdir` and every mount destination, so mise trusts the Jackin project checkouts without requiring a manual `mise trust` inside the container. Other workspaces are not affected, and an explicitly configured `MISE_TRUSTED_CONFIG_PATHS` env var still wins.
-
 ## Workspace auto-detection
 
 When you open the operator console (`jackin console`), it checks whether your current directory falls under a saved workspace's host `workdir` or one of its mounted host paths. If it does, that workspace is preselected — saving you a selection step and reinforcing the value of naming project boundaries once. Container-only `workdir` values like `/workspace` can still be auto-detected as long as one of the workspace's mounted host paths contains your current directory. You can always override the preselection by choosing a different workspace or "Current directory."
-
-## Storage
-
-Workspace definitions are stored in `~/.config/jackin/config.toml`. They're local operator configuration — not part of any project or role repo.

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -5,6 +5,16 @@ description: How jackin' orchestrates containers, networks, and persisted state
 
 import ArchitectureDiagram from '../../../components/diagrams/ArchitectureDiagram.astro'
 import ImageLayers from '../../../components/diagrams/ImageLayers.astro'
+import RepoFile from '../../../components/RepoFile.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<Aside type="note">
+This page is **for contributors** — anyone who wants to understand or
+work on jackin' itself. Operators do not need to read it to use
+jackin'; the [Operator Guide](/guides/workspaces/) and
+[Concepts](/getting-started/concepts/) cover everything an operator
+needs.
+</Aside>
 
 ## High-level architecture
 
@@ -222,16 +232,22 @@ If the main thing you need is the strongest local boundary for autonomous agents
 
 ## Technology stack
 
-jackin' itself is built in Rust:
+jackin' is built in Rust. The runtime dependencies, grouped by what they own, match <RepoFile path="Cargo.toml" />:
 
-| Component | Technology |
+| Concern | Crates |
 |---|---|
-| CLI parsing | `clap` |
-| Terminal UI | `ratatui` + `crossterm` |
+| CLI parsing & manpages | `clap`, `clap_mangen` |
+| Terminal UI | `ratatui`, `crossterm`, `ratatui-textarea`, `tui-widget-list`, `dialoguer` |
 | Table output | `tabled` |
-| Configuration | `serde` + `toml` |
+| Configuration (parse + edit) | `serde`, `serde_json`, `toml`, `toml_edit` |
+| XDG paths and process locking | `directories`, `fs2` |
 | Dockerfile parsing | `dockerfile-parser-rs` |
-| Error handling | `anyhow` + `thiserror` |
+| Error handling | `anyhow`, `thiserror` |
 | Colored output | `owo-colors` |
+| Filesystem helpers | `tempfile` |
+| Open external URLs | `open` |
+| Test helpers (dev) | `assert_cmd`, `predicates` |
 
-The project targets Rust edition 2024 and forbids unsafe code.
+The project targets **Rust edition 2024** with a current MSRV of **1.94** (see `rust-version` in <RepoFile path="Cargo.toml" />) and `unsafe_code = "forbid"` at the crate root. Clippy lints are configured with `correctness` and `suspicious` set to `deny` and `complexity`/`style`/`perf`/`pedantic`/`nursery` set to `warn` — see <RepoFile path="Cargo.toml" /> for the full lint table.
+
+When this list drifts from <RepoFile path="Cargo.toml" />, <RepoFile path="Cargo.toml" /> wins. Update both in the same PR.

--- a/docs/src/content/docs/reference/codebase-map.mdx
+++ b/docs/src/content/docs/reference/codebase-map.mdx
@@ -1,0 +1,219 @@
+---
+title: Codebase Map
+description: Where the source lives, how the modules fit together, and where to start reading
+---
+import RepoFile from '../../../components/RepoFile.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+This page is a **contributor's map** of the jackin' source tree. It is
+written for people who want to understand how jackin' is built, debug
+its internals, or work on the project itself. If you only want to *use*
+jackin', start at [Concepts](/getting-started/concepts/) and the
+[Operator Guide](/guides/workspaces/) — you do not need this page.
+
+<Aside type="note">
+**This page is the canonical module map for jackin'.** When module
+structure changes, this page is updated in the same PR — see the
+"Code ↔ Docs Cross-Reference" table in <RepoFile path="PROJECT_STRUCTURE.md" />.
+`PROJECT_STRUCTURE.md` itself is a short, agent-facing pointer that
+covers the multi-repo ecosystem and the per-PR docs contract; it
+sends readers here for the actual module-level detail.
+</Aside>
+
+## Repository layout
+
+| Path | What lives there |
+|---|---|
+| `src/` | Rust CLI binary — every command jackin' implements |
+| `docker/construct/` | Source for the shared base Docker image (`projectjackin/construct:trixie`) |
+| <RepoFile path="docker/runtime/entrypoint.sh" /> | The entrypoint script jackin' injects into every derived image |
+| `docs/` | This documentation site (Astro + Starlight) |
+| `.github/workflows/` | CI for jackin', the construct image, and the docs site |
+| `tests/` | End-to-end and integration tests |
+
+## Where to start reading
+
+Different contribution shapes have different natural entry points.
+
+### "I want to add or change a CLI flag"
+
+Start at <RepoFile path="src/cli/mod.rs" /> — the top-level `Cli` and
+`Command` enum. Each subcommand has its own clap module:
+
+| Subcommand | Module |
+|---|---|
+| `load` / `hardline` / `console` | <RepoFile path="src/cli/role.rs" /> |
+| `eject` / `purge` | <RepoFile path="src/cli/cleanup.rs" /> |
+| `workspace` | <RepoFile path="src/cli/workspace.rs" /> |
+| `config` | <RepoFile path="src/cli/config.rs" /> |
+| `exile` (unit variant) | <RepoFile path="src/cli/mod.rs" /> |
+| Bare `jackin` / `console` dispatch | <RepoFile path="src/cli/dispatch.rs" /> |
+
+Command dispatch lives in `src/app/`. Every clap subcommand has a
+match arm in <RepoFile path="src/app/mod.rs" /> (`run`) that calls
+into the relevant domain module (`workspace/`, `runtime/`, `config/`,
+etc.). When you add a flag, also update the matching docs page under
+`docs/src/content/docs/commands/`.
+
+### "I want to change container lifecycle behaviour"
+
+The container lifecycle lives in `src/runtime/`:
+
+- <RepoFile path="src/runtime/launch.rs" /> — the load path: clone/update
+  role repo, validate the contract, generate a derived Dockerfile, build
+  the image on the host Docker engine, start the DinD sidecar and the
+  agent container, attach.
+- <RepoFile path="src/runtime/attach.rs" /> — the attach + reconnect path
+  (`hardline`).
+- <RepoFile path="src/runtime/cleanup.rs" /> — `eject`, `exile`, `purge`,
+  and orphan GC.
+- <RepoFile path="src/runtime/image.rs" /> — `docker build` invocation.
+- <RepoFile path="src/runtime/repo_cache.rs" /> — the role-repo cache lock
+  + fetch logic.
+- <RepoFile path="src/runtime/caffeinate.rs" /> — the macOS keep-awake
+  reconciler.
+
+The end-to-end shape of "what happens when you run `jackin load`" is
+described in [Architecture → Container lifecycle](/reference/architecture/#container-lifecycle).
+
+### "I want to change workspace or mount behaviour"
+
+The workspace model is in `src/workspace/`:
+
+- <RepoFile path="src/workspace/mod.rs" /> — types and re-exports.
+- <RepoFile path="src/workspace/mounts.rs" /> — mount parsing and validation.
+- <RepoFile path="src/workspace/planner.rs" /> — `plan_create`, `plan_edit`,
+  `plan_collapse` (the redundant-mount invariant).
+- <RepoFile path="src/workspace/resolve.rs" /> — runtime resolution from
+  workspace + ad-hoc + global mounts.
+- <RepoFile path="src/workspace/sensitive.rs" /> — sensitive-mount detection
+  for the warn-and-confirm gate.
+
+Per-mount isolation (worktree / clone) lives in a separate module
+because it has its own materialization lifecycle:
+
+- <RepoFile path="src/isolation/materialize.rs" /> — worktree and clone
+  materialization + `MaterializedWorkspace`.
+- <RepoFile path="src/isolation/state.rs" /> — `isolation.json` IO.
+- <RepoFile path="src/isolation/finalize.rs" /> — the post-attach
+  finalizer that decides between *preserve* / *clean* / *return-to-agent*.
+
+### "I want to change a config-file shape"
+
+The TOML config model lives in `src/config/`:
+
+- <RepoFile path="src/config/mod.rs" /> — top-level `AppConfig` struct
+  and submodule re-exports.
+- <RepoFile path="src/config/persist.rs" /> — `AppConfig::load_or_init`
+  (config-load + builtin sync).
+- <RepoFile path="src/config/editor.rs" /> — `ConfigEditor` (the save
+  path used by every CLI mutator).
+- <RepoFile path="src/config/workspaces.rs" /> — workspace CRUD plus
+  the `require_workspace` helper.
+- <RepoFile path="src/config/mounts.rs" />,
+  <RepoFile path="src/config/roles.rs" /> — CRUD and resolution per
+  area (global mounts; builtin sync, trust, and auth-forward).
+
+Whenever a config field changes, also update
+[Configuration File](/reference/configuration/) so the schema reference
+stays accurate.
+
+### "I want to change role-manifest behaviour"
+
+The `jackin.role.toml` schema and validator live in `src/manifest/`:
+
+- <RepoFile path="src/manifest/mod.rs" /> — schema structs, `load`,
+  `display_name`.
+- <RepoFile path="src/manifest/validate.rs" /> — `RoleManifest::validate`
+  and `validate_agent_consistency`.
+
+Whenever the manifest schema changes, also update
+[Role Manifest](/developing/role-manifest/).
+
+### "I want to change the operator console (TUI)"
+
+The interactive console lives in `src/console/`:
+
+- <RepoFile path="src/console/mod.rs" /> — `run_console` entrypoint,
+  event loop, and the quit-confirm overlay; per-screen drawing lives
+  under `src/console/manager/render/`.
+- <RepoFile path="src/console/state.rs" /> — `ConsoleState` and
+  `WorkspaceChoice`.
+- <RepoFile path="src/console/preview.rs" /> — workspace preview and
+  detail lines.
+- `src/console/manager/` — the workspace-manager TUI subsystem.
+- `src/console/widgets/` — reusable modal and widget components.
+
+General terminal-UI helpers (palette, intro/outro animation, prompt
+helpers) are split out into `src/tui/`.
+
+## Cross-cutting helpers
+
+A handful of files at the crate root own concerns that don't cluster
+into a single module:
+
+| File | Owns |
+|---|---|
+| <RepoFile path="src/env_model.rs" /> | Reserved-runtime-env list, `is_reserved`, interpolation reference extraction, topological env order with cycle detection. |
+| <RepoFile path="src/env_resolver.rs" /> | Runtime env resolution — interpolation, interactive prompts. |
+| <RepoFile path="src/selector.rs" /> | Role-selector parsing (`agent-smith`, `chainargos/backend-engineer`, …). |
+| <RepoFile path="src/repo.rs" /> | Role-repo validation — required files, path-traversal checks. |
+| <RepoFile path="src/repo_contract.rs" /> | Enforces that role `Dockerfile`s extend the construct base. |
+| <RepoFile path="src/derived_image.rs" /> | Generates the derived Dockerfile from the role's repo + the construct base. |
+| <RepoFile path="src/docker.rs" /> | Docker command builder — `CommandRunner` trait and `ShellRunner`. |
+| <RepoFile path="src/paths.rs" /> | XDG-compliant data and config directory resolution (`JackinPaths`). |
+
+## Code ↔ docs cross-reference
+
+When a code change affects user-visible behaviour, the matching docs
+page must change in the same PR. The full table lives at the bottom of
+<RepoFile path="PROJECT_STRUCTURE.md" />; the most common pairings are:
+
+| Code change in | Update docs in |
+|---|---|
+| `src/cli/**` | [Commands](/commands/load/) |
+| `src/workspace/**` (mount logic) | [Workspaces](/guides/workspaces/), [Mounts](/guides/mounts/) |
+| `src/config/**` | [Configuration File](/reference/configuration/) |
+| `src/runtime/**` | [Architecture](/reference/architecture/) |
+| `src/isolation/**` | Workspaces (per-mount isolation), Architecture (materialization + finalizer), [Configuration File](/reference/configuration/) |
+| `src/manifest/**` | [Role Manifest](/developing/role-manifest/) |
+| <RepoFile path="src/instance/auth.rs" /> | [Authentication](/guides/authentication/), [Security Model](/guides/security-model/) |
+| <RepoFile path="src/derived_image.rs" /> | [Construct Image](/developing/construct-image/) |
+| <RepoFile path="docker/construct/Dockerfile" /> | [Construct Image](/developing/construct-image/) |
+
+## Docs site source
+
+The docs site (this site) is an Astro + Starlight project under `docs/`.
+Bun is the only supported package manager.
+
+| Path | Purpose |
+|---|---|
+| <RepoFile path="docs/astro.config.ts" /> | Site metadata, sidebar layout, edit-link target |
+| `docs/src/content/docs/` | All MDX content — file path maps to URL |
+| `docs/src/components/overrides/` | Starlight component overrides (Head, SiteTitle, …) |
+| <RepoFile path="docs/src/pages/index.astro" /> | Landing route — plain Astro page, NOT a Starlight content entry |
+
+To run the site locally:
+
+```sh
+cd docs
+bun install --frozen-lockfile
+bun run dev   # http://localhost:4321/
+```
+
+## Contributor entry points
+
+If you have not contributed before, these files are worth reading
+first:
+
+- <RepoFile path="AGENTS.md" /> — house rules (apply equally to humans and agents).
+- <RepoFile path="CONTRIBUTING.md" /> — contribution flow, DCO sign-off.
+- <RepoFile path="BRANCHING.md" /> — branch naming and merge policy.
+- <RepoFile path="COMMITS.md" /> — Conventional Commits format.
+- <RepoFile path="TESTING.md" /> — how to run the test suite.
+- <RepoFile path="PROJECT_STRUCTURE.md" /> — agent-facing pointer covering the multi-repo ecosystem and the per-PR docs contract; the detailed module map this page surfaces is the source of truth.
+
+The [Roadmap](/reference/roadmap/) is the catalogue of in-flight and
+planned design work. When picking up a task, the matching roadmap
+entry usually has the problem statement, the chosen approach, and the
+related source files.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -4,6 +4,16 @@ description: "The config.toml schema and storage locations"
 ---
 import { Aside } from '@astrojs/starlight/components'
 
+<Aside type="note">
+This page is an **internals reference** for contributors and operators
+who want to read, audit, or hand-edit jackin's config file directly —
+typically while debugging or shipping a fix. Day-to-day operator work
+goes through `jackin workspace …`, `jackin config …`, and the
+operator console, none of which require touching this file. Start
+from the [Operator Guide](/guides/workspaces/) instead if that is
+what you're after.
+</Aside>
+
 ## Storage locations
 
 | Path | Purpose |
@@ -95,12 +105,10 @@ Values can be:
 - Anything else — literal
 
 <Aside type="caution" title="Reserved names cannot be overridden">
-A small set of names — `JACKIN`, `JACKIN_DIND_HOSTNAME`, `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, `DOCKER_CERT_PATH` — are owned by the jackin runtime and set internally on every launch. Declaring them at any of the four layers above is rejected at config load. There is no way to override these values. See [Reserved names](/guides/environment-variables/#reserved-names) for the full list.
+A small set of names is owned by the jackin' runtime and set internally on every launch. Declaring them at any of the four layers above is rejected at config load. See [Reserved names](/guides/environment-variables/#reserved-names) for the canonical list.
 </Aside>
 
-Reserved runtime names (`JACKIN`, `JACKIN_DIND_HOSTNAME`, `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, `DOCKER_CERT_PATH`) are rejected at config load.
-
-See [Environment Variables](/guides/environment-variables) for the full guide.
+See [Environment Variables](/guides/environment-variables/) for the full guide.
 
 ### Workspaces
 

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -8,17 +8,18 @@ import RepoFile from '../../../components/RepoFile.astro'
 
 ## Current status
 
-jackin' is a functional proof of concept with Claude Code as its first supported agent runtime, namespaced roles, workspace management, and an interactive operator console.
+jackin' is a functional proof of concept. **`Claude Code` and `Codex` ship today as fully integrated agent runtimes**, with namespaced roles, workspace management, per-mount isolation for parallel agents, layered authentication forwarding (including `1Password` references), and an interactive operator console (TUI). **`Amp` is under active development** — when it lands, this section will be updated to reflect it.
 
 ## Completed
 
-- Claude Code agent runtime with full permission mode
-- Docker container isolation with Docker-in-Docker
-- Interactive operator console with workspace and agent selection
-- Workspace management (add, edit, remove, list, show)
-- Global mount configuration with agent scoping
-- Role repo contract validation
-- Derived Dockerfile generation with UID/GID remapping
+- `Claude Code` and `Codex` agent runtimes with full-speed mode (`--dangerously-skip-permissions` / YOLO) inside the container boundary
+- Layered authentication forwarding per (workspace × role × agent) — `sync` / `api_key` / `oauth_token` / `ignore` for `Claude Code`, and `sync` / `api_key` / `ignore` for `Codex` (which does not support `oauth_token`)
+- `Docker` container isolation with `Docker-in-Docker`
+- Interactive operator console (TUI) with workspace, role, and agent selection
+- Workspace management (add, edit, remove, list, show) — CLI and TUI
+- Global mount configuration with role scoping
+- Role repository contract validation
+- Derived `Dockerfile` generation with UID/GID remapping
 - State persistence across sessions
 - Agent identity (display names)
 - UID/GID host user mapping
@@ -26,7 +27,7 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 - Homebrew installation
 - Namespaced roles (e.g., `chainargos/frontend-engineer`)
 - Last-agent memory per workspace
-- [Custom Claude plugin marketplaces](/reference/roadmap/custom-plugin-marketplace/) in `jackin.role.toml`
+- [Custom `Claude Code` plugin marketplaces](/reference/roadmap/custom-plugin-marketplace/) in `jackin.role.toml`
 - [Sensitive mount path warnings](/reference/roadmap/sensitive-mount-warnings/) (warn-and-confirm for `~/.ssh`, `~/.aws`, etc.)
 - [Automatic orphaned DinD cleanup](/reference/roadmap/orphaned-dind-cleanup/) (pre-launch garbage collection)
 - [`${env.VAR}` interpolation](/reference/roadmap/env-var-interpolation/) in env var prompts and defaults for dependent variables
@@ -41,14 +42,14 @@ jackin' is a functional proof of concept with Claude Code as its first supported
 ## Partially implemented
 
 - [1Password integration](/reference/roadmap/onepassword-integration/) — workspace-managed `op://` env references shipped; file-mount generation (option 4) still deferred
-- [Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/) — Codex foundation slice shipped; Amp and full feature parity still in flight
+- [Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/) — Codex shipped as a fully integrated runtime; Amp runtime integration is under active development; full feature parity across `claude` / `codex` / `amp` still ongoing
 
 ## Planned
 
 ### Agent runtimes
 
 <Aside type="note">
-The Codex foundation slice is in (see Partially implemented above). The remaining work to reach `claude` / `codex` / `amp` parity — runtime-specific auth, config, state, entrypoint behavior, and Amp itself — continues under the same roadmap item.
+`Claude Code` and `Codex` are fully integrated runtimes today (see Partially implemented above). `Amp` is under active development. The remaining work to reach full `claude` / `codex` / `amp` feature parity — runtime-specific auth, config, state, and entrypoint behaviour — continues under the same roadmap item.
 </Aside>
 - **[Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/)** — finish the runtime abstraction so one role can launch under `claude`, `codex`, or `amp` interchangeably. Phase 1 focuses on secure local usability, not full Claude-feature parity.
 
@@ -73,29 +74,39 @@ The Codex foundation slice is in (see Partially implemented above). The remainin
 
 ### Operator surface and fleet operations
 
-- **[Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)** — phased program of 18 leaf items closing the gap between jackin's primitives and the operator surface that adjacent tools (notably [`multicode`](https://github.com/yawkat/multicode)) ship today. Covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts — the missing pieces that prevent jackin' from being the canonical orchestrator teams compose on instead of building their own. The full list of 18 leaves lives in the program doc and the sidebar under **Reference → Roadmap → Active programs → Universal Orchestrator Program**.
+- **[Universal Orchestrator Program](/reference/roadmap/multicode-inspired-features/)** — phased program of 18 leaf items closing the gap between jackin's primitives and the operator surface that adjacent tools (notably [`multicode`](https://github.com/yawkat/multicode)) ship today. Covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts — the missing pieces that prevent jackin' from being the canonical orchestrator teams compose on instead of building their own. The full list of 18 leaves lives in the program doc and the sidebar under **Reference → Roadmap → Universal Orchestrator Program**.
 
 ### Codebase health
 
 - **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
 - **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see <RepoFile path="AGENTS.md" /> → "Code review & automated scanning").
 
+### Configuration ergonomics
+
+- **[Split `config.toml` into per-workspace files](/reference/roadmap/split-workspace-config-files/)** — keep the TOML format, but move every workspace into `~/.config/jackin/workspaces/<name>.toml`, leaving `config.toml` for global settings only. Designed for one-file sharing, fresh-machine reuse, and selective version control (e.g. via [chezmoi](https://www.chezmoi.io/)).
+
 ### Documentation infrastructure
 
 - **[Greenfield workspace pattern](/reference/roadmap/greenfield-workspace/)** — workspace-onboarding pattern for empty projects (status: deferred to Phase 3 — trigger not yet met, but architecture is ready)
 - **[Markdown linting for docs](/reference/roadmap/docs-markdown-linting/)** — uniform Markdown lint pipeline for the docs site (status: proposed — design captured, no implementation committed)
+- **[Move documentation to a separate repository](/reference/roadmap/docs-separate-repository/)** — promote `docs/` out of the CLI repo into its own `jackin-project/jackin-docs` repo so the ecosystem-level docs have an ecosystem-level home; the load-bearing question is how to keep the docs as fresh as same-repo co-location makes them today (status: deferred — needs design pass on the cross-repo freshness story)
 - **[Rustdoc → Starlight integration](/reference/roadmap/rustdoc-json-starlight/)** — surface rustdoc JSON inside the Starlight docs site (status: deferred — Phase 3)
 
 <Aside type="tip">
-Detailed design documents for individual TODO items are linked from the sidebar under **Roadmap → Open items** and **Roadmap → Resolved**. Each page is a self-contained proposal with problem statement, options, and related files.
+Detailed design documents for individual TODO items are linked from the sidebar under **Roadmap** (each open category — `Universal Orchestrator Program`, `Codebase health`, `Agent runtimes & authentication`, `Isolation & security`, `Infrastructure`, `Documentation tooling`, `Configuration ergonomics`) and **Roadmap → Resolved** for shipped items. Each page is a self-contained proposal with problem statement, options, and related files.
 </Aside>
 ## Vision
 
-jackin' is designed as a **local-first development tool** with a focus on excellent UX and practical isolation. The near-term goal is to be the best way to run AI coding agents in parallel on a local machine — lightweight, composable, and open source.
+The user-facing summary of where jackin' is headed lives on the
+[Why jackin'? → Vision](/getting-started/why/#vision) page so it is
+visible to operators and role authors, not only to contributors who
+end up on the roadmap. The longer-term shape of the project, the
+local-first focus, and the eventual move toward Kubernetes-backed
+debug workflows are all captured there.
 
-The longer-term vision extends to deployment ecosystems. Kubernetes support will enable jackin' as a debug container platform — loading an AI agent into a production pod to safely investigate issues, with the same workspace and mount controls that make local use safe.
-
-The project welcomes suggestions and contributions. If jackin' works for your use case — or almost works but needs something different — [open an issue](https://github.com/jackin-project/jackin/issues) or submit a pull request.
+If jackin' works for your use case — or almost works but needs
+something different — [open an issue](https://github.com/jackin-project/jackin/issues)
+or submit a pull request.
 
 ## Contributing
 

--- a/docs/src/content/docs/reference/roadmap/docs-separate-repository.mdx
+++ b/docs/src/content/docs/reference/roadmap/docs-separate-repository.mdx
@@ -1,0 +1,216 @@
+---
+title: "Move documentation to a separate repository"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Documentation infrastructure). Decision deferred until the cross-repo freshness story is solid.
+
+## Problem
+
+The Astro Starlight documentation site currently lives inside this
+repo under `docs/` (entry point: <RepoFile path="docs/astro.config.ts" />).
+That worked while jackin' was a
+single Rust crate, but the project is now an **ecosystem of GitHub
+repositories**:
+
+- `jackin-project/jackin` — CLI source (this repo) + the docs site
+- `jackin-project/jackin-agent-smith` — default role
+- `jackin-project/jackin-the-architect` — Rust development role
+- `jackin-project/homebrew-tap` — install channel
+- `jackin-project/jackin-marketplace` — Claude plugin marketplace
+- `jackin-project/validate-agent-action` — role manifest validator
+- `jackin-project/jackin-dev`, `jackin-project/jackin-github-terraform`
+  — supporting infrastructure
+
+The docs site is the only place where the **whole ecosystem** is
+explained — what each repo is for, how they fit together, the
+operator-facing UX, the contributor-facing internals, the roadmap. It
+is not specifically *about* the CLI repo, even though it currently
+ships from there. Hosting it inside the CLI repo creates two
+asymmetries:
+
+- The docs cover behaviour spread across *all* repos, but every PR
+  that affects docs has to land in **this** repo.
+- Contributors to a sibling repo (a role author tweaking
+  `jackin-agent-smith`, for example) cannot update the docs in the
+  same PR as the change they describe — they have to open a second
+  PR here.
+
+The argument *for* moving the docs site into its own repository is
+simple: the docs are an ecosystem-level concern, and an ecosystem-level
+artefact deserves its own home, the same way every other component
+already does.
+
+## Why this is not obviously a win
+
+The big counter-argument is **freshness**. The single biggest
+documentation problem in any project is staleness. Today, freshness
+is enforced by physical co-location:
+
+- A behaviour change in `src/cli/**` ships with the matching update to
+  `docs/src/content/docs/commands/<cmd>.mdx` in the same commit.
+- The per-PR contract in <RepoFile path="PROJECT_STRUCTURE.md" /> ("Code
+  ↔ Docs Cross-Reference" table) is enforceable because both sides are
+  in the same diff.
+- The PR review surface naturally includes docs.
+
+If we move the docs site to a separate repository, every one of those
+properties weakens unless we explicitly engineer it back. Drift becomes
+a real risk, not a theoretical one.
+
+So the question is **not** "should the docs move out?" — the question is
+"can we keep the docs as fresh as they are today after they move out?"
+This roadmap item exists to answer that.
+
+## Why it might still be worth it
+
+- **Audience match.** The docs cover the whole ecosystem. Hosting them
+  in the CLI repo implicitly suggests they are about the CLI.
+- **Independent edit surface.** Contributors to other repos, role
+  authors, and documentation-only contributors can work without
+  reading the Rust crate.
+- **CI and tooling separation.** The docs build (Astro + bun +
+  pagefind) and the Rust build (cargo + nextest) currently share a
+  single repo's CI minutes and PR checks. A split would isolate them.
+- **Versioning.** A separate docs repo can grow a versioned-docs flow
+  (multiple sidebars per major version of jackin') without polluting
+  the CLI repo's branches.
+- **Same-repo bleed.** Docs PRs and code PRs currently compete for
+  reviewer attention; splitting clarifies the ownership of each PR.
+
+## Open questions
+
+This is the part the roadmap item exists to figure out.
+
+### Q1. Where do the docs live?
+
+Likely candidates:
+
+- `jackin-project/jackin-docs` — symmetric with the rest of the
+  ecosystem.
+- `jackin-project/docs` — short and unambiguous.
+- A monorepo-style umbrella like `jackin-project/website`.
+
+The naming is downstream of where the published site lives
+(`jackin.tailrocks.com` today). DNS does not care about the repo
+name.
+
+### Q2. How do we keep docs fresh across repos?
+
+This is the load-bearing question. Options to consider, alone or in
+combination:
+
+1. **Required co-PR.** A change to source areas listed in the "Code ↔
+   Docs Cross-Reference" table requires a linked PR in the docs
+   repository before merge. Enforced by a CI check that reads the PR
+   body for a `Docs-PR:` trailer (or similar) and queries the GitHub
+   API to confirm the linked PR exists and is open or already merged.
+2. **Docs-deploy webhook.** Source PRs ping the docs repo on merge so
+   contributors are nudged to update. This is informational, not
+   blocking.
+3. **Structural CI checks in the docs repo.** Lychee link-check and
+   `<RepoFile />` validation already remap GitHub blob URLs to the
+   live source — extend that to fail when a referenced file no longer
+   exists in any sibling repo.
+4. **Docs-as-a-submodule.** The docs site lives in its own repo but
+   is consumed as a git submodule by `jackin-project/jackin`. CI in
+   the CLI repo can run `git diff --submodule` to enforce that
+   structural source changes bump the docs commit.
+5. **Per-repo contribution snippets.** Each sibling repo (role repos,
+   tap, marketplace) ships a small `DOCS.md` that lists which docs
+   pages it owns. PR templates remind contributors to update them.
+6. **Generated reference.** Anything that *can* be generated from
+   source (CLI flag tables, manifest schema, env-var reserved-name
+   list) is generated rather than hand-edited, so drift is impossible
+   for those pages. The generator runs on the source repo and pushes
+   to the docs repo on release.
+
+We do not need to pick one. We need to pick the **smallest
+combination** that makes drift unlikely and contribution easy.
+
+### Q3. What about the PR review surface?
+
+Today, a reviewer sees both the source and the docs change in the same
+diff. After a split, reviewers have to look at two PRs in two repos.
+Mitigations:
+
+- The CLI PR's body links to the docs PR in a standard place
+  (`Docs-PR: jackin-project/jackin-docs#123`).
+- The docs PR's body links back.
+- A small bot (or a `gh` script in CI) embeds a rendered preview of
+  the docs PR in the CLI PR conversation, so reviewers do not have to
+  context-switch.
+
+### Q4. What does Edit-on-GitHub do?
+
+The Starlight `editLink.baseUrl` currently points at
+`https://github.com/jackin-project/jackin/edit/main/docs/`. After the
+move it points at `https://github.com/jackin-project/jackin-docs/edit/main/`.
+The friction of an "Edit this page" round trip drops, because the
+contributor lands directly in the docs-only repo.
+
+### Q5. How do we ship the move?
+
+Doing this without breaking anything is the primary risk.
+
+- Pick the new repo and set it up to build the same site at the same
+  domain.
+- Mirror the existing `docs/` history into the new repo (`git
+  filter-repo` or `git subtree split`).
+- Switch the GitHub Actions deploy workflow.
+- Delete `docs/` from this repo in the same release cut, and update
+  every reference (<RepoFile path="PROJECT_STRUCTURE.md" />,
+  <RepoFile path="AGENTS.md" />, <RepoFile path="docs/AGENTS.md" />,
+  and the docs cross-reference table).
+
+Per <RepoFile path="AGENTS.md" /> ("Project status: pre-release"), the
+move can be a hard cut — no compatibility shim, no parallel docs trees.
+
+## Inspirations / prior art
+
+Worth studying when fleshing out the design:
+
+- **Astro itself** — `withastro/astro` keeps docs in `withastro/docs`.
+  Their migration story and tooling are well-documented.
+- **Starlight** — same arrangement (the docs site for the framework
+  this site uses lives in its own repo).
+- **Vue** — `vuejs/docs` is a separate repo from `vuejs/core`; large
+  documented site, multi-language community, contribution flow worth
+  studying.
+- **Rust Book** — `rust-lang/book` is a dedicated repo distinct from
+  `rust-lang/rust`. Cargo's own book is the opposite shape: the
+  Cargo Book lives in-repo at `rust-lang/cargo/src/doc/`. Both
+  shapes coexist in the same ecosystem, which is itself a useful
+  reference.
+- **Kubernetes** — `kubernetes/website` is famously its own repo,
+  with a strict cross-repo PR policy and a large translator
+  community.
+
+The pattern is roughly: small projects keep docs in-repo;
+ecosystem-shaped projects move them out. jackin' is on the line.
+
+## Acceptance criteria
+
+When this lands, the following should all be true:
+
+1. The docs site is published from a separate repository.
+2. There is a documented, enforceable mechanism that prevents source
+   changes in any of the listed code areas from merging without the
+   matching docs change either landing first or being linked.
+3. PR review across two repos costs no more than one extra click for
+   the reviewer.
+4. `PROJECT_STRUCTURE.md` and the cross-reference table are updated to
+   point at the new repo and explain the new flow.
+5. The freshness check from the docs site's own <RepoFile path="docs/AGENTS.md" />
+   ("Roadmap sidebar discipline", `<RepoFile />` validation, lychee
+   link checks) is preserved or improved.
+
+## Related
+
+- [Codebase Map](/reference/codebase-map/) — must be updated to point
+  at the new repo when this lands.
+- [Split `config.toml` into per-workspace files](/reference/roadmap/split-workspace-config-files/) — orthogonal, but in the same "configuration / workflow ergonomics" cluster.
+- [Greenfield workspace pattern](/reference/roadmap/greenfield-workspace/) — also a docs-discoverability item, since both depend on docs being easy to find and edit.
+- <RepoFile path="PROJECT_STRUCTURE.md" /> — the "Code ↔ Docs
+  Cross-Reference" table is the single biggest piece of in-repo state
+  that has to migrate or be re-enforced.

--- a/docs/src/content/docs/reference/roadmap/split-workspace-config-files.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-workspace-config-files.mdx
@@ -1,0 +1,205 @@
+---
+title: "Split config.toml into per-workspace files"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Configuration ergonomics)
+
+## Problem
+
+Today every workspace, role, global mount, and `auth_forward` setting
+lives in a single monolithic file at `~/.config/jackin/config.toml`.
+The format itself stays useful (TOML is fine, and changing it is not
+the goal here), but a single file makes everyday operator tasks
+unnecessarily painful:
+
+- **Reusing on a fresh machine.** To carry a setup over to a new
+  laptop, you copy the whole file — including unrelated workspaces,
+  unrelated roles, and unrelated secrets references that the new
+  machine may not need.
+- **Sharing one workspace with a colleague.** "Here is how I have my
+  monorepo set up" turns into "let me read through `config.toml`,
+  delete every unrelated workspace, scrub every unrelated role
+  trust, and paste back the trimmed result." That is friction every
+  team member hits, and the trimming is error-prone.
+- **Versioning a subset.** Tools like
+  [chezmoi](https://www.chezmoi.io/) make it easy to put your dotfiles
+  under version control, but a single `config.toml` forces an
+  all-or-nothing decision: either the whole file is tracked (and a
+  one-off workspace creates a noisy diff) or none of it is. There is
+  no clean way to say "version-control these three workspaces; leave
+  the others alone."
+- **Diff legibility.** Mount-list reordering inside one TOML file
+  produces big diffs even when only one workspace changed.
+
+The shape jackin' writes today (one big file with `[[workspaces.<name>.mounts]]`
+arrays interleaved with role trust entries, global mounts, and
+top-level `[claude] / [codex]` blocks) makes all of these worse —
+related rows for one workspace can be scattered across the file.
+
+## Goal
+
+Split the operator config so that **each workspace is its own file**,
+without changing the TOML format itself. Concretely:
+
+```
+~/.config/jackin/
+├── config.toml                    # global settings only
+└── workspaces/
+    ├── jackin.toml                # workspace "jackin"
+    ├── chainargos.toml            # workspace "chainargos"
+    └── jackin-roles.toml          # workspace "jackin-roles"
+```
+
+Rules:
+
+1. **Workspace name = file name.** `workspaces/jackin.toml` *is* the
+   `jackin` workspace. No `[workspaces.jackin]` header inside; the
+   file describes a single workspace and its name comes from the
+   filename. Headers inside collapse from
+   `[workspaces.jackin.mounts]` → `[[mounts]]`,
+   `[workspaces.jackin.keep_awake]` → `[keep_awake]`, and so on.
+2. **`config.toml` keeps everything that is not a workspace.** Global
+   `[env]`, `[claude] / [codex]` defaults, `[roles.<selector>]` trust
+   and source, `[docker.mounts]`, and any future global setting stay
+   in the top-level file.
+3. **Filename rules match the existing workspace-name rules.**
+   Whatever character set jackin' currently allows in workspace names
+   is also the character set allowed in `workspaces/*.toml`
+   filenames. Anything not allowed as a workspace name is rejected
+   on load with a clear error.
+
+## Why it matters
+
+- **Sharing.** "Drop this `workspaces/monorepo.toml` into your
+  `~/.config/jackin/workspaces/`" is a one-line instruction. No
+  trimming, no scrubbing.
+- **Fresh machine.** Copy `config.toml` plus the subset of
+  `workspaces/*.toml` you actually want.
+- **Selective version control.** chezmoi (or plain
+  `git init` in the workspaces directory) can track exactly the
+  workspaces you want under version control — leave the others
+  out, or `.gitignore` them. Personal scratch workspaces stay
+  private; team workspaces get reviewed in PRs.
+- **Cleaner diffs.** A change to one workspace's mounts only
+  touches one file.
+- **Easier rollback.** Delete a single file to drop a workspace.
+
+This work is fundamentally about **operator ergonomics around the
+config**, not about the data model or the TOML format.
+
+## Migration
+
+The first jackin' release that ships this layout migrates the
+existing `config.toml` automatically:
+
+1. On startup, if the top-level config still contains any
+   `[workspaces.*]` tables, jackin' moves each workspace into
+   `workspaces/<name>.toml` (creating the directory if needed).
+2. The top-level file is rewritten without the `[workspaces.*]`
+   tables but with everything else intact.
+3. Migration is idempotent: a config that is already split is left
+   alone.
+4. A short message is printed to stderr the first time the migration
+   runs so the operator notices the new layout.
+
+Per <RepoFile path="AGENTS.md" /> ("Project status: pre-release
+(agent-only)") this can be a hard cut for code that reads the config
+once the new shape ships — no compatibility shim, no
+`tolerant ignore + warn`. The migration above is a one-shot helper,
+not a permanent fallback parser.
+
+## Sketch
+
+`config.toml` after split:
+
+```toml
+# Global Claude / Codex defaults
+[claude]
+auth_forward = "sync"
+
+# Global mounts (applied to all roles / scopes)
+[docker.mounts]
+
+# Role trust + git source
+[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true
+
+[roles.the-architect]
+git = "https://github.com/jackin-project/jackin-the-architect.git"
+trusted = true
+
+[roles."chainargos/agent-brown"]
+git = "https://github.com/chainargos/jackin-agent-brown.git"
+trusted = true
+```
+
+`workspaces/jackin.toml`:
+
+```toml
+workdir = "/Users/donbeave/Projects/jackin-project"
+allowed_roles = ["the-architect"]
+last_role = "the-architect"
+git_pull_on_entry = true
+
+[keep_awake]
+enabled = true
+
+[[mounts]]
+src = "/Users/donbeave/Projects/jackin-project/jackin"
+dst = "/Users/donbeave/Projects/jackin-project/jackin"
+readonly = false
+isolation = "clone"
+
+[[mounts]]
+src = "/Users/donbeave/Projects/jackin-project/jackin-agent-smith"
+dst = "/Users/donbeave/Projects/jackin-project/jackin-agent-smith"
+readonly = false
+isolation = "worktree"
+
+# … further mounts for this workspace …
+```
+
+The contents of each workspace file are **only** that workspace's
+fields — no `[workspaces.jackin.*]` header repetition. The workspace
+name is the filename, full stop.
+
+`workspaces/chainargos.toml` and the rest follow the same shape. Per-(workspace × role) overrides
+(`[roles.<role>.env]`, `[<role>.claude]`, `[<role>.codex]`) live
+inside the workspace file as nested tables — for example
+`[roles."chainargos/agent-brown".env]`.
+
+## Open questions
+
+- **Workspace-name characters in filenames.** Today's workspace names
+  may include `/` (namespaced) — for example
+  `jackin-roles`. The split must agree with the OS filesystem on what
+  is legal. A first cut: forbid `/`, `\`, and OS-reserved names in
+  workspace identifiers, and migrate any existing names that violate
+  the new rule.
+- **Atomic multi-file writes.** `jackin workspace edit` may need to
+  touch the workspace file *and* the global file (e.g. when adding a
+  mount that resolves a previously-untrusted role). Either keep the
+  edit single-file or write a small lock-around-multiple-files
+  helper.
+- **TUI workspace-manager UX.** The console's workspace-manager list
+  still shows workspaces by name, regardless of where they live on
+  disk. Confirm there are no surprises with file-watch refresh
+  semantics.
+- **Empty workspace directory.** A fresh install has no workspaces,
+  so `workspaces/` may be empty (or absent). Both must be valid.
+- **Roles, env scopes.** Decide whether per-role config
+  (`[roles.<selector>]`) and global env (`[env]`) ever belong in
+  their own files, or whether the only split is workspaces. The
+  initial proposal is **only workspaces** — keep the surface area
+  small until the workspace split has shipped and we have evidence
+  of demand.
+
+## Related
+
+- <RepoFile path="src/config/persist.rs" /> — `AppConfig::load_or_init` (single-file load today).
+- <RepoFile path="src/config/editor.rs" /> — `ConfigEditor::save` (single-file write today).
+- <RepoFile path="src/config/workspaces.rs" /> — workspace CRUD entry points.
+- [Configuration File](/reference/configuration/) — internals reference; will need a rewrite to describe the split layout once shipped.
+- [Workspaces](/guides/workspaces/) — operator-facing guide; the operator-side promise (CLI/TUI manages everything) does not change.

--- a/docs/src/styles/docs-theme.css
+++ b/docs/src/styles/docs-theme.css
@@ -968,3 +968,32 @@ site-search dialog {
 .pagination-links a:hover svg {
   color: var(--jk-brand);
 }
+
+/* Brand-styled inline name for "jackin'" — automatically wrapped
+   by the `rehype-jk` plugin (see docs/scripts/rehype-jk.ts). Uses
+   `--jk-text` so the name reads white-on-dark and black-on-light
+   (theme-aware) and stays maximally legible in long prose. The
+   weight bump distinguishes it from the surrounding paragraph
+   without using a saturated brand colour mid-sentence. Skips code
+   blocks. */
+.jk-name {
+  color: var(--jk-text);
+  font-weight: 600;
+}
+
+.jk-name:hover {
+  text-decoration: none;
+}
+
+/* Inside headings the existing heading weight wins so we do not
+   double-bold. Colour still inherits the heading's own colour, which
+   is `--jk-text` in both themes by default. */
+:where(h1, h2, h3, h4, h5, h6) .jk-name {
+  font-weight: inherit;
+}
+
+/* Inside links the link colour wins so the name stays underlined
+   without competing against the surrounding link text. */
+a .jk-name {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary

Reorganize the documentation site into clear audience-targeted sidebar
groups, and rewrite the operator-facing pages so they describe
behaviour through CLI/TUI flows rather than through TOML schemas.

Operators (people using jackin' as a product) and contributors (people
working on jackin' itself or authoring role repos) now have distinct
sidebar surfaces:

- **Getting Started**, **Operator Guide**, and **Commands** are
  written exclusively for operators. They no longer reference
  `~/.config/jackin/config.toml` shapes, derived Dockerfile generation,
  persisted-state directory layout, or other code-level internals —
  those readers manage every operator setting through `jackin workspace`,
  `jackin config`, or the operator console.
- **Behind jackin' — Internals** gathers contributor- and
  role-author-facing pages: Architecture, the Configuration File schema,
  the new Codebase Map, Role Repos, Creating a Role, Construct Image,
  Role Manifest, and the full Roadmap.

All page slugs are kept stable — external links and lychee anchor
references continue to resolve. The audience split is enforced in
`docs/astro.config.ts` and reinforced by a top-of-page `Aside` on the
internals pages.

## What changed

- `docs/astro.config.ts` is regrouped to enforce the audience split.
- `getting-started/concepts.mdx` is trimmed: the derived-image deep
  dive, the per-container state-directory paths, and the multi-step
  "Putting it all together" Docker/DinD flow are removed and the
  operator mental model is kept. Internals readers are pointed at
  `reference/architecture`.
- `guides/workspaces.mdx`, `guides/mounts.mdx`,
  `guides/environment-variables.mdx`, and `guides/authentication.mdx`
  are rewritten to use `jackin workspace …`, `jackin config …`, and
  operator-console flows everywhere TOML examples used to appear. The
  conceptual layered/scoped models are kept; the on-disk shape is not.
- `guides/role-repos.mdx`, `developing/*`, `reference/architecture`,
  and `reference/configuration` get a top-of-page `Aside` identifying
  them as contributor- or role-author-targeted. Their content is
  otherwise unchanged.
- `reference/codebase-map.mdx` is **new** — a contributor entry point
  that mirrors and links back to `PROJECT_STRUCTURE.md`, lists module
  starting points organized by contribution shape ("I want to add a
  CLI flag", "I want to change container lifecycle behaviour", etc.),
  and ties code paths to docs pages.
- `PROJECT_STRUCTURE.md` is updated to reflect the new sidebar grouping
  and to label every docs page by its audience.

## Why

The current site mixed both audiences inside the same sidebar groups.
Operators landed on pages that explained derived Dockerfiles, the
on-disk format of `config.toml`, and the layout of
`~/.jackin/data/<container>/` — none of which they ever need, because
every operator setting has a CLI or TUI flow. Contributors and role
authors, conversely, had to discover those internals scattered across
the operator guide.

The new structure keeps each audience on the surface that matches
their job. Operators get behaviour and CLI/TUI; contributors and role
authors get architecture, schema, and code.

## Verify locally

### Checkout

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin chore/docs-audience-split:refs/remotes/origin/chore/docs-audience-split
git checkout -B chore/docs-audience-split refs/remotes/origin/chore/docs-audience-split
```

### Run the docs site locally

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`.

### Direct links to changed pages

Open each one and confirm the audience-split lands the way you want
it. The first three should read as "operator product docs"; the last
group should read as "contributor / role-author internals".

- <http://localhost:4321/getting-started/concepts/> — operator mental model, no internals
- <http://localhost:4321/guides/workspaces/> — CLI/TUI flows
- <http://localhost:4321/guides/mounts/> — CLI/TUI flows
- <http://localhost:4321/guides/environment-variables/> — CLI flows
- <http://localhost:4321/guides/authentication/> — CLI + Auth-tab flows
- <http://localhost:4321/reference/architecture/> — internals (Aside at top)
- <http://localhost:4321/reference/configuration/> — internals (Aside at top)
- <http://localhost:4321/reference/codebase-map/> — **new** — contributor entry point
- <http://localhost:4321/guides/role-repos/> — internals (Aside at top)
- <http://localhost:4321/developing/creating-roles/> — internals (Aside at top)
- <http://localhost:4321/developing/construct-image/> — internals (Aside at top)
- <http://localhost:4321/developing/role-manifest/> — internals (Aside at top)

The new `Codebase Map` entry should appear in the sidebar under
**Behind jackin' — Internals**. The first three sidebar groups should
contain only operator-targeted pages.

### Sidebar audit

```sh
ls docs/src/content/docs/reference/roadmap/*.mdx \
  | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
grep -oE "reference/roadmap/[a-z0-9-]+" docs/astro.config.ts \
  | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-sidebar
diff /tmp/roadmap-files /tmp/roadmap-sidebar
```

The diff is empty.

### Static checks

```sh
cd docs
bun run check:repo-links
bun run build
```

Both pass; the build emits 91 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

