### PR TITLE
refactor(auth_kind): collapse `AuthKind` to `enum { Agent(Agent), Github }`

### DIFF
--- a/src/console/manager/auth_kind.rs
+++ b/src/console/manager/auth_kind.rs
@@ -23,13 +23,21 @@ use crate::config::{AuthForwardMode, GithubAuthMode};
 
 /// Which auth section the operator is currently editing.
 ///
-/// See module docs for why this is wider than `Agent`.
+/// `Agent(_)` lifts the runtime [`Agent`] enum directly — every per-
+/// agent table (`label`, `supported_modes`, `required_env_var`)
+/// delegates to `Agent` so adding a fourth runtime is one line on
+/// `Agent`, not five scattered match arms here. `Github` is the lone
+/// non-runtime kind and stays its own variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AuthKind {
-    Claude,
-    Codex,
-    Amp,
+    Agent(Agent),
     Github,
+}
+
+impl From<Agent> for AuthKind {
+    fn from(agent: Agent) -> Self {
+        Self::Agent(agent)
+    }
 }
 
 impl AuthKind {
@@ -38,9 +46,9 @@ impl AuthKind {
     #[must_use]
     pub const fn label(self) -> &'static str {
         match self {
-            Self::Claude => "Claude Code",
-            Self::Codex => "Codex",
-            Self::Amp => "Amp",
+            Self::Agent(Agent::Claude) => "Claude Code",
+            Self::Agent(Agent::Codex) => "Codex",
+            Self::Agent(Agent::Amp) => "Amp",
             Self::Github => "GitHub CLI",
         }
     }
@@ -52,69 +60,52 @@ impl AuthKind {
     #[must_use]
     pub const fn supported_modes(self) -> &'static [AuthMode] {
         match self {
-            Self::Claude => &[
+            Self::Agent(Agent::Claude) => &[
                 AuthMode::Sync,
                 AuthMode::ApiKey,
                 AuthMode::OAuthToken,
                 AuthMode::Ignore,
             ],
-            Self::Codex | Self::Amp => &[AuthMode::Sync, AuthMode::ApiKey, AuthMode::Ignore],
+            Self::Agent(Agent::Codex | Agent::Amp) => {
+                &[AuthMode::Sync, AuthMode::ApiKey, AuthMode::Ignore]
+            }
             Self::Github => &[AuthMode::Sync, AuthMode::Token, AuthMode::Ignore],
         }
     }
 
     /// Well-known env var that carries the auth credential for this
-    /// (kind, mode) combination, if any. Returns `None` for modes that
-    /// don't inject a credential (sync, ignore) or for combinations
-    /// that don't make sense for the kind.
+    /// (kind, mode) combination, if any.
     #[must_use]
     pub const fn required_env_var(self, mode: AuthMode) -> Option<&'static str> {
         match (self, mode) {
-            (Self::Claude, AuthMode::ApiKey) => Some("ANTHROPIC_API_KEY"),
-            (Self::Claude, AuthMode::OAuthToken) => Some("CLAUDE_CODE_OAUTH_TOKEN"),
-            (Self::Codex, AuthMode::ApiKey) => Some("OPENAI_API_KEY"),
-            (Self::Amp, AuthMode::ApiKey) => Some("AMP_API_KEY"),
+            (Self::Agent(Agent::Claude), AuthMode::ApiKey) => Some("ANTHROPIC_API_KEY"),
+            (Self::Agent(Agent::Claude), AuthMode::OAuthToken) => Some("CLAUDE_CODE_OAUTH_TOKEN"),
+            (Self::Agent(Agent::Codex), AuthMode::ApiKey) => Some("OPENAI_API_KEY"),
+            (Self::Agent(Agent::Amp), AuthMode::ApiKey) => Some("AMP_API_KEY"),
             (Self::Github, AuthMode::Token) => Some(crate::env_model::GH_TOKEN_ENV_NAME),
             _ => None,
         }
     }
 
-    /// Map a runtime [`Agent`] onto its [`AuthKind`] counterpart. The
-    /// inverse direction (`Agent::for_auth_kind`) is intentionally
-    /// absent — `AuthKind::Github` has no `Agent` partner.
-    #[must_use]
-    pub const fn for_agent(agent: Agent) -> Self {
-        match agent {
-            Agent::Claude => Self::Claude,
-            Agent::Codex => Self::Codex,
-            Agent::Amp => Self::Amp,
-        }
-    }
-
-    /// Convert back to the runtime [`Agent`] axis for code paths that
-    /// remain agent-keyed (Claude / Codex persistence diffs, the
-    /// shared `resolve_mode` helper that takes an `Agent`). Returns
-    /// `None` for `Self::Github`, which has no runtime peer.
+    /// Convert to the runtime [`Agent`] axis for code paths that remain
+    /// agent-keyed (per-agent persistence diffs, `resolve_mode`).
+    /// `Self::Github` has no runtime peer.
     #[must_use]
     pub const fn agent(self) -> Option<Agent> {
         match self {
-            Self::Claude => Some(Agent::Claude),
-            Self::Codex => Some(Agent::Codex),
-            Self::Amp => Some(Agent::Amp),
+            Self::Agent(a) => Some(a),
             Self::Github => None,
         }
     }
 
     /// Whether the role-override entry already carries a block for
-    /// this kind. Used by the auth-role-override picker (filter out
-    /// roles that already have an override) and the render-side row
-    /// builder (decide whether to draw a `RoleHeader`).
+    /// this kind.
     #[must_use]
     pub const fn role_override_present(self, ro: &crate::config::WorkspaceRoleOverride) -> bool {
         match self {
-            Self::Claude => ro.claude.is_some(),
-            Self::Codex => ro.codex.is_some(),
-            Self::Amp => ro.amp.is_some(),
+            Self::Agent(Agent::Claude) => ro.claude.is_some(),
+            Self::Agent(Agent::Codex) => ro.codex.is_some(),
+            Self::Agent(Agent::Amp) => ro.amp.is_some(),
             Self::Github => ro.github.is_some(),
         }
     }
@@ -206,9 +197,9 @@ mod tests {
 
     #[test]
     fn label_matches_design_spec() {
-        assert_eq!(AuthKind::Claude.label(), "Claude Code");
-        assert_eq!(AuthKind::Codex.label(), "Codex");
-        assert_eq!(AuthKind::Amp.label(), "Amp");
+        assert_eq!(AuthKind::Agent(Agent::Claude).label(), "Claude Code");
+        assert_eq!(AuthKind::Agent(Agent::Codex).label(), "Codex");
+        assert_eq!(AuthKind::Agent(Agent::Amp).label(), "Amp");
         assert_eq!(AuthKind::Github.label(), "GitHub CLI");
     }
 
@@ -220,20 +211,20 @@ mod tests {
 
     #[test]
     fn claude_supported_modes_include_oauth_token() {
-        let modes = AuthKind::Claude.supported_modes();
+        let modes = AuthKind::Agent(Agent::Claude).supported_modes();
         assert!(modes.contains(&AuthMode::OAuthToken));
     }
 
     #[test]
     fn codex_supported_modes_exclude_oauth_token_and_token() {
-        let modes = AuthKind::Codex.supported_modes();
+        let modes = AuthKind::Agent(Agent::Codex).supported_modes();
         assert!(!modes.contains(&AuthMode::OAuthToken));
         assert!(!modes.contains(&AuthMode::Token));
     }
 
     #[test]
     fn amp_supported_modes_exclude_oauth_token_and_token() {
-        let modes = AuthKind::Amp.supported_modes();
+        let modes = AuthKind::Agent(Agent::Amp).supported_modes();
         assert!(!modes.contains(&AuthMode::OAuthToken));
         assert!(!modes.contains(&AuthMode::Token));
     }
@@ -255,41 +246,59 @@ mod tests {
     #[test]
     fn claude_required_env_vars_match_runtime_table() {
         assert_eq!(
-            AuthKind::Claude.required_env_var(AuthMode::ApiKey),
+            AuthKind::Agent(Agent::Claude).required_env_var(AuthMode::ApiKey),
             Some("ANTHROPIC_API_KEY")
         );
         assert_eq!(
-            AuthKind::Claude.required_env_var(AuthMode::OAuthToken),
+            AuthKind::Agent(Agent::Claude).required_env_var(AuthMode::OAuthToken),
             Some("CLAUDE_CODE_OAUTH_TOKEN")
         );
-        assert_eq!(AuthKind::Claude.required_env_var(AuthMode::Sync), None);
-        assert_eq!(AuthKind::Claude.required_env_var(AuthMode::Ignore), None);
+        assert_eq!(
+            AuthKind::Agent(Agent::Claude).required_env_var(AuthMode::Sync),
+            None
+        );
+        assert_eq!(
+            AuthKind::Agent(Agent::Claude).required_env_var(AuthMode::Ignore),
+            None
+        );
     }
 
     #[test]
     fn amp_required_env_vars_match_runtime_table() {
         assert_eq!(
-            AuthKind::Amp.required_env_var(AuthMode::ApiKey),
+            AuthKind::Agent(Agent::Amp).required_env_var(AuthMode::ApiKey),
             Some("AMP_API_KEY")
         );
-        assert_eq!(AuthKind::Amp.required_env_var(AuthMode::Sync), None);
-        assert_eq!(AuthKind::Amp.required_env_var(AuthMode::Ignore), None);
-        assert_eq!(AuthKind::Amp.required_env_var(AuthMode::OAuthToken), None);
+        assert_eq!(
+            AuthKind::Agent(Agent::Amp).required_env_var(AuthMode::Sync),
+            None
+        );
+        assert_eq!(
+            AuthKind::Agent(Agent::Amp).required_env_var(AuthMode::Ignore),
+            None
+        );
+        assert_eq!(
+            AuthKind::Agent(Agent::Amp).required_env_var(AuthMode::OAuthToken),
+            None
+        );
     }
 
     #[test]
-    fn for_agent_round_trip() {
-        assert_eq!(AuthKind::for_agent(Agent::Claude), AuthKind::Claude);
-        assert_eq!(AuthKind::for_agent(Agent::Codex), AuthKind::Codex);
-        assert_eq!(AuthKind::for_agent(Agent::Amp), AuthKind::Amp);
+    fn from_agent_round_trip() {
+        assert_eq!(
+            AuthKind::from(Agent::Claude),
+            AuthKind::Agent(Agent::Claude)
+        );
+        assert_eq!(AuthKind::from(Agent::Codex), AuthKind::Agent(Agent::Codex));
+        assert_eq!(AuthKind::from(Agent::Amp), AuthKind::Agent(Agent::Amp));
     }
 
     #[test]
     fn agent_returns_none_for_github() {
         assert_eq!(AuthKind::Github.agent(), None);
-        assert_eq!(AuthKind::Claude.agent(), Some(Agent::Claude));
-        assert_eq!(AuthKind::Codex.agent(), Some(Agent::Codex));
-        assert_eq!(AuthKind::Amp.agent(), Some(Agent::Amp));
+        assert_eq!(AuthKind::Agent(Agent::Claude).agent(), Some(Agent::Claude));
+        assert_eq!(AuthKind::Agent(Agent::Codex).agent(), Some(Agent::Codex));
+        assert_eq!(AuthKind::Agent(Agent::Amp).agent(), Some(Agent::Amp));
     }
 
     #[test]
@@ -331,9 +340,9 @@ mod tests {
     #[test]
     fn role_override_present_false_when_no_blocks_set() {
         let ro = crate::config::WorkspaceRoleOverride::default();
-        assert!(!AuthKind::Claude.role_override_present(&ro));
-        assert!(!AuthKind::Codex.role_override_present(&ro));
-        assert!(!AuthKind::Amp.role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(!AuthKind::Github.role_override_present(&ro));
     }
 
@@ -346,9 +355,9 @@ mod tests {
             }),
             ..crate::config::WorkspaceRoleOverride::default()
         };
-        assert!(AuthKind::Claude.role_override_present(&ro));
-        assert!(!AuthKind::Codex.role_override_present(&ro));
-        assert!(!AuthKind::Amp.role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(!AuthKind::Github.role_override_present(&ro));
 
         // Codex-only override → only Codex returns true.
@@ -360,9 +369,9 @@ mod tests {
             )),
             ..crate::config::WorkspaceRoleOverride::default()
         };
-        assert!(!AuthKind::Claude.role_override_present(&ro));
-        assert!(AuthKind::Codex.role_override_present(&ro));
-        assert!(!AuthKind::Amp.role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(!AuthKind::Github.role_override_present(&ro));
 
         // Amp-only override → only Amp returns true.
@@ -374,9 +383,9 @@ mod tests {
             )),
             ..crate::config::WorkspaceRoleOverride::default()
         };
-        assert!(!AuthKind::Claude.role_override_present(&ro));
-        assert!(!AuthKind::Codex.role_override_present(&ro));
-        assert!(AuthKind::Amp.role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(!AuthKind::Github.role_override_present(&ro));
 
         // Github-only override → only Github returns true.
@@ -387,9 +396,9 @@ mod tests {
             }),
             ..crate::config::WorkspaceRoleOverride::default()
         };
-        assert!(!AuthKind::Claude.role_override_present(&ro));
-        assert!(!AuthKind::Codex.role_override_present(&ro));
-        assert!(!AuthKind::Amp.role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(!AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(AuthKind::Github.role_override_present(&ro));
     }
 
@@ -415,9 +424,9 @@ mod tests {
             }),
             ..crate::config::WorkspaceRoleOverride::default()
         };
-        assert!(AuthKind::Claude.role_override_present(&ro));
-        assert!(AuthKind::Codex.role_override_present(&ro));
-        assert!(AuthKind::Amp.role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Claude).role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Codex).role_override_present(&ro));
+        assert!(AuthKind::Agent(Agent::Amp).role_override_present(&ro));
         assert!(AuthKind::Github.role_override_present(&ro));
     }
 }

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -10,6 +10,7 @@
 //! (Claude/Codex write `[workspaces.<ws>(.roles.<role>)?].<agent>`;
 //! Github writes `[workspaces.<ws>(.roles.<role>)?].github`).
 
+use crate::agent::Agent;
 use crossterm::event::{KeyCode, KeyEvent};
 
 use super::super::super::widgets::auth_panel::{AuthForm, CredentialInput};
@@ -155,9 +156,9 @@ const fn target_kind(target: &AuthFormTarget) -> AuthKind {
 fn clear_role_kind(editor: &mut EditorState<'_>, role: &str, kind: AuthKind) {
     if let Some(ro) = editor.pending.roles.get_mut(role) {
         match kind {
-            AuthKind::Claude => ro.claude = None,
-            AuthKind::Codex => ro.codex = None,
-            AuthKind::Amp => ro.amp = None,
+            AuthKind::Agent(Agent::Claude) => ro.claude = None,
+            AuthKind::Agent(Agent::Codex) => ro.codex = None,
+            AuthKind::Agent(Agent::Amp) => ro.amp = None,
             AuthKind::Github => ro.github = None,
         }
     }
@@ -165,9 +166,9 @@ fn clear_role_kind(editor: &mut EditorState<'_>, role: &str, kind: AuthKind) {
 
 fn clear_workspace_kind(ws: &mut crate::workspace::WorkspaceConfig, kind: AuthKind) {
     match kind {
-        AuthKind::Claude => ws.claude = None,
-        AuthKind::Codex => ws.codex = None,
-        AuthKind::Amp => ws.amp = None,
+        AuthKind::Agent(Agent::Claude) => ws.claude = None,
+        AuthKind::Agent(Agent::Codex) => ws.codex = None,
+        AuthKind::Agent(Agent::Amp) => ws.amp = None,
         AuthKind::Github => ws.github = None,
     }
 }
@@ -181,7 +182,7 @@ fn current_mode_and_credential(
 ) -> (Option<AuthMode>, Option<EnvValue>) {
     match target {
         AuthFormTarget::Workspace { kind } => match kind {
-            AuthKind::Claude => {
+            AuthKind::Agent(Agent::Claude) => {
                 let mode = editor
                     .pending
                     .claude
@@ -191,7 +192,7 @@ fn current_mode_and_credential(
                 let cred = env_var.and_then(|v| editor.pending.env.get(v).cloned());
                 (mode, cred)
             }
-            AuthKind::Codex => {
+            AuthKind::Agent(Agent::Codex) => {
                 let mode = editor
                     .pending
                     .codex
@@ -201,7 +202,7 @@ fn current_mode_and_credential(
                 let cred = env_var.and_then(|v| editor.pending.env.get(v).cloned());
                 (mode, cred)
             }
-            AuthKind::Amp => {
+            AuthKind::Agent(Agent::Amp) => {
                 let mode = editor
                     .pending
                     .amp
@@ -234,7 +235,7 @@ fn current_mode_and_credential(
         AuthFormTarget::WorkspaceRole { role, kind } => {
             let override_ref = editor.pending.roles.get(role);
             match kind {
-                AuthKind::Claude => {
+                AuthKind::Agent(Agent::Claude) => {
                     let mode = override_ref
                         .and_then(|ro| ro.claude.as_ref())
                         .map(|c| AuthMode::from_auth_forward(c.auth_forward));
@@ -243,7 +244,7 @@ fn current_mode_and_credential(
                         env_var.and_then(|v| override_ref.and_then(|ro| ro.env.get(v).cloned()));
                     (mode, cred)
                 }
-                AuthKind::Codex => {
+                AuthKind::Agent(Agent::Codex) => {
                     let mode = override_ref
                         .and_then(|ro| ro.codex.as_ref())
                         .map(|c| AuthMode::from_auth_forward(c.0.auth_forward));
@@ -252,7 +253,7 @@ fn current_mode_and_credential(
                         env_var.and_then(|v| override_ref.and_then(|ro| ro.env.get(v).cloned()));
                     (mode, cred)
                 }
-                AuthKind::Amp => {
+                AuthKind::Agent(Agent::Amp) => {
                     let mode = override_ref
                         .and_then(|ro| ro.amp.as_ref())
                         .map(|c| AuthMode::from_auth_forward(c.0.auth_forward));
@@ -741,7 +742,7 @@ fn persist_form(editor: &mut EditorState<'_>, target: &AuthFormTarget, form: &Au
             set_workspace_mode(&mut editor.pending, *kind, Some(outcome.mode));
             if let (Some(name), Some(value)) = (outcome.env_var_name, outcome.env_value.clone()) {
                 match kind {
-                    AuthKind::Claude | AuthKind::Codex | AuthKind::Amp => {
+                    AuthKind::Agent(_) => {
                         editor.pending.env.insert(name.to_string(), value);
                     }
                     AuthKind::Github => {
@@ -756,7 +757,7 @@ fn persist_form(editor: &mut EditorState<'_>, target: &AuthFormTarget, form: &Au
             set_role_mode(entry, *kind, Some(outcome.mode));
             if let (Some(name), Some(value)) = (outcome.env_var_name, outcome.env_value.clone()) {
                 match kind {
-                    AuthKind::Claude | AuthKind::Codex | AuthKind::Amp => {
+                    AuthKind::Agent(_) => {
                         entry.env.insert(name.to_string(), value);
                     }
                     AuthKind::Github => {
@@ -792,17 +793,17 @@ fn set_workspace_mode(
     mode: Option<AuthMode>,
 ) {
     match kind {
-        AuthKind::Claude => {
+        AuthKind::Agent(Agent::Claude) => {
             ws.claude = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| AgentAuthConfig { auth_forward });
         }
-        AuthKind::Codex => {
+        AuthKind::Agent(Agent::Codex) => {
             ws.codex = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| CodexAuthConfig(AgentAuthConfig { auth_forward }));
         }
-        AuthKind::Amp => {
+        AuthKind::Agent(Agent::Amp) => {
             ws.amp = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| AmpAuthConfig(AgentAuthConfig { auth_forward }));
@@ -825,17 +826,17 @@ fn set_workspace_mode(
 
 fn set_role_mode(entry: &mut WorkspaceRoleOverride, kind: AuthKind, mode: Option<AuthMode>) {
     match kind {
-        AuthKind::Claude => {
+        AuthKind::Agent(Agent::Claude) => {
             entry.claude = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| AgentAuthConfig { auth_forward });
         }
-        AuthKind::Codex => {
+        AuthKind::Agent(Agent::Codex) => {
             entry.codex = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| CodexAuthConfig(AgentAuthConfig { auth_forward }));
         }
-        AuthKind::Amp => {
+        AuthKind::Agent(Agent::Amp) => {
             entry.amp = mode
                 .and_then(AuthMode::to_auth_forward)
                 .map(|auth_forward| AmpAuthConfig(AgentAuthConfig { auth_forward }));
@@ -899,7 +900,7 @@ mod tests {
                 matches!(
                     r,
                     AuthRow::WorkspaceMode {
-                        kind: AuthKind::Claude,
+                        kind: AuthKind::Agent(Agent::Claude),
                     }
                 )
             })
@@ -950,7 +951,7 @@ mod tests {
         let ws = cfg.workspaces.get("proj").unwrap().clone();
         let mut editor = EditorState::new_edit("proj".into(), ws);
         editor.active_tab = crate::console::manager::state::EditorTab::Auth;
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
         let ws_claude_idx = workspace_claude_row_idx(&editor, &cfg);
         editor.active_field = FieldFocus::Row(ws_claude_idx);
         state.stage = ManagerStage::Editor(editor);
@@ -1191,7 +1192,7 @@ mod tests {
                     r,
                     AuthRow::RoleMode {
                         role,
-                        kind: AuthKind::Claude,
+                        kind: AuthKind::Agent(Agent::Claude),
                     } if role == "smith"
                 )
             })
@@ -1205,7 +1206,7 @@ mod tests {
             target,
             &AuthFormTarget::WorkspaceRole {
                 role: "smith".into(),
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             }
         );
 
@@ -1405,9 +1406,9 @@ mod tests {
         // to leak through Esc.)
         editor.pending_auth_form_return = Some(AuthFormReturnPath {
             target: AuthFormTarget::Workspace {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             },
-            state: Box::new(AuthForm::new(AuthKind::Claude)),
+            state: Box::new(AuthForm::new(AuthKind::Agent(Agent::Claude))),
             focus: AuthFormFocus::Mode,
             literal_buffer: String::new(),
         });

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -3723,13 +3723,14 @@ mod auth_cursor_step_tests {
     use super::super::super::auth_kind::AuthKind;
     use super::super::super::render::editor::AuthRow;
     use super::{step_auth_cursor_down, step_auth_cursor_up};
+    use crate::agent::Agent;
 
     fn rows() -> Vec<AuthRow> {
         // Mirrors the focused-mode shape: WorkspaceMode → Spacer →
         // RoleHeader → Spacer → AddSentinel.
         vec![
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             },
             AuthRow::Spacer,
             AuthRow::RoleHeader {
@@ -3763,7 +3764,7 @@ mod auth_cursor_step_tests {
         // candidate verbatim (caller already clamped to `max`).
         let r = vec![
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             },
             AuthRow::Spacer,
         ];
@@ -3791,7 +3792,7 @@ mod auth_cursor_step_tests {
         let r = vec![
             AuthRow::Spacer,
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             },
         ];
         assert_eq!(step_auth_cursor_up(&r, 0), 0);

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -4,6 +4,7 @@
 //! (General / Mounts / Roles / Secrets), and the contextual footer
 //! composition that varies with the active tab + cursor.
 
+use crate::agent::Agent;
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -704,13 +705,13 @@ pub fn auth_flat_rows(editor: &EditorState<'_>, config: &AppConfig) -> Vec<AuthR
         // `crate::console::manager::auth_kind` for the design notes.
         return vec![
             AuthRow::AuthKindRow {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
             },
             AuthRow::AuthKindRow {
-                kind: AuthKind::Codex,
+                kind: AuthKind::Agent(Agent::Codex),
             },
             AuthRow::AuthKindRow {
-                kind: AuthKind::Amp,
+                kind: AuthKind::Agent(Agent::Amp),
             },
             AuthRow::AuthKindRow {
                 kind: AuthKind::Github,
@@ -791,12 +792,7 @@ fn resolve_panel_mode(
 ) -> crate::console::manager::auth_kind::AuthMode {
     use crate::console::manager::auth_kind::{AuthKind, AuthMode};
     match kind {
-        AuthKind::Claude | AuthKind::Codex | AuthKind::Amp => {
-            // `kind.agent()` returns `Some` for Claude/Codex/Amp; the
-            // GitHub arm below means the unwrap is unreachable here.
-            let agent = kind
-                .agent()
-                .expect("Claude/Codex/Amp kinds map to an Agent");
+        AuthKind::Agent(agent) => {
             let mode = crate::config::resolve_mode(cfg, agent, workspace, role);
             AuthMode::from_auth_forward(mode)
         }
@@ -1284,15 +1280,15 @@ fn explicit_workspace_mode(
 ) -> Option<crate::console::manager::auth_kind::AuthMode> {
     use crate::console::manager::auth_kind::{AuthKind, AuthMode};
     match kind {
-        AuthKind::Claude => ws
+        AuthKind::Agent(Agent::Claude) => ws
             .claude
             .as_ref()
             .map(|c| AuthMode::from_auth_forward(c.auth_forward)),
-        AuthKind::Codex => ws
+        AuthKind::Agent(Agent::Codex) => ws
             .codex
             .as_ref()
             .map(|c| AuthMode::from_auth_forward(c.0.auth_forward)),
-        AuthKind::Amp => ws
+        AuthKind::Agent(Agent::Amp) => ws
             .amp
             .as_ref()
             .map(|c| AuthMode::from_auth_forward(c.0.auth_forward)),
@@ -1316,9 +1312,7 @@ fn auth_source_value<'a>(
     use crate::console::manager::auth_kind::AuthKind;
     match kind {
         AuthKind::Github => github_source_value(synthesized, workspace_name, role, env_name),
-        AuthKind::Claude | AuthKind::Codex | AuthKind::Amp => {
-            agent_env_source_value(synthesized, workspace_name, role, env_name)
-        }
+        AuthKind::Agent(_) => agent_env_source_value(synthesized, workspace_name, role, env_name),
     }
 }
 
@@ -2827,6 +2821,7 @@ mod parse_path_breadcrumb_tests {
 #[cfg(test)]
 mod auth_flat_rows_tests {
     use super::{AuthRow, auth_flat_rows};
+    use crate::agent::Agent;
     use crate::config::AppConfig;
     use crate::console::manager::auth_kind::AuthKind;
     use crate::console::manager::state::EditorState;
@@ -2840,13 +2835,13 @@ mod auth_flat_rows_tests {
             rows,
             vec![
                 AuthRow::AuthKindRow {
-                    kind: AuthKind::Claude,
+                    kind: AuthKind::Agent(Agent::Claude),
                 },
                 AuthRow::AuthKindRow {
-                    kind: AuthKind::Codex,
+                    kind: AuthKind::Agent(Agent::Codex),
                 },
                 AuthRow::AuthKindRow {
-                    kind: AuthKind::Amp,
+                    kind: AuthKind::Agent(Agent::Amp),
                 },
                 AuthRow::AuthKindRow {
                     kind: AuthKind::Github,
@@ -2869,7 +2864,7 @@ mod auth_flat_rows_tests {
         ws.roles.insert("the-architect".into(), over);
 
         let mut editor = EditorState::new_edit("ws".into(), ws);
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
         let rows = auth_flat_rows(&editor, &AppConfig::default());
 
         let header_idx = rows
@@ -2911,7 +2906,7 @@ mod auth_flat_rows_tests {
         ws.roles.insert("the-architect".into(), over);
 
         let mut editor = EditorState::new_edit("ws".into(), ws);
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
         editor.auth_expanded.insert("the-architect".into());
         let rows = auth_flat_rows(&editor, &AppConfig::default());
 
@@ -2921,7 +2916,7 @@ mod auth_flat_rows_tests {
             .expect("expanded role header missing");
         assert!(matches!(
             rows[header_pos + 1],
-            AuthRow::RoleMode { ref role, kind: AuthKind::Claude } if role == "the-architect"
+            AuthRow::RoleMode { ref role, kind: AuthKind::Agent(Agent::Claude) } if role == "the-architect"
         ));
     }
 
@@ -2931,7 +2926,7 @@ mod auth_flat_rows_tests {
         use crate::workspace::WorkspaceConfig;
 
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
         let cfg = AppConfig::default();
         let rows = auth_flat_rows(&editor, &cfg);
         let workspace_claude_idx = rows
@@ -2940,7 +2935,7 @@ mod auth_flat_rows_tests {
                 matches!(
                     r,
                     AuthRow::WorkspaceMode {
-                        kind: AuthKind::Claude
+                        kind: AuthKind::Agent(Agent::Claude)
                     }
                 )
             })
@@ -2948,7 +2943,7 @@ mod auth_flat_rows_tests {
         assert_eq!(
             super::resolve_auth_row_target(&editor, &cfg, workspace_claude_idx),
             Some(AuthFormTarget::Workspace {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }),
         );
     }
@@ -2957,7 +2952,7 @@ mod auth_flat_rows_tests {
     fn resolve_auth_row_target_returns_none_for_navigation_and_header_rows() {
         use crate::workspace::WorkspaceConfig;
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
         let cfg = AppConfig::default();
         let rows = auth_flat_rows(&editor, &cfg);
         for (idx, row) in rows.iter().enumerate() {
@@ -2989,14 +2984,14 @@ mod auth_flat_rows_tests {
             ..AppConfig::default()
         };
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
-        editor.auth_selected_kind = Some(AuthKind::Claude);
+        editor.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
 
         let rows = auth_flat_rows(&editor, &config);
         assert!(
             rows.iter().any(|r| matches!(
                 r,
                 AuthRow::WorkspaceSource {
-                    kind: AuthKind::Claude
+                    kind: AuthKind::Agent(Agent::Claude)
                 }
             )),
             "global claude.auth_forward = api_key must surface WorkspaceSource row; got {rows:?}"

--- a/src/console/widgets/auth_panel/form.rs
+++ b/src/console/widgets/auth_panel/form.rs
@@ -168,6 +168,7 @@ const fn mode_requires_credential(kind: AuthKind, mode: AuthMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::Agent;
 
     fn dummy_op_ref() -> OpRef {
         OpRef {
@@ -178,34 +179,34 @@ mod tests {
 
     #[test]
     fn save_disabled_when_mode_unset() {
-        let f = AuthForm::new(AuthKind::Claude);
+        let f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         assert!(!f.can_save(), "no mode picked");
     }
 
     #[test]
     fn save_enabled_for_sync() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::Sync);
         assert!(f.can_save(), "sync needs no credential");
     }
 
     #[test]
     fn save_enabled_for_ignore() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::Ignore);
         assert!(f.can_save());
     }
 
     #[test]
     fn save_disabled_for_api_key_without_credential() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         assert!(!f.can_save(), "api_key requires credential");
     }
 
     #[test]
     fn save_enabled_for_api_key_with_literal() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal("sk-ant-test".into());
         assert!(f.can_save());
@@ -213,7 +214,7 @@ mod tests {
 
     #[test]
     fn save_disabled_for_api_key_with_empty_literal() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal(String::new());
         assert!(!f.can_save());
@@ -221,7 +222,7 @@ mod tests {
 
     #[test]
     fn save_enabled_for_api_key_with_op_ref() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         f.set_op_ref(dummy_op_ref());
         assert!(f.can_save());
@@ -234,7 +235,7 @@ mod tests {
     /// after the broken config had been written to disk.
     #[test]
     fn save_disabled_for_api_key_with_empty_op_ref() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         // Both fields empty: rejected.
         f.set_op_ref(OpRef {
@@ -258,7 +259,7 @@ mod tests {
 
     #[test]
     fn mode_switch_to_sync_collapses_credential_block() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal("sk-ant-test".into());
         assert!(f.shows_credential_block());
@@ -270,21 +271,21 @@ mod tests {
 
     #[test]
     fn codex_form_does_not_offer_oauth_token() {
-        let f = AuthForm::new(AuthKind::Codex);
+        let f = AuthForm::new(AuthKind::Agent(Agent::Codex));
         let modes = f.available_modes();
         assert!(!modes.contains(&AuthMode::OAuthToken));
     }
 
     #[test]
     fn amp_form_does_not_offer_oauth_token() {
-        let f = AuthForm::new(AuthKind::Amp);
+        let f = AuthForm::new(AuthKind::Agent(Agent::Amp));
         let modes = f.available_modes();
         assert!(!modes.contains(&AuthMode::OAuthToken));
     }
 
     #[test]
     fn save_emits_correct_env_var_name_for_claude_api_key() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal("sk-ant-test".into());
         let outcome = f.commit().unwrap();
@@ -295,7 +296,7 @@ mod tests {
 
     #[test]
     fn save_emits_correct_env_var_name_for_claude_oauth_token() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::OAuthToken);
         f.set_op_ref(dummy_op_ref());
         let outcome = f.commit().unwrap();
@@ -304,7 +305,7 @@ mod tests {
 
     #[test]
     fn save_emits_correct_env_var_name_for_codex_api_key() {
-        let mut f = AuthForm::new(AuthKind::Codex);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Codex));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal("sk-test".into());
         let outcome = f.commit().unwrap();
@@ -313,7 +314,7 @@ mod tests {
 
     #[test]
     fn save_emits_correct_env_var_name_for_amp_api_key() {
-        let mut f = AuthForm::new(AuthKind::Amp);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Amp));
         f.set_mode(AuthMode::ApiKey);
         f.set_literal("sgamp-test".into());
         let outcome = f.commit().unwrap();
@@ -322,7 +323,7 @@ mod tests {
 
     #[test]
     fn save_returns_none_for_sync_with_no_credential() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::Sync);
         let outcome = f.commit().unwrap();
         assert_eq!(outcome.mode, AuthMode::Sync);
@@ -333,7 +334,7 @@ mod tests {
     #[test]
     fn from_existing_pre_populates_literal_credential() {
         let f = AuthForm::from_existing(
-            AuthKind::Claude,
+            AuthKind::Agent(Agent::Claude),
             AuthMode::ApiKey,
             Some(EnvValue::Plain("sk-ant-existing".into())),
         );
@@ -349,7 +350,7 @@ mod tests {
     fn from_existing_pre_populates_op_ref_credential() {
         let r = dummy_op_ref();
         let f = AuthForm::from_existing(
-            AuthKind::Claude,
+            AuthKind::Agent(Agent::Claude),
             AuthMode::OAuthToken,
             Some(EnvValue::OpRef(r.clone())),
         );
@@ -417,7 +418,7 @@ mod tests {
 
     #[test]
     fn op_picker_failed_read_blocks_commit() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         let attempted = OpRef {
             op: "op://uuid/missing".into(),
@@ -434,7 +435,7 @@ mod tests {
 
     #[test]
     fn op_picker_successful_read_persists_op_ref() {
-        let mut f = AuthForm::new(AuthKind::Claude);
+        let mut f = AuthForm::new(AuthKind::Agent(Agent::Claude));
         f.set_mode(AuthMode::ApiKey);
         let r = OpRef {
             op: "op://uuid/anthropic".into(),

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -281,6 +281,7 @@ const fn selected_button_style(selected: bool, style: Style) -> Style {
 #[cfg(test)]
 mod form_render_tests {
     use super::*;
+    use crate::agent::Agent;
     use crate::console::manager::auth_kind::{AuthKind, AuthMode};
     use crate::operator_env::OpRef;
     use ratatui::{Terminal, backend::TestBackend};
@@ -306,7 +307,7 @@ mod form_render_tests {
 
     #[test]
     fn form_header_is_short() {
-        let form = AuthForm::new(AuthKind::Claude);
+        let form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         let s = dump_form(&form);
         assert!(s.contains("Edit auth"), "missing header; dump:\n{s}");
         assert!(
@@ -317,7 +318,7 @@ mod form_render_tests {
 
     #[test]
     fn form_with_unset_mode_hides_credential_block_and_dims_save() {
-        let form = AuthForm::new(AuthKind::Claude);
+        let form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         let s = dump_form(&form);
         assert!(s.contains("Mode"), "missing mode line; dump:\n{s}");
         assert!(
@@ -341,7 +342,7 @@ mod form_render_tests {
 
     #[test]
     fn form_with_sync_mode_hides_credential_block_and_enables_save() {
-        let mut form = AuthForm::new(AuthKind::Claude);
+        let mut form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         form.set_mode(AuthMode::Sync);
         let s = dump_form(&form);
         assert!(s.contains("sync"), "missing sync mode label; dump:\n{s}");
@@ -355,7 +356,7 @@ mod form_render_tests {
 
     #[test]
     fn form_with_api_key_literal_shows_credential_block_and_resolves() {
-        let mut form = AuthForm::new(AuthKind::Claude);
+        let mut form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         form.set_mode(AuthMode::ApiKey);
         form.set_literal("sk-ant-test".into());
         let s = dump_form(&form);
@@ -376,7 +377,7 @@ mod form_render_tests {
 
     #[test]
     fn form_with_op_ref_credential_shows_path_and_picker_button() {
-        let mut form = AuthForm::new(AuthKind::Claude);
+        let mut form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         form.set_mode(AuthMode::ApiKey);
         form.set_op_ref(OpRef {
             op: "op://uuid/anthropic".into(),
@@ -395,7 +396,7 @@ mod form_render_tests {
 
     #[test]
     fn long_credential_env_name_has_gap_before_source_label() {
-        let mut form = AuthForm::new(AuthKind::Claude);
+        let mut form = AuthForm::new(AuthKind::Agent(Agent::Claude));
         form.set_mode(AuthMode::OAuthToken);
         form.set_op_ref(OpRef {
             op: "op://uuid/oauth".into(),

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use jackin::{
+    agent::Agent,
     config::{AppConfig, ConfigEditor},
     console::{
         ConsoleStage, ConsoleState,
@@ -2714,12 +2715,12 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }
         )
     });
@@ -2858,12 +2859,12 @@ fn auth_credential_source_enter_opens_source_picker() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }
         )
     });
@@ -2920,7 +2921,7 @@ fn auth_add_role_override_flow_uses_selected_auth_kind() -> Result<()> {
         .clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
 
     let sentinel_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::AddSentinel { .. }));
     ed.active_field = FieldFocus::Row(sentinel_idx);
@@ -2941,7 +2942,7 @@ fn auth_add_role_override_flow_uses_selected_auth_kind() -> Result<()> {
                     jackin::console::manager::state::AuthFormTarget::WorkspaceRole { role, kind },
                 ..
             }) => {
-                assert_eq!(*kind, AuthKind::Claude);
+                assert_eq!(*kind, AuthKind::Agent(Agent::Claude));
                 assert!(
                     !role.is_empty(),
                     "role must propagate from AuthRolePicker → AuthForm"
@@ -2973,7 +2974,7 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let header_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
@@ -3008,7 +3009,7 @@ fn auth_role_header_d_clears_selected_auth_kind_override() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let header_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
     state.stage = ManagerStage::Editor(ed);
@@ -3060,13 +3061,15 @@ fn auth_role_agent_row_d_silently_clears_single_agent() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(jackin::console::manager::auth_kind::AuthKind::Claude);
+    ed.auth_selected_kind = Some(jackin::console::manager::auth_kind::AuthKind::Agent(
+        Agent::Claude,
+    ));
     ed.auth_expanded.insert("the-architect".into());
     let claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::RoleMode {
-                kind: AuthKind::Claude,
+                kind: AuthKind::Agent(Agent::Claude),
                 ..
             }
         )
@@ -3112,7 +3115,7 @@ fn auth_enter_on_auth_kind_focuses_selected_agent() -> Result<()> {
         matches!(
             r,
             AuthRow::AuthKindRow {
-                kind: AuthKind::Codex
+                kind: AuthKind::Agent(Agent::Codex)
             }
         )
     });
@@ -3122,7 +3125,7 @@ fn auth_enter_on_auth_kind_focuses_selected_agent() -> Result<()> {
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Enter))?;
 
     let ed = editor(&state);
-    assert_eq!(ed.auth_selected_kind, Some(AuthKind::Codex));
+    assert_eq!(ed.auth_selected_kind, Some(AuthKind::Agent(Agent::Codex)));
     assert!(
         matches!(ed.active_field, FieldFocus::Row(0)),
         "Enter on AuthKind must reset cursor to Row(0); got {:?}",
@@ -3146,7 +3149,7 @@ fn auth_esc_from_focused_view_pops_to_picker_without_dirty_modal() -> Result<()>
     let ws = config.workspaces.get("big-monorepo").unwrap().clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     // Mutate `pending` so `is_dirty()` is true — this is what would
     // otherwise route Esc through `Modal::SaveDiscardCancel`.
     ed.pending.git_pull_on_entry = !ed.pending.git_pull_on_entry;
@@ -3186,7 +3189,7 @@ fn auth_tab_cycle_off_auth_clears_selected_agent() -> Result<()> {
     let ws = config.workspaces.get("big-monorepo").unwrap().clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     state.stage = ManagerStage::Editor(ed);
 
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
@@ -3221,12 +3224,12 @@ fn auth_workspace_source_d_clears_workspace_mode() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let source_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceSource {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }
         )
     });
@@ -3268,12 +3271,12 @@ fn auth_credential_text_input_cancel_restores_form() -> Result<()> {
     let ws = config.workspaces.get("big-monorepo").unwrap().clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }
         )
     });
@@ -3337,12 +3340,12 @@ fn auth_source_picker_op_disabled_when_op_missing() -> Result<()> {
     let ws = config.workspaces.get("big-monorepo").unwrap().clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
-    ed.auth_selected_kind = Some(AuthKind::Claude);
+    ed.auth_selected_kind = Some(AuthKind::Agent(Agent::Claude));
     let ws_claude_idx = auth_row_idx(&ed, &config, |r| {
         matches!(
             r,
             AuthRow::WorkspaceMode {
-                kind: AuthKind::Claude
+                kind: AuthKind::Agent(Agent::Claude)
             }
         )
     });


### PR DESCRIPTION
## Summary

Collapse the four-variant `AuthKind { Claude, Codex, Amp, Github }` shape in favour of `AuthKind { Agent(Agent), Github }`. The original enum duplicated every per-agent table that the runtime `Agent` enum already keys (label, supported modes, required env var, runtime mapping); the nested-enum shape lifts `Agent` directly so adding a fourth runtime is one line on `Agent`, not five scattered match arms in `auth_kind.rs`. The `.expect("Claude/Codex/Amp kinds map to an Agent")` call at `render/editor.rs::resolve_panel_mode` is gone — the new shape compile-checks what the comment used to promise. Closes the third (and final non-roadmap) item the multi-agent review flagged as deferred from the original amp PR ([#248](https://github.com/jackin-project/jackin/pull/248)).

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin refactor/auth-kind-nested-enum:refs/remotes/origin/refactor/auth-kind-nested-enum
git checkout -B refactor/auth-kind-nested-enum refs/remotes/origin/refactor/auth-kind-nested-enum
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib -- -D warnings
```

### Tests

```sh
cargo test --lib console::manager::auth_kind
cargo test --lib console::manager
cargo test --lib console::widgets::auth_panel
cargo test --test manager_flow
```

The auth-kind tests pin the per-kind label / supported-modes / required-env-var tables across the rebuilt enum; the manager-flow integration tests exercise the auth-tab modal end-to-end (workspace and per-role overrides for every kind) so a regression in the new `From<Agent>` plumbing or the rewritten match arms surfaces immediately.

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

In the TUI, open a workspace → Auth tab. The root list still shows four kinds (`Claude Code` / `Codex` / `Amp` / `GitHub CLI`) in that order; opening any of the three agent kinds and overriding a role still routes through the same auth-edit form. No operator-visible behaviour change beyond the `.expect()` removal.

## Migration notes

None. Pre-release, no released schema to migrate. `AuthKind::for_agent` is removed; use `AuthKind::from(agent)` (via the new `From<Agent> for AuthKind` impl). External consumers do not exist.
