### PR TITLE
feat(config): split workspace config files

### DIFF
--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -18,13 +18,17 @@ what you're after.
 
 | Path | Purpose |
 |---|---|
-| `~/.config/jackin/config.toml` | Operator configuration (workspaces, global mounts) |
+| `~/.config/jackin/config.toml` | Global operator configuration (auth defaults, role trust/source, global mounts, global env) |
+| `~/.config/jackin/workspaces/<name>.toml` | One saved workspace per file. The workspace name is the filename stem. |
 | `~/.jackin/roles/` | Cached role repository checkouts |
 | `~/.jackin/data/<container-name>/` | Persisted agent state (Claude history, settings, GitHub CLI config, plugins) |
 
 ## config.toml schema
 
-The configuration file is TOML format at `~/.config/jackin/config.toml`. It's managed through CLI commands — you generally don't need to edit it by hand.
+The configuration is TOML. Global settings live at
+`~/.config/jackin/config.toml`; saved workspaces live one-per-file under
+`~/.config/jackin/workspaces/`. The CLI and console manage both locations
+for you, so you generally don't need to edit them by hand.
 
 ### Agent auth-forward settings
 
@@ -43,25 +47,29 @@ auth_forward = "sync"  # "sync" (default), "api_key", or "ignore" — Codex reje
 auth_forward = "sync"  # "sync" (default), "api_key", or "ignore" — Amp rejects "oauth_token"
 
 # Layer 2 — workspace-wide override
-[workspaces.my-app.claude]
+[claude]
 auth_forward = "oauth_token"
 
-[workspaces.my-app.codex]
+[codex]
 auth_forward = "api_key"
 
-[workspaces.my-app.amp]
+[amp]
 auth_forward = "api_key"
 
 # Layer 3 — most-specific (workspace × role × agent) override
-[workspaces.my-app.roles.agent-smith.claude]
+[roles.agent-smith.claude]
 auth_forward = "ignore"
 
-[workspaces.my-app.roles.agent-smith.codex]
+[roles.agent-smith.codex]
 auth_forward = "sync"
 
-[workspaces.my-app.roles.agent-smith.amp]
+[roles.agent-smith.amp]
 auth_forward = "ignore"
 ```
+
+The layer 2 and 3 examples above belong in
+`~/.config/jackin/workspaces/my-app.toml`; the global defaults belong in
+`config.toml`.
 
 | Field | Description | Default |
 |---|---|---|
@@ -74,12 +82,12 @@ Accepted values: `sync` \| `api_key` \| `oauth_token` \| `ignore`.
 Locations the field may appear at, in resolution order
 (most-specific first):
 
-- `[workspaces.<ws>.roles.<role>.claude].auth_forward`
-- `[workspaces.<ws>.roles.<role>.codex].auth_forward`
-- `[workspaces.<ws>.roles.<role>.amp].auth_forward`
-- `[workspaces.<ws>.claude].auth_forward`
-- `[workspaces.<ws>.codex].auth_forward`
-- `[workspaces.<ws>.amp].auth_forward`
+- `[roles.<role>.claude].auth_forward` in `workspaces/<ws>.toml`
+- `[roles.<role>.codex].auth_forward` in `workspaces/<ws>.toml`
+- `[roles.<role>.amp].auth_forward` in `workspaces/<ws>.toml`
+- `[claude].auth_forward` in `workspaces/<ws>.toml`
+- `[codex].auth_forward` in `workspaces/<ws>.toml`
+- `[amp].auth_forward` in `workspaces/<ws>.toml`
 - `[claude].auth_forward` (global default)
 - `[codex].auth_forward` (global default)
 - `[amp].auth_forward` (global default)
@@ -101,23 +109,26 @@ agent in the container.
 auth_forward = "sync"   # "sync" (default), "token", or "ignore"
 
 # Layer 2 — workspace-wide override (e.g. a customer-facing PAT)
-[workspaces.customer-acme.github]
+[github]
 auth_forward = "token"
 
-[workspaces.customer-acme.github.env]
+[github.env]
 GH_TOKEN = { op = "op://abc.../def.../fld...", path = "Work/ACME/github-fine-grained-pat" }
 
 # Layer 3 — workspace × role override (e.g. a tighter release-bot token)
-[workspaces.customer-acme.roles.release-bot.github]
+[roles.release-bot.github]
 auth_forward = "token"
 
-[workspaces.customer-acme.roles.release-bot.github.env]
+[roles.release-bot.github.env]
 GH_TOKEN = { op = "op://abc.../def.../fld...", path = "Work/ACME/github-release-pat" }
 
 # Per-role opt-out — throwaway role with no GitHub access
-[workspaces.customer-acme.roles.scratch.github]
+[roles.scratch.github]
 auth_forward = "ignore"
 ```
+
+Workspace-scoped GitHub blocks live in
+`~/.config/jackin/workspaces/customer-acme.toml`.
 
 Mode behaviour:
 
@@ -133,8 +144,8 @@ Mode behaviour:
 
 Resolution order, most-specific first:
 
-- `[workspaces.<ws>.roles.<role>.github].auth_forward`
-- `[workspaces.<ws>.github].auth_forward`
+- `[roles.<role>.github].auth_forward` in `workspaces/<ws>.toml`
+- `[github].auth_forward` in `workspaces/<ws>.toml`
 - `[github].auth_forward` (global default)
 
 Operator-only — role manifests cannot set or override `[github]`,
@@ -156,13 +167,16 @@ OPERATOR_ORG = "acme-corp"
 API_TOKEN = "op://Personal/api/token"
 
 # Layer 3 — per workspace
-[workspaces.big-monorepo.env]
+[env]
 REGISTRY = "${COMPANY_REGISTRY_URL}"
 
 # Layer 4 — per (workspace, role)
-[workspaces.big-monorepo.roles.agent-smith.env]
+[roles.agent-smith.env]
 API_TOKEN = "op://Work/shared-smith/token"
 ```
+
+Layer 3 and 4 env blocks are stored in
+`~/.config/jackin/workspaces/big-monorepo.toml`.
 
 Values can be:
 
@@ -179,29 +193,32 @@ See [Environment Variables](/guides/environment-variables/) for the full guide.
 ### Workspaces
 
 ```toml
-[workspaces.my-app]
 workdir = "/home/user/Projects/my-app"
 allowed_roles = ["agent-smith", "the-architect"]
 default_role = "agent-smith"
 default_agent = "amp"
 last_role = "the-architect"
 
-[[workspaces.my-app.mounts]]
+[[mounts]]
 src = "/home/user/Projects/my-app"
 dst = "/home/user/Projects/my-app"
 readonly = false
 isolation = "worktree"
 
-[[workspaces.my-app.mounts]]
+[[mounts]]
 src = "/home/user/cache"
 dst = "/cache"
 readonly = true
 
-[workspaces.my-app.keep_awake]
+[keep_awake]
 enabled = true
 
 git_pull_on_entry = true
 ```
+
+This example is the contents of
+`~/.config/jackin/workspaces/my-app.toml`; there is no
+`[workspaces.my-app]` header inside the file.
 
 | Field | Description |
 |---|---|
@@ -210,7 +227,7 @@ git_pull_on_entry = true
 | `mounts[].src` | Host path |
 | `mounts[].dst` | Container path |
 | `mounts[].readonly` | Read-only flag |
-| `mounts[].isolation` | Per-mount isolation mode: `shared` (default), `worktree`, or `clone`. Omitting the field deserializes to `shared`, but every save writes the field explicitly so old configs migrate to the new shape on first save. Global mounts (under `[docker.mounts]` or `[[mounts]]`) reject this field at parse time. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation). |
+| `mounts[].isolation` | Per-mount isolation mode: `shared` (default), `worktree`, or `clone`. Omitting the field deserializes to `shared`, but every save writes the field explicitly so old configs migrate to the new shape on first save. Global mounts (under `[docker.mounts]`) reject this field at parse time. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation). |
 | `allowed_roles` | List of allowed role selectors |
 | `default_role` | Default role selector |
 | `default_agent` | Optional workspace default agent (`"claude"`, `"codex"`, or `"amp"`). Omit to default to Claude. |

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -5,6 +5,7 @@
 //! user-written comments, blank lines, and key ordering intact in
 //! sections untouched by the mutation.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -22,14 +23,14 @@ pub enum EnvScope {
         workspace: String,
         role: String,
     },
-    /// `[workspaces.<workspace>.github.env]` — the github-kind env
+    /// `[github.env]` inside the workspace file — the github-kind env
     /// block, parallel to the regular workspace `env` map but read by
     /// [`crate::config::build_github_env_layers`] instead of the
     /// regular launch-time env merge. Used to thread `GH_TOKEN` /
     /// `GH_HOST` / `GH_ENTERPRISE_TOKEN` without polluting the
     /// agent-facing env map.
     WorkspaceGithub(String),
-    /// `[workspaces.<workspace>.roles.<role>.github.env]` — most-
+    /// `[roles.<role>.github.env]` inside the workspace file — most
     /// specific layer of the github env layering.
     WorkspaceRoleGithub {
         workspace: String,
@@ -40,6 +41,9 @@ pub enum EnvScope {
 pub struct ConfigEditor {
     doc: DocumentMut,
     path: PathBuf,
+    workspaces_dir: PathBuf,
+    workspace_docs: BTreeMap<String, DocumentMut>,
+    removed_workspaces: BTreeSet<String>,
 }
 
 impl ConfigEditor {
@@ -47,7 +51,11 @@ impl ConfigEditor {
     /// does not exist, delegates to `AppConfig::load_or_init` to
     /// materialize defaults, then reopens the resulting file.
     pub fn open(paths: &JackinPaths) -> anyhow::Result<Self> {
-        if !paths.config_file.exists() {
+        if paths.config_file.exists() {
+            let raw = std::fs::read_to_string(&paths.config_file)
+                .with_context(|| format!("reading {}", paths.config_file.display()))?;
+            let _ = crate::config::persist::load_split_config(paths, Some(raw))?;
+        } else {
             AppConfig::load_or_init(paths)?;
         }
         let raw = std::fs::read_to_string(&paths.config_file)
@@ -55,9 +63,13 @@ impl ConfigEditor {
         let doc: DocumentMut = raw
             .parse()
             .with_context(|| format!("parsing {}", paths.config_file.display()))?;
+        let workspace_docs = load_workspace_docs(paths)?;
         Ok(Self {
             doc,
             path: paths.config_file.clone(),
+            workspaces_dir: paths.workspaces_dir.clone(),
+            workspace_docs,
+            removed_workspaces: BTreeSet::new(),
         })
     }
 
@@ -73,33 +85,11 @@ impl ConfigEditor {
     /// that `load_or_init` ran once at `open` time, so builtins are
     /// already in place.
     pub fn save(self) -> anyhow::Result<AppConfig> {
-        let contents = self.doc.to_string();
-        let tmp = self.path.with_extension("tmp");
+        let global_contents = self.doc.to_string();
 
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&tmp)?;
-            file.write_all(contents.as_bytes())?;
-            file.sync_all()?;
-        }
-
-        #[cfg(not(unix))]
-        std::fs::write(&tmp, &contents)?;
-
-        // Validate before rename so an invalid mutation can't brick
-        // subsequent CLI commands.
-        let config: AppConfig = match validate_candidate(&contents) {
+        let config: AppConfig = match validate_candidate(&global_contents, &self.workspace_docs) {
             Ok(cfg) => cfg,
             Err(err) => {
-                // Best-effort cleanup so the real error reaches caller.
-                let _ = std::fs::remove_file(&tmp);
                 return Err(err.context(format!(
                     "rejecting candidate config (would have written to {})",
                     self.path.display()
@@ -107,7 +97,22 @@ impl ConfigEditor {
             }
         };
 
-        std::fs::rename(&tmp, &self.path)?;
+        crate::config::persist::atomic_write(&self.path, &global_contents)?;
+        std::fs::create_dir_all(&self.workspaces_dir)?;
+        for name in self.workspace_docs.keys() {
+            crate::config::persist::validate_workspace_file_stem(name)?;
+        }
+        for (name, doc) in &self.workspace_docs {
+            crate::config::persist::atomic_write(&self.workspace_file(name), &doc.to_string())?;
+        }
+        for removed in &self.removed_workspaces {
+            let path = self.workspace_file(removed);
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
         Ok(config)
     }
 
@@ -120,8 +125,8 @@ impl ConfigEditor {
         use crate::operator_env::EnvValue;
         use toml_edit::{InlineTable, Item, Value, value as toml_value};
 
-        let path = env_scope_path(scope);
-        let table = table_path_mut(&mut self.doc, &path);
+        let (doc, path) = self.doc_and_path_for_env_scope(scope);
+        let table = table_path_mut(doc, &path);
         let item = match value {
             EnvValue::Plain(s) => toml_value(s),
             EnvValue::OpRef(r) => {
@@ -136,10 +141,10 @@ impl ConfigEditor {
     }
 
     pub fn set_env_comment(&mut self, scope: &EnvScope, key: &str, comment: Option<&str>) {
-        let path = env_scope_path(scope);
+        let (doc, path) = self.doc_and_path_for_env_scope(scope);
         // Walk without creating — setting a comment on a nonexistent key
         // is a silent no-op (same contract as remove_env_var).
-        let mut current: &mut Item = self.doc.as_item_mut();
+        let mut current: &mut Item = doc.as_item_mut();
         for segment in &path {
             match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
                 Some(next) => current = next,
@@ -263,7 +268,7 @@ impl ConfigEditor {
         table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
     }
 
-    /// Write or clear `[workspaces.<workspace>.<agent>].auth_forward`.
+    /// Write or clear `[<agent>].auth_forward` inside the workspace file.
     ///
     /// `mode = Some(m)` writes the named mode; `mode = None` removes the
     /// `auth_forward` field (and the agent block if it becomes empty),
@@ -278,33 +283,25 @@ impl ConfigEditor {
         agent: crate::agent::Agent,
         mode: Option<crate::config::AuthForwardMode>,
     ) {
-        let agent_path = vec![
-            "workspaces".to_string(),
-            workspace.to_string(),
-            agent.slug().to_string(),
-        ];
-        match mode {
-            Some(m) => {
-                let table = table_path_mut(&mut self.doc, &agent_path);
-                table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
-            }
-            None => {
-                clear_auth_forward_field(&mut self.doc, &agent_path);
-            }
+        let agent_path = vec![agent.slug().to_string()];
+        let doc = self.workspace_doc_mut(workspace);
+        if let Some(m) = mode {
+            let table = table_path_mut(doc, &agent_path);
+            table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
+        } else {
+            clear_auth_forward_field(doc, &agent_path);
         }
     }
 
-    /// Write or clear `[workspaces.<workspace>].op_account`.
+    /// Write or clear `op_account` inside the workspace file.
     ///
     /// Pins every `op` invocation made on behalf of the workspace to
     /// the named 1P account. Operator can pass UUID, label, or email
     /// — `op` accepts all three.
     pub fn set_workspace_op_account(&mut self, workspace: &str, account: Option<&str>) {
         use toml_edit::value as toml_value;
-        let table = table_path_mut(
-            &mut self.doc,
-            &["workspaces".to_string(), workspace.to_string()],
-        );
+        let doc = self.workspace_doc_mut(workspace);
+        let table = table_path_mut(doc, &[]);
         match account {
             Some(acc) => {
                 table.insert("op_account", toml_value(acc));
@@ -315,7 +312,7 @@ impl ConfigEditor {
         }
     }
 
-    /// Write or clear `[workspaces.<workspace>.roles.<role>.<agent>].auth_forward`.
+    /// Write or clear `[roles.<role>.<agent>].auth_forward` inside the workspace file.
     ///
     /// Mirrors [`Self::set_workspace_auth_forward`] one layer deeper.
     /// Used by the workspace-manager's Auth tab when the operator commits
@@ -328,24 +325,20 @@ impl ConfigEditor {
         mode: Option<crate::config::AuthForwardMode>,
     ) {
         let agent_path = vec![
-            "workspaces".to_string(),
-            workspace.to_string(),
             "roles".to_string(),
             role.to_string(),
             agent.slug().to_string(),
         ];
-        match mode {
-            Some(m) => {
-                let table = table_path_mut(&mut self.doc, &agent_path);
-                table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
-            }
-            None => {
-                clear_auth_forward_field(&mut self.doc, &agent_path);
-            }
+        let doc = self.workspace_doc_mut(workspace);
+        if let Some(m) = mode {
+            let table = table_path_mut(doc, &agent_path);
+            table.insert("auth_forward", toml_edit::value(auth_forward_str(m)));
+        } else {
+            clear_auth_forward_field(doc, &agent_path);
         }
     }
 
-    /// Write or clear `[workspaces.<workspace>.github].auth_forward`.
+    /// Write or clear `[github].auth_forward` inside the workspace file.
     ///
     /// Mirrors [`Self::set_workspace_auth_forward`] but threads the
     /// GitHub kind's `[github]` block instead of an `Agent`-keyed
@@ -357,23 +350,17 @@ impl ConfigEditor {
         workspace: &str,
         mode: Option<crate::config::GithubAuthMode>,
     ) {
-        let github_path = vec![
-            "workspaces".to_string(),
-            workspace.to_string(),
-            "github".to_string(),
-        ];
-        match mode {
-            Some(m) => {
-                let table = table_path_mut(&mut self.doc, &github_path);
-                table.insert("auth_forward", toml_edit::value(github_mode_str(m)));
-            }
-            None => {
-                clear_auth_forward_field(&mut self.doc, &github_path);
-            }
+        let github_path = vec!["github".to_string()];
+        let doc = self.workspace_doc_mut(workspace);
+        if let Some(m) = mode {
+            let table = table_path_mut(doc, &github_path);
+            table.insert("auth_forward", toml_edit::value(github_mode_str(m)));
+        } else {
+            clear_auth_forward_field(doc, &github_path);
         }
     }
 
-    /// Write or clear `[workspaces.<workspace>.roles.<role>.github].auth_forward`.
+    /// Write or clear `[roles.<role>.github].auth_forward` inside the workspace file.
     ///
     /// Mirrors [`Self::set_workspace_role_auth_forward`] one kind
     /// dimension wider — `github` lives at the same three layers as
@@ -384,21 +371,13 @@ impl ConfigEditor {
         role: &str,
         mode: Option<crate::config::GithubAuthMode>,
     ) {
-        let github_path = vec![
-            "workspaces".to_string(),
-            workspace.to_string(),
-            "roles".to_string(),
-            role.to_string(),
-            "github".to_string(),
-        ];
-        match mode {
-            Some(m) => {
-                let table = table_path_mut(&mut self.doc, &github_path);
-                table.insert("auth_forward", toml_edit::value(github_mode_str(m)));
-            }
-            None => {
-                clear_auth_forward_field(&mut self.doc, &github_path);
-            }
+        let github_path = vec!["roles".to_string(), role.to_string(), "github".to_string()];
+        let doc = self.workspace_doc_mut(workspace);
+        if let Some(m) = mode {
+            let table = table_path_mut(doc, &github_path);
+            table.insert("auth_forward", toml_edit::value(github_mode_str(m)));
+        } else {
+            clear_auth_forward_field(doc, &github_path);
         }
     }
 
@@ -429,9 +408,9 @@ impl ConfigEditor {
     }
 
     pub fn remove_env_var(&mut self, scope: &EnvScope, key: &str) -> bool {
-        let path = env_scope_path(scope);
+        let (doc, path) = self.doc_and_path_for_env_scope(scope);
         // Walk without creating: return false if any segment is missing.
-        let mut current: &mut Item = self.doc.as_item_mut();
+        let mut current: &mut Item = doc.as_item_mut();
         for segment in &path {
             match current.as_table_mut().and_then(|t| t.get_mut(segment)) {
                 Some(next) => current = next,
@@ -448,16 +427,14 @@ impl ConfigEditor {
             // the `env` segment and its kind parent, but no further —
             // workspace / role identifier slots stay untouched even
             // when an operator names them "env" / "github" / etc.
-            prune_empty_trailing_tables(&mut self.doc, &path, 2);
+            prune_empty_trailing_tables(doc, &path, 2);
         }
         removed
     }
 
     pub fn set_last_agent(&mut self, workspace: &str, agent_key: &str) {
-        let table = table_path_mut(
-            &mut self.doc,
-            &["workspaces".to_string(), workspace.to_string()],
-        );
+        let doc = self.workspace_doc_mut(workspace);
+        let table = table_path_mut(doc, &[]);
         table.insert("last_role", toml_edit::value(agent_key));
     }
 
@@ -475,36 +452,25 @@ impl ConfigEditor {
         if old == new {
             return Ok(());
         }
-        let workspaces = self
-            .doc
-            .get_mut("workspaces")
-            .and_then(|i| i.as_table_mut())
-            .ok_or_else(|| anyhow::anyhow!("no workspaces table"))?;
-
-        if !workspaces.contains_key(old) {
+        if !self.workspace_docs.contains_key(old) {
             anyhow::bail!("workspace {old:?} not found");
         }
-        if workspaces.contains_key(new) {
+        if self.workspace_docs.contains_key(new) {
             anyhow::bail!("workspace {new:?} already exists");
         }
 
-        // Extract, remove under old name, re-insert under new name.
-        let value = workspaces.remove(old).expect("checked above");
-        workspaces.insert(new, value);
+        crate::config::persist::validate_workspace_file_stem(new)?;
+        let value = self.workspace_docs.remove(old).expect("checked above");
+        self.workspace_docs.insert(new.to_string(), value);
+        self.removed_workspaces.insert(old.to_string());
         Ok(())
     }
 
     pub fn remove_workspace(&mut self, name: &str) -> anyhow::Result<()> {
-        let Some(workspaces) = self
-            .doc
-            .get_mut("workspaces")
-            .and_then(|i| i.as_table_mut())
-        else {
-            anyhow::bail!("workspace {name:?} not found");
-        };
-        if workspaces.remove(name).is_none() {
+        if self.workspace_docs.remove(name).is_none() {
             anyhow::bail!("workspace {name:?} not found");
         }
+        self.removed_workspaces.insert(name.to_string());
         Ok(())
     }
 
@@ -517,8 +483,8 @@ impl ConfigEditor {
         // (collision check, workdir / mount-destination relationship,
         // plan-collapse sanity) so the editor path behaves identically
         // to the direct-mutation path. Mirrors edit_workspace's pattern.
-        let mut in_memory: AppConfig = toml::from_str(&self.doc.to_string())
-            .context("re-parsing current doc into AppConfig for workspace creation")?;
+        let mut in_memory = validate_candidate(&self.doc.to_string(), &self.workspace_docs)
+            .context("re-parsing current docs into AppConfig for workspace creation")?;
         in_memory.create_workspace(name, ws)?;
         let inserted = in_memory
             .workspaces
@@ -531,11 +497,8 @@ impl ConfigEditor {
             .parse()
             .with_context(|| format!("re-parsing serialized workspace {name:?}"))?;
 
-        let workspaces_table =
-            table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
-        for (key, item) in parsed.as_table() {
-            workspaces_table.insert(key, item.clone());
-        }
+        self.workspace_docs.insert(name.to_string(), parsed);
+        self.removed_workspaces.remove(name);
 
         Ok(())
     }
@@ -546,8 +509,8 @@ impl ConfigEditor {
         edit: crate::workspace::WorkspaceEdit,
     ) -> anyhow::Result<()> {
         // Snapshot current on-disk state into an AppConfig.
-        let mut in_memory: AppConfig = toml::from_str(&self.doc.to_string())
-            .context("re-parsing current doc into AppConfig for workspace edit")?;
+        let mut in_memory = validate_candidate(&self.doc.to_string(), &self.workspace_docs)
+            .context("re-parsing current docs into AppConfig for workspace edit")?;
 
         // Apply the edit using the existing validated logic. Mutates
         // in_memory or returns Err with the validation message on failure.
@@ -559,20 +522,62 @@ impl ConfigEditor {
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("workspace {name:?} disappeared after edit"))?;
 
-        // Replace the entire [workspaces.<name>] table. This preserves
+        // Replace the entire workspace document. This preserves
         // comments in OTHER workspaces and in unrelated top-level sections,
         // which is what the migration cares about. Comments inside the
         // edited workspace itself are consumed — that's acceptable because
         // the edit IS the change the user is making to that workspace.
         let rendered = toml::to_string(updated)?;
         let parsed: DocumentMut = rendered.parse()?;
-        let target = table_path_mut(&mut self.doc, &["workspaces".to_string(), name.to_string()]);
-        target.clear();
-        for (key, item) in parsed.as_table() {
-            target.insert(key, item.clone());
-        }
+        self.workspace_docs.insert(name.to_string(), parsed);
 
         Ok(())
+    }
+
+    fn workspace_file(&self, name: &str) -> PathBuf {
+        self.workspaces_dir.join(format!("{name}.toml"))
+    }
+
+    fn workspace_doc_mut(&mut self, workspace: &str) -> &mut DocumentMut {
+        crate::config::persist::validate_workspace_file_stem(workspace)
+            .expect("workspace name must be valid for split config filename");
+        self.removed_workspaces.remove(workspace);
+        self.workspace_docs
+            .entry(workspace.to_string())
+            .or_default()
+    }
+
+    fn doc_and_path_for_env_scope(&mut self, scope: &EnvScope) -> (&mut DocumentMut, Vec<String>) {
+        match scope {
+            EnvScope::Global | EnvScope::Role(_) => (&mut self.doc, env_scope_path(scope)),
+            EnvScope::Workspace(w) => {
+                let doc = self.workspace_doc_mut(w);
+                (doc, vec!["env".to_string()])
+            }
+            EnvScope::WorkspaceRole { workspace, role } => {
+                let doc = self.workspace_doc_mut(workspace);
+                (
+                    doc,
+                    vec!["roles".to_string(), role.clone(), "env".to_string()],
+                )
+            }
+            EnvScope::WorkspaceGithub(w) => {
+                let doc = self.workspace_doc_mut(w);
+                (doc, vec!["github".to_string(), "env".to_string()])
+            }
+            EnvScope::WorkspaceRoleGithub { workspace, role } => {
+                let doc = self.workspace_doc_mut(workspace);
+                (
+                    doc,
+                    vec![
+                        "roles".to_string(),
+                        role.clone(),
+                        "github".to_string(),
+                        "env".to_string(),
+                    ],
+                )
+            }
+        }
     }
 }
 
@@ -629,10 +634,52 @@ fn env_scope_path(scope: &EnvScope) -> Vec<String> {
 /// role missing `git`) and `validate_reserved_names`. Skips
 /// `validate_workspaces` — only `create_workspace`/`edit_workspace`
 /// mutate that geometry and they already validate.
-fn validate_candidate(contents: &str) -> anyhow::Result<AppConfig> {
-    let config: AppConfig = toml::from_str(contents).context("deserializing candidate config")?;
+fn validate_candidate(
+    global_contents: &str,
+    workspace_docs: &BTreeMap<String, DocumentMut>,
+) -> anyhow::Result<AppConfig> {
+    let mut config: AppConfig =
+        toml::from_str(global_contents).context("deserializing candidate global config")?;
+    if !config.workspaces.is_empty() {
+        anyhow::bail!("global config.toml must not contain [workspaces] tables");
+    }
+    for (name, doc) in workspace_docs {
+        crate::config::persist::validate_workspace_file_stem(name)?;
+        let workspace = toml::from_str(&doc.to_string())
+            .with_context(|| format!("deserializing candidate workspace {name:?}"))?;
+        config.workspaces.insert(name.clone(), workspace);
+    }
     crate::operator_env::validate_reserved_names(&config)?;
     Ok(config)
+}
+
+fn load_workspace_docs(paths: &JackinPaths) -> anyhow::Result<BTreeMap<String, DocumentMut>> {
+    let mut docs = BTreeMap::new();
+    let entries = match std::fs::read_dir(&paths.workspaces_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(docs),
+        Err(e) => return Err(e.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow::anyhow!("invalid workspace filename {}", path.display()))?;
+        crate::config::persist::validate_workspace_file_stem(stem)
+            .with_context(|| format!("invalid workspace filename {}", path.display()))?;
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading workspace config {}", path.display()))?;
+        let doc = raw
+            .parse()
+            .with_context(|| format!("parsing workspace config {}", path.display()))?;
+        docs.insert(stem.to_string(), doc);
+    }
+    Ok(docs)
 }
 
 /// Remove the `auth_forward` field at `kind_path` (a `[…claude]` /
@@ -725,6 +772,10 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn workspace_file_contents(paths: &JackinPaths, name: &str) -> String {
+        std::fs::read_to_string(paths.workspaces_dir.join(format!("{name}.toml"))).unwrap()
+    }
+
     #[test]
     fn set_env_var_creates_global_env_table() {
         let temp = tempdir().unwrap();
@@ -776,9 +827,9 @@ workdir = "/workspace/prod"
             .unwrap();
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        let out = workspace_file_contents(&paths, "prod");
         assert!(
-            out.contains("[workspaces.prod.roles.agent-smith.env]"),
+            out.contains("[roles.agent-smith.env]"),
             "missing nested table: {out}"
         );
         assert!(
@@ -1074,15 +1125,22 @@ API_TOKEN = "op://vault-id/item-id/field"
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
-        let original = r#"# workspace a — keep this comment
-[workspaces.a]
+        std::fs::write(&paths.config_file, "").unwrap();
+        std::fs::create_dir_all(&paths.workspaces_dir).unwrap();
+        std::fs::write(
+            paths.workspaces_dir.join("a.toml"),
+            r#"# workspace a — keep this comment
 workdir = "/a"
-
-# workspace b — also keep
-[workspaces.b]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            paths.workspaces_dir.join("b.toml"),
+            r#"# workspace b — also keep
 workdir = "/b"
-"#;
-        std::fs::write(&paths.config_file, original).unwrap();
+"#,
+        )
+        .unwrap();
 
         let mut editor = ConfigEditor::open(&paths).unwrap();
         editor
@@ -1090,9 +1148,12 @@ workdir = "/b"
             .unwrap();
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        let out = workspace_file_contents(&paths, "b");
         assert!(out.contains("# workspace b — also keep"), "{out}");
-        assert!(out.contains("# workspace a — keep this comment"), "{out}");
+        let out_a = workspace_file_contents(&paths, "a");
+        assert!(out_a.contains("K = \"v\""), "{out_a}");
+        let global = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!global.contains("[workspaces."), "{global}");
     }
 
     #[test]
@@ -1109,9 +1170,12 @@ workdir = "/b"
 
         let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
         assert_eq!(
-            round_tripped, original,
-            "fixture round-trip is lossy — toml_edit is dropping something"
+            round_tripped.contains("[workspaces."),
+            false,
+            "global file should contain only global config after split:\n{round_tripped}"
         );
+        assert!(paths.workspaces_dir.join("prod.toml").exists());
+        assert!(paths.workspaces_dir.join("playground.toml").exists());
     }
 
     #[test]
@@ -1146,10 +1210,16 @@ API_TOKEN = "op://Personal/api/token"
         let editor = ConfigEditor::open(&paths).unwrap();
         editor.save().unwrap();
 
-        let round_tripped = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert_eq!(
-            round_tripped, original,
-            "open → save must be byte-identical"
+        let global = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(!global.contains("[workspaces."), "{global}");
+        let workspace = workspace_file_contents(&paths, "prod");
+        assert!(
+            workspace.contains(r#"workdir = "/workspace/prod""#),
+            "{workspace}"
+        );
+        assert!(
+            workspace.contains(r#"API_TOKEN = "op://Personal/api/token""#),
+            "{workspace}"
         );
     }
 
@@ -1494,8 +1564,8 @@ workdir = "/tmp/proj"
         );
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[workspaces.proj.claude]"), "{out}");
+        let out = workspace_file_contents(&paths, "proj");
+        assert!(out.contains("[claude]"), "{out}");
         assert!(out.contains(r#"auth_forward = "api_key""#), "{out}");
     }
 
@@ -1520,9 +1590,9 @@ auth_forward = "api_key"
         editor.set_workspace_auth_forward("proj", crate::agent::Agent::Claude, None);
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        let out = workspace_file_contents(&paths, "proj");
         assert!(
-            !out.contains("[workspaces.proj.claude]"),
+            !out.contains("[claude]"),
             "agent block must be removed when mode = None; {out}"
         );
         assert!(
@@ -1554,8 +1624,8 @@ workdir = "/tmp/proj"
         );
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[workspaces.proj.roles.smith.codex]"), "{out}");
+        let out = workspace_file_contents(&paths, "proj");
+        assert!(out.contains("[roles.smith.codex]"), "{out}");
         assert!(out.contains(r#"auth_forward = "api_key""#), "{out}");
     }
 
@@ -1580,11 +1650,8 @@ auth_forward = "oauth_token"
         editor.set_workspace_role_auth_forward("proj", "smith", crate::agent::Agent::Claude, None);
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(
-            !out.contains("[workspaces.proj.roles.smith.claude]"),
-            "{out}"
-        );
+        let out = workspace_file_contents(&paths, "proj");
+        assert!(!out.contains("[roles.smith.claude]"), "{out}");
     }
 
     #[test]
@@ -1630,8 +1697,12 @@ auth_forward = "oauth_token"
         editor.create_workspace("new-ws", ws).unwrap();
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[workspaces.new-ws]"), "{out}");
+        let out = workspace_file_contents(&paths, "new-ws");
+        assert!(
+            !std::fs::read_to_string(&paths.config_file)
+                .unwrap()
+                .contains("[workspaces.")
+        );
         assert!(out.contains(r#"workdir = "/workspace/new""#), "{out}");
     }
 
@@ -1682,7 +1753,7 @@ default_role = "agent-smith"
         editor.set_last_agent("prod", "agent-smith");
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
+        let out = workspace_file_contents(&paths, "prod");
         assert!(out.contains(r#"last_role = "agent-smith""#), "{out}");
         assert!(out.contains(r#"default_role = "agent-smith""#), "{out}");
     }
@@ -1739,7 +1810,8 @@ workdir = "/b"
 
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
         assert!(!out.contains("[workspaces.a]"), "{out}");
-        assert!(out.contains("[workspaces.b]"), "{out}");
+        assert!(!paths.workspaces_dir.join("a.toml").exists());
+        assert!(paths.workspaces_dir.join("b.toml").exists());
     }
 
     #[test]
@@ -1763,17 +1835,45 @@ dst = "/a"
         editor.rename_workspace("old-name", "new-name").unwrap();
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[workspaces.new-name]"), "{out}");
+        let out = workspace_file_contents(&paths, "new-name");
+        assert!(!paths.workspaces_dir.join("old-name.toml").exists());
         assert!(
             out.contains(r#"workdir = "/a""#),
             "nested field preserved: {out}"
         );
-        assert!(
-            out.contains("[[workspaces.new-name.mounts]]"),
-            "array table preserved: {out}"
-        );
+        assert!(out.contains("[[mounts]]"), "array table preserved: {out}");
         assert!(!out.contains("old-name"), "{out}");
+    }
+
+    #[test]
+    fn rename_workspace_write_failure_preserves_old_file() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::create_dir_all(&paths.workspaces_dir).unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+        std::fs::write(
+            paths.workspaces_dir.join("old-name.toml"),
+            r#"workdir = "/a"
+"#,
+        )
+        .unwrap();
+
+        let mut editor = ConfigEditor::open(&paths).unwrap();
+        editor.rename_workspace("old-name", "new-name").unwrap();
+        std::fs::create_dir(paths.workspaces_dir.join("new-name.toml")).unwrap();
+
+        let err = editor.save().unwrap_err();
+
+        assert!(
+            err.to_string().contains("Is a directory")
+                || err.to_string().contains("is a directory"),
+            "{err}"
+        );
+        assert!(
+            paths.workspaces_dir.join("old-name.toml").exists(),
+            "failed rename save must leave the original workspace file in place"
+        );
     }
 
     #[test]
@@ -1894,8 +1994,8 @@ workdir = "/workspace/prod"
         editor.save().unwrap();
 
         // Sanity: both the kind block and its env subtable land on disk.
-        let after_save = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(after_save.contains("[workspaces.prod.github]"));
+        let after_save = workspace_file_contents(&paths, "prod");
+        assert!(after_save.contains("[github]"));
         assert!(after_save.contains("auth_forward"));
         assert!(after_save.contains("GH_TOKEN"));
 
@@ -1906,13 +2006,13 @@ workdir = "/workspace/prod"
         assert!(editor.remove_env_var(&env_scope, "GH_TOKEN"));
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
+        let cleaned = workspace_file_contents(&paths, "prod");
         assert!(
             !cleaned.contains("github"),
             "stale [github] / [github.env] table left on disk:\n{cleaned}"
         );
         assert!(
-            cleaned.contains("[workspaces.prod]"),
+            cleaned.contains("workdir"),
             "workspace block was wrongly removed by the cascade:\n{cleaned}"
         );
         assert!(
@@ -1957,7 +2057,7 @@ workdir = "/workspace/prod"
         assert!(editor.remove_env_var(&env_scope, "GH_TOKEN"));
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
+        let cleaned = workspace_file_contents(&paths, "prod");
         assert!(
             !cleaned.contains("github"),
             "stale [github] / [github.env] table left on disk:\n{cleaned}"
@@ -1992,17 +2092,17 @@ auth_forward = "ignore"
         editor.set_workspace_github_auth_forward("prod", None);
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
+        let cleaned = workspace_file_contents(&paths, "prod");
         assert!(
-            !cleaned.contains("[workspaces.prod.github]"),
+            !cleaned.contains("[github]"),
             "github block should be removed:\n{cleaned}"
         );
         assert!(
-            cleaned.contains("[workspaces.prod.claude]"),
+            cleaned.contains("[claude]"),
             "claude block must survive:\n{cleaned}"
         );
         assert!(
-            cleaned.contains("[workspaces.prod.codex]"),
+            cleaned.contains("[codex]"),
             "codex block must survive:\n{cleaned}"
         );
     }
@@ -2034,13 +2134,13 @@ GH_TOKEN = "ghp_real"
         assert!(editor.remove_env_var(&env_scope, "GH_TOKEN"));
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
+        let cleaned = workspace_file_contents(&paths, "prod");
         assert!(
-            !cleaned.contains("[workspaces.prod.github.env]"),
+            !cleaned.contains("[github.env]"),
             "empty env subtable must be pruned:\n{cleaned}"
         );
         assert!(
-            cleaned.contains("[workspaces.prod.github]"),
+            cleaned.contains("[github]"),
             "kind block must survive (still has auth_forward):\n{cleaned}"
         );
         assert!(
@@ -2078,13 +2178,13 @@ GH_TOKEN = "ghp_real"
         assert!(editor.remove_env_var(&env_scope, "GH_TOKEN"));
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
+        let cleaned = workspace_file_contents(&paths, "prod");
         assert!(
-            !cleaned.contains("[workspaces.prod.github"),
+            !cleaned.contains("[github"),
             "github / github.env tables should be pruned:\n{cleaned}"
         );
         assert!(
-            cleaned.contains("[workspaces.prod]"),
+            cleaned.contains("workdir"),
             "workspace block must survive:\n{cleaned}"
         );
         assert!(
@@ -2121,11 +2221,10 @@ auth_forward = "ignore"
         editor.set_workspace_github_auth_forward("github", None);
         editor.save().unwrap();
 
-        let cleaned = std::fs::read_to_string(&paths.config_file).unwrap();
-        // Inner [workspaces.github.github] gone (kind block); outer
-        // [workspaces.github] (workspace identifier) preserved.
+        let cleaned = workspace_file_contents(&paths, "github");
+        // Inner [github] gone (kind block); workspace file preserved.
         assert!(
-            cleaned.contains("[workspaces.github]"),
+            cleaned.contains("workdir"),
             "workspace named 'github' must survive:\n{cleaned}"
         );
         assert!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -287,7 +287,7 @@ pub struct AppConfig {
     pub roles: BTreeMap<String, RoleSource>,
     #[serde(default)]
     pub docker: DockerConfig,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub workspaces: BTreeMap<String, WorkspaceConfig>,
 }
 

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -1,5 +1,154 @@
 use super::AppConfig;
 use crate::paths::JackinPaths;
+use anyhow::Context;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub fn validate_workspace_file_stem(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("workspace name cannot be empty");
+    }
+    if name == "." || name == ".." {
+        anyhow::bail!("workspace name {name:?} is reserved");
+    }
+    if name.contains('/') || name.contains('\\') {
+        anyhow::bail!("workspace name {name:?} cannot contain path separators");
+    }
+    #[cfg(windows)]
+    {
+        const RESERVED: &[&str] = &[
+            "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+            "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        ];
+        if RESERVED
+            .iter()
+            .any(|reserved| name.eq_ignore_ascii_case(reserved))
+        {
+            anyhow::bail!("workspace name {name:?} is reserved on Windows");
+        }
+        if name.ends_with('.') || name.ends_with(' ') {
+            anyhow::bail!("workspace name {name:?} cannot end with a dot or space on Windows");
+        }
+    }
+    Ok(())
+}
+
+pub fn workspace_file_path(paths: &JackinPaths, name: &str) -> PathBuf {
+    paths.workspaces_dir.join(format!("{name}.toml"))
+}
+
+pub fn load_split_config(
+    paths: &JackinPaths,
+    contents_opt: Option<String>,
+) -> anyhow::Result<AppConfig> {
+    let mut config: AppConfig = match contents_opt {
+        Some(c) => toml::from_str(&c)?,
+        None => AppConfig::default(),
+    };
+
+    let legacy_workspaces = std::mem::take(&mut config.workspaces);
+    if !legacy_workspaces.is_empty() {
+        migrate_legacy_workspaces(paths, &config, &legacy_workspaces)?;
+        eprintln!(
+            "jackin migrated saved workspaces into {}",
+            paths.workspaces_dir.display()
+        );
+    }
+
+    config.workspaces = load_workspace_files(&paths.workspaces_dir)?;
+    Ok(config)
+}
+
+pub fn load_workspace_files(
+    workspaces_dir: &Path,
+) -> anyhow::Result<BTreeMap<String, crate::workspace::WorkspaceConfig>> {
+    let mut workspaces = BTreeMap::new();
+    let entries = match std::fs::read_dir(workspaces_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(workspaces),
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow::anyhow!("invalid workspace filename {}", path.display()))?;
+        validate_workspace_file_stem(stem)
+            .with_context(|| format!("invalid workspace filename {}", path.display()))?;
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading workspace config {}", path.display()))?;
+        let workspace = toml::from_str(&raw)
+            .with_context(|| format!("parsing workspace config {}", path.display()))?;
+        workspaces.insert(stem.to_string(), workspace);
+    }
+    Ok(workspaces)
+}
+
+fn migrate_legacy_workspaces(
+    paths: &JackinPaths,
+    global_config: &AppConfig,
+    workspaces: &BTreeMap<String, crate::workspace::WorkspaceConfig>,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(&paths.workspaces_dir)?;
+    for (name, workspace) in workspaces {
+        validate_workspace_file_stem(name)?;
+        let path = workspace_file_path(paths, name);
+        if path.exists() {
+            let existing: crate::workspace::WorkspaceConfig = toml::from_str(
+                &std::fs::read_to_string(&path)
+                    .with_context(|| format!("reading existing workspace {}", path.display()))?,
+            )
+            .with_context(|| format!("parsing existing workspace {}", path.display()))?;
+            if &existing == workspace {
+                continue;
+            }
+            anyhow::bail!(
+                "cannot migrate workspace {name:?}: {} already exists with different contents",
+                path.display()
+            );
+        }
+        let contents = toml::to_string_pretty(workspace)
+            .with_context(|| format!("serializing workspace {name:?}"))?;
+        atomic_write(&path, &contents)?;
+    }
+
+    let global_contents = toml::to_string_pretty(global_config)?;
+    atomic_write(&paths.config_file, &global_contents)?;
+    Ok(())
+}
+
+pub fn atomic_write(path: &Path, contents: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("tmp");
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+    }
+
+    #[cfg(not(unix))]
+    std::fs::write(&tmp, contents)?;
+
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
 
 impl AppConfig {
     pub fn load_or_init(paths: &JackinPaths) -> anyhow::Result<Self> {
@@ -11,10 +160,7 @@ impl AppConfig {
             Err(e) => return Err(e.into()),
         };
 
-        let mut config: Self = match contents_opt {
-            Some(c) => toml::from_str(&c)?,
-            None => Self::default(),
-        };
+        let mut config = load_split_config(paths, contents_opt)?;
 
         // Run the reserved-name validation against the on-disk shape
         // BEFORE the builtin-sync editor save below. `ConfigEditor::save`
@@ -35,29 +181,8 @@ impl AppConfig {
             // through the lossy serde path first — that would destroy
             // every user comment before the editor could preserve them.
             if !paths.config_file.exists() {
-                // Inline of the removed AppConfig::save. Atomic write:
-                // serialize → .tmp (0o600 on unix, fsync) → rename.
                 let contents = toml::to_string_pretty(&config)?;
-                let tmp = paths.config_file.with_extension("tmp");
-
-                #[cfg(unix)]
-                {
-                    use std::io::Write;
-                    use std::os::unix::fs::OpenOptionsExt;
-                    let mut file = std::fs::OpenOptions::new()
-                        .write(true)
-                        .create(true)
-                        .truncate(true)
-                        .mode(0o600)
-                        .open(&tmp)?;
-                    file.write_all(contents.as_bytes())?;
-                    file.sync_all()?;
-                }
-
-                #[cfg(not(unix))]
-                std::fs::write(&tmp, &contents)?;
-
-                std::fs::rename(&tmp, &paths.config_file)?;
+                atomic_write(&paths.config_file, &contents)?;
             }
             let mut editor = crate::config::ConfigEditor::open(paths)?;
             for &(name, git) in crate::config::roles::BUILTIN_ROLES {
@@ -181,5 +306,60 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
             .unwrap();
 
         assert_eq!(mtime_before, mtime_after);
+    }
+
+    #[test]
+    fn load_migrates_legacy_workspaces_into_split_files() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(
+            &paths.config_file,
+            r#"[env]
+GLOBAL = "yes"
+
+[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+
+[workspaces.prod]
+workdir = "/workspace/prod"
+
+[[workspaces.prod.mounts]]
+src = "/tmp/prod"
+dst = "/workspace/prod"
+
+[workspaces.prod.env]
+LOCAL = "only-prod"
+"#,
+        )
+        .unwrap();
+
+        let config = AppConfig::load_or_init(&paths).unwrap();
+        assert!(config.workspaces.contains_key("prod"));
+
+        let global = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(global.contains("[env]"), "{global}");
+        assert!(!global.contains("[workspaces."), "{global}");
+
+        let workspace = std::fs::read_to_string(paths.workspaces_dir.join("prod.toml")).unwrap();
+        assert!(
+            workspace.contains(r#"workdir = "/workspace/prod""#),
+            "{workspace}"
+        );
+        assert!(workspace.contains("[env]"), "{workspace}");
+        assert!(workspace.contains(r#"LOCAL = "only-prod""#), "{workspace}");
+    }
+
+    #[test]
+    fn load_rejects_invalid_workspace_filename() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::create_dir_all(&paths.workspaces_dir).unwrap();
+        std::fs::write(paths.workspaces_dir.join("..toml"), "").unwrap();
+
+        let err = AppConfig::load_or_init(&paths).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid workspace filename"), "{msg}");
     }
 }

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -592,6 +592,7 @@ mod tests {
                 home_dir: data.into(),
                 config_dir: data.into(),
                 config_file: data.join("config.toml"),
+                workspaces_dir: data.join("workspaces"),
                 roles_dir: data.into(),
                 data_dir: data.into(),
                 cache_dir: data.into(),

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1101,10 +1101,10 @@ mod tests {
         apply_auth_forward_diff(&mut editor, "proj", &original, &pending);
         editor.save().unwrap();
 
-        let out = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(out.contains("[workspaces.proj.amp]"), "{out}");
+        let out = std::fs::read_to_string(paths.workspaces_dir.join("proj.toml")).unwrap();
+        assert!(out.contains("[amp]"), "{out}");
         assert!(out.contains(r#"auth_forward = "api_key""#), "{out}");
-        assert!(out.contains("[workspaces.proj.roles.smith.amp]"), "{out}");
+        assert!(out.contains("[roles.smith.amp]"), "{out}");
         assert!(out.contains(r#"auth_forward = "ignore""#), "{out}");
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -6,6 +6,7 @@ pub struct JackinPaths {
     pub home_dir: PathBuf,
     pub config_dir: PathBuf,
     pub config_file: PathBuf,
+    pub workspaces_dir: PathBuf,
     pub roles_dir: PathBuf,
     pub data_dir: PathBuf,
     pub cache_dir: PathBuf,
@@ -20,6 +21,7 @@ impl JackinPaths {
 
         Ok(Self {
             config_file: config_dir.join("config.toml"),
+            workspaces_dir: config_dir.join("workspaces"),
             roles_dir: home_dir.join(".jackin/roles"),
             data_dir: home_dir.join(".jackin/data"),
             cache_dir: home_dir.join(".jackin/cache"),
@@ -33,6 +35,7 @@ impl JackinPaths {
         let config_dir = root.join("config");
         Self {
             config_file: config_dir.join("config.toml"),
+            workspaces_dir: config_dir.join("workspaces"),
             roles_dir: home_dir.join(".jackin/roles"),
             data_dir: home_dir.join(".jackin/data"),
             cache_dir: home_dir.join(".jackin/cache"),

--- a/tests/cli_env.rs
+++ b/tests/cli_env.rs
@@ -35,6 +35,15 @@ fn read_config(env: &Env) -> String {
     fs::read_to_string(config_path(env)).unwrap()
 }
 
+fn read_workspace_config(env: &Env, name: &str) -> String {
+    fs::read_to_string(
+        env.home
+            .join(".config/jackin/workspaces")
+            .join(format!("{name}.toml")),
+    )
+    .unwrap()
+}
+
 /// `[roles.<name>]` needs the required `git` field for serde to
 /// accept the table.
 fn seed_agent(env: &Env, name: &str) {
@@ -214,11 +223,8 @@ fn workspace_env_set_workspace_scope() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Set DB_URL."));
-    let contents = read_config(&env);
-    assert!(
-        contents.contains("[workspaces.prod.env]"),
-        "missing [workspaces.prod.env]:\n{contents}"
-    );
+    let contents = read_workspace_config(&env, "prod");
+    assert!(contents.contains("[env]"), "missing [env]:\n{contents}");
     assert!(
         contents.contains("DB_URL = \"postgres://localhost:5432/prod\""),
         "missing DB_URL entry:\n{contents}"
@@ -243,10 +249,10 @@ fn workspace_env_set_workspace_agent_scope() {
         ])
         .assert()
         .success();
-    let contents = read_config(&env);
+    let contents = read_workspace_config(&env, "prod");
     assert!(
-        contents.contains("[workspaces.prod.roles.agent-smith.env]"),
-        "missing [workspaces.prod.roles.agent-smith.env]:\n{contents}"
+        contents.contains("[roles.agent-smith.env]"),
+        "missing [roles.agent-smith.env]:\n{contents}"
     );
     assert!(
         contents.contains("OPENAI_KEY = \"sk-literal-key\""),

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2811,7 +2811,7 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     assert_eq!(
         ws_on_disk.claude.as_ref().map(|c| c.auth_forward),
         Some(jackin::config::AuthForwardMode::ApiKey),
-        "reload must see [workspaces.big-monorepo.claude] auth_forward = api_key"
+        "reload must see [claude] auth_forward = api_key in the workspace file"
     );
     let env_value = ws_on_disk
         .env
@@ -2827,9 +2827,9 @@ fn auth_form_save_persists_mode_and_credential_to_disk() -> Result<()> {
     // Belt-and-braces: read the raw TOML and confirm the literal text is
     // there. Catches a future regression where a typed accessor papered
     // over a missing block (e.g. resolver fall-through).
-    let toml = std::fs::read_to_string(&paths.config_file)?;
+    let toml = std::fs::read_to_string(paths.workspaces_dir.join("big-monorepo.toml"))?;
     assert!(
-        toml.contains("[workspaces.big-monorepo.claude]"),
+        toml.contains("[claude]"),
         "raw TOML must carry the workspace claude block; got:\n{toml}"
     );
     assert!(
@@ -3386,9 +3386,9 @@ fn auth_source_picker_op_disabled_when_op_missing() -> Result<()> {
 // Mirror-shape with `auth_form_save_persists_mode_and_credential_to_disk`
 // for Claude — open the form on the workspace × Github row, set mode =
 // token + a literal `GH_TOKEN`, commit, save, reload from disk, and
-// assert the persisted TOML carries BOTH the
-// `[workspaces.<ws>.github] auth_forward = "token"` block AND the
-// `GH_TOKEN` env var on the matching `[github.env]` block.
+// assert the persisted TOML carries BOTH the `[github]`
+// auth_forward = "token" block AND the `GH_TOKEN` env var on the
+// matching `[github.env]` block.
 #[allow(clippy::too_many_lines)]
 #[test]
 fn github_auth_form_save_persists_token_mode_and_gh_token_to_disk() -> Result<()> {
@@ -3505,7 +3505,7 @@ fn github_auth_form_save_persists_token_mode_and_gh_token_to_disk() -> Result<()
     let github_on_disk = ws_on_disk
         .github
         .as_ref()
-        .expect("[workspaces.big-monorepo.github] block must be on disk after save");
+        .expect("[github] block must be on disk after save");
     assert_eq!(
         github_on_disk.auth_forward,
         jackin::config::GithubAuthMode::Token
@@ -3522,16 +3522,14 @@ fn github_auth_form_save_persists_token_mode_and_gh_token_to_disk() -> Result<()
     // reload (the kind-scoped layer is the only place it should live).
     assert!(
         !ws_on_disk.env.contains_key("GH_TOKEN"),
-        "GH_TOKEN must not appear in [workspaces.<ws>.env]; only in [workspaces.<ws>.github.env]"
+        "GH_TOKEN must not appear in [env]; only in [github.env]"
     );
 
-    // Belt-and-braces: read the raw TOML and confirm the literal text
-    // landed on `[workspaces.big-monorepo.github]` and
-    // `[workspaces.big-monorepo.github.env]`, not on
-    // `[workspaces.big-monorepo.env]`.
-    let toml = std::fs::read_to_string(&paths.config_file)?;
+    // Belt-and-braces: read the raw workspace TOML and confirm the
+    // literal text landed on `[github]` / `[github.env]`, not `[env]`.
+    let toml = std::fs::read_to_string(paths.workspaces_dir.join("big-monorepo.toml"))?;
     assert!(
-        toml.contains("[workspaces.big-monorepo.github]"),
+        toml.contains("[github]"),
         "raw TOML must carry the workspace github block; got:\n{toml}"
     );
     assert!(
@@ -3546,7 +3544,7 @@ fn github_auth_form_save_persists_token_mode_and_gh_token_to_disk() -> Result<()
 }
 
 /// `D` on a Github `RoleHeader` clears the role's
-/// `[workspaces.<ws>.roles.<role>.github]` override end-to-end through
+/// `[roles.<role>.github]` override end-to-end through
 /// the input dispatcher (in addition to the unit-level coverage in
 /// `src/console/manager/input/auth.rs`).
 #[test]


### PR DESCRIPTION
## Summary

Splits saved workspace configuration out of the global `config.toml` into one TOML file per workspace under `workspaces/<name>.toml`. Global settings remain in `config.toml`; `AppConfig::load_or_init` still returns the merged in-memory shape callers already use, so launch, manager, and CLI resolution do not need to learn a second config model.

Legacy monolithic `[workspaces.*]` tables migrate automatically on load. The migration writes each workspace to its split file, rewrites `config.toml` without the workspace map, rejects unsafe workspace filenames, and refuses to overwrite an existing split file with different contents. The comment-preserving editor now reads and writes the split workspace documents directly, including workspace env, role env, auth blocks, GitHub auth/env, mounts, rename, and delete flows.

Docs and integration coverage are updated for the collapsed per-workspace file shape: inside `workspaces/prod.toml`, workspace-local tables are written as `[env]`, `[claude]`, `[github]`, `[roles.<role>.env]`, and so on, with no `[workspaces.prod]` wrapper.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feat/split-workspace-config-files:refs/remotes/origin/feat/split-workspace-config-files
git checkout -B feat/split-workspace-config-files refs/remotes/origin/feat/split-workspace-config-files
```

### Static checks

```sh
cargo fmt --check
cargo clippy -- -D warnings
```

### Tests

```sh
cargo test config::persist::tests --lib
cargo test config::editor::tests --lib
cargo test --test cli_env
cargo test --test manager_flow -- --test-threads=1
cargo test -- --test-threads=1
```

The persist tests cover legacy migration into split files, idempotent loads, validation failures, and filename rejection. The editor tests cover comment-preserving writes across split workspace documents, create/edit/rename/delete, auth/env table placement, and invalid candidate rollback. The CLI and manager integration tests pin the user-facing workspace env/auth save flows against the new on-disk layout. The full serial suite covers the rest of the crate before merge.

### User smoke

```sh
export JACKIN_CONFIG_HOME="$(mktemp -d)"
mkdir -p "$JACKIN_CONFIG_HOME"
cat > "$JACKIN_CONFIG_HOME/config.toml" <<'TOML'
[workspaces.prod]
workdir = "/workspace"
default_agent = "claude"

[[workspaces.prod.mounts]]
src = "/tmp"
dst = "/workspace"

[workspaces.prod.env]
ANTHROPIC_API_KEY = "test-key"

[workspaces.prod.github]
auth_forward = "token"

[workspaces.prod.github.env]
GH_TOKEN = "ghp_test"
TOML

cargo run --bin jackin -- workspace show prod

printf '\n--- global config ---\n'
cat "$JACKIN_CONFIG_HOME/config.toml"

printf '\n--- workspace config ---\n'
cat "$JACKIN_CONFIG_HOME/workspaces/prod.toml"
```

Expected result: `workspace show prod` succeeds, `config.toml` no longer contains any `[workspaces.*]` tables, and `workspaces/prod.toml` contains the workspace fields at the file root with `[env]`, `[github]`, and `[github.env]` sections.

Then smoke a write through the editor-backed CLI path:

```sh
cargo run --bin jackin -- config env set --workspace prod SMOKE_VALUE plain-text
cat "$JACKIN_CONFIG_HOME/workspaces/prod.toml"
```

Expected result: `SMOKE_VALUE = "plain-text"` lands in `workspaces/prod.toml` under `[env]`, not in global `config.toml`.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/configuration/**  
UPDATED page. Confirm the configuration layout describes `config.toml` plus `workspaces/<name>.toml`, and workspace examples use collapsed file-local tables instead of `[workspaces.<name>.*]` wrappers.

**http://localhost:4321/reference/roadmap/split-workspace-config-files/**  
ROADMAP SOURCE. Confirm the implementation matches the roadmap intent: workspaces live in separate files, global config stays global, and legacy config migrates automatically.

## Migration notes

Existing pre-split configs with `[workspaces.<name>]` tables migrate automatically the next time jackin loads the config. Each workspace is written to `workspaces/<name>.toml`, and the global `config.toml` is rewritten without the legacy workspace tables.

If `workspaces/<name>.toml` already exists with identical parsed contents, migration is idempotent. If it exists with different contents, jackin refuses to overwrite it and reports the conflict so the operator can resolve the duplicate manually.
