### PR TITLE
ci(construct): scope BUILDX_BUILDER to the build job, not workflow-wide

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -15,13 +15,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  BUILDX_BUILDER: jackin-construct
   # Single source of truth for the digest directory — `build` writes
   # into it, `publish-manifest` reads from it.
   DIGEST_DIR: /tmp/jackin-construct-digests
   # Single source of truth for the registry coordinate — keeps the
   # two buildcache refs in sync.
   REGISTRY_IMAGE: projectjackin/construct
+  # NOTE: BUILDX_BUILDER is set at the `build` job level only, not
+  # workflow-wide. Setting it workflow-wide leaks into `publish-manifest`,
+  # which has no buildx builder and would then fail with
+  # `ERROR: no builder "jackin-construct" found` because docker buildx
+  # treats BUILDX_BUILDER as the default-builder selection.
 
 jobs:
   changes:
@@ -83,6 +87,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    env:
+      # Scoped to the build job only. Setting it workflow-wide leaks
+      # into `publish-manifest`, which has no buildx builder and would
+      # then fail with `ERROR: no builder "jackin-construct" found`.
+      BUILDX_BUILDER: jackin-construct
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Hotfix the construct-image workflow break introduced by #256. After that PR merged, the `Construct Image / publish manifest` job on `main` failed with:

```
ERROR: no builder "jackin-construct" found
error: Recipe `construct-publish-manifest` failed with exit code 1
```

## Root cause

#256 hoisted `BUILDX_BUILDER: jackin-construct` into the workflow-level `env:` block when it dropped the redundant `setup-buildx-action` / `Bootstrap buildx` pair from the `publish-manifest` job (correct on the merits — `docker buildx imagetools create` / `inspect` are registry-side ops that need no local builder). The unintended consequence: `BUILDX_BUILDER` is read by the docker buildx CLI as the default-builder selection. With the env var present and no builder of that name created in the `publish-manifest` job, every `docker buildx` invocation fails with "no builder found".

The break did not surface in PR CI because `publish-manifest` is gated to `push to main || (workflow_dispatch && main)` — neither runs on a `pull_request` event, so the publish path was effectively untested before merge.

## Fix

Move `BUILDX_BUILDER` out of the workflow-level `env:` block into the `build` job's job-level `env:` block. `publish-manifest` no longer sees the env var, falls back to the default builder, and `imagetools` runs as designed. The `build` job's `setup-buildx-action with: name: ${{ env.BUILDX_BUILDER }}` resolves correctly because step-level `env` lookups walk the job-level env first.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin ci/fix-construct-publish-manifest-builder:refs/remotes/origin/ci/fix-construct-publish-manifest-builder
git checkout -B ci/fix-construct-publish-manifest-builder refs/remotes/origin/ci/fix-construct-publish-manifest-builder
```

### Static checks

```sh
yq . .github/workflows/construct.yml >/dev/null
```

The push to `main` after this PR merges will be the actual fidelity test — `publish-manifest` should run and succeed.

## Hardening follow-ups

The class of break (env-var leak into a third-party CLI's default-selection semantics, surfacing only on push-to-main) was invisible to PR-time CI and to all three review passes. Two hardening PRs follow this one to make the same mistake catchable in PR next time:

- A `jackin` PR adding workflow-env-scoping guidance to `AGENTS.md` and a "smoke-test push-only jobs via `gh workflow run` from the feature branch" rule to `PULL_REQUESTS.md`.
- A `jackin-github-terraform` PR expanding the required-status-check list for `jackin` to include the new `ci-required`, `construct-required`, `docs-required`, and `validate` aggregators, and turning on `strict_required_status_checks_policy` plus a single required reviewer.
