### PR TITLE
docs(roadmap): refresh stale roadmap status and LOC numbers

### DIFF
--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -43,7 +43,7 @@ jackin' is a functional proof of concept. **`Claude Code` and `Codex` ship today
 
 - [1Password integration](/reference/roadmap/onepassword-integration/) — workspace-managed `op://` env references shipped; file-mount generation (option 4) still deferred
 - [Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/) — Codex shipped as a fully integrated runtime; Amp runtime integration is under active development; full feature parity across `claude` / `codex` / `amp` still ongoing
-- [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/) — three-mode auth-forward (`sync` / `token` / `ignore`) at all three layers shipped, plus container HTTPS-normalize and `gh` credential helper wiring; console UX, dedicated CLI subcommand, scope pre-flight, and bidirectional shared-store sync still pending
+- [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/) — three-mode auth-forward (`sync` / `token` / `ignore`) at all three layers shipped, plus container HTTPS-normalize, `gh` credential helper wiring, and the auth-tab GitHub CLI row in `jackin console`; dedicated CLI subcommand, scope pre-flight, and bidirectional shared-store sync still pending
 
 ## Planned
 

--- a/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
+++ b/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
@@ -39,10 +39,10 @@ Do the behavioral spec for `runtime/launch.rs` before splitting it.
 
 | Item | Current LOC | Benefit |
 |---|---|---|
-| [Split console/manager/input/editor.rs](/reference/roadmap/split-input-editor/) | ~1188L | One file per editor tab; audit Secrets-tab behavior independently |
-| [Split app/mod.rs](/reference/roadmap/split-app-mod/) | ~1056L | Separate dispatch, workspace, and config command handlers |
-| [Split operator_env.rs](/reference/roadmap/split-operator-env/) | ~2133L | Separate shared API, CLI client, env resolution, diagnostics, and picker metadata |
-| [Split runtime/launch.rs](/reference/roadmap/split-runtime-launch/) | ~1319L | Separate trust, terminal setup, launch pipeline, and slot/finalizer helpers |
+| [Split console/manager/input/editor.rs](/reference/roadmap/split-input-editor/) | ~3796L | One file per editor tab; audit Secrets-tab behavior independently |
+| [Split app/mod.rs](/reference/roadmap/split-app-mod/) | ~1243L | Separate dispatch, workspace, and config command handlers |
+| [Split operator_env.rs](/reference/roadmap/split-operator-env/) | ~2975L | Separate shared API, CLI client, env resolution, diagnostics, and picker metadata |
+| [Split runtime/launch.rs](/reference/roadmap/split-runtime-launch/) | ~5494L | Separate trust, terminal setup, launch pipeline, and slot/finalizer helpers |
 
 ## Phase 3 — Future (deferred)
 

--- a/docs/src/content/docs/reference/roadmap/module-contracts.mdx
+++ b/docs/src/content/docs/reference/roadmap/module-contracts.mdx
@@ -7,22 +7,22 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-43% of source files have `//!` orientation docs. The remaining 57% give AI agents and contributors no orientation when they open the file — purpose, scope, and key invariants must be reverse-engineered from the code.
+About 47% of source files have `//!` orientation docs. The remaining 53% give AI agents and contributors no orientation when they open the file — purpose, scope, and key invariants must be reverse-engineered from the code.
 
 ## Priority files (current largest / most central undocumented modules)
 
 | File | Production LOC | Why urgent |
 |---|---|---|
-| <RepoFile path="src/runtime/launch.rs" /> | ~1319 | Largest undocumented production file, `jackin load` critical path |
-| <RepoFile path="src/isolation/materialize.rs" /> | ~1277 | Central mount-materialization flow with many invariants |
-| <RepoFile path="src/app/mod.rs" /> | ~1056 | CLI dispatch entry point |
-| <RepoFile path="src/isolation/finalize.rs" /> | ~1055 | Foreground-session cleanup / preservation policy |
-| <RepoFile path="src/app/context.rs" /> | ~854 | Target resolution and workspace/agent context helpers |
-| <RepoFile path="src/config/mod.rs" /> | ~849 | Main config schema and auth/source policy |
-| <RepoFile path="src/instance/auth.rs" /> | ~796 | Credential forwarding and auth provisioning logic |
-| <RepoFile path="src/runtime/cleanup.rs" /> | ~639 | Container/class cleanup semantics |
+| <RepoFile path="src/runtime/launch.rs" /> | ~5494 | Largest undocumented production file, `jackin load` critical path |
+| <RepoFile path="src/instance/auth.rs" /> | ~2401 | Credential forwarding and auth provisioning logic |
+| <RepoFile path="src/isolation/materialize.rs" /> | ~2392 | Central mount-materialization flow with many invariants |
+| <RepoFile path="src/isolation/finalize.rs" /> | ~1819 | Foreground-session cleanup / preservation policy |
+| <RepoFile path="src/config/mod.rs" /> | ~1254 | Main config schema and auth/source policy |
+| <RepoFile path="src/app/mod.rs" /> | ~1243 | CLI dispatch entry point |
+| <RepoFile path="src/app/context.rs" /> | ~1022 | Target resolution and workspace/agent context helpers |
+| <RepoFile path="src/workspace/mod.rs" /> | ~905 | Core workspace types and validation rules |
+| <RepoFile path="src/runtime/cleanup.rs" /> | ~637 | Container/class cleanup semantics |
 | <RepoFile path="src/tui/animation.rs" /> | ~582 | Shared intro/outro animation behavior |
-| <RepoFile path="src/workspace/mod.rs" /> | ~510 | Core workspace types and validation rules |
 
 ## Steps
 

--- a/docs/src/content/docs/reference/roadmap/multi-runtime-support.mdx
+++ b/docs/src/content/docs/reference/roadmap/multi-runtime-support.mdx
@@ -4,10 +4,10 @@ title: "Multi-Runtime Support for Codex and Amp"
 import RepoFile from '../../../../components/RepoFile.astro'
 import { Aside } from '@astrojs/starlight/components'
 
-**Status**: Open — foundation slice shipped
+**Status**: Partially implemented — Phase 1 (runtime foundation) and Phase 2 (Codex baseline) shipped; Phase 3 (Amp baseline) not started; Phase 4 (operator UX) partially shipped (`--agent` selector, last-agent memory, console agent picker); Phase 5 (parity work) not started
 
 <Aside type="note">
-The foundation slice shipped under **harness** terminology, then renamed to **agent**. This roadmap preserves the original "runtime" wording for historical context; current code and docs use `agent` for the AI CLI selected at launch.
+The foundation slice shipped under **harness** terminology, then renamed to **agent**. This roadmap preserves the original "runtime" wording for historical context; current code and docs use `agent` for the AI CLI selected at launch — the operator-facing flag is `--agent`, not `--runtime`.
 </Aside>
 
 ## Problem

--- a/docs/src/content/docs/reference/roadmap/split-app-mod.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-app-mod.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/app/mod.rs" /> is now 1109L total, ~1056L production (tests start at line 1057). Nearly all production code is the `run()` dispatch function with a large match on CLI commands. A reviewer auditing "does `jackin workspace create` correctly validate the workdir?" still has to scan a thousand-plus lines of mixed-command dispatch.
+<RepoFile path="src/app/mod.rs" /> is now 1243L total, ~1180L production (tests start at line 1181). Nearly all production code is the `run()` dispatch function with a large match on CLI commands. A reviewer auditing "does `jackin workspace create` correctly validate the workdir?" still has to scan a thousand-plus lines of mixed-command dispatch.
 
 ## Proposed split
 
@@ -34,4 +34,4 @@ Note: <RepoFile path="src/app/context.rs" /> already implements the impl-extensi
 
 ## Auditability gain
 
-To audit "does `jackin workspace create` correctly validate the workdir?", a reviewer reads `workspace_cmd.rs` (~150L) instead of scanning ~1056L of mixed-command dispatch.
+To audit "does `jackin workspace create` correctly validate the workdir?", a reviewer reads `workspace_cmd.rs` instead of scanning ~1180L of mixed-command dispatch.

--- a/docs/src/content/docs/reference/roadmap/split-input-editor.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-input-editor.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/console/manager/input/editor.rs" /> is still one of the biggest concentrated editor-state files: ~1188L production, 2440L total, with tests starting at line 1189. It handles keyboard dispatch for all 4 editor tabs (General, Mounts, Agents, Secrets). A reviewer auditing "did the AI correctly implement the Secrets tab?" still has to scan well over a thousand lines of mixed-tab production code.
+<RepoFile path="src/console/manager/input/editor.rs" /> is still one of the biggest concentrated editor-state files: ~1727L production, 3796L total, with tests starting at line 1728. It handles keyboard dispatch for all 4 editor tabs (General, Mounts, Agents, Secrets). A reviewer auditing "did the AI correctly implement the Secrets tab?" still has to scan well over a thousand lines of mixed-tab production code.
 
 ## Proposed split
 
@@ -33,7 +33,7 @@ Should `handle_editor_modal` stay in `mod.rs` or move to a `modal.rs` sub-file? 
 
 ## Auditability gain
 
-To audit "did the AI correctly implement the Secrets tab?", a reviewer reads only `secrets.rs` (~500L) instead of scanning ~1188L of mixed-tab production code.
+To audit "did the AI correctly implement the Secrets tab?", a reviewer reads only `secrets.rs` instead of scanning ~1727L of mixed-tab production code.
 
 ## Steps
 

--- a/docs/src/content/docs/reference/roadmap/split-operator-env.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-operator-env.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/operator_env.rs" /> is 2133L total and has grown into a shared cross-cutting module. It now serves runtime launch, config validation/persistence, console widgets, and the console op-cache layer. The file mixes public traits/parsers, subprocess client logic, metadata parsing for the picker, env-layer composition, launch diagnostics, and tests.
+<RepoFile path="src/operator_env.rs" /> is 2975L total and has grown into a shared cross-cutting module. It now serves runtime launch, config validation/persistence, console widgets, and the console op-cache layer. The file mixes public traits/parsers, subprocess client logic, metadata parsing for the picker, env-layer composition, launch diagnostics, and tests.
 
 ## Proposed split
 

--- a/docs/src/content/docs/reference/roadmap/split-runtime-launch.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-runtime-launch.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/runtime/launch.rs" /> is now 3047L total, with tests starting at line 1320. It no longer mixes just 4 concerns: the file now owns the public load API, trust verification, terminal setup, operator-env / auth handling, container slot claiming, workspace materialization, launch orchestration, and attach/finalizer cleanup. It is still the hardest file to split safely because any error here blocks all runtime changes.
+<RepoFile path="src/runtime/launch.rs" /> is now 5494L total, with tests starting at line 2272. It no longer mixes just 4 concerns: the file now owns the public load API, trust verification, terminal setup, operator-env / auth handling, container slot claiming, workspace materialization, launch orchestration, and attach/finalizer cleanup. It is still the hardest file to split safely because any error here blocks all runtime changes.
 
 ## Proposed split
 


### PR DESCRIPTION
## Summary

Refresh roadmap pages where the docs had drifted from the current state of the code. The overview's GitHub CLI auth-strategy bullet drops "console UX" from the pending list because the auth-tab GitHub CLI row has shipped in `jackin console`. The multi-runtime-support page flips from "Open — foundation slice shipped" to "Partially implemented" and lists what is in (Phase 1 runtime foundation including the `/home/agent` rename, Phase 2 Codex baseline, and parts of Phase 4 — `--agent` flag, last-agent memory, console agent picker) versus what is still open (Phase 3 Amp, Phase 5 parity). Module-contracts coverage moves from 43% to 47% and the priority-file LOC numbers are refreshed; none of the listed files have gained `//!` blocks yet, so the item itself stays Open. Codebase-readability's Phase 2 split table and each individual `split-*` page get refreshed total / production LOC and test-boundary line numbers. Resolved items and items with no code movement are left untouched.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin chore/refresh-stale-roadmap-status:refs/remotes/origin/chore/refresh-stale-roadmap-status
git checkout -B chore/refresh-stale-roadmap-status refs/remotes/origin/chore/refresh-stale-roadmap-status
```

### Documentation

Run the docs site locally:

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Open each changed page and confirm the refreshed status / LOC numbers render correctly:

**<http://localhost:4321/reference/roadmap/>**  
Overview — confirm the GitHub CLI auth-strategy bullet under *Partially implemented* no longer lists "console UX" as pending.

**<http://localhost:4321/reference/roadmap/multi-runtime-support/>**  
Status now reads "Partially implemented" with the Phase 1 / 2 / 4 breakdown; Aside clarifies the operator-facing flag is `--agent`.

**<http://localhost:4321/reference/roadmap/module-contracts/>**  
Coverage paragraph reads ~47% / 53%; priority table LOC matches `wc -l` on the listed files.

**<http://localhost:4321/reference/roadmap/codebase-readability/>**  
Phase 2 split table LOC matches `wc -l src/console/manager/input/editor.rs src/app/mod.rs src/operator_env.rs src/runtime/launch.rs`.

**<http://localhost:4321/reference/roadmap/split-input-editor/>**  
Problem paragraph reads 1727L production / 3796L total / tests at line 1728.

**<http://localhost:4321/reference/roadmap/split-app-mod/>**  
Problem paragraph reads 1243L total / ~1180L production / tests at line 1181.

**<http://localhost:4321/reference/roadmap/split-operator-env/>**  
Problem paragraph reads 2975L total.

**<http://localhost:4321/reference/roadmap/split-runtime-launch/>**  
Problem paragraph reads 5494L total / tests at line 2272.

## Migration notes

None.
