### PR TITLE
ci: address post-merge audit findings (M1, M2, M3, L3, L4, L5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# NOTE: `preview.yml` triggers on `workflow_run.workflows: ["CI"]`,
+# so the workflow name below is load-bearing. Renaming this file's
+# `name:` field silently breaks the Homebrew preview publish chain.
 name: CI
 
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,7 @@ jobs:
           filters: |
             docs:
               - '.github/workflows/docs.yml'
+              - '.github/actions/check-deployed-docs/**'
               - 'docs/**'
 
   # The docs site links to repository files via the <RepoFile path="…" />
@@ -215,10 +216,14 @@ jobs:
           github-token: ${{ github.token }}
 
   # Skip on schedule because schedule runs only `check-deployed` and a
-  # one-job aggregator on schedule has no value.
+  # one-job aggregator on schedule has no value. `check-deployed` is
+  # included in needs so a failure on `workflow_dispatch` from
+  # non-main (the only non-schedule event where check-deployed runs)
+  # still surfaces in the aggregator instead of being silently
+  # absorbed by the four-other-skips-pass-as-success path.
   docs-required:
     if: always() && github.event_name != 'schedule'
-    needs: [changes, repo-link-check, docs-link-check, deploy]
+    needs: [changes, repo-link-check, docs-link-check, deploy, check-deployed]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -117,8 +117,15 @@ jobs:
             # guard prevents a future maintainer from accidentally
             # adding a wildcard that would match it.
             [ -z "$path" ] && continue
+            # Path globs are intentionally a subset of ci.yml's `rust:`
+            # filter: tests/** and .github/workflows/ci.yml change the
+            # Rust build but don't change the binary that ships in the
+            # Homebrew tarball, so they don't need a preview republish.
+            # The shared paths (Cargo.*, rust-toolchain.toml, build.rs,
+            # src/, docker/runtime/) MUST drift together with ci.yml
+            # — when adding a new build input there, add it here too.
             case "$path" in
-              .github/workflows/preview.yml|Cargo.toml|Cargo.lock|rust-toolchain.toml|build.rs|src/*|docker/runtime/*)
+              .github/workflows/preview.yml|Cargo.toml|Cargo.lock|rust-toolchain.toml|build.rs|src/**|docker/runtime/**)
                 source=true
                 ;;
             esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ on:
 permissions:
   contents: read
 
+# Two simultaneous tag pushes (or a tag push racing a workflow_dispatch
+# from main) would otherwise both reach `gh release create` and the
+# second loses to a 422 from a duplicate tag/release. Group key is
+# specifically `release-` (no ref) because we want serialization
+# across tags too.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -139,6 +148,11 @@ jobs:
             --generate-notes
 
   homebrew:
+    # Explicit success gate so a future change to the `release` job
+    # that turns a failure into a soft-error / continue-on-error path
+    # cannot silently let `bump-homebrew-formula-action` ship a
+    # formula update for an unreleased version.
+    if: needs.release.result == 'success'
     needs: [check-version, release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

End-of-arc audit pass after the path-aware-workflows hardening landed. Six tightenings, no behavior change in the happy path — each closes a small drift or forward-safety risk surfaced by the post-merge audit.

- **M1 — preview.yml source-globs cross-link**: Annotate the classifier's path globs with the load-bearing contract relative to `ci.yml`'s `rust:` filter (`tests/**` and `.github/workflows/ci.yml` are intentionally NOT in preview's list because tests don't ship in the binary; the shared paths MUST drift together). Switch to the `**` glob shape for textual alignment with ci.yml.

- **M2 — docs paths-filter covers composite action**: Add `.github/actions/check-deployed-docs/**` to docs.yml's `docs:` filter. A PR that edits the composite action now correctly exercises the full docs-link-check + deploy chain.

- **M3 — docs-required aggregates check-deployed**: Add `check-deployed` to the aggregator's `needs:` list. The previous form passed green when `check-deployed` failed on `workflow_dispatch` from non-main (because the four other upstreams all skipped). The aggregator now reflects the actual run state on every event.

- **L3 — ci.yml documents the preview cross-coupling**: Add a leading file comment naming the load-bearing `workflow_run.workflows: ["CI"]` reference in preview.yml. Renaming `name: CI` would silently break the Homebrew preview publish chain; the comment surfaces that at the edit site.

- **L4 — release.yml concurrency group**: Add `concurrency: { group: release, cancel-in-progress: false }` so two simultaneous tag pushes (or a tag race against a workflow_dispatch from main) don't both reach `gh release create`. The second invocation would otherwise lose to a 422 from a duplicate tag/release.

- **L5 — release.yml homebrew explicit gate**: Add `if: needs.release.result == 'success'`. The job already implicitly required `release` via its `needs:` chain, but the explicit gate documents the contract and prevents a future continue-on-error refactor of `release` from silently letting `bump-homebrew-formula-action` ship an update for a release that didn't actually publish.

## What's deferred

Lows that don't justify a workflow change:

- **L1**: `repo-link-check` standalone (no `needs:`) — design choice, runs in parallel with `changes`.
- **L2**: preview.yml hard-codes the homebrew-tap raw URL — fall-open path masks tap rename; periodic check would catch rot but would duplicate `renovate-validate`'s spirit.
- **L6**: `lychee-action` master pin — already tracked in TODO.md as `lychee-action-sha-pin`.
- **L7**: `build-validator` aggregator presence misleading on PR (always skipped) — covered by the smoke-test rule in PULL_REQUESTS.md; the `*-required` aggregator pattern correctly treats skipped as success.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin ci/post-merge-audit-tightening:refs/remotes/origin/ci/post-merge-audit-tightening
git checkout -B ci/post-merge-audit-tightening refs/remotes/origin/ci/post-merge-audit-tightening
```

### Static checks

```sh
for f in .github/workflows/*.yml .github/actions/*/action.yml; do
  yq . "$f" >/dev/null
done
```

CI on this PR is the actual fidelity test — `publish-manifest-rehearsal` should re-run from #273 and stay green; `docs-required` now waits on `check-deployed` (which only runs on schedule / dispatch-from-non-main) and should still report green on a normal PR because skipped-needs are treated as success in the aggregator.
