### PR TITLE
chore(amp): apply post-merge review follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,33 @@ If you are uncertain which agent is creating the commit, ask — the trailer is 
 
 All review-time rules — accepted-exception catalog, design-principles check, applying review fixes, iterating on operator feedback — live in [`PULL_REQUESTS.md`](PULL_REQUESTS.md). Read that file before reviewing or iterating on any PR.
 
+## Code comments — explain only what is not obvious
+
+**Comments earn their place by encoding non-obvious WHY, not by narrating WHAT.** Well-named identifiers, type signatures, and surrounding code already say what the code does; a comment that repeats them is noise that pushes real signal off the screen and rots faster than the code it describes.
+
+Comment when, and only when, one of these is true:
+
+- The code looks suspicious, weird, or wrong on first read but is intentional. Name the constraint that forced it (TOCTOU, parser-bypass safety, ordering invariant, race window, kernel quirk, upstream bug).
+- A non-local invariant is being preserved. Point at the invariant and the call site that depends on it.
+- The shape could reasonably be written a different way. Name the trade-off that picked the current shape.
+- The code interacts with an externally documented behaviour an unfamiliar reader would not predict (POSIX edge case, Docker daemon quirk, library footgun).
+
+Do not comment when:
+
+- The identifier name already says it (`fn provision_amp_auth` does not need `// Provision Amp auth`).
+- The function signature already says it (`Result<T, io::Error>` does not need `// returns an io::Error on failure`).
+- The control flow says it (`for x in items { … }` does not need `// loop over items`).
+- The diff says it (`// renamed from foo`, `// added in PR #N`, `// previously did X`).
+
+Style:
+
+- Prefer one sentence to a paragraph. Trim until removing one more word would make the comment unclear.
+- Lead with the constraint, not the code. "TOCTOU on settings.json: …" beats "We do this thing because there is a TOCTOU…".
+- Drop "mirrors X" / "matches Y" parallel-structure narration — the parallel code structure already encodes that, and the cross-reference dates the moment one side drifts.
+- Code blocks, function names, error strings, and CLI flag names are exact and never abbreviated; English prose around them is as terse as possible.
+
+This rule applies to inline `//` comments, multi-line `/// `/// `//!` doc comments, and to test-method docstrings. Operator-facing surfaces (`clap` `--help` text, `eprintln!` lines the operator sees, README prose) follow the docs split rules in `docs/AGENTS.md` instead — those are not "comments" in the sense above.
+
 ## Walking the operator through local validation (agent-only)
 
 When walking the operator through manual validation of a jackin feature (smoke testing a PR, reproducing a bug, executing a PR test plan), every `jackin <subcommand>` invocation in the recipe MUST include `--debug`. That includes `cargo run --bin jackin -- <subcommand> --debug` while iterating from a checkout.

--- a/docs/src/content/docs/getting-started/design-principles.mdx
+++ b/docs/src/content/docs/getting-started/design-principles.mdx
@@ -101,8 +101,9 @@ host ↔ container boundary is the operator's call.
 
 `Claude Code`'s `--dangerously-skip-permissions`, `Codex`'s
 `workspace-write` + `--dangerously-bypass-approvals-and-sandbox`
-(aliased `--yolo`), and the equivalents shipping in every other
-agent runtime — jackin' enables all of them by default.
+(aliased `--yolo`), `Amp`'s `--dangerously-allow-all`, and the
+equivalents shipping in every other agent runtime — jackin'
+enables all of them by default.
 
 The reason this is safe: the container, not the in-runtime
 prompt, is the trust boundary. Once you've decided to drop an

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,6 +11,14 @@ pub enum Agent {
 }
 
 impl Agent {
+    /// Every variant in declaration order. Single source of truth for
+    /// per-variant enumeration; call sites that need to iterate every
+    /// agent (TUI picker rows, manifest validator's three-table loop,
+    /// derived-image install ordering, test fixtures) consult this
+    /// instead of hand-rolling their own array. Adding a new variant
+    /// is one line here, not seven scattered edits.
+    pub const ALL: &'static [Self] = &[Self::Claude, Self::Codex, Self::Amp];
+
     pub const fn slug(self) -> &'static str {
         match self {
             Self::Claude => "claude",

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,12 +11,8 @@ pub enum Agent {
 }
 
 impl Agent {
-    /// Every variant in declaration order. Single source of truth for
-    /// per-variant enumeration; call sites that need to iterate every
-    /// agent (TUI picker rows, manifest validator's three-table loop,
-    /// derived-image install ordering, test fixtures) consult this
-    /// instead of hand-rolling their own array. Adding a new variant
-    /// is one line here, not seven scattered edits.
+    /// Every variant in declaration order. Iteration sites consult
+    /// this instead of hand-rolling their own array.
     pub const ALL: &'static [Self] = &[Self::Claude, Self::Codex, Self::Amp];
 
     pub const fn slug(self) -> &'static str {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,12 @@ fn parse_auth_forward_mode_from_cli(raw: &str) -> anyhow::Result<config::AuthFor
     raw.parse().map_err(|e: String| anyhow::anyhow!("{e}"))
 }
 
+/// Parse an agent slug as it arrived from the CLI.
+fn parse_agent_from_cli(raw: &str) -> anyhow::Result<crate::agent::Agent> {
+    raw.parse()
+        .map_err(|_| anyhow::anyhow!("unknown agent {raw:?}; expected one of: claude, codex, amp"))
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run(cli: Cli) -> Result<()> {
     let paths = JackinPaths::detect()?;
@@ -366,12 +372,20 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
             },
             cli::ConfigCommand::Auth(auth_cmd) => match auth_cmd {
-                cli::AuthCommand::Set { mode } => {
+                cli::AuthCommand::Set { mode, agent } => {
+                    let parsed_agent = parse_agent_from_cli(&agent)?;
                     let parsed_mode = parse_auth_forward_mode_from_cli(&mode)?;
+                    if !parsed_agent.supported_modes().contains(&parsed_mode) {
+                        anyhow::bail!(
+                            "auth_forward {parsed_mode} is not supported for {parsed_agent}; \
+                             supported modes: {:?}",
+                            parsed_agent.supported_modes()
+                        );
+                    }
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
-                    editor.set_global_auth_forward(parsed_mode);
+                    editor.set_global_auth_forward(parsed_agent, parsed_mode);
                     editor.save()?;
-                    println!("Set global Claude auth forwarding to {parsed_mode}.");
+                    println!("Set global {parsed_agent} auth forwarding to {parsed_mode}.");
                     Ok(())
                 }
                 cli::AuthCommand::Show => {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -84,22 +84,23 @@ Examples:
 
 #[derive(Debug, Subcommand, PartialEq, Eq)]
 pub enum AuthCommand {
-    /// Set the global Claude authentication forwarding mode
+    /// Set the global authentication forwarding mode for an agent
     ///
-    /// Controls how the host's Claude authentication is made available to
-    /// role containers at the global layer (writes `[claude].auth_forward`).
-    /// The Codex, Amp, and GitHub axes have their own per-axis blocks
-    /// (`[codex]` / `[amp]` / `[github]`) and are configured through the
-    /// operator console's Auth tab today, not this CLI verb — extending
-    /// `auth set` to take an explicit agent argument is a tracked follow-up.
+    /// Controls how the host's agent authentication is made available to
+    /// role containers at the global layer (writes
+    /// `[<agent>].auth_forward`). Defaults to `claude` when `--agent` is
+    /// omitted. The GitHub axis has its own `[github]` block and is
+    /// configured through the operator console's Auth tab today, not
+    /// this CLI verb.
     ///
     /// Modes: sync (default — overwrite container auth from host on each
     /// launch when host auth exists; preserve container auth when host auth
-    /// is absent), ignore (revoke and never forward), `oauth_token` (use a
-    /// long-lived `CLAUDE_CODE_OAUTH_TOKEN` resolved from the operator env),
-    /// `api_key` (use a short-lived `ANTHROPIC_API_KEY` resolved from the
-    /// operator env). Tokens and keys are never written to disk; see
-    /// `jackin` docs on auth forwarding for setup.
+    /// is absent), ignore (revoke and never forward), `oauth_token` (Claude
+    /// only — long-lived `CLAUDE_CODE_OAUTH_TOKEN` resolved from the operator
+    /// env), `api_key` (short-lived `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` /
+    /// `AMP_API_KEY` from the operator env). Tokens and keys are never
+    /// written to disk. Modes unsupported by the chosen agent are rejected
+    /// — see `jackin` docs on auth forwarding for setup.
     #[command(
         before_help = BANNER,
         styles = HELP_STYLES,
@@ -108,11 +109,16 @@ Examples:
   jackin config auth set sync
   jackin config auth set ignore
   jackin config auth set oauth_token
-  jackin config auth set api_key"
+  jackin config auth set api_key
+  jackin config auth set api_key --agent codex
+  jackin config auth set sync --agent amp"
     )]
     Set {
         /// Authentication forwarding mode: sync, ignore, `api_key`, or `oauth_token`
         mode: String,
+        /// Agent to configure: `claude` (default), `codex`, or `amp`.
+        #[arg(long, default_value = "claude")]
+        agent: String,
     },
     /// Show the current authentication forwarding mode
     #[command(
@@ -397,13 +403,13 @@ mod tests {
     }
 
     #[test]
-    fn parses_config_auth_set_global() {
+    fn parses_config_auth_set_global_defaults_to_claude() {
         let cli = Cli::try_parse_from(["jackin", "config", "auth", "set", "sync"]).unwrap();
         assert!(matches!(
             cli.command,
             Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
-                        ref mode,
-                    }))) if mode == "sync"
+                        ref mode, ref agent,
+                    }))) if mode == "sync" && agent == "claude"
         ));
     }
 
@@ -413,8 +419,22 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
-                        ref mode,
+                        ref mode, ..
                     }))) if mode == "oauth_token"
+        ));
+    }
+
+    #[test]
+    fn parses_config_auth_set_with_agent_flag() {
+        let cli = Cli::try_parse_from([
+            "jackin", "config", "auth", "set", "api_key", "--agent", "codex",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Config(ConfigCommand::Auth(AuthCommand::Set {
+                        ref mode, ref agent,
+                    }))) if mode == "api_key" && agent == "codex"
         ));
     }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -22,9 +22,9 @@ pub enum ConfigCommand {
 pub enum EnvCommand {
     /// Set an env var at global or per-role scope
     ///
-    /// Without `--role`, writes to the global `[env]` table. With
-    /// `--role <SELECTOR>`, writes to `[roles.<selector>.env]`. The role
-    /// selector is not pre-validated — the table path is written regardless
+    /// Without `--role`, writes the env var globally. With
+    /// `--role <SELECTOR>`, scopes it to that role only. The role
+    /// selector is not pre-validated — the value is recorded regardless
     /// of whether that role is registered, matching `config auth set`.
     #[command(
         before_help = BANNER,
@@ -43,7 +43,7 @@ Examples:
         /// Apply to a specific role instead of globally
         #[arg(long)]
         role: Option<String>,
-        /// Write a TOML comment line above the key
+        /// Attach a comment to the key (recorded alongside the value)
         #[arg(long)]
         comment: Option<String>,
     },
@@ -87,11 +87,9 @@ pub enum AuthCommand {
     /// Set the global authentication forwarding mode for an agent
     ///
     /// Controls how the host's agent authentication is made available to
-    /// role containers at the global layer (writes
-    /// `[<agent>].auth_forward`). Defaults to `claude` when `--agent` is
-    /// omitted. The GitHub axis has its own `[github]` block and is
-    /// configured through the operator console's Auth tab today, not
-    /// this CLI verb.
+    /// role containers at the global layer. Defaults to `claude` when
+    /// `--agent` is omitted. GitHub CLI auth is configured through the
+    /// operator console's Auth tab today, not this CLI verb.
     ///
     /// Modes: sync (default — overwrite container auth from host on each
     /// launch when host auth exists; preserve container auth when host auth

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -229,8 +229,8 @@ Examples:
 pub enum WorkspaceEnvCommand {
     /// Set an env var at workspace or workspace-role scope
     ///
-    /// Without `--role`, writes to `[workspaces.<workspace>.env]`. With
-    /// `--role <SELECTOR>`, writes to `[workspaces.<workspace>.roles.<selector>.env]`.
+    /// Without `--role`, scopes the env var to the whole workspace. With
+    /// `--role <SELECTOR>`, narrows it to that role within the workspace.
     /// The role selector is not pre-validated.
     #[command(
         before_help = BANNER,
@@ -251,7 +251,7 @@ Examples:
         /// Apply to a specific role inside this workspace
         #[arg(long)]
         role: Option<String>,
-        /// Write a TOML comment line above the key
+        /// Attach a comment to the key (recorded alongside the value)
         #[arg(long)]
         comment: Option<String>,
     },

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -253,9 +253,14 @@ impl ConfigEditor {
         }
     }
 
-    pub fn set_global_auth_forward(&mut self, mode: crate::config::AuthForwardMode) {
-        let claude_table = table_path_mut(&mut self.doc, &["claude".to_string()]);
-        claude_table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+    /// Write `[<agent.slug>].auth_forward = <mode>` at the global layer.
+    pub fn set_global_auth_forward(
+        &mut self,
+        agent: crate::agent::Agent,
+        mode: crate::config::AuthForwardMode,
+    ) {
+        let table = table_path_mut(&mut self.doc, &[agent.slug().to_string()]);
+        table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
     }
 
     /// Write or clear `[workspaces.<workspace>.<agent>].auth_forward`.
@@ -1425,19 +1430,25 @@ trusted = true
     }
 
     #[test]
-    fn set_global_auth_forward_writes_root_claude_table() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        paths.ensure_base_dirs().unwrap();
-        std::fs::write(&paths.config_file, "").unwrap();
+    fn set_global_auth_forward_writes_per_agent_table() {
+        for (agent, header) in [
+            (crate::agent::Agent::Claude, "[claude]"),
+            (crate::agent::Agent::Codex, "[codex]"),
+            (crate::agent::Agent::Amp, "[amp]"),
+        ] {
+            let temp = tempdir().unwrap();
+            let paths = JackinPaths::for_tests(temp.path());
+            paths.ensure_base_dirs().unwrap();
+            std::fs::write(&paths.config_file, "").unwrap();
 
-        let mut editor = ConfigEditor::open(&paths).unwrap();
-        editor.set_global_auth_forward(crate::config::AuthForwardMode::Sync);
-        editor.save().unwrap();
+            let mut editor = ConfigEditor::open(&paths).unwrap();
+            editor.set_global_auth_forward(agent, crate::config::AuthForwardMode::Sync);
+            editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[claude]"), "{out}");
-        assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+            let out = std::fs::read_to_string(&paths.config_file).unwrap();
+            assert!(out.contains(header), "expected {header} in:\n{out}");
+            assert!(out.contains(r#"auth_forward = "sync""#), "{out}");
+        }
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -169,10 +169,9 @@ pub struct GithubAuthConfig {
 pub struct CodexAuthConfig(pub(crate) AgentAuthConfig);
 
 impl CodexAuthConfig {
-    /// Construct a `CodexAuthConfig`, rejecting unsupported modes. The
-    /// inner field is `pub(crate)` so external callers must funnel
-    /// through this constructor and cannot bypass the parse-time
-    /// invariant by tuple-constructing an `OAuthToken` value.
+    /// Construct, rejecting `OAuthToken`. The only public path to
+    /// build the newtype, so the parse-time invariant survives
+    /// post-deserialize.
     pub fn new(cfg: AgentAuthConfig) -> Result<Self, &'static str> {
         if cfg.auth_forward == AuthForwardMode::OAuthToken {
             return Err("auth_forward 'oauth_token' is not supported for codex");
@@ -213,8 +212,7 @@ impl std::ops::Deref for CodexAuthConfig {
 pub struct AmpAuthConfig(pub(crate) AgentAuthConfig);
 
 impl AmpAuthConfig {
-    /// Construct an `AmpAuthConfig`, rejecting unsupported modes. See
-    /// [`CodexAuthConfig::new`] for the invariant rationale.
+    /// Construct, rejecting `OAuthToken`. See [`CodexAuthConfig::new`].
     pub fn new(cfg: AgentAuthConfig) -> Result<Self, &'static str> {
         if cfg.auth_forward == AuthForwardMode::OAuthToken {
             return Err("auth_forward 'oauth_token' is not supported for amp");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -166,7 +166,20 @@ pub struct GithubAuthConfig {
 /// deserialization time keeps the type system honest so downstream code
 /// never has to handle the impossible combination.
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
-pub struct CodexAuthConfig(pub AgentAuthConfig);
+pub struct CodexAuthConfig(pub(crate) AgentAuthConfig);
+
+impl CodexAuthConfig {
+    /// Construct a `CodexAuthConfig`, rejecting unsupported modes. The
+    /// inner field is `pub(crate)` so external callers must funnel
+    /// through this constructor and cannot bypass the parse-time
+    /// invariant by tuple-constructing an `OAuthToken` value.
+    pub fn new(cfg: AgentAuthConfig) -> Result<Self, &'static str> {
+        if cfg.auth_forward == AuthForwardMode::OAuthToken {
+            return Err("auth_forward 'oauth_token' is not supported for codex");
+        }
+        Ok(Self(cfg))
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for CodexAuthConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -197,7 +210,18 @@ impl std::ops::Deref for CodexAuthConfig {
 /// via an `AMP_API_KEY` or its own settings file); rejecting it at
 /// deserialization time keeps the type system honest.
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
-pub struct AmpAuthConfig(pub AgentAuthConfig);
+pub struct AmpAuthConfig(pub(crate) AgentAuthConfig);
+
+impl AmpAuthConfig {
+    /// Construct an `AmpAuthConfig`, rejecting unsupported modes. See
+    /// [`CodexAuthConfig::new`] for the invariant rationale.
+    pub fn new(cfg: AgentAuthConfig) -> Result<Self, &'static str> {
+        if cfg.auth_forward == AuthForwardMode::OAuthToken {
+            return Err("auth_forward 'oauth_token' is not supported for amp");
+        }
+        Ok(Self(cfg))
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for AmpAuthConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -14,7 +14,6 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
 const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 const WHITE: Color = Color::Rgb(255, 255, 255);
-const AGENTS: [Agent; 3] = [Agent::Claude, Agent::Codex, Agent::Amp];
 
 #[derive(Debug, Clone)]
 pub struct AgentChoiceState {
@@ -28,19 +27,19 @@ impl AgentChoiceState {
         }
     }
 
-    pub const fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
+    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
         match key.code {
             KeyCode::Down | KeyCode::Char('j') => {
                 let idx = focus_index(self.focused);
-                if idx + 1 < AGENTS.len() {
-                    self.focused = AGENTS[idx + 1];
+                if idx + 1 < Agent::ALL.len() {
+                    self.focused = Agent::ALL[idx + 1];
                 }
                 ModalOutcome::Continue
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 let idx = focus_index(self.focused);
                 if idx > 0 {
-                    self.focused = AGENTS[idx - 1];
+                    self.focused = Agent::ALL[idx - 1];
                 }
                 ModalOutcome::Continue
             }
@@ -51,11 +50,18 @@ impl AgentChoiceState {
     }
 }
 
-const fn focus_index(agent: Agent) -> usize {
+fn focus_index(agent: Agent) -> usize {
+    Agent::ALL
+        .iter()
+        .position(|a| *a == agent)
+        .expect("Agent::ALL contains every Agent variant")
+}
+
+const fn agent_picker_label(agent: Agent) -> &'static str {
     match agent {
-        Agent::Claude => 0,
-        Agent::Codex => 1,
-        Agent::Amp => 2,
+        Agent::Claude => "Claude",
+        Agent::Codex => "Codex",
+        Agent::Amp => "Amp",
     }
 }
 
@@ -97,11 +103,10 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AgentChoiceState) {
         ])
         .split(inner);
 
-    let lines = vec![
-        make_row(Agent::Claude, "Claude"),
-        make_row(Agent::Codex, "Codex"),
-        make_row(Agent::Amp, "Amp"),
-    ];
+    let lines: Vec<Line> = Agent::ALL
+        .iter()
+        .map(|a| make_row(*a, agent_picker_label(*a)))
+        .collect();
     frame.render_widget(Paragraph::new(lines), rows[0]);
 
     let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -769,16 +769,11 @@ fn write_private_file(path: &Path, content: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tighten permissions on an existing file to `0o600` if it exists.
-/// Refuses to operate on symlinks.  No-op on non-Unix or if the file
-/// doesn't exist.
-///
-/// Errors are logged via `eprintln!` rather than returned: this runs
-/// from within a successful `Sync` host-missing arm where the operator
-/// already has a working role-state file. A failed chmod must not
-/// abort the launch, but it must not be silent either — leaving a
-/// credential file at world-readable perms with no operator signal is
-/// a security regression.
+/// Tighten permissions on an existing file to `0o600`. No-op on
+/// symlinks, non-Unix, or missing files. Errors are logged rather
+/// than returned: callers are mid-Sync and must not abort the launch,
+/// but a silent chmod failure on a credential file is a security
+/// regression.
 fn repair_permissions(path: &Path) {
     #[cfg(unix)]
     {
@@ -2754,10 +2749,8 @@ mod amp_auth_tests {
     #[cfg(unix)]
     #[test]
     fn synced_secrets_json_has_restricted_permissions() {
-        // Pin the role-state file at 0o600 after Sync. Mirrors Codex /
-        // Claude — a future Amp-specific bypass that swapped
-        // `write_private_file` for `std::fs::write` would otherwise leak
-        // credentials at 0o644.
+        // Bypassing `write_private_file` would land at 0o644 and leak
+        // the token. Pin 0o600 explicitly.
         use std::os::unix::fs::PermissionsExt;
         let temp = tempdir().unwrap();
         let secrets_json = temp.path().join("secrets.json");
@@ -2782,10 +2775,8 @@ mod amp_auth_tests {
     #[cfg(unix)]
     #[test]
     fn sync_repairs_permissions_when_host_secrets_missing() {
-        // The HostMissing arm is the only path where a prior role-state
-        // file persists across a re-launch. Pin that the arm tightens
-        // permissions on the carried-over file rather than leaving
-        // whatever mode the previous owner gave it. Mirrors Codex.
+        // HostMissing is the only path that carries a prior file
+        // across launches; the arm must tighten its perms.
         use std::os::unix::fs::PermissionsExt;
         let temp = tempdir().unwrap();
         let secrets_json = temp.path().join("secrets.json");
@@ -2811,11 +2802,8 @@ mod amp_auth_tests {
 
     #[test]
     fn sync_ignores_xdg_config_settings_json_decoy() {
-        // Pin that Sync reads only `~/.local/share/amp/secrets.json`
-        // (XDG_DATA, the canonical token store). A decoy at the
-        // XDG_CONFIG path `~/.config/amp/settings.json` — Amp's
-        // preferences file, never the credential store — must not be
-        // forwarded. Catches a regression that swapped the source path.
+        // Catches a regression that swapped the Sync source from
+        // XDG_DATA `secrets.json` to XDG_CONFIG `settings.json`.
         let temp = tempdir().unwrap();
         let secrets_json = temp.path().join("secrets.json");
         let host_home = temp.path().join("host_home");
@@ -2844,9 +2832,8 @@ mod amp_auth_tests {
 
     #[test]
     fn sync_treats_empty_host_secrets_as_host_missing() {
-        // Pin the empty-content guard: a zero-byte / whitespace-only
-        // host file must surface as HostMissing rather than silently
-        // copying an empty payload that Amp can't authenticate against.
+        // Without this guard, an empty host file would be Synced and
+        // the agent would fail to auth with no breadcrumb.
         let temp = tempdir().unwrap();
         let secrets_json = temp.path().join("secrets.json");
         let host_home = stage_host_secrets(&temp, "   \n\t  \n");

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -120,15 +120,21 @@ impl RoleState {
                     AuthProvisionOutcome::HostMissing
                 }
                 Err(e) => {
-                    // Surface unexpected read errors (EACCES, EIO, ENOTDIR,
-                    // …) instead of misdiagnosing them as "host missing"
-                    // and silently dropping the operator into a re-login
-                    // loop they cannot escape until they notice the bad
-                    // permission/dir/etc. on `~/.codex/auth.json`.
-                    anyhow::bail!(
-                        "failed to read host {}: {e} (run with --debug to capture the underlying error)",
-                        host_auth_json.display()
-                    );
+                    // Preserve `io::Error` source chain so `{e:#}` /
+                    // `--debug` exposes the kind (PermissionDenied,
+                    // NotADirectory) instead of misdiagnosing as
+                    // host-missing.
+                    let hint = match e.kind() {
+                        std::io::ErrorKind::PermissionDenied => {
+                            " (check host file permissions on the parent dir)"
+                        }
+                        _ => "",
+                    };
+                    return Err(anyhow::Error::new(e).context(format!(
+                        "failed to read host {}{}",
+                        host_auth_json.display(),
+                        hint
+                    )));
                 }
             },
         };
@@ -544,6 +550,19 @@ impl RoleState {
                 AuthProvisionOutcome::Skipped
             }
             AuthForwardMode::Sync => match std::fs::read_to_string(&host_secrets) {
+                Ok(content) if content.trim().is_empty() => {
+                    // Empty/whitespace host file would otherwise silently
+                    // copy as Synced and the agent would re-prompt login
+                    // inside the container with no breadcrumb.
+                    eprintln!(
+                        "[jackin] host {} is empty/whitespace — treating as host-missing",
+                        host_secrets.display()
+                    );
+                    if secrets_json.exists() {
+                        repair_permissions(secrets_json);
+                    }
+                    AuthProvisionOutcome::HostMissing
+                }
                 Ok(content) => {
                     write_private_file(secrets_json, &content).with_context(|| {
                         format!(
@@ -753,21 +772,39 @@ fn write_private_file(path: &Path, content: &str) -> anyhow::Result<()> {
 /// Tighten permissions on an existing file to `0o600` if it exists.
 /// Refuses to operate on symlinks.  No-op on non-Unix or if the file
 /// doesn't exist.
+///
+/// Errors are logged via `eprintln!` rather than returned: this runs
+/// from within a successful `Sync` host-missing arm where the operator
+/// already has a working role-state file. A failed chmod must not
+/// abort the launch, but it must not be silent either — leaving a
+/// credential file at world-readable perms with no operator signal is
+/// a security regression.
 fn repair_permissions(path: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        // Use symlink_metadata so we don't follow symlinks.
-        if let Ok(meta) = std::fs::symlink_metadata(path) {
-            if meta.file_type().is_symlink() {
-                eprintln!(
-                    "[jackin] warning: refusing to chmod symlink at {}",
-                    path.display()
-                );
-                return;
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) => {
+                if meta.file_type().is_symlink() {
+                    eprintln!(
+                        "[jackin] warning: refusing to chmod symlink at {}",
+                        path.display()
+                    );
+                    return;
+                }
+                if meta.is_file()
+                    && let Err(e) =
+                        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                {
+                    eprintln!(
+                        "[jackin] warning: failed to chmod 0o600 on {}: {e}",
+                        path.display()
+                    );
+                }
             }
-            if meta.is_file() {
-                let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                eprintln!("[jackin] warning: stat failed on {}: {e}", path.display());
             }
         }
     }
@@ -2711,6 +2748,118 @@ mod amp_auth_tests {
             !rendered.contains("not found")
                 && !rendered.to_ascii_lowercase().contains("nonexistent"),
             "EACCES must not be reported as not-found: {rendered}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn synced_secrets_json_has_restricted_permissions() {
+        // Pin the role-state file at 0o600 after Sync. Mirrors Codex /
+        // Claude — a future Amp-specific bypass that swapped
+        // `write_private_file` for `std::fs::write` would otherwise leak
+        // credentials at 0o644.
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempdir().unwrap();
+        let secrets_json = temp.path().join("secrets.json");
+        let host_home = stage_host_secrets(
+            &temp,
+            "{\"apiKey@https://ampcode.com/\":\"sgamp_user_test\"}",
+        );
+
+        RoleState::provision_amp_auth(&secrets_json, AuthForwardMode::Sync, &host_home).unwrap();
+
+        let mode = std::fs::metadata(&secrets_json)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "synced secrets.json must be 0o600, got {mode:o}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_repairs_permissions_when_host_secrets_missing() {
+        // The HostMissing arm is the only path where a prior role-state
+        // file persists across a re-launch. Pin that the arm tightens
+        // permissions on the carried-over file rather than leaving
+        // whatever mode the previous owner gave it. Mirrors Codex.
+        use std::os::unix::fs::PermissionsExt;
+        let temp = tempdir().unwrap();
+        let secrets_json = temp.path().join("secrets.json");
+        std::fs::write(&secrets_json, "{\"in_container_login\":true}").unwrap();
+        std::fs::set_permissions(&secrets_json, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let host_home = temp.path().join("empty_host_home");
+
+        let (outcome, _) =
+            RoleState::provision_amp_auth(&secrets_json, AuthForwardMode::Sync, &host_home)
+                .unwrap();
+
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+        let mode = std::fs::metadata(&secrets_json)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "HostMissing must repair the carry-over file's permissions; got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn sync_ignores_xdg_config_settings_json_decoy() {
+        // Pin that Sync reads only `~/.local/share/amp/secrets.json`
+        // (XDG_DATA, the canonical token store). A decoy at the
+        // XDG_CONFIG path `~/.config/amp/settings.json` — Amp's
+        // preferences file, never the credential store — must not be
+        // forwarded. Catches a regression that swapped the source path.
+        let temp = tempdir().unwrap();
+        let secrets_json = temp.path().join("secrets.json");
+        let host_home = temp.path().join("host_home");
+
+        // Only the XDG_CONFIG decoy exists; the canonical XDG_DATA
+        // path is empty.
+        let xdg_config = host_home.join(".config/amp");
+        std::fs::create_dir_all(&xdg_config).unwrap();
+        std::fs::write(xdg_config.join("settings.json"), "WRONG").unwrap();
+
+        let (outcome, mounted) =
+            RoleState::provision_amp_auth(&secrets_json, AuthForwardMode::Sync, &host_home)
+                .unwrap();
+
+        assert_eq!(
+            outcome,
+            AuthProvisionOutcome::HostMissing,
+            "decoy at XDG_CONFIG must not produce a Sync"
+        );
+        assert!(mounted.is_none());
+        assert!(
+            !secrets_json.exists(),
+            "decoy contents must not be copied into the role state"
+        );
+    }
+
+    #[test]
+    fn sync_treats_empty_host_secrets_as_host_missing() {
+        // Pin the empty-content guard: a zero-byte / whitespace-only
+        // host file must surface as HostMissing rather than silently
+        // copying an empty payload that Amp can't authenticate against.
+        let temp = tempdir().unwrap();
+        let secrets_json = temp.path().join("secrets.json");
+        let host_home = stage_host_secrets(&temp, "   \n\t  \n");
+
+        let (outcome, mounted) =
+            RoleState::provision_amp_auth(&secrets_json, AuthForwardMode::Sync, &host_home)
+                .unwrap();
+
+        assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
+        assert!(mounted.is_none());
+        assert!(
+            !secrets_json.exists(),
+            "empty host file must not produce a role-state copy"
         );
     }
 }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2977,11 +2977,12 @@ fn auth_role_header_d_clears_selected_auth_kind_override() -> Result<()> {
     over.claude = Some(jackin::config::AgentAuthConfig {
         auth_forward: jackin::config::AuthForwardMode::Ignore,
     });
-    over.codex = Some(jackin::config::CodexAuthConfig(
-        jackin::config::AgentAuthConfig {
+    over.codex = Some(
+        jackin::config::CodexAuthConfig::new(jackin::config::AgentAuthConfig {
             auth_forward: jackin::config::AuthForwardMode::ApiKey,
-        },
-    ));
+        })
+        .unwrap(),
+    );
     ws.roles.insert("the-architect".into(), over);
 
     let mut state = ManagerState::from_config(&config, cwd);
@@ -3028,11 +3029,12 @@ fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
     over.claude = Some(jackin::config::AgentAuthConfig {
         auth_forward: jackin::config::AuthForwardMode::Ignore,
     });
-    over.codex = Some(jackin::config::CodexAuthConfig(
-        jackin::config::AgentAuthConfig {
+    over.codex = Some(
+        jackin::config::CodexAuthConfig::new(jackin::config::AgentAuthConfig {
             auth_forward: jackin::config::AuthForwardMode::ApiKey,
-        },
-    ));
+        })
+        .unwrap(),
+    );
     ws.roles.insert("the-architect".into(), over);
 
     let mut state = ManagerState::from_config(&config, cwd);


### PR DESCRIPTION
## Summary

Apply the post-merge review follow-ups flagged on the amp PR ([#248](https://github.com/jackin-project/jackin/pull/248)). Type-design hardens the per-agent newtypes against the post-deserialize bypass, code-reuse introduces `Agent::ALL` for canonical variant enumeration, the `jackin config auth set` verb gains a `--agent` flag so operators can configure Codex / Amp from the CLI, the Codex `Sync` read-error arm aligns with Amp's `io::Error`-chain-preserving pattern, the Amp `Sync` arm rejects empty/whitespace host secrets, and `repair_permissions` no longer swallows chmod / stat errors silently. New regression tests pin permission tightening on the `HostMissing` carry-over path, the canonical-XDG_DATA source path, the empty-content guard, and the `--agent` CLI flag.

## What's deferred (follow-up PRs)

These are larger refactors that belong on their own branches and were intentionally left out of this commit so the diff stays reviewable:

- **`AuthKind` redesign** — collapse `enum AuthKind { Claude, Codex, Amp, Github }` into `enum AuthKind { Agent(Agent), Github }` so the partial `agent() -> Option<Agent>` accessor disappears (along with the `.expect()` at `editor.rs:799`) and the per-kind tables collapse to one delegation each.
- **`AgentRuntimeState::Claude` migration to `Option<PathBuf>`** — Codex / Amp already use the cleaner shape; Claude's `forward_auth: bool + always-Some PathBuf` lets `forward_auth=true, file-doesn't-exist` be expressible.
- **`tui::agent_auth_notice` extraction** — the Claude and Amp launch-summary `eprintln` blocks in `runtime/launch.rs` are near-verbatim copies; a single agent-aware helper would close the duplication without touching Codex's already-extracted `tui::codex_auth_notice` path.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin chore/amp-pr-followups:refs/remotes/origin/chore/amp-pr-followups
git checkout -B chore/amp-pr-followups refs/remotes/origin/chore/amp-pr-followups
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib -- -D warnings
```

### Tests

```sh
cargo test --lib instance::auth::amp_auth_tests
cargo test --lib instance::auth::codex_auth_tests
cargo test --lib cli::config::tests
cargo test --lib console::manager::auth_kind
cargo test --lib config::editor
cargo test --test manager_flow
```

Covers the new amp tests (`synced_secrets_json_has_restricted_permissions`, `sync_repairs_permissions_when_host_secrets_missing`, `sync_ignores_xdg_config_settings_json_decoy`, `sync_treats_empty_host_secrets_as_host_missing`), the codex EACCES surface assertion against the new `anyhow::Error::new(e).context(...)` shape, the per-agent `set_global_auth_forward` table writer, and the `--agent` CLI flag round-trip.

### User smoke

```sh
cargo run --bin jackin -- config auth set api_key --agent codex --debug
cargo run --bin jackin -- config auth set sync --agent amp --debug
cargo run --bin jackin -- config auth show --debug
```

The first two writes should land in `[codex].auth_forward` and `[amp].auth_forward` respectively (visible in `~/.config/jackin/config.toml`). `auth show` should reflect the chosen modes per agent. Attempting an unsupported mode (`config auth set oauth_token --agent amp`) should error out before touching the config file.

## Migration notes

None. Pre-release, no released schema to migrate. The CLI `--agent` flag defaults to `claude`, so existing scripts that ran `jackin config auth set <mode>` continue to behave identically.
