### PR TITLE
docs(rules): codify workflow env scoping and push-only-job smoke-test rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ All rules for opening, iterating on, refreshing, reviewing, and merging pull req
 - PR-body refresh policy: refresh **on operator request** or at merge-readiness, not after every iteration commit.
 - Documentation-only PR requirements (run the docs site locally + bold-URL-per-page format).
 - CI-must-be-green-before-merge, title/description reconciliation, squash-merge messages with PR-number + trailers.
+- Workflow / CI changes — third-party-CLI env vars must be scoped to the consuming job (workflow-level `env:` leaks into every job and breaks tools that read those vars as default-selection); changes to push-only / main-only / `workflow_run`-gated jobs must be smoke-tested via `gh workflow run --ref <feature-branch>` before merge because PR-time CI never exercises them; registry / production publish steps must hard-gate on `main` so PRs and feature-branch dispatches verify-build but never publish.
 
 [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) is the canonical body shape with inline guidance. Copy it as the starting point and fill in the placeholders.
 

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -248,6 +248,40 @@ Don't ask the operator for permission to bring the metadata into agreement with 
 
 Why this rule exists: the operator relies on PR titles and bodies as the long-term navigable record of what shipped. Drift between description and diff is the single most common cause of "what does this PR actually do?" archaeology after the fact.
 
+## Workflow / CI changes (agent-only)
+
+CI workflow files (`.github/workflows/*.yml`, `.github/actions/*/action.yml`) have failure modes that are invisible to PR-time CI because most gated jobs do not run on a `pull_request` event. Two rules apply when an agent modifies these files.
+
+### Scope third-party-CLI env vars to the consuming job
+
+Environment variables that a third-party CLI reads as a default-selection — most notably `BUILDX_BUILDER` for `docker buildx`, `DOCKER_BUILDKIT`, `GH_TOKEN` / `GITHUB_TOKEN`, `KUBECONFIG`, `AWS_PROFILE`, `RUSTUP_TOOLCHAIN`, `npm_config_*` — MUST be declared at the job level, not at the workflow level. Setting such a variable at the workflow level leaks it into every job in the file; a job that did not opt into the corresponding tool setup will then fail at runtime when the CLI dereferences the variable against state that does not exist for that job.
+
+Workflow-level `env:` is reserved for in-house naming and paths (`DIGEST_DIR`, `REGISTRY_IMAGE`, internal labels) where the value has no runtime effect on third-party tooling and leaking into all jobs is harmless.
+
+The break in [jackin-project/jackin#266](https://github.com/jackin-project/jackin/pull/266) is the canonical example: a refactor hoisted `BUILDX_BUILDER: jackin-construct` to workflow level. The `publish-manifest` job intentionally creates no buildx builder because `docker buildx imagetools create` / `inspect` are registry-side operations, but with the env var leaked in, every `docker buildx` invocation tried to look up a builder by that name and exited with `ERROR: no builder "jackin-construct" found`. Fixed by moving the env var into the `build` job's `env:` block where the matching `setup-buildx-action` actually creates that builder.
+
+### Hard-gate registry / production publishing to main
+
+Every workflow that writes to a public registry, a tag, a release, a Homebrew formula, or any other production artifact MUST gate the actual publish step on `main`. PRs and dispatches from feature branches are allowed to *build* and *test* but are forbidden from publishing. The canonical pattern in jackin is the `is_publish` flag on the `Construct Image` workflow's `changes` job: it is true only when `event_name == 'push'` (already main-by-construction because `on.push.branches: [main]`) or when `event_name == 'workflow_dispatch' && ref == 'refs/heads/main'`. Login, push-by-digest, digest upload, and the multi-platform manifest publish all gate on `is_publish == 'true'`; the local-only build path gates on `is_publish != 'true'` and runs from any branch.
+
+Equivalent contracts apply to `publish-preview` (Publish Homebrew Preview, hard-gated to dispatch-from-main and to `workflow_run.head_branch == 'main'`), `deploy` (Docs, gated to push-to-main and dispatch-from-main), and `build-validator` (CI, gated to push-to-main and dispatch). A PR-time run of any of these workflows must never produce a registry- or release-visible side effect.
+
+When introducing a new publishing workflow or step, mirror this shape: derive a single `is_publish` (or analogous) boolean once, in the `changes` job, and gate every side-effect step on it. Do not restate the conditions inline at multiple steps — the duplication is exactly how a reviewer or refactor accidentally widens the gate.
+
+### Smoke-test push-only / main-only jobs before requesting merge
+
+Jobs gated to `push to main`, `workflow_dispatch && ref == 'refs/heads/main'`, or `workflow_run.conclusion == 'success' && head_branch == 'main'` do not run on `pull_request` events. Their runtime path is therefore untested by PR-time CI. Examples in jackin today: `build-validator` (CI), `publish-manifest` (Construct Image), `deploy` (Docs), `publish-preview` (Publish Homebrew Preview).
+
+Before requesting merge on a PR that touches such a job — the job's `if:` clause, its `needs:` chain, any env var it consumes, the recipe it ultimately runs, or any composite/reusable action it depends on — the agent must:
+
+1. Trigger the workflow against the PR's feature branch with `gh workflow run <workflow.yml> --ref <branch>`. Every workflow in jackin already declares `workflow_dispatch:` for exactly this purpose.
+2. Wait for the dispatched run with `gh run watch <run-id>` and confirm the touched job succeeded.
+3. Note the run URL in the PR's "Verify locally" section so a reviewer can audit it.
+
+When the gated job's safety rails forbid running it from a feature branch (for example `publish-preview` is hard-gated to dispatch from `main` only because it publishes to a public Homebrew tap), the PR description must explicitly call out the gap and what manual verification was performed instead — at minimum, walking the code path against the production state and naming the assumptions that could not be exercised.
+
+PR-time CI is necessary but not sufficient for workflow-file changes. The smoke-test step closes the largest remaining hole.
+
 ## PR squash merge messages
 
 When an agent merges a pull request, the resulting squash commit must preserve the GitHub PR reference and enough attribution to make the shipped history auditable.


### PR DESCRIPTION
## Summary

Codify two CI-merge-safety rules that the recent #256 / #266 incident exposed: workflow-level env vars that target third-party CLIs (notably `BUILDX_BUILDER`) leak into every job in the file and silently break unrelated jobs at runtime; and push-only / main-only jobs (`build-validator`, `publish-manifest`, `deploy`, `publish-preview`) never run on a `pull_request` event, so PR-time CI is structurally unable to verify them. Both failure modes fell through PR-time CI and three review passes during #256 because the green PR did not — and could not — exercise the post-merge code path. The merged change went red on `main` 30 seconds after it landed.

This PR is documentation-only. It adds three rules to `PULL_REQUESTS.md` and a one-line cross-reference in `AGENTS.md`:

1. **Scope third-party-CLI env vars to the consuming job.** Workflow-level `env:` is reserved for in-house naming and paths. Any env var that a third-party CLI dereferences as default-selection (`BUILDX_BUILDER`, `DOCKER_BUILDKIT`, `GH_TOKEN` / `GITHUB_TOKEN`, `KUBECONFIG`, `AWS_PROFILE`, `RUSTUP_TOOLCHAIN`, `npm_config_*`) must be set at the job level only.
2. **Hard-gate registry / production publishing to main.** Codifies the `is_publish` flag pattern from `construct.yml` as the canonical shape for every workflow that writes to a public registry, tag, release, or Homebrew formula. PRs and feature-branch dispatches must build/verify only — never publish. The contract spans login, push-by-digest, digest upload, and manifest publish; all gate on `is_publish == 'true'`, while the local-only build path gates on `!= 'true'` and runs from any branch.
3. **Smoke-test push-only / main-only jobs before requesting merge.** When a PR touches such a job, its `if:` clause, its `needs:` chain, an env var it consumes, the recipe it ultimately runs, or a composite action it depends on — the agent must run `gh workflow run <workflow.yml> --ref <branch>` against the PR's feature branch and confirm the touched job succeeded, before asking the operator to merge. Workflows that hard-gate to main-only (e.g. `publish-preview` is locked to dispatch-from-main because the tap is public) require the PR body to call out the gap explicitly.

## What's deferred (follow-up PRs)

- A companion `jackin-github-terraform` PR raising the required-status-check list for `jackin` to include the new `ci-required`, `construct-required`, `docs-required`, and `validate` aggregator jobs, plus enabling `strict_required_status_checks_policy` and `required_approving_review_count = 1`. That change lives outside this repo because branch-protection rules are managed via Terraform.
- Reusable-workflow `dry-run: true` inputs for the four push-only jobs so the full job chain can be exercised in PR with side effects mocked. Higher cost / higher fidelity than the smoke-test rule shipped here; deferred until the smoke-test rule plus the terraform-side checks prove insufficient.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/workflow-merge-safety-rules:refs/remotes/origin/docs/workflow-merge-safety-rules
git checkout -B docs/workflow-merge-safety-rules refs/remotes/origin/docs/workflow-merge-safety-rules
```

### Static checks

```sh
markdownlint AGENTS.md PULL_REQUESTS.md 2>&1 | head -10 || true
diff <(grep -c '^## ' PULL_REQUESTS.md) <(echo 14)
```

(Markdownlint optional; the second diff confirms PULL_REQUESTS.md picked up the new top-level section.)
