### PR TITLE
docs: clarify agent PR process rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ When the first release is being cut, the operator will explicitly ask for the ch
 All rules for opening, iterating on, refreshing, reviewing, and merging pull requests live in [`PULL_REQUESTS.md`](PULL_REQUESTS.md). **Read that file before opening any PR.** It covers:
 
 - Per-PR merge authorization (agents never merge without explicit "merge it" confirmation).
+- Force-push authorization (agents never rewrite an existing remote branch without explicit operator approval).
 - Required PR body shape (Summary / hard-rule callout / What's deferred / Verify locally / Migration notes).
 - "Verify locally" templates, including the `export TIRITH=0` line that lets multi-line pastes survive the `tirith` paste scanner.
 - PR-body authoring rules — no hard-wrap, no verbosity / duplication, no deployed-docs links, no mechanical CI-shaped checks.

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -7,3 +7,21 @@ Never commit directly to `main`.
 - Use prefixes that match the type of change: `feature/`, `fix/`, `refactor/`, `chore/`
 - Keep branch names short, lowercase, and hyphen-separated
 - Merge back to `main` via pull request after review
+
+## Force pushes
+
+Force pushes rewrite shared review history. Agents must never run
+`git push --force`, `git push --force-with-lease`, or any equivalent
+history-rewriting GitHub operation unless the operator has explicitly approved
+that force push in the current conversation for the specific branch or pull
+request.
+
+Normal pushes that add new commits to an agent branch are fine without extra
+approval. If a history rewrite seems useful - for example, amending a missed
+DCO sign-off, rebasing an open PR, or squashing review commits before merge -
+ask first and name the branch/PR plus the reason. Prefer a normal follow-up
+commit unless the operator asks for rewritten history.
+
+This rule does not prohibit `git fetch -f` in verification recipes. Forced
+fetch updates only the local remote-tracking ref; it does not rewrite GitHub's
+remote branch.

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -94,7 +94,7 @@ git fetch -f origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
 git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
 ```
 
-The `-f` (`--force`) on `git fetch` is required, not optional. Agent-authored PR branches are routinely force-pushed during iteration (review-fix amend, rebase onto fresh `main`, body-only fix-ups). Without `-f`, every force-push breaks the operator's verify recipe with `! [rejected] <branch> -> origin/<branch> (non-fast-forward)`, and the local `refs/remotes/origin/<branch>` stays pinned to the pre-force-push tip. The `git checkout -B` rewrites the local branch unconditionally, but only against whatever the remote-tracking ref points at — so the fetch must update that ref through force-pushes to be useful. Equivalent recipe: `git fetch origin '+<BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>'`. Prefer the `-f` form for readability.
+The `-f` (`--force`) on `git fetch` is required, not optional. Agent-authored PR branches may have been force-pushed after explicit operator approval (DCO amend, rebase onto fresh `main`, body-only fix-ups). Without `-f`, every force-push breaks the operator's verify recipe with `! [rejected] <branch> -> origin/<branch> (non-fast-forward)`, and the local `refs/remotes/origin/<branch>` stays pinned to the pre-force-push tip. The `git checkout -B` rewrites the local branch unconditionally, but only against whatever the remote-tracking ref points at - so the fetch must update that ref through force-pushes to be useful. Equivalent recipe: `git fetch origin '+<BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>'`. Prefer the `-f` form for readability.
 
 #### Static Checks
 
@@ -214,7 +214,7 @@ During iteration:
 - Do **not** run broad/final verification by default during iteration. In particular, do not run `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo nextest run`, or GitHub Actions polling unless the operator explicitly asks for verification/final prep or the PR is moving to merge-readiness.
 - If a small targeted run reveals a formatting or clippy issue, fix the obvious local cause when it is part of the changed code, but do not escalate into the full formatting + clippy + full-suite pipeline unless the operator asks.
 - Do not update the PR body after every iteration unless the operator asks for it or the PR description has become actively misleading for someone reviewing right now.
-- Do not amend, force-push, or wait for GitHub Actions as a reflex after every small feedback pass. If the branch already has a PR open, a normal follow-up commit is acceptable during review unless the operator asked to keep the PR as one amended commit.
+- Do not amend, force-push, or wait for GitHub Actions as a reflex after every small feedback pass. Force-pushes require explicit operator approval per [BRANCHING.md](BRANCHING.md). If the branch already has a PR open, a normal follow-up commit is acceptable during review unless the operator asked to keep the PR as one amended commit.
 - Summarize what changed and tell the operator what lightweight local check, if any, was run. Then stop so the operator can validate the UI/behavior.
 
 Move to merge-readiness only when the operator gives a clear signal such as "this is correct", "prepare it", "ready for review", "run the full checks", or "now we can merge". At that point run the full verification suite, reconcile the PR body with the final diff, push/update the branch, and check CI.
@@ -258,6 +258,10 @@ When an agent merges a pull request, the resulting squash commit must preserve t
 - Prefer GitHub's default squash title when it already matches that format.
 - If overriding the commit title, manually append `(#PR_NUMBER)`.
 - For Codex `gh` merges: do not pass a custom title unless necessary; if one is passed, it must include `(#PR_NUMBER)`.
+- Before merging, explicitly check the exact title that will be written to
+  history. If using GitHub's default, confirm it already includes `(#PR_NUMBER)`.
+  If passing `--subject`, build it from the final PR title plus the PR suffix
+  and read it back before running the merge command.
 - Generate the squash commit body at merge time in a temporary file. Do not pollute the visible PR description with commit-only trailer footers just to influence GitHub's default squash message.
 - The generated squash commit body must summarize what actually shipped in clear prose. Use the PR title/body, diff, and commit messages as source material, but do not paste the full PR body, local verification instructions, checklists, or raw commit list into the final commit.
 - The generated body can be one paragraph for small PRs or a few concise paragraphs for larger PRs. It should be detailed enough to explain the change when reading `git log`, but free of process noise.


### PR DESCRIPTION
## Summary

- Make the force-push approval rule explicit in `BRANCHING.md`, including the distinction between normal pushes and history rewrites.
- Update `PULL_REQUESTS.md` so force-pushes during PR iteration point back to that rule.
- Tighten the squash-merge checklist so custom merge subjects preserve the `(#PR_NUMBER)` suffix.

## Hard-rule callout

This is process documentation only. It strengthens the operator-approval rule for force-pushes and the existing squash-title audit rule; it does not change runtime behavior.

## Verify locally

```sh
git fetch -f origin docs/agent-pr-process-followups:refs/remotes/origin/docs/agent-pr-process-followups
git checkout -B docs/agent-pr-process-followups refs/remotes/origin/docs/agent-pr-process-followups
git diff --check origin/main...
```

## Migration notes

No user-facing migration. These are contributor and agent process docs only.