### PR TITLE
refactor(instance): migrate `AgentRuntimeState::Claude` to `Option<PathBuf>`

### DIFF
--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -872,10 +872,16 @@ plugins = []
         .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(state.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
-        assert!(!state.claude_credentials_json().unwrap().exists());
+        assert!(
+            !state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
         assert_eq!(outcome, AuthProvisionOutcome::Skipped);
     }
 
@@ -898,12 +904,12 @@ plugins = []
         .unwrap();
 
         assert!(
-            std::fs::read_to_string(state.claude_account_json().unwrap())
+            std::fs::read_to_string(state.root.join("claude/account.json").as_path())
                 .unwrap()
                 .contains("test@example.com")
         );
         assert_eq!(
-            std::fs::read_to_string(state.claude_credentials_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state.root.join("claude/credentials.json").as_path()).unwrap(),
             TEST_CREDENTIALS
         );
         assert_eq!(outcome, AuthProvisionOutcome::Synced);
@@ -928,10 +934,16 @@ plugins = []
         .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(state.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
-        assert!(!state.claude_credentials_json().unwrap().exists());
+        assert!(
+            !state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
         assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
     }
 
@@ -957,7 +969,7 @@ plugins = []
 
         // Simulate container modifying its own .claude.json
         std::fs::write(
-            state.claude_account_json().unwrap(),
+            state.root.join("claude/account.json").as_path(),
             r#"{"container":"data"}"#,
         )
         .unwrap();
@@ -979,7 +991,7 @@ plugins = []
         .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(state2.claude_credentials_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/credentials.json").as_path()).unwrap(),
             updated_creds
         );
         assert_eq!(outcome2, AuthProvisionOutcome::Synced);
@@ -1005,7 +1017,13 @@ plugins = []
             crate::agent::Agent::Claude,
         )
         .unwrap();
-        assert!(state.claude_credentials_json().unwrap().exists());
+        assert!(
+            state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
 
         // Operator switches to ignore — credentials must be wiped
         let (state2, _) = RoleState::prepare(
@@ -1019,10 +1037,16 @@ plugins = []
         )
         .unwrap();
         assert_eq!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
-        assert!(!state2.claude_credentials_json().unwrap().exists());
+        assert!(
+            !state2
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
     }
 
     #[test]
@@ -1045,11 +1069,15 @@ plugins = []
         .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(state.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
         assert!(
-            !state.claude_credentials_json().unwrap().exists(),
+            !state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists(),
             "token mode must not write .credentials.json"
         );
         assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
@@ -1083,7 +1111,11 @@ plugins = []
         )
         .unwrap();
         assert!(
-            state.claude_credentials_json().unwrap().exists(),
+            state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists(),
             "precondition: sync seeded .credentials.json"
         );
 
@@ -1099,12 +1131,16 @@ plugins = []
         .unwrap();
 
         assert_eq!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path()).unwrap(),
             "{}",
             "api_key mode must reset .claude.json to empty object"
         );
         assert!(
-            !state2.claude_credentials_json().unwrap().exists(),
+            !state2
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists(),
             "api_key mode must wipe .credentials.json"
         );
         assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
@@ -1128,7 +1164,13 @@ plugins = []
             crate::agent::Agent::Claude,
         )
         .unwrap();
-        assert!(state.claude_credentials_json().unwrap().exists());
+        assert!(
+            state
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
 
         // Operator switches to token — credentials must be wiped and
         // .claude.json reset to {} so Claude Code inside the container
@@ -1144,10 +1186,16 @@ plugins = []
         )
         .unwrap();
         assert_eq!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
-        assert!(!state2.claude_credentials_json().unwrap().exists());
+        assert!(
+            !state2
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
         assert_eq!(outcome, AuthProvisionOutcome::TokenMode);
     }
 
@@ -1170,7 +1218,7 @@ plugins = []
         )
         .unwrap();
         assert_eq!(
-            std::fs::read_to_string(state.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
 
@@ -1186,12 +1234,12 @@ plugins = []
         )
         .unwrap();
         assert!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap())
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path())
                 .unwrap()
                 .contains("test@example.com")
         );
         assert_eq!(
-            std::fs::read_to_string(state2.claude_credentials_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/credentials.json").as_path()).unwrap(),
             TEST_CREDENTIALS
         );
         assert_eq!(outcome, AuthProvisionOutcome::Synced);
@@ -1228,10 +1276,16 @@ plugins = []
         )
         .unwrap();
         assert_eq!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path()).unwrap(),
             "{}"
         );
-        assert!(!state2.claude_credentials_json().unwrap().exists());
+        assert!(
+            !state2
+                .root
+                .join("claude/credentials.json")
+                .as_path()
+                .exists()
+        );
         assert_eq!(outcome, AuthProvisionOutcome::Skipped);
     }
 
@@ -1260,7 +1314,11 @@ plugins = []
 
         // Container may have its own auth by now (from manual login inside)
         let container_auth = r#"{"oauthAccount":{"emailAddress":"container@example.com"}}"#;
-        std::fs::write(state.claude_account_json().unwrap(), container_auth).unwrap();
+        std::fs::write(
+            state.root.join("claude/account.json").as_path(),
+            container_auth,
+        )
+        .unwrap();
 
         // Second run: host auth missing — container auth must be preserved
         let (state2, outcome) = RoleState::prepare(
@@ -1274,7 +1332,7 @@ plugins = []
         )
         .unwrap();
         assert_eq!(
-            std::fs::read_to_string(state2.claude_account_json().unwrap()).unwrap(),
+            std::fs::read_to_string(state2.root.join("claude/account.json").as_path()).unwrap(),
             container_auth
         );
         assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
@@ -1301,7 +1359,7 @@ plugins = []
         )
         .unwrap();
 
-        let perms = std::fs::metadata(state.claude_account_json().unwrap())
+        let perms = std::fs::metadata(state.root.join("claude/account.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(
@@ -1309,7 +1367,7 @@ plugins = []
             0o600,
             "claude.json should have 0600 permissions"
         );
-        let creds_perms = std::fs::metadata(state.claude_credentials_json().unwrap())
+        let creds_perms = std::fs::metadata(state.root.join("claude/credentials.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(
@@ -1342,11 +1400,11 @@ plugins = []
 
         // Simulate a legacy state file with permissive mode
         std::fs::set_permissions(
-            state.claude_account_json().unwrap(),
+            state.root.join("claude/account.json").as_path(),
             std::fs::Permissions::from_mode(0o644),
         )
         .unwrap();
-        let perms = std::fs::metadata(state.claude_account_json().unwrap())
+        let perms = std::fs::metadata(state.root.join("claude/account.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(perms.mode() & 0o777, 0o644, "precondition: file is 0644");
@@ -1364,7 +1422,7 @@ plugins = []
         )
         .unwrap();
 
-        let perms = std::fs::metadata(state2.claude_account_json().unwrap())
+        let perms = std::fs::metadata(state2.root.join("claude/account.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(
@@ -1398,11 +1456,11 @@ plugins = []
 
         // Simulate legacy permissive modes on both auth files
         std::fs::set_permissions(
-            state.claude_account_json().unwrap(),
+            state.root.join("claude/account.json").as_path(),
             std::fs::Permissions::from_mode(0o644),
         )
         .unwrap();
-        let creds_path = state.claude_credentials_json().unwrap();
+        let creds_path = state.root.join("claude/credentials.json");
         std::fs::set_permissions(creds_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         // Remove host auth so sync takes the preserve path
@@ -1422,7 +1480,7 @@ plugins = []
         .unwrap();
         assert_eq!(outcome, AuthProvisionOutcome::HostMissing);
 
-        let json_perms = std::fs::metadata(state2.claude_account_json().unwrap())
+        let json_perms = std::fs::metadata(state2.root.join("claude/account.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(
@@ -1430,7 +1488,7 @@ plugins = []
             0o600,
             "sync should repair .claude.json permissions even when host auth is missing"
         );
-        let creds_perms = std::fs::metadata(state2.claude_credentials_json().unwrap())
+        let creds_perms = std::fs::metadata(state2.root.join("claude/credentials.json").as_path())
             .unwrap()
             .permissions();
         assert_eq!(
@@ -1465,8 +1523,9 @@ plugins = []
         // Replace .claude.json with a symlink to a decoy file
         let decoy = temp.path().join("decoy.txt");
         std::fs::write(&decoy, "original").unwrap();
-        std::fs::remove_file(state.claude_account_json().unwrap()).unwrap();
-        std::os::unix::fs::symlink(&decoy, state.claude_account_json().unwrap()).unwrap();
+        std::fs::remove_file(state.root.join("claude/account.json").as_path()).unwrap();
+        std::os::unix::fs::symlink(&decoy, state.root.join("claude/account.json").as_path())
+            .unwrap();
 
         // Sync should refuse to write through the symlink
         let err = RoleState::prepare(
@@ -1511,9 +1570,9 @@ plugins = []
         // Replace .credentials.json with a symlink
         let decoy = temp.path().join("decoy-creds.txt");
         std::fs::write(&decoy, "secret").unwrap();
-        let creds_path = state.claude_credentials_json().unwrap();
-        std::fs::remove_file(creds_path).unwrap();
-        std::os::unix::fs::symlink(&decoy, creds_path).unwrap();
+        let creds_path = state.root.join("claude/credentials.json");
+        std::fs::remove_file(&creds_path).unwrap();
+        std::os::unix::fs::symlink(&decoy, &creds_path).unwrap();
 
         // Sync should refuse to write through the symlink
         let err = RoleState::prepare(

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -165,34 +165,26 @@ pub enum GithubProvisionKind {
 /// `/home/agent/.local/share/amp/`) to carry image-baked config without
 /// being masked by a runtime mount.
 ///
-/// The mount decision is encoded in `forward_auth` (Claude) or in the
-/// optional path fields directly (Codex/Amp). For Claude,
-/// `forward_auth = false` means the agent authenticates via env vars
-/// (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`) and the auth files
-/// must not flow into the container even though they exist on the host
-/// (`wipe_claude_state` leaves a `{}` shell behind). For Codex/Amp,
-/// `None` on the optional path field means the same thing — wiped on
-/// disk, no mount, env-driven authentication
-/// (`OPENAI_API_KEY` / `AMP_API_KEY`).
+/// Every variant encodes mount eligibility in `Option<PathBuf>`:
+/// `Some(p)` ⇔ the file should bind-mount at `/jackin/<agent>/<file>`,
+/// `None` ⇔ env-driven auth (`CLAUDE_CODE_OAUTH_TOKEN` /
+/// `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `AMP_API_KEY`) or the
+/// host-missing fallback. `wipe_claude_state` may still leave a `{}`
+/// shell on disk; this type tracks mount, not on-disk presence.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum AgentRuntimeState {
     Claude {
-        /// Host path to Claude's account-metadata file. Always
-        /// populated by `prepare` (as `{}` for non-sync modes); only
-        /// bind-mounted when `forward_auth` is `true` *and* the file
-        /// exists on disk.
-        account_json: PathBuf,
-        /// Host path to Claude's OAuth credentials file. May not exist
-        /// on disk in env-driven modes (the wipe path removes it).
-        /// Only bind-mounted when `forward_auth` is `true` *and* the
-        /// file exists.
-        credentials_json: PathBuf,
-        /// Whether `account_json` and `credentials_json` should be
-        /// bind-mounted under `/jackin/claude/`. `false` for
-        /// `ignore`/`api_key`/`oauth_token` (env-driven authentication
-        /// — no host filesystem state must reach the container).
-        forward_auth: bool,
+        /// Host path mounted at `/jackin/claude/account.json`. `None`
+        /// when env-driven modes wiped it / mounted nothing, matching
+        /// the `Some` ⇔ mountable invariant Codex and Amp variants
+        /// follow. The role-state file itself may still exist as `{}`
+        /// after a non-sync mode; this field tracks mount eligibility,
+        /// not on-disk presence.
+        account_json: Option<PathBuf>,
+        /// Host path mounted at `/jackin/claude/credentials.json`.
+        /// Same `Some` ⇔ mountable invariant as `account_json`.
+        credentials_json: Option<PathBuf>,
     },
     Codex {
         /// Host path mounted at `/jackin/codex/config.toml` (always —
@@ -231,48 +223,27 @@ pub struct RoleState {
 }
 
 impl RoleState {
-    /// Host path to Claude's account-metadata file. `None` when not
-    /// prepared for `Agent::Claude`. The path is returned regardless
-    /// of mount eligibility — call sites that care whether the file
-    /// will reach the container should also consult
-    /// [`Self::claude_forwards_auth`].
+    /// Host path to Claude's account-metadata file. `None` when no
+    /// mount is eligible (env-driven mode wiped it / non-Claude
+    /// state).
     #[must_use]
     pub fn claude_account_json(&self) -> Option<&Path> {
         match &self.agent_runtime {
-            AgentRuntimeState::Claude { account_json, .. } => Some(account_json),
+            AgentRuntimeState::Claude { account_json, .. } => account_json.as_deref(),
             AgentRuntimeState::Codex { .. } | AgentRuntimeState::Amp { .. } => None,
         }
     }
 
-    /// Host path to Claude's OAuth credentials file. `None` when not
-    /// prepared for `Agent::Claude`. As with [`Self::claude_account_json`],
-    /// the path is returned regardless of whether the file currently
-    /// exists on disk or will be bind-mounted into the container; pair
-    /// with [`Self::claude_forwards_auth`] when filtering for runtime
-    /// reachability.
+    /// Host path to Claude's OAuth credentials file. `None` when no
+    /// mount is eligible.
     #[must_use]
     pub fn claude_credentials_json(&self) -> Option<&Path> {
         match &self.agent_runtime {
             AgentRuntimeState::Claude {
                 credentials_json, ..
-            } => Some(credentials_json),
+            } => credentials_json.as_deref(),
             AgentRuntimeState::Codex { .. } | AgentRuntimeState::Amp { .. } => None,
         }
-    }
-
-    /// Whether Claude's auth files (`account.json`, `credentials.json`)
-    /// should flow into the container under `/jackin/claude/`. `false`
-    /// for env-driven modes (`ignore`/`api_key`/`oauth_token`) and for
-    /// non-Claude states.
-    #[must_use]
-    pub const fn claude_forwards_auth(&self) -> bool {
-        matches!(
-            &self.agent_runtime,
-            AgentRuntimeState::Claude {
-                forward_auth: true,
-                ..
-            }
-        )
     }
 
     /// Host path to Codex's `config.toml` (mounted at
@@ -359,20 +330,34 @@ impl RoleState {
                 let claude_dir = root.join("claude");
                 std::fs::create_dir_all(&claude_dir)?;
 
-                let account_json = claude_dir.join("account.json");
-                let credentials_json = claude_dir.join("credentials.json");
+                let account_path = claude_dir.join("account.json");
+                let credentials_path = claude_dir.join("credentials.json");
                 let (outcome, forward_auth) = Self::provision_claude_auth(
-                    &account_json,
-                    &credentials_json,
+                    &account_path,
+                    &credentials_path,
                     auth_forward,
                     host_home,
                 )?;
+
+                // Mount eligibility: forward_auth gates the whole pair
+                // (env-driven modes never bind host state), then each
+                // file's existence gates its own mount. `provision_claude_auth`
+                // always writes account.json (as `{}` when wiping) so it
+                // exists post-call under sync; credentials.json may have
+                // been removed by the wipe path.
+                let (account_json, credentials_json) = if forward_auth {
+                    (
+                        account_path.exists().then_some(account_path),
+                        credentials_path.exists().then_some(credentials_path),
+                    )
+                } else {
+                    (None, None)
+                };
 
                 (
                     AgentRuntimeState::Claude {
                         account_json,
                         credentials_json,
-                        forward_auth,
                     },
                     outcome,
                 )
@@ -460,32 +445,17 @@ plugins = []
         )
         .unwrap();
 
-        // Auth files exist as `{}` placeholders even under env-driven
-        // modes; they just won't be bind-mounted (`forward_auth = false`).
-        assert_eq!(
-            std::fs::read_to_string(state.claude_account_json().unwrap()).unwrap(),
-            "{}"
-        );
-        assert!(
-            !state.claude_forwards_auth(),
-            "Ignore mode must not forward auth into the container",
-        );
+        // Mount accessors return `None` under Ignore (env-driven mode
+        // never bind-mounts host state). The role-state file itself
+        // still exists on disk as a `{}` placeholder.
+        assert!(state.claude_account_json().is_none());
+        assert!(state.claude_credentials_json().is_none());
         assert!(state.codex_config_toml().is_none());
 
-        // Pin the host-side grouped layout: a regression to the legacy
-        // flat shape (`.claude/state/.credentials.json` at the data-dir
-        // root) would still satisfy the accessor checks
-        // above, since they only look up paths through the enum. These
-        // assertions verify the actual host paths under
-        // `<container>/claude/`.
         let container_root = paths.data_dir.join("jackin-agent-smith");
         assert_eq!(
-            state.claude_account_json().unwrap(),
-            container_root.join("claude").join("account.json"),
-        );
-        assert_eq!(
-            state.claude_credentials_json().unwrap(),
-            container_root.join("claude").join("credentials.json"),
+            std::fs::read_to_string(container_root.join("claude").join("account.json")).unwrap(),
+            "{}"
         );
     }
 
@@ -529,6 +499,5 @@ agents = ["codex"]
         // makes the absence structural rather than a runtime nil.
         assert!(state.claude_account_json().is_none());
         assert!(state.claude_credentials_json().is_none());
-        assert!(!state.claude_forwards_auth());
     }
 }

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -213,28 +213,13 @@ fn agent_mounts(state: &crate::instance::RoleState) -> Vec<String> {
         AgentRuntimeState::Claude {
             account_json,
             credentials_json,
-            forward_auth,
         } => {
             let mut mounts = Vec::new();
-            // Auth files only flow into the container under sync mode
-            // (`forward_auth = true`) AND only when the file exists on
-            // disk. Env-driven modes (api_key/oauth_token/ignore) leave
-            // `forward_auth = false`, keeping host filesystem state out
-            // of the container even though `wipe_claude_state` may have
-            // left a `{}` placeholder behind.
-            if *forward_auth {
-                if account_json.exists() {
-                    mounts.push(format!(
-                        "{}:/jackin/claude/account.json",
-                        account_json.display()
-                    ));
-                }
-                if credentials_json.exists() {
-                    mounts.push(format!(
-                        "{}:/jackin/claude/credentials.json",
-                        credentials_json.display()
-                    ));
-                }
+            if let Some(p) = account_json {
+                mounts.push(format!("{}:/jackin/claude/account.json", p.display()));
+            }
+            if let Some(p) = credentials_json {
+                mounts.push(format!("{}:/jackin/claude/credentials.json", p.display()));
             }
             mounts
         }


### PR DESCRIPTION
## Summary

Bring `AgentRuntimeState::Claude` to the same shape `Codex` and `Amp` already use: two `Option<PathBuf>` fields where `Some` ⇔ mount-eligible and `None` ⇔ env-driven mode (or wiped, or never written). Drops the `forward_auth: bool + always-Some PathBuf` shape that let the type system express the impossible state `forward_auth=true, file-doesn't-exist`. Closes the second item the multi-agent review flagged as deferred from the original amp PR ([#248](https://github.com/jackin-project/jackin/pull/248)).

## What's deferred (follow-up PRs)

- **`AuthKind` redesign** to `enum AuthKind { Agent(Agent), Github }` — separate PR.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin refactor/claude-agent-runtime-state-option:refs/remotes/origin/refactor/claude-agent-runtime-state-option
git checkout -B refactor/claude-agent-runtime-state-option refs/remotes/origin/refactor/claude-agent-runtime-state-option
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib -- -D warnings
```

### Tests

```sh
cargo test --lib instance::auth
cargo test --lib instance::tests
cargo test --lib runtime::launch
cargo test --test e2e_auth_modes
cargo test --test amp_launch
cargo test --test codex_launch
```

The instance auth-mode tests (sync / api_key / oauth_token / ignore + the four mode-transition tests) verify the new mount-eligibility invariant: `claude_account_json()` is `Some` only when `auth_forward = "sync"` and the file is on disk; `None` everywhere else.

### User smoke

```sh
cargo run --bin jackin -- load the-architect "$HOME/Projects/jackin-project/test/jackin" --agent claude --debug
```

Watch the assembled `docker run` line in the debug log: under `auth_forward = "sync"` it should bind-mount `/jackin/claude/account.json` and (when the host file exists) `/jackin/claude/credentials.json`. Under `api_key` / `oauth_token` / `ignore` the line should contain neither `/jackin/claude/account.json` nor `/jackin/claude/credentials.json`. Behaviour is unchanged from before this PR; only the underlying type is tighter.

## Migration notes

None. Pre-release, no released schema to migrate. The on-disk role-state layout under `<container>/claude/` is unchanged. `RoleState::claude_forwards_auth()` is removed; the equivalent question is `state.claude_account_json().is_some()` against the new type.
