### PR TITLE
docs(roadmap): config versioning and migration framework

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -322,6 +322,7 @@ export default defineConfig({
                   label: 'Configuration ergonomics',
                   collapsed: true,
                   items: [
+                    { label: 'Config versioning and migration', slug: 'reference/roadmap/config-versioning-migration' },
                     { label: 'Split config.toml into per-workspace files', slug: 'reference/roadmap/split-workspace-config-files' },
                   ],
                 },

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -93,6 +93,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 
 ### Configuration ergonomics
 
+- **[Config versioning and migration framework](/reference/roadmap/config-versioning-migration/)** — add a `version` integer to `config.toml` and `jackin.role.toml` so jackin can detect stale files and migrate them automatically (operator config) or guide role authors through an explicit upgrade path (role manifests). Includes a `jackin validate --migrate` subcommand and an optional `--pr` flag that opens a migration pull request in the role repo (status: open — design proposal).
 - **[Split `config.toml` into per-workspace files](/reference/roadmap/split-workspace-config-files/)** — keep the TOML format, but move every workspace into `~/.config/jackin/workspaces/<name>.toml`, leaving `config.toml` for global settings only. Designed for one-file sharing, fresh-machine reuse, and selective version control (e.g. via [chezmoi](https://www.chezmoi.io/)).
 
 ### Documentation infrastructure

--- a/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
+++ b/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
@@ -1,0 +1,154 @@
+---
+title: "Config versioning and migration framework"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Configuration ergonomics)
+
+## Problem
+
+Every time jackin' introduces a structural change to `~/.config/jackin/config.toml`, workspace files, or the `jackin.role.toml` role manifest, operators and role authors are expected to delete and recreate their setup from scratch. There is no signal that a file is stale, no path from an old shape to a new one, and no tooling to help — just a confusing parse error from `serde` when `deny_unknown_fields` fires or a required key is missing.
+
+Two classes of files are affected differently:
+
+- **Jackin-owned files** (`config.toml`, per-workspace files once [Split config.toml into per-workspace files](/reference/roadmap/split-workspace-config-files/) ships) — jackin writes these. It can migrate them silently on startup before the operator touches anything.
+- **Role-owned files** (`jackin.role.toml` in each role repo) — the role author writes these. Jackin reads them but has no write authority without an explicit operator action. A breaking change in the manifest schema forces every role author to update their repo manually and with no guidance beyond "it broke."
+
+Neither class has a `version` field today. Jackin cannot distinguish "file was never created" from "file predates the current schema" from "file was written by a newer binary this older binary cannot read."
+
+## Why it matters
+
+- **Operators lose their entire setup on upgrade.** Workspace configs, mount lists, per-workspace role overrides, and auth-forward settings all disappear when the schema changes. The correct response today is "delete and recreate" — which is unacceptable once jackin' moves past proof-of-concept.
+- **Role authors are collateral damage.** When the manifest schema gains a required field or renames a section, every third-party `jackin.role.toml` silently breaks until the author notices and patches it. There is no upgrade guide, no version gate, no migration tool.
+- **Breaking changes become risky to ship.** Without a migration path, the maintainer must weigh "correct shape" against "all existing users break" — a tension that slows the design or forces bad compromises.
+- **`deny_unknown_fields` makes serde errors cryptic.** The parse error names the unknown field but gives no hint that the file is simply outdated.
+
+## Proposed shape
+
+### Config version field
+
+Add a top-level integer `version` field to `config.toml` (and to each per-workspace file, once the workspace split ships):
+
+```toml
+version = 1
+
+[claude]
+auth_forward = "sync"
+# … rest of config …
+```
+
+Absence of `version` is treated as version `0` (the pre-versioning era). On load, jackin compares the file's version to the current expected version baked into the binary. If the file is older, jackin runs the migration chain before the config reaches any caller.
+
+### Role manifest version field
+
+Add a top-level integer `version` field to `jackin.role.toml`:
+
+```toml
+version = 1
+
+dockerfile = "Dockerfile"
+agents = ["claude", "codex"]
+# … rest of manifest …
+```
+
+Role manifests are not owned by jackin, so migration is opt-in and explicit rather than automatic (see [Role manifest migration](#role-manifest-migration) below).
+
+### Migration registry
+
+Each version step is a pure function that transforms a `toml::Value` to the next version's `toml::Value`. The registry is a compile-time slice:
+
+```rust
+const CONFIG_MIGRATIONS: &[fn(toml::Value) -> anyhow::Result<toml::Value>] = &[
+    migrate_config_v0_to_v1,
+    migrate_config_v1_to_v2,
+    // …
+];
+```
+
+The current expected version is `CONFIG_MIGRATIONS.len()` — there is no separate constant to keep in sync. Applying migrations is a fold over the slice from `file_version` to the end.
+
+`toml_edit` (already in the workspace) is used for the actual file rewrite so that comments and whitespace outside the migrated tables are preserved where possible.
+
+## Config file migration
+
+On every startup, `AppConfig::load_or_init` (in <RepoFile path="src/config/persist.rs" />) runs the migration step before deserializing into typed structs:
+
+1. Read the raw TOML as `toml::Value`.
+2. Extract the `version` integer (default `0` if absent).
+3. If `version == CURRENT_VERSION`, deserialize as today.
+4. If `version < CURRENT_VERSION`, apply `CONFIG_MIGRATIONS[version..]` in sequence. Write the migrated result back to disk via `ConfigEditor` (<RepoFile path="src/config/editor.rs" />) to preserve operator-added comments. Print one line to stderr: `[jackin] config migrated v{old} → v{new}`.
+5. If `version > CURRENT_VERSION`, error: the file was written by a newer binary and this binary cannot safely read it.
+
+Migration is **always automatic for config files** — operators do not need to run any command. The worst-case outcome is a write to `config.toml` that the operator can review with `git diff` if they version-control their dotfiles.
+
+## Role manifest migration
+
+Role manifests live in role repos that jackin does not own. The policy is:
+
+- **Version matches**: proceed as today.
+- **Version absent or older than expected**: jackin refuses to use the role and emits a human-readable error: `role "the-architect" manifest is at v{old}, expected v{current}; run "jackin validate --migrate the-architect" to upgrade the local copy, or open a PR to the role repo`.
+- **Version newer than expected**: jackin refuses and emits: `role manifest is at v{new}, this binary only understands up to v{current}; upgrade jackin`.
+
+The `jackin validate --migrate <role>` subcommand applies the manifest migration chain to the local role clone and writes the result back. The operator can then inspect the diff, commit, and push — or pass `--pr` to have jackin open a pull request in the role repo automatically via `gh`.
+
+The `--pr` path requires:
+- `gh` authenticated with write access to the role repo.
+- The role repo to be a GitHub-hosted repo (the `git` source in `config.toml` resolves to a `github.com` URL).
+- A branch name derived from the migration: `jackin/manifest-migrate-v{old}-to-v{new}`.
+
+This makes it practical for the jackin maintainer to migrate all first-party role repos in one pass when a breaking manifest change ships, and for operators to send migration PRs to third-party role repos they rely on.
+
+## Error mode table
+
+| Situation | Config file | Role manifest |
+|---|---|---|
+| `version` absent | Treat as v0; migrate automatically | Treat as v0; error + suggest `--migrate` |
+| `version` < current | Migrate automatically on startup | Error + suggest `--migrate` |
+| `version` == current | Load normally | Load normally |
+| `version` > current | Error: binary too old | Error: binary too old |
+
+## Relationship to the pre-release rule
+
+<RepoFile path="AGENTS.md" /> currently states: "Do not write migration code, compatibility shims, fallback parsers for old field names, 'tolerant ignore + warn' handlers, or deprecation warnings. Make the new shape the only shape; let stale configs fail with the standard parser error." That rule was written for a pre-release project where breaking changes were expected and no users had long-lived configs worth preserving.
+
+This roadmap item is the **transition point** out of that rule for config and manifest files. Once the migration framework ships, the AGENTS.md pre-release exemption retires for `config.toml`, per-workspace files, and `jackin.role.toml`: breaking schema changes must be accompanied by a migration function and a version bump. The pre-release exemption remains in force for other surfaces (CLI flags, internal Rust APIs) until the first tagged release.
+
+## Implementation phases
+
+**Phase 1 — Config file versioning**
+
+1. Add `version` extraction to the raw TOML read layer in <RepoFile path="src/config/persist.rs" /> (before deserialization into `AppConfig`).
+2. Implement the migration registry and the fold-and-rewrite logic using `toml_edit` (<RepoFile path="src/config/editor.rs" />).
+3. Ship with `CURRENT_CONFIG_VERSION = 1`; the v0→v1 migration is a no-op that adds `version = 1` to existing files.
+4. All future breaking config changes bump the version and add a migration function.
+
+**Phase 2 — Role manifest versioning**
+
+1. Add `version: Option<u32>` to `RoleManifest` in <RepoFile path="src/manifest/mod.rs" />.
+2. Implement the version-gate logic at manifest load time with the error messages described above.
+3. Ship with `CURRENT_MANIFEST_VERSION = 1`; treat missing `version` as v0.
+4. Add `jackin validate --migrate <role>` that applies the migration chain and writes the updated manifest back to the local role clone.
+
+**Phase 3 — `--pr` auto-migration**
+
+1. After `--migrate` writes the updated manifest, optionally create a branch + PR in the role repo via `gh`.
+2. Gated on `gh` auth, GitHub remote detection, and explicit `--pr` flag.
+3. Allows the jackin maintainer (and operators) to submit migration PRs to third-party role repos with a single command.
+
+## Open questions
+
+- **Integer versions vs. semver strings.** Integers are sufficient for sequential migration and simpler to implement. Semver only helps if roles need to express "compatible with jackin ≥ 1.2" — not a current requirement. Start with integers.
+- **Comment preservation during migration.** `toml_edit` preserves document structure for unchanged tables; migrated tables (renamed keys, restructured sections) lose their original comments. Acceptable for a first cut; document it.
+- **Config migration failure recovery.** If the migration write fails (disk full, permissions), the in-memory migrated config is valid but the file is stale. Atomic rename (write to a temp file, `rename(2)`) is the right answer; a failed rename should abort startup with a clear error rather than silently proceeding with a stale file.
+- **Workspace file versioning.** Once [Split config.toml into per-workspace files](/reference/roadmap/split-workspace-config-files/) ships, each workspace file also carries its own `version` field. Decide whether config.toml and workspace files share one version counter or track independently. Independent tracking is more precise (a workspace-only schema change does not bump the global version) but requires two migration registries.
+- **Schema changelog.** Each version bump needs a companion note: "what changed between vN and vN+1, and why." This belongs in the jackin changelog (once it activates at first release) or in a dedicated schema changelog reference page. Decide location before Phase 1 ships.
+
+## Related files
+
+- <RepoFile path="src/config/persist.rs" /> — `AppConfig::load_or_init`, the migration entry point.
+- <RepoFile path="src/config/editor.rs" /> — `ConfigEditor`, used for comment-preserving file rewrites.
+- <RepoFile path="src/manifest/mod.rs" /> — `RoleManifest`, the role manifest struct.
+- <RepoFile path="src/config/mod.rs" /> — `AppConfig` and workspace config structs.
+- [Split config.toml into per-workspace files](/reference/roadmap/split-workspace-config-files/) — sibling ergonomics item; migration must handle both the monolithic and split layouts if both can exist in the field.
+- [Agent version pinning](/reference/roadmap/reproducibility-pinning/) — related: pinning roles to tagged versions implies a version relationship between the jackin binary and the role manifest schema.
+- [Configuration File](/reference/configuration/) — internals reference; version field and migration behavior will need to be documented here once Phase 1 ships.


### PR DESCRIPTION
## Summary

- Adds a new roadmap item at `docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx` proposing a versioning and migration framework for `config.toml`, per-workspace files, and `jackin.role.toml`.
- Registers the item in the sidebar (`docs/astro.config.ts`) under **Configuration ergonomics**.
- Adds a summary bullet to the roadmap overview (`docs/src/content/docs/reference/roadmap.mdx`) under the same section.

The proposal covers:

- **Automatic silent migration** for jackin-owned config files (`config.toml`, workspace files) — on startup, jackin detects the `version` field, runs any pending migrations via a compile-time registry of pure `toml::Value → toml::Value` functions, rewrites the file with `toml_edit` to preserve comments, and prints a one-line notice.
- **Explicit opt-in migration** for role manifests (`jackin.role.toml`) — jackin gates on version mismatch with a human-readable error, and a new `jackin validate --migrate <role>` subcommand applies the migration chain and writes back. A `--pr` flag opens a migration PR in the role repo via `gh`.
- **Three implementation phases**: Phase 1 (config file versioning), Phase 2 (role manifest versioning + `--migrate`), Phase 3 (`--pr` auto-migration).
- **Retirement of the AGENTS.md pre-release "no migration code" exemption** for config and manifest files once Phase 1 ships.

## Hard-rule callout

No host-side writes are introduced — this is a documentation-only PR. The proposed runtime behavior (config migration writes) targets `~/.config/jackin/config.toml` and the locally-cached role clone, both of which are jackin-managed paths, not operator-authored host state.

## What's deferred

- Implementation of any migration functions or version fields in Rust — this PR is the design proposal only.
- The `--pr` auto-migration path (Phase 3) — depends on `gh` auth and GitHub remote detection; deferred to its own PR once Phases 1 and 2 land.

## Verify locally

```bash
export TIRITH=0
cd docs
bun install --frozen-lockfile
bun run build
```

Build should complete with no broken links or TypeScript errors. To spot-check the sidebar audit:

```bash
ls docs/src/content/docs/reference/roadmap/*.mdx \
  | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
grep -oE "reference/roadmap/[a-z0-9-]+" docs/astro.config.ts \
  | sed 's|reference/roadmap/||' | sort -u > /tmp/roadmap-sidebar
diff /tmp/roadmap-files /tmp/roadmap-sidebar
```

The diff must be empty.

## Migration notes

Documentation-only PR — no config schema changes, no migration needed.

https://claude.ai/code/session_01YZ6LvUK7uGbuMsDro1KLR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ6LvUK7uGbuMsDro1KLR2)_