### PR TITLE
test(op_picker): clear in-flight probe rx in seed blocks to fix flake

### DIFF
--- a/src/console/widgets/op_picker/mod.rs
+++ b/src/console/widgets/op_picker/mod.rs
@@ -303,6 +303,18 @@ impl OpPickerState {
     /// Public so the outer console event loop can drain pending
     /// results every tick — keeps the picker responsive without
     /// requiring keystrokes. Idempotent on an empty channel.
+    /// Discard any in-flight load result and force the picker into
+    /// the `Ready` state. Intended for tests that seed picker state
+    /// directly after the constructor's async probe has already been
+    /// kicked off — without this, `handle_key`'s leading `poll_load`
+    /// call can drain a stale `Err(...)` from the still-open
+    /// receiver and short-circuit the test through the Fatal-error
+    /// guard, racing the test against the probe thread.
+    pub fn cancel_in_flight_load(&mut self) {
+        self.rx = None;
+        self.load_state = OpLoadState::Ready;
+    }
+
     pub fn poll_load(&mut self) {
         let Some(rx) = self.rx.as_ref() else {
             return;

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -741,6 +741,11 @@ fn op_picker_commit_writes_value_directly_to_pending() -> Result<()> {
                 picker.field_list_state.select(Some(0));
                 picker.stage = OpPickerStage::Field;
                 picker.load_state = OpLoadState::Ready;
+                // Drop any in-flight probe result so handle_key's
+                // leading poll_load doesn't race the test by draining
+                // a stale `Err(...)` from the constructor's account
+                // probe and routing into the Fatal-error guard.
+                picker.cancel_in_flight_load();
             }
             other => panic!("expected OpPicker modal; got {other:?}"),
         }
@@ -840,6 +845,11 @@ fn op_picker_sentinel_p_flow() -> Result<()> {
                 picker.field_list_state.select(Some(0));
                 picker.stage = OpPickerStage::Field;
                 picker.load_state = OpLoadState::Ready;
+                // Drop any in-flight probe result so handle_key's
+                // leading poll_load doesn't race the test by draining
+                // a stale `Err(...)` from the constructor's account
+                // probe and routing into the Fatal-error guard.
+                picker.cancel_in_flight_load();
             }
             other => panic!("expected OpPicker modal; got {other:?}"),
         }
@@ -1231,6 +1241,11 @@ fn op_picker_multi_account_flow() -> Result<()> {
                 picker.selected_account = None;
                 picker.stage = OpPickerStage::Account;
                 picker.load_state = OpLoadState::Ready;
+                // Drop any in-flight probe result so handle_key's
+                // leading poll_load doesn't race the test by draining
+                // a stale `Err(...)` from the constructor's account
+                // probe and routing into the Fatal-error guard.
+                picker.cancel_in_flight_load();
             }
             other => panic!("expected OpPicker modal; got {other:?}"),
         }
@@ -1283,6 +1298,11 @@ fn op_picker_multi_account_flow() -> Result<()> {
                 picker.field_list_state.select(Some(0));
                 picker.stage = OpPickerStage::Field;
                 picker.load_state = OpLoadState::Ready;
+                // Drop any in-flight probe result so handle_key's
+                // leading poll_load doesn't race the test by draining
+                // a stale `Err(...)` from the constructor's account
+                // probe and routing into the Fatal-error guard.
+                picker.cancel_in_flight_load();
             }
             other => panic!("expected OpPicker modal; got {other:?}"),
         }


### PR DESCRIPTION
## Summary

Fix the flaky `op_picker_multi_account_flow` test (plus three sibling tests that share the same seed pattern). On the CI runner the test fails intermittently with `assertion left == right failed: left: Account, right: Vault`; the root cause is a race between the picker's constructor-spawned account-probe thread and the test's `handle_key(Enter)` call.

When the test opens the picker via `'p'`, the constructor kicks off `start_account_load`, which spawns a background thread to call `OpStructRunner::account_list()`. On CI without `op` installed (the default for the standard runner) that thread eventually returns `Err("command not found")` and sends the error into the picker's `mpsc` receiver. The test seed block then overwrites `picker.accounts` / `account_list_state` / `stage` / `load_state`, but does not clear `picker.rx`. When the test's `handle_key(Enter)` call runs, `handle_key` invokes `poll_load` first; if the probe thread has landed by then, `poll_load` drains the stale `Err`, sets `load_state = Error(Fatal(NotInstalled))`, and the Fatal guard short-circuits the rest of `handle_key`. The Enter handler never runs, the stage stays `Account`, and the test fails with the message above.

Locally the probe thread is usually slower than the test (`op` is typically installed and `account_list` returns immediately or the cache layer satisfies it before the spawn even completes), so the same code passes 100 % of the time. CI flake = order-of-arrival race between the spawned probe thread and the test's first `handle_key`.

## Fix

Add `pub fn cancel_in_flight_load(&mut self)` on `OpPickerState` that clears `rx` and resets `load_state` to `Ready`. Call it at the end of all four seed blocks in `tests/manager_flow.rs`. Documented intent: tests that seed picker state directly should not also race the constructor's async probe.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/op-picker-test-flake:refs/remotes/origin/fix/op-picker-test-flake
git checkout -B fix/op-picker-test-flake refs/remotes/origin/fix/op-picker-test-flake
```

### Tests

```sh
cargo test --test manager_flow op_picker
for i in $(seq 1 30); do cargo test --test manager_flow op_picker_multi_account_flow 2>&1 | grep "test result"; done
```

The first command runs all six op_picker integration tests once. The stress loop runs the previously-flaky test 30 times in a row — every iteration must show `1 passed; 0 failed`. All passed locally on the fix branch.
