### PR TITLE
ci(construct): add PR-time publish-manifest-rehearsal to catch buildx env-var leaks

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -187,9 +187,51 @@ jobs:
       - name: Publish multi-platform manifest
         run: just construct-publish-manifest
 
+  # PR-time rehearsal of `publish-manifest`'s setup. Runs the same
+  # docker buildx CLI plumbing publish-manifest depends on, without
+  # logging in to Docker Hub or writing a manifest to the registry,
+  # so a workflow- or job-level env-var leak that breaks
+  # `docker buildx` resolution surfaces in PR rather than
+  # post-merge on main. Catches the exact failure class from
+  # jackin-project/jackin#266 — `docker buildx ls` evaluates
+  # BUILDX_BUILDER at startup and exits non-zero on a missing-builder
+  # reference, regardless of whether the rest of the command would
+  # have hit the network. The rehearsal runs on the events
+  # publish-manifest itself skips: PR and feature-branch dispatch
+  # that touch construct paths.
+  publish-manifest-rehearsal:
+    name: publish manifest (rehearsal)
+    if: needs.changes.outputs.construct == 'true' && needs.changes.outputs.is_publish != 'true'
+    needs: [changes, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      - name: Verify docker buildx CLI resolves under workflow env
+        # `docker buildx ls` reads BUILDX_BUILDER (and the rest of
+        # buildx's env-driven config) and fails fast on a missing
+        # builder reference. This is the exact error shape from
+        # jackin-project/jackin#266 — running it on PR + feature-branch
+        # dispatch surfaces a leak that publish-manifest would
+        # otherwise only hit post-merge on main.
+        run: docker buildx ls
+
+      - name: Verify imagetools CLI plugin loads
+        # Exercises the same plugin path publish-manifest's
+        # `docker buildx imagetools create` / `inspect` commands rely
+        # on. Cheap, network-free smoke that the plugin is bundled
+        # and loadable on the runner.
+        run: docker buildx imagetools --help >/dev/null
+
   construct-required:
     if: always()
-    needs: [changes, build, publish-manifest]
+    needs: [changes, build, publish-manifest, publish-manifest-rehearsal]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Tier 3 follow-up to the post-#266 hardening. Adds a PR-time `publish-manifest-rehearsal` job to `construct.yml` that runs the same `docker buildx` CLI plumbing `publish-manifest` depends on, without the side-effect steps (Docker Hub login, `imagetools create`, `imagetools inspect`). The rehearsal closes the gap that let #266 reach `main`: workflow-level env vars consumed by third-party CLIs (in #266's case `BUILDX_BUILDER`) were never exercised on PR because every job that calls `docker buildx` is gated to push-to-main.

## How the rehearsal catches the #266 class of break

`docker buildx ls` evaluates `BUILDX_BUILDER` (and any other buildx-controlling env var) at startup and exits non-zero on a missing-builder reference. That's the exact failure shape `publish-manifest` emitted post-#256-merge:

```
ERROR: no builder "jackin-construct" found
error: Recipe `construct-publish-manifest` failed with exit code 1
```

Running the same call without registry credentials surfaces the same error before any network write. A second cheap step — `docker buildx imagetools --help >/dev/null` — confirms the buildx CLI plugin is bundled and loadable on the runner.

The rehearsal runs on the events `publish-manifest` itself skips: PR and feature-branch `workflow_dispatch` that touch construct paths. The `construct-required` aggregator now lists `publish-manifest-rehearsal` in `needs:` so its result is rolled up into the same single required-check name branch protection enforces.

## What's deferred

Similar rehearsals for `build-validator` (CI), `deploy` (Docs), and `publish-preview` (Homebrew preview) are not included. None of those side-effect surfaces — release artifacts in GitHub-side storage, GitHub Pages publish, Homebrew tap PR-create — has the same network-free reproducibility shape `buildx ls` provides for docker. Adding rehearsals for them would either require synthesizing fake side effects (high false-confidence risk) or re-architecting the workflow trigger (preview.yml fires on `workflow_run` from CI completion on main, not PR). Reopen if a #266-class break surfaces in any of them.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin ci/construct-publish-manifest-rehearsal:refs/remotes/origin/ci/construct-publish-manifest-rehearsal
git checkout -B ci/construct-publish-manifest-rehearsal refs/remotes/origin/ci/construct-publish-manifest-rehearsal
```

### Static checks

```sh
yq . .github/workflows/construct.yml >/dev/null
```

### Smoke (CI runner only — local docker may not bundle buildx)

```sh
docker buildx ls
docker buildx imagetools --help >/dev/null && echo ok
```

The CI run on this PR is the actual fidelity test — `publish-manifest-rehearsal` should run, report green, and be visible in the `construct-required` rollup. Push to main on merge will skip the rehearsal (because `is_publish == 'true'`) and run the real `publish-manifest`, exactly as before this PR.
