### PR TITLE
docs: clarify preview project status

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -45,7 +45,7 @@ for the discussion of moving it out).
 | [`jackin-project/jackin`](https://github.com/jackin-project/jackin) (this repo) | CLI source, the `construct` Dockerfile under `docker/construct/`, the docs site under `docs/`, CI workflows |
 | [`jackin-project/jackin-agent-smith`](https://github.com/jackin-project/jackin-agent-smith) | Default general-purpose role (`agent-smith`) |
 | [`jackin-project/jackin-the-architect`](https://github.com/jackin-project/jackin-the-architect) | Rust-development role (`the-architect`) used to develop jackin' itself |
-| [`jackin-project/homebrew-tap`](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for stable + preview channels |
+| [`jackin-project/homebrew-tap`](https://github.com/jackin-project/homebrew-tap) | Homebrew formulae for preview now and stable once jackin reaches its first stable release |
 | [`jackin-project/jackin-marketplace`](https://github.com/jackin-project/jackin-marketplace) | Claude plugin marketplace consumed by role manifests |
 | [`jackin-project/validate-agent-action`](https://github.com/jackin-project/validate-agent-action) | GitHub Action that validates `jackin.role.toml` in role repos |
 | [`jackin-project/jackin-dev`](https://github.com/jackin-project/jackin-dev) | Internal development tooling and shared dotfiles |

--- a/README.md
+++ b/README.md
@@ -6,17 +6,12 @@ jackin' is the **ecosystem layer around** AI coding agents — not another agent
 
 Documentation: <https://jackin.tailrocks.com/>
 
-> **Current status:** jackin' is a proof of concept. [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://github.com/openai/codex) ship today as fully integrated agent runtimes. [Amp](https://ampcode.com) is under active development and will join them; full feature parity across all three is tracked on the [roadmap](https://jackin.tailrocks.com/reference/roadmap/). The isolation model is runtime-agnostic — adding another runtime is a matter of installing and starting it inside the container, not changing the boundary.
+> **Current status:** jackin' is experimental preview software. It has not reached a stable release yet, and breaking changes are expected while the core design and basic functionality settle. The docs track the rolling preview channel, which is the best way to see what the project is today. [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://github.com/openai/codex) ship today as fully integrated agent runtimes. [Amp](https://ampcode.com) is under active development and will join them; full feature parity across all three is tracked on the [roadmap](https://jackin.tailrocks.com/reference/roadmap/).
 
 ## Install
 
 ```sh
 brew tap jackin-project/tap
-
-# Stable
-brew install jackin
-
-# OR rolling preview channel
 brew install jackin@preview
 ```
 

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -14,16 +14,15 @@ import { Aside, TabItem, Tabs } from '@astrojs/starlight/components'
 
 The easiest way to install on macOS or Linux is via Homebrew. The Homebrew formulae are maintained in the [jackin-project/homebrew-tap](https://github.com/jackin-project/homebrew-tap) repository.
 
+<Aside type="caution" title="Experimental preview">
+jackin' has not reached a stable release yet. The documentation tracks the rolling preview channel, which is the recommended install path while the core design and basic functionality settle. Breaking changes are expected.
+</Aside>
+
 <Tabs>
 <TabItem label="Homebrew">
 
 ```bash
 brew tap jackin-project/tap
-
-# Stable
-brew install jackin
-
-# Or install the rolling preview channel
 brew install jackin@preview
 ```
 
@@ -46,7 +45,7 @@ jackin --version
 You should see the jackin' version and the banner:
 
 ```
-jackin 1.0.0
+jackin 0.6.0-preview.<n>+<sha>
 ```
 
 ## Docker setup

--- a/docs/src/content/docs/getting-started/why.mdx
+++ b/docs/src/content/docs/getting-started/why.mdx
@@ -170,7 +170,7 @@ jackin' is built in Rust for three reasons:
 ## Current status
 
 <Aside type="note">
-jackin' is currently a proof of concept. `Claude Code`, `Codex`, and `Amp` ship today as built-in agent runtimes; full feature parity across all three is tracked on the [Roadmap](/reference/roadmap/). The isolation model is runtime-agnostic by design — adding a new runtime is a matter of teaching jackin' how to install and start it inside the `construct`, not redesigning the boundary.
+jackin' is experimental preview software and has not reached a stable release yet. `Claude Code`, `Codex`, and `Amp` ship today as built-in agent runtimes; full feature parity across all three is tracked on the [Roadmap](/reference/roadmap/). Breaking changes are expected while the core design and basic functionality settle.
 </Aside>
 The core isolation model works, workspaces and mounts are configurable, the interactive operator console is functional, and the role system supports namespaced, team-shareable environments. It's licensed under Apache 2.0.
 

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -8,7 +8,7 @@ import RepoFile from '../../../components/RepoFile.astro'
 
 ## Current status
 
-jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` ship today as built-in agent runtimes**, with namespaced roles, workspace management, per-mount isolation for parallel agents, layered authentication forwarding (including `1Password` references), and an interactive operator console (TUI).
+jackin' is experimental preview software and has not reached a stable release yet. **`Claude Code`, `Codex`, and `Amp` ship today as built-in agent runtimes**, with namespaced roles, workspace management, per-mount isolation for parallel agents, layered authentication forwarding (including `1Password` references), and an interactive operator console (TUI). Breaking changes are expected while the core design and basic functionality settle.
 
 ## Completed
 


### PR DESCRIPTION
## Summary

Clarifies that jackin is experimental preview software rather than stable, removes the stable Homebrew install path from the README and installation docs, and points operators at the rolling preview channel while the project is still settling its core design and functionality.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin codex-experimental-preview-positioning:refs/remotes/origin/codex-experimental-preview-positioning
git checkout -B codex-experimental-preview-positioning refs/remotes/origin/codex-experimental-preview-positioning
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/getting-started/installation/**  
UPDATED page. Confirm the Homebrew install path only shows the rolling preview formula, the experimental-preview Aside explains that stable has not shipped yet, and the version example uses a non-stale preview placeholder.

**http://localhost:4321/getting-started/why/**  
UPDATED page. Confirm Current status says jackin is experimental preview software and breaking changes are expected.

**http://localhost:4321/reference/roadmap/**  
UPDATED page. Confirm Current status matches the experimental preview framing without implying a stable release exists.

## Migration notes

None. This is documentation and project-positioning only.
