### PR TITLE
refactor(launch): extract `tui::agent_outcome_notice` for Claude/Amp

### DIFF
--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1469,114 +1469,33 @@ fn load_role_with(
         // from the operator env config's raw declaration (the op://
         // reference or $NAME ref as written). Resolved values are never
         // printed.
-        if agent == crate::agent::Agent::Claude {
-            // Per-mode auth notice: for credential-injecting modes we look
-            // up the raw declaration of the mode's required env var
-            // (resolved through `Agent::required_env_var`) and surface its
-            // source reference; sync/ignore have no env source to print.
-            if let Some(env_var) = agent.required_env_var(auth_mode) {
+        // Resolve the credential source-reference once per launch and
+        // gate it on a non-empty resolved value, so a layer that
+        // contributed an empty/whitespace string is not advertised as
+        // the source. The raw lookup is the operator-typed declaration
+        // (`op://...`, `$VAR`, literal); the env-var name is the
+        // fallback when the resolver tracked the value but no raw
+        // declaration string is recorded.
+        let resolved_source: Option<String> =
+            agent.required_env_var(auth_mode).and_then(|env_var| {
                 let raw = lookup_operator_env_raw(
                     config,
                     Some(&role_key),
                     workspace_name.as_deref(),
                     env_var,
                 );
-                let source_ref = auth_token_source_reference(env_var, raw.as_deref());
-                tui::auth_mode_notice(agent, &auth_mode.to_string(), Some(&source_ref));
-            } else {
-                tui::auth_mode_notice(agent, &auth_mode.to_string(), None);
-            }
-
-            // Verbose outcome notices kept for operator context.
-            match auth_outcome {
-                crate::instance::AuthProvisionOutcome::Synced => {
-                    eprintln!(
-                        "[jackin] Synced host Claude Code authentication into role state \
-                         (auth_forward=sync)."
-                    );
-                }
-                crate::instance::AuthProvisionOutcome::TokenMode => {
-                    if let Some(env_var) = agent.required_env_var(auth_mode) {
-                        eprintln!(
-                            "[jackin] auth_forward={auth_mode} — role will use \
-                             {env_var} from the resolved env."
-                        );
-                    }
-                }
-                crate::instance::AuthProvisionOutcome::HostMissing => {
-                    if matches!(auth_mode, crate::config::AuthForwardMode::Sync) {
-                        eprintln!(
-                            "[jackin] auth_forward=sync but no host credentials found; \
-                                 preserving existing container auth if present."
-                        );
-                    }
-                }
-                crate::instance::AuthProvisionOutcome::Skipped => {}
-            }
-        } else if agent == crate::agent::Agent::Codex {
-            // For Codex, the credential env var is OPENAI_API_KEY in
-            // ApiKey mode and absent for Sync/Ignore. Drive the lookup
-            // through `Agent::required_env_var` to keep this generic.
-            let codex_env_var = agent.required_env_var(auth_mode);
-            let raw_source = codex_env_var.and_then(|v| {
-                lookup_operator_env_raw(config, Some(&role_key), workspace_name.as_deref(), v)
-            });
-            let resolved_source = codex_env_var.and_then(|v| {
-                resolved_env
+                let has_value = resolved_env
                     .vars
                     .iter()
-                    .any(|(k, value)| k == v && !value.trim().is_empty())
-                    .then(|| raw_source.as_deref().unwrap_or(v))
+                    .any(|(k, v)| k == env_var && !v.trim().is_empty());
+                has_value.then(|| raw.unwrap_or_else(|| env_var.to_string()))
             });
-            tui::codex_auth_notice(resolved_source, (auth_mode, auth_outcome).into());
-        } else if agent == crate::agent::Agent::Amp {
-            // Only report a source-ref when the resolved env actually
-            // carries a non-empty value for the credential var. The raw
-            // lookup alone would advertise a layer that contributed an
-            // empty/whitespace string.
-            let amp_env_var = agent.required_env_var(auth_mode);
-            let raw_source = amp_env_var.and_then(|v| {
-                lookup_operator_env_raw(config, Some(&role_key), workspace_name.as_deref(), v)
-            });
-            let resolved_source = amp_env_var.and_then(|v| {
-                resolved_env
-                    .vars
-                    .iter()
-                    .any(|(k, value)| k == v && !value.trim().is_empty())
-                    .then(|| raw_source.as_deref().unwrap_or(v))
-            });
-            tui::auth_mode_notice(agent, &auth_mode.to_string(), resolved_source);
 
-            match auth_outcome {
-                crate::instance::AuthProvisionOutcome::Synced => {
-                    eprintln!(
-                        "[jackin] Synced host Amp authentication into role state \
-                         (auth_forward=sync)."
-                    );
-                }
-                crate::instance::AuthProvisionOutcome::TokenMode => {
-                    if let Some(env_var) = amp_env_var {
-                        eprintln!(
-                            "[jackin] auth_forward={auth_mode} — role will use \
-                             {env_var} from the resolved env."
-                        );
-                    }
-                }
-                crate::instance::AuthProvisionOutcome::HostMissing => {
-                    if matches!(auth_mode, crate::config::AuthForwardMode::Sync) {
-                        eprintln!(
-                            "[jackin] auth_forward=sync but no host Amp secrets.json found; \
-                             preserving existing container auth if present."
-                        );
-                    }
-                }
-                crate::instance::AuthProvisionOutcome::Skipped => {
-                    eprintln!(
-                        "[jackin] auth_forward=ignore — wiped any prior synced \
-                         secrets.json; agent will require interactive login."
-                    );
-                }
-            }
+        if agent == crate::agent::Agent::Codex {
+            tui::codex_auth_notice(resolved_source.as_deref(), (auth_mode, auth_outcome).into());
+        } else {
+            tui::auth_mode_notice(agent, &auth_mode.to_string(), resolved_source.as_deref());
+            tui::agent_outcome_notice(agent, auth_mode, auth_outcome);
         }
 
         // GitHub auth summary line — agent-neutral. The breadcrumb walks

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -95,9 +95,9 @@ pub mod prompt;
 
 pub use animation::{intro_animation, outro_animation, simple_outro};
 pub use output::{
-    CodexSyncState, auth_mode_notice, clear_screen, codex_auth_notice, fatal, github_auth_notice,
-    hint, print_config_table, print_deploying, print_logo, set_terminal_title, shorten_home,
-    step_fail, step_quiet, step_shimmer,
+    CodexSyncState, agent_outcome_notice, auth_mode_notice, clear_screen, codex_auth_notice, fatal,
+    github_auth_notice, hint, print_config_table, print_deploying, print_logo, set_terminal_title,
+    shorten_home, step_fail, step_quiet, step_shimmer,
 };
 pub use prompt::{prompt_choice, require_interactive_stdin, spin_wait};
 

--- a/src/tui/output.rs
+++ b/src/tui/output.rs
@@ -221,6 +221,66 @@ fn format_auth_mode_notice_for_test(
     format!("{label} {}", body.color(rgb(PHOSPHOR_DIM)))
 }
 
+/// Verbose outcome eprintln line that follows [`auth_mode_notice`] for
+/// the file-driven agents (Claude, Amp). Codex uses [`codex_auth_notice`]
+/// instead.
+pub fn agent_outcome_notice(
+    agent: crate::agent::Agent,
+    auth_mode: crate::config::AuthForwardMode,
+    auth_outcome: crate::instance::AuthProvisionOutcome,
+) {
+    use crate::agent::Agent as A;
+    use crate::config::AuthForwardMode as M;
+    use crate::instance::AuthProvisionOutcome as O;
+
+    let display = match agent {
+        A::Claude => "Claude Code",
+        A::Codex => "Codex",
+        A::Amp => "Amp",
+    };
+    match auth_outcome {
+        O::Synced => {
+            eprintln!(
+                "[jackin] Synced host {display} authentication into role state \
+                 (auth_forward=sync)."
+            );
+        }
+        O::TokenMode => {
+            if let Some(env_var) = agent.required_env_var(auth_mode) {
+                eprintln!(
+                    "[jackin] auth_forward={auth_mode} — role will use \
+                     {env_var} from the resolved env."
+                );
+            }
+        }
+        O::HostMissing => {
+            if matches!(auth_mode, M::Sync) {
+                let host_file = match agent {
+                    A::Claude => "credentials",
+                    A::Codex => "auth.json",
+                    A::Amp => "secrets.json",
+                };
+                eprintln!(
+                    "[jackin] auth_forward=sync but no host {display} {host_file} found; \
+                     preserving existing container auth if present."
+                );
+            }
+        }
+        O::Skipped => {
+            // Only Amp emits a Skipped breadcrumb today; Claude/Codex
+            // are silent. The asymmetry is intentional — Amp's wipe
+            // path is the only one where the operator's next launch
+            // surfaces interactive-login prompts.
+            if matches!(agent, A::Amp) {
+                eprintln!(
+                    "[jackin] auth_forward=ignore — wiped any prior synced \
+                     secrets.json; agent will require interactive login."
+                );
+            }
+        }
+    }
+}
+
 /// Sync-state half of the Codex auth notice.
 ///
 /// Derived from `(AuthForwardMode, AuthProvisionOutcome)` via [`From`]


### PR DESCRIPTION
## Summary

Collapses the two near-verbatim launch-summary blocks for `Claude` and `Amp` in `runtime/launch.rs` into one `tui::agent_outcome_notice(agent, mode, outcome)` helper. Adding a fourth file-driven agent is now a one-line match arm in `tui::output` instead of a third 25-line paste in the launch path. The credential source-reference resolver also moves out of the per-agent branches into a single expression keyed off `Agent::required_env_var`. Closes the first item the multi-agent review flagged as deferred from the original amp PR ([#248](https://github.com/jackin-project/jackin/pull/248)).

## What's deferred (follow-up PRs)

- **`AuthKind` redesign** to `enum AuthKind { Agent(Agent), Github }` — separate PR.
- **`AgentRuntimeState::Claude` migration to `Option<PathBuf>`** — separate PR.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin refactor/extract-agent-auth-notice:refs/remotes/origin/refactor/extract-agent-auth-notice
git checkout -B refactor/extract-agent-auth-notice refs/remotes/origin/refactor/extract-agent-auth-notice
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib -- -D warnings
```

### Tests

```sh
cargo test --lib tui::output
cargo test --lib runtime::launch
cargo test --test amp_launch
cargo test --test codex_launch
```

The tui formatter tests pin the per-agent label and env-var fallback the new helper consumes; the launch tests pin the assembled `docker run` for both `sync` and `api_key` flows on Amp and Codex.

### User smoke

```sh
cargo run --bin jackin -- load the-architect "$HOME/Projects/jackin-project/test/jackin" --agent claude --debug
cargo run --bin jackin -- load the-architect "$HOME/Projects/jackin-project/test/jackin" --agent amp --debug
```

For each launch, the `--debug` log should show one `<agent> auth: …` notice line followed by the matching `[jackin] …` outcome line. Sync mode that finds a host file should print "Synced host …", sync mode without a host file should print "auth_forward=sync but no host …", and `api_key` mode should print "auth_forward=api_key — role will use … from the resolved env." There should be no breadcrumb that advertises the bare env-var name when no resolved value exists — the previous Claude arm had that behavior; this PR closes the gap.

## Migration notes

None. Pre-release, no released schema to migrate. No operator-facing behaviour change beyond the Claude source-ref now correctly suppressing itself when the resolved env is empty (matches Amp's pre-existing behavior).
