### PR TITLE
fix(migrations): add v1alpha2 version ordering

### DIFF
--- a/docs/src/content/docs/developing/creating-roles.mdx
+++ b/docs/src/content/docs/developing/creating-roles.mdx
@@ -28,7 +28,7 @@ Creating a custom agent lets you define a specialized environment for a specific
 2. **Create the manifest file**
 
    ```toml
-   version = "v1alpha1"
+   version = "v1alpha2"
    dockerfile = "Dockerfile"
 
    [claude]
@@ -126,7 +126,7 @@ USER agent
 Role repos can declare Claude Code plugins to install. Add them to the `[claude]` section in your manifest:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -142,7 +142,7 @@ These plugin IDs are written into the agent's runtime state and installed automa
 If you need plugins from a custom marketplace, declare the marketplace separately and keep plugin IDs fully qualified:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -171,7 +171,7 @@ jackin adds each declared marketplace at container startup, then installs each p
 An role can support more than one agent while keeping one shared Dockerfile:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 

--- a/docs/src/content/docs/developing/role-manifest.mdx
+++ b/docs/src/content/docs/developing/role-manifest.mdx
@@ -21,7 +21,7 @@ jackin' enforces **strict parsing** — unknown fields are rejected with an erro
 ## Full schema
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -70,7 +70,7 @@ default = "feature/${env.PROJECT}"
 
 | Field | Required | Description |
 |---|---|---|
-| `version` | Yes | Manifest schema version. Current value is `v1alpha1`. |
+| `version` | Yes | Manifest schema version. Current value is `v1alpha2`. |
 | `dockerfile` | Yes | Relative path to the Dockerfile within the repo |
 | `agents` | No | Non-empty list of agent slugs this role supports: `"claude"`, `"codex"`, or `"amp"`. When omitted, jackin treats the manifest as Claude-only. |
 
@@ -84,7 +84,7 @@ The Dockerfile path must:
 Every agent listed in `agents` must have a matching `[<agent>]` table, even when that table is empty. A manifest with `agents = ["claude", "codex", "amp"]` needs `[claude]`, `[codex]`, and `[amp]`.
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -108,7 +108,7 @@ model = "gpt-5"
 Example values:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -139,7 +139,7 @@ The `[codex]` table is required when `"codex"` appears in `agents`.
 | `model` | No | Optional Codex model passed to `codex -m` at launch |
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -152,7 +152,7 @@ model = "gpt-5"
 The `[amp]` table is required when `"amp"` appears in `agents`. It is empty today and reserved for future Amp-specific settings.
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -366,7 +366,7 @@ Interactive prompts happen before the Docker image build, so you won't wait thro
 The smallest valid manifest:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -376,7 +376,7 @@ plugins = []
 ## Complete example
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "docker/Dockerfile.agent"
 
 [identity]

--- a/docs/src/content/docs/guides/role-repos.mdx
+++ b/docs/src/content/docs/guides/role-repos.mdx
@@ -120,7 +120,7 @@ Role repos only own their agent-specific environment layer. jackin' owns everyth
 A minimal role repo for a Node.js development agent:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -31,7 +31,7 @@ Saved workspaces live one-per-file under `~/.config/jackin/workspaces/` rather t
 - **Restore the full setup on a new machine** by checking out the dotfile repo and running `chezmoi apply` (or equivalent), with no manual TOML reconstruction.
 - **Diff a single workspace** in PR review without seeing churn in unrelated workspaces, which is impossible when every change touches a shared `[workspaces.*]` block.
 
-Each file carries its own `version = "v1alpha1"` stamp, so a dotfile-managed setup that is partially old (some workspaces stamped, some not) migrates per-file on first load. See [Schema Versions](/reference/schema-versions/) for the full version history and the legacy-to-`v1alpha1` migration matrix.
+Each file carries its own `version = "v1alpha2"` stamp, so a dotfile-managed setup that is partially old (some workspaces stamped, some not) migrates per-file on first load. See [Schema Versions](/reference/schema-versions/) for the full version history and migration matrix.
 
 ## config.toml schema
 
@@ -40,7 +40,7 @@ The configuration is TOML. Global settings live at
 `~/.config/jackin/workspaces/`. The CLI and console manage both locations
 for you, so you generally don't need to edit them by hand.
 
-Top-level `version` is the config schema version. jackin' writes `version = "v1alpha1"` today. Older config files with no `version` are treated as legacy and migrated automatically on startup before parsing. See [Schema Versions](/reference/schema-versions/) for the full version history and migration matrix.
+Top-level `version` is the config schema version. jackin' writes `version = "v1alpha2"` today. Older config files with no `version` are treated as legacy and migrated automatically on startup before parsing. See [Schema Versions](/reference/schema-versions/) for the full version history and migration matrix.
 
 ### Agent auth-forward settings
 
@@ -48,7 +48,7 @@ Top-level `version` is the config schema version. jackin' writes `version = "v1a
 layers, with most-specific wins:
 
 ```toml
-version = "v1alpha1"
+version = "v1alpha2"
 
 # Layer 1 — global default (per agent)
 [claude]

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -46,7 +46,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 - [Multi-runtime support for Codex and Amp](/reference/roadmap/multi-runtime-support/) — built-in runtime launch is documented in standard docs; roadmap tracks deeper runtime parity
 - [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/) — shipped GitHub auth forwarding is documented in standard docs; roadmap tracks the CLI subcommand, scope pre-flight, and deeper GHE coverage
 - [Workspace Claude token setup](/reference/roadmap/workspace-claude-token-setup/) — shipped token commands are documented in standard docs; roadmap tracks the canonical auth slot, TUI generate action, Apple Keychain backend, validity probe, and bulk migration
-- [Config versioning and migration framework](/reference/roadmap/config-versioning-migration/) — shipped per-file `version = "v1alpha1"` gates for config, workspace files, and role manifests, plus automatic config/workspace migration and explicit role manifest `--migrate`; roadmap tracks deferred `--pr` automation and the Renovate-style auto-migration GitHub Action
+- [Config versioning and migration framework](/reference/roadmap/config-versioning-migration/) — shipped per-file schema gates for config, workspace files, and role manifests, plus automatic config/workspace migration and explicit role manifest `--migrate`; roadmap tracks deferred `--pr` automation and the Renovate-style auto-migration GitHub Action
 
 ## Planned
 

--- a/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
+++ b/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
@@ -30,7 +30,7 @@ A file with no `version` is ambiguous: it could be a file that was never created
 `config.toml` and every per-workspace file use a top-level Kubernetes-style `version` field:
 
 ```toml
-version = "v1alpha1"
+version = "v1alpha2"
 
 [claude]
 auth_forward = "sync"
@@ -46,7 +46,7 @@ The main config file and workspace files are versioned independently. A workspac
 `jackin.role.toml` uses the same top-level Kubernetes-style `version` field:
 
 ```toml
-version = "v1alpha1"
+version = "v1alpha2"
 
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]

--- a/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
+++ b/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
@@ -71,6 +71,7 @@ workspace overrides come later if a use case surfaces.
 
 ```toml
 # jackin.role.toml
+version = "v1alpha1"
 dockerfile = "Dockerfile"
 
 [runtime.limits]

--- a/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
+++ b/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
@@ -69,8 +69,7 @@ workspace overrides come later if a use case surfaces.
 
 ### Config
 
-```toml
-# jackin.role.toml
+```toml title="jackin.role.toml"
 version = "v1alpha1"
 dockerfile = "Dockerfile"
 

--- a/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
+++ b/docs/src/content/docs/reference/roadmap/declarative-resource-limits.mdx
@@ -70,7 +70,7 @@ workspace overrides come later if a use case surfaces.
 ### Config
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [runtime.limits]

--- a/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
+++ b/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
@@ -58,8 +58,7 @@ the hook based on observed status.
 
 ### Role config
 
-```toml
-# jackin.role.toml
+```toml title="jackin.role.toml"
 version = "v1alpha1"
 
 [runtime.idle]

--- a/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
+++ b/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
@@ -60,6 +60,7 @@ the hook based on observed status.
 
 ```toml
 # jackin.role.toml
+version = "v1alpha1"
 
 [runtime.idle]
 commands = [

--- a/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
+++ b/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
@@ -59,7 +59,7 @@ the hook based on observed status.
 ### Role config
 
 ```toml title="jackin.role.toml"
-version = "v1alpha1"
+version = "v1alpha2"
 
 [runtime.idle]
 commands = [

--- a/docs/src/content/docs/reference/schema-versions.mdx
+++ b/docs/src/content/docs/reference/schema-versions.mdx
@@ -40,7 +40,7 @@ Each entry is one upgrade path the current binary applies. <RepoFile path="tests
 | Workspace (`workspaces/<name>.toml`) | `legacy` | Automatic on startup | <RepoFile path="tests/fixtures/migrations/workspace/from-legacy/meta.toml" /> |
 | Manifest (`jackin.role.toml`) | `legacy` | Explicit `jackin-validate --migrate <role-repo-path>` | <RepoFile path="tests/fixtures/migrations/manifest/from-legacy/meta.toml" /> |
 
-**Summary**: introduces the top-level `version` field. The migration adds `version = "v1alpha1"` to every file kind and leaves all existing keys, comments, and section ordering untouched. Splitting legacy `[workspaces.<name>]` tables out of `config.toml` runs as a separate startup step (see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design)); the version migration above is independent of that split.
+**Summary**: introduces the top-level `version` field. The migration writes `version = "v1alpha1"` as the first line in every file kind, then preserves existing keys, comments, and section ordering below it. Splitting legacy `[workspaces.<name>]` tables out of `config.toml` runs as a separate startup step (see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design)); the version migration above is independent of that split.
 
 **Before** (legacy operator config — excerpt):
 
@@ -83,7 +83,7 @@ config, jackin migrates this automatically before parsing.
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` |
+| Added | `version = "v1alpha1"` as the first line |
 | Preserved | Global agent auth, GitHub auth, env, role sources, Docker mounts |
 | Removed | None |
 | Renamed | None |
@@ -122,7 +122,7 @@ a `[workspaces.<name>]` table embedded in legacy `config.toml`.
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` |
+| Added | `version = "v1alpha1"` as the first line |
 | Preserved | Workdir, mounts, role selection, env, auth overrides, keep-awake, 1Password account |
 | Removed | None |
 | Renamed | None |
@@ -170,7 +170,7 @@ does not auto-write role repositories during normal role loading. Run
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` |
+| Added | `version = "v1alpha1"` as the first line |
 | Moved | None |
 | Preserved | Dockerfile, published image, identity, agents, runtime settings, hooks, env prompts |
 | Removed | None |

--- a/docs/src/content/docs/reference/schema-versions.mdx
+++ b/docs/src/content/docs/reference/schema-versions.mdx
@@ -24,13 +24,41 @@ The split-workspace layout described in [Configuration File](/reference/configur
 
 | File | Current version | Owner | Migration mode |
 |---|---|---|---|
-| `~/.config/jackin/config.toml` | `v1alpha1` | jackin | Automatic on startup |
-| `~/.config/jackin/workspaces/<name>.toml` | `v1alpha1` | jackin | Automatic on startup |
-| `jackin.role.toml` | `v1alpha1` | Role repository | Explicit `jackin-validate --migrate <role-repo-path>` |
+| `~/.config/jackin/config.toml` | `v1alpha2` | jackin | Automatic on startup |
+| `~/.config/jackin/workspaces/<name>.toml` | `v1alpha2` | jackin | Automatic on startup |
+| `jackin.role.toml` | `v1alpha2` | Role repository | Explicit `jackin-validate --migrate <role-repo-path>` |
 
 ## Timeline
 
 Each entry is one upgrade path the current binary applies. <RepoFile path="tests/migration_fixtures.rs" /> walks every fixture on every CI run, so a regression breaks here before it breaks on a delayed operator's machine. Newest first; append, never edit.
+
+### `v1alpha2` — 2026-05-11
+
+| File kind | Predecessor | Migration mode | Fixture |
+|---|---|---|---|
+| Config (`config.toml`) | `v1alpha1` | Automatic on startup | <RepoFile path="tests/fixtures/migrations/config/from-v1alpha1/meta.toml" /> |
+| Workspace (`workspaces/<name>.toml`) | `v1alpha1` | Automatic on startup | <RepoFile path="tests/fixtures/migrations/workspace/from-v1alpha1/meta.toml" /> |
+| Manifest (`jackin.role.toml`) | `v1alpha1` | Explicit `jackin-validate --migrate <role-repo-path>` | <RepoFile path="tests/fixtures/migrations/manifest/from-v1alpha1/meta.toml" /> |
+
+**Summary**: restamps existing `v1alpha1` files as `v1alpha2` and moves `version = "v1alpha2"` to the first line. This is intentionally a sequential migration rather than a silent rewrite of `v1alpha1`: operators already have `v1alpha1` files where the version key may sit below other top-level keys.
+
+**Before** (v1alpha1 workspace file — excerpt):
+
+```toml
+workdir = "/workspace/prod"
+allowed_roles = ["the-architect"]
+last_role = "the-architect"
+version = "v1alpha1"
+```
+
+**After** (v1alpha2):
+
+```toml
+version = "v1alpha2"
+workdir = "/workspace/prod"
+allowed_roles = ["the-architect"]
+last_role = "the-architect"
+```
 
 ### `v1alpha1` — 2026-05-10
 
@@ -40,7 +68,7 @@ Each entry is one upgrade path the current binary applies. <RepoFile path="tests
 | Workspace (`workspaces/<name>.toml`) | `legacy` | Automatic on startup | <RepoFile path="tests/fixtures/migrations/workspace/from-legacy/meta.toml" /> |
 | Manifest (`jackin.role.toml`) | `legacy` | Explicit `jackin-validate --migrate <role-repo-path>` | <RepoFile path="tests/fixtures/migrations/manifest/from-legacy/meta.toml" /> |
 
-**Summary**: introduces the top-level `version` field. The migration writes `version = "v1alpha1"` as the first line in every file kind, then preserves existing keys, comments, and section ordering below it. Splitting legacy `[workspaces.<name>]` tables out of `config.toml` runs as a separate startup step (see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design)); the version migration above is independent of that split.
+**Summary**: introduces the top-level `version` field. The migration adds `version = "v1alpha1"` to every file kind and leaves all existing keys, comments, and section ordering untouched. Splitting legacy `[workspaces.<name>]` tables out of `config.toml` runs as a separate startup step (see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design)); the version migration above is independent of that split.
 
 **Before** (legacy operator config — excerpt):
 
@@ -71,8 +99,7 @@ Schema versions use Kubernetes-style names:
 | `v1beta1` | More mature but still not stable |
 | `v1` | Stable schema |
 
-The current project is still unstable, so all current schemas start at
-`v1alpha1`.
+The current project is still unstable, so all current schemas use the `v1alpha*` family.
 
 ## `config.toml`
 
@@ -83,18 +110,18 @@ config, jackin migrates this automatically before parsing.
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` as the first line |
+| Added | `version = "v1alpha1"` |
 | Preserved | Global agent auth, GitHub auth, env, role sources, Docker mounts |
 | Removed | None |
 | Renamed | None |
 
 The split-from-`config.toml` work for legacy `[workspaces.<name>]` tables runs as a separate startup migration alongside the version stamp; see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design).
 
-### `v1alpha1`
+### `v1alpha2`
 
 | Field | Type | Required | Since | Notes |
 |---|---|---|---|---|
-| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha1` |
+| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha2` |
 | `[claude].auth_forward` | string | No | `legacy` | `sync`, `api_key`, `oauth_token`, or `ignore` |
 | `[codex].auth_forward` | string | No | `legacy` | `sync`, `api_key`, or `ignore` |
 | `[amp].auth_forward` | string | No | `legacy` | `sync`, `api_key`, or `ignore` |
@@ -122,18 +149,18 @@ a `[workspaces.<name>]` table embedded in legacy `config.toml`.
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` as the first line |
+| Added | `version = "v1alpha1"` |
 | Preserved | Workdir, mounts, role selection, env, auth overrides, keep-awake, 1Password account |
 | Removed | None |
 | Renamed | None |
 
 Legacy embedded `[workspaces.<name>]` tables in `config.toml` are split into per-workspace files by a separate startup migration; see [Configuration File](/reference/configuration/#one-file-per-workspace-by-design).
 
-### `v1alpha1`
+### `v1alpha2`
 
 | Field | Type | Required | Since | Notes |
 |---|---|---|---|---|
-| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha1` |
+| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha2` |
 | `workdir` | string | Yes | `legacy` | Container working directory |
 | `allowed_roles` | string array | No | `legacy` | Roles allowed in this workspace |
 | `default_role` | string | No | `legacy` | Preferred role for new sessions |
@@ -170,17 +197,17 @@ does not auto-write role repositories during normal role loading. Run
 
 | Change to `v1alpha1` | Detail |
 |---|---|
-| Added | `version = "v1alpha1"` as the first line |
+| Added | `version = "v1alpha1"` |
 | Moved | None |
 | Preserved | Dockerfile, published image, identity, agents, runtime settings, hooks, env prompts |
 | Removed | None |
 | Renamed | None |
 
-### `v1alpha1`
+### `v1alpha2`
 
 | Field | Type | Required | Since | Notes |
 |---|---|---|---|---|
-| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha1` |
+| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha2` |
 | `dockerfile` | string | Yes | `legacy` | Relative path to role Dockerfile |
 | `published_image` | string | No | `legacy` | Pre-built role image override |
 | `agents` | string array | No | `legacy` | `claude`, `codex`, and/or `amp`; omitted means Claude-only |

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -964,7 +964,7 @@ mod tests {
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -990,7 +990,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -1022,7 +1022,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -1048,7 +1048,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("solo").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -1186,7 +1186,7 @@ workdir = "/b"
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        let original = r#"version = "v1alpha1"
+        let original = r#"version = "v1alpha2"
 # Top-of-file note about this config
 [claude]
 auth_forward = "sync"

--- a/src/config/fixtures/config.round_trip.toml
+++ b/src/config/fixtures/config.round_trip.toml
@@ -1,4 +1,4 @@
-version = "v1alpha1"
+version = "v1alpha2"
 # Jackin config — top-of-file note
 # keep this across saves
 

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use toml_edit::DocumentMut;
 
-pub const CURRENT_CONFIG_VERSION: &str = "v1alpha1";
-pub const CURRENT_WORKSPACE_VERSION: &str = "v1alpha1";
+pub const CURRENT_CONFIG_VERSION: &str = "v1alpha2";
+pub const CURRENT_WORKSPACE_VERSION: &str = "v1alpha2";
 pub const LEGACY_VERSION: &str = "legacy";
 
 pub type Migration = fn(&mut DocumentMut) -> anyhow::Result<()>;
@@ -17,16 +17,30 @@ pub struct MigrationStep {
     pub migrate: Migration,
 }
 
-const CONFIG_MIGRATIONS: &[MigrationStep] = &[MigrationStep {
-    from: LEGACY_VERSION,
-    to: CURRENT_CONFIG_VERSION,
-    migrate: noop_migration,
-}];
-const WORKSPACE_MIGRATIONS: &[MigrationStep] = &[MigrationStep {
-    from: LEGACY_VERSION,
-    to: CURRENT_WORKSPACE_VERSION,
-    migrate: noop_migration,
-}];
+const CONFIG_MIGRATIONS: &[MigrationStep] = &[
+    MigrationStep {
+        from: LEGACY_VERSION,
+        to: "v1alpha1",
+        migrate: noop_migration,
+    },
+    MigrationStep {
+        from: "v1alpha1",
+        to: CURRENT_CONFIG_VERSION,
+        migrate: noop_migration,
+    },
+];
+const WORKSPACE_MIGRATIONS: &[MigrationStep] = &[
+    MigrationStep {
+        from: LEGACY_VERSION,
+        to: "v1alpha1",
+        migrate: noop_migration,
+    },
+    MigrationStep {
+        from: "v1alpha1",
+        to: CURRENT_WORKSPACE_VERSION,
+        migrate: noop_migration,
+    },
+];
 
 /// Schema version of a jackin-owned configuration file.
 ///
@@ -359,7 +373,7 @@ mod tests {
         assert!(migrate_config_file_if_needed(&path).unwrap());
         let out = std::fs::read_to_string(&path).unwrap();
         let parsed: toml::Value = toml::from_str(&out).unwrap();
-        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha2");
         assert!(out.contains("# keep me"), "{out}");
     }
 
@@ -372,7 +386,7 @@ mod tests {
         assert!(migrate_workspace_file_if_needed(&path).unwrap());
         let out = std::fs::read_to_string(&path).unwrap();
         let parsed: toml::Value = toml::from_str(&out).unwrap();
-        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha2");
         assert!(out.contains("# keep me"), "{out}");
     }
 
@@ -382,7 +396,7 @@ mod tests {
         let path = temp.path().join("prod.toml");
         std::fs::write(
             &path,
-            "version = \"v1alpha1\"\nworkdir = \"/workspace/prod\"\n",
+            "version = \"v1alpha2\"\nworkdir = \"/workspace/prod\"\n",
         )
         .unwrap();
 
@@ -396,7 +410,7 @@ mod tests {
         std::fs::write(&path, r#"version = "v2alpha1""#).unwrap();
 
         let err = migrate_config_file_if_needed(&path).unwrap_err();
-        assert!(err.to_string().contains("only understands up to v1alpha1"));
+        assert!(err.to_string().contains("only understands up to v1alpha2"));
     }
 
     #[test]
@@ -712,7 +726,7 @@ mod tests {
 
         assert!(migrate_workspace_file_if_needed(&path).unwrap());
         let out = std::fs::read_to_string(&path).unwrap();
-        assert!(out.starts_with("version = \"v1alpha1\""), "{out}");
+        assert!(out.starts_with("version = \"v1alpha2\""), "{out}");
         assert!(out.contains("workdir = \"/workspace/prod\""), "{out}");
         assert!(out.contains("# trailing comment"), "{out}");
     }

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -268,6 +268,13 @@ fn split_first_nondigit(s: &str) -> Option<(&str, &str)> {
 
 pub fn set_doc_version(doc: &mut DocumentMut, version: &str) {
     doc["version"] = toml_edit::value(version);
+    doc.as_table_mut().sort_values_by(|left, _, right, _| {
+        match (left.get() == "version", right.get() == "version") {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        }
+    });
 }
 
 // Stamp-only registry slot for transitions whose only delta is `version`.
@@ -698,18 +705,15 @@ mod tests {
     }
 
     #[test]
-    fn version_field_position_with_top_level_keys_first() {
-        // toml_edit appends `version` after existing top-level keys when no
-        // table headers precede them; the file stays human-readable and the
-        // operator's `workdir = ...` first-line layout survives.
+    fn version_field_is_migrated_to_first_line() {
         let temp = tempdir().unwrap();
         let path = temp.path().join("prod.toml");
         std::fs::write(&path, "workdir = \"/workspace/prod\"\n# trailing comment\n").unwrap();
 
         assert!(migrate_workspace_file_if_needed(&path).unwrap());
         let out = std::fs::read_to_string(&path).unwrap();
-        assert!(out.starts_with("workdir ="), "{out}");
+        assert!(out.starts_with("version = \"v1alpha1\""), "{out}");
+        assert!(out.contains("workdir = \"/workspace/prod\""), "{out}");
         assert!(out.contains("# trailing comment"), "{out}");
-        assert!(out.contains(r#"version = "v1alpha1""#), "{out}");
     }
 }

--- a/src/config/persist.rs
+++ b/src/config/persist.rs
@@ -355,7 +355,7 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
 
         assert_eq!(config.version, crate::config::CURRENT_CONFIG_VERSION);
-        assert!(out.contains(r#"version = "v1alpha1""#), "{out}");
+        assert!(out.contains(r#"version = "v1alpha2""#), "{out}");
         assert!(out.contains("# keep me"), "{out}");
     }
 
@@ -368,7 +368,7 @@ git = "https://github.com/jackin-project/jackin-agent-smith.git"
 
         let err = AppConfig::load_or_init(&paths).unwrap_err();
 
-        assert!(err.to_string().contains("only understands up to v1alpha1"));
+        assert!(err.to_string().contains("only understands up to v1alpha2"));
     }
 
     #[test]
@@ -448,12 +448,12 @@ LOCAL = "only-prod"
         assert!(config.workspaces.contains_key("prod"));
 
         let global = std::fs::read_to_string(&paths.config_file).unwrap();
-        assert!(global.contains(r#"version = "v1alpha1""#), "{global}");
+        assert!(global.contains(r#"version = "v1alpha2""#), "{global}");
         assert!(global.contains("[env]"), "{global}");
         assert!(!global.contains("[workspaces."), "{global}");
 
         let workspace = std::fs::read_to_string(paths.workspaces_dir.join("prod.toml")).unwrap();
-        assert!(workspace.contains(r#"version = "v1alpha1""#), "{workspace}");
+        assert!(workspace.contains(r#"version = "v1alpha2""#), "{workspace}");
         assert!(
             workspace.contains(r#"workdir = "/workspace/prod""#),
             "{workspace}"
@@ -470,7 +470,7 @@ LOCAL = "only-prod"
         std::fs::create_dir_all(&paths.workspaces_dir).unwrap();
         std::fs::write(
             paths.workspaces_dir.join("prod.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 workdir = "/other"
 "#,
         )
@@ -501,7 +501,7 @@ workdir = "/workspace/prod"
         let out = std::fs::read_to_string(&paths.config_file).unwrap();
 
         assert_eq!(config.version, crate::config::CURRENT_CONFIG_VERSION);
-        assert!(out.contains(r#"version = "v1alpha1""#), "{out}");
+        assert!(out.contains(r#"version = "v1alpha2""#), "{out}");
     }
 
     #[test]
@@ -588,7 +588,7 @@ workdir = "/workspace/prod"
     fn load_or_init_dual_migrates_legacy_config_with_legacy_workspaces() {
         // Pin the dual-migration contract: a legacy `config.toml` (no
         // `version`) carrying `[workspaces.X]` tables ends up with
-        // `version = "v1alpha1"` on the global file AND on each split
+        // `version = "v1alpha2"` on the global file AND on each split
         // workspace file after one load. The current registries are
         // no-ops; once a real content-changing config migration lands,
         // this test guards the ordering that the version migration runs
@@ -617,12 +617,12 @@ dst = "/workspace/prod"
 
         let global_on_disk = std::fs::read_to_string(&paths.config_file).unwrap();
         let global_parsed: toml::Value = toml::from_str(&global_on_disk).unwrap();
-        assert_eq!(global_parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert_eq!(global_parsed["version"].as_str().unwrap(), "v1alpha2");
         assert!(!global_on_disk.contains("[workspaces."), "{global_on_disk}");
 
         let prod_on_disk = std::fs::read_to_string(paths.workspaces_dir.join("prod.toml")).unwrap();
         let prod_parsed: toml::Value = toml::from_str(&prod_on_disk).unwrap();
-        assert_eq!(prod_parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert_eq!(prod_parsed["version"].as_str().unwrap(), "v1alpha2");
 
         // Re-running is a no-op: file content stays byte-identical.
         let global_before = std::fs::read(&paths.config_file).unwrap();
@@ -639,7 +639,7 @@ dst = "/workspace/prod"
         // Pin the contract that legacy `workspaces/<name>.toml` files (no
         // `version` key) get rewritten on first load. Without this test the
         // migrate-on-scan call in `load_workspace_files` is unreachable in
-        // tests — every other workspace fixture uses `version = "v1alpha1"`.
+        // tests — every other workspace fixture uses `version = "v1alpha2"`.
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
@@ -655,7 +655,7 @@ dst = "/workspace/prod"
 
         let on_disk = std::fs::read_to_string(paths.workspaces_dir.join("prod.toml")).unwrap();
         let parsed: toml::Value = toml::from_str(&on_disk).unwrap();
-        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha2");
         assert!(on_disk.contains("# keep me"), "{on_disk}");
     }
 
@@ -669,7 +669,7 @@ dst = "/workspace/prod"
         std::fs::create_dir_all(&paths.workspaces_dir).unwrap();
         std::fs::write(
             paths.workspaces_dir.join("real.toml"),
-            "version = \"v1alpha1\"\nworkdir = \"/w\"\n",
+            "version = \"v1alpha2\"\nworkdir = \"/w\"\n",
         )
         .unwrap();
         std::fs::write(

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1825,7 +1825,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -711,7 +711,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -743,7 +743,7 @@ source = "hooks/source.sh"
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -782,7 +782,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -811,7 +811,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -844,7 +844,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -811,7 +811,7 @@ mod tests {
     fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::RoleManifest {
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -433,7 +433,7 @@ mod tests {
     fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::RoleManifest {
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -503,7 +503,7 @@ plugins = []
 
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 

--- a/src/manifest/migrations.rs
+++ b/src/manifest/migrations.rs
@@ -65,6 +65,7 @@ mod tests {
         assert_eq!(old, "legacy");
         assert_eq!(new, "v1alpha1");
         assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha1");
+        assert!(out.starts_with("version = \"v1alpha1\""), "{out}");
         assert!(out.contains("# keep me"), "{out}");
     }
 

--- a/src/manifest/migrations.rs
+++ b/src/manifest/migrations.rs
@@ -3,14 +3,20 @@ use std::path::Path;
 use anyhow::bail;
 use toml_edit::DocumentMut;
 
-pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha1";
+pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha2";
 
-const MANIFEST_MIGRATIONS: &[crate::config::migrations::MigrationStep] =
-    &[crate::config::migrations::MigrationStep {
+const MANIFEST_MIGRATIONS: &[crate::config::migrations::MigrationStep] = &[
+    crate::config::migrations::MigrationStep {
         from: crate::config::migrations::LEGACY_VERSION,
+        to: "v1alpha1",
+        migrate: crate::config::migrations::noop_migration,
+    },
+    crate::config::migrations::MigrationStep {
+        from: "v1alpha1",
         to: CURRENT_MANIFEST_VERSION,
         migrate: crate::config::migrations::noop_migration,
-    }];
+    },
+];
 
 pub fn current_manifest_version() -> String {
     CURRENT_MANIFEST_VERSION.to_string()
@@ -21,7 +27,7 @@ pub fn current_manifest_version() -> String {
 ///
 /// Returns `Some((old, new))` when a migration ran, `None` when the manifest
 /// was already current. `old` and `new` are display strings (`"legacy"`,
-/// `"v1alpha1"`) — `jackin-validate --migrate` prints them as-is and does
+/// `"v1alpha2"`) — `jackin-validate --migrate` prints them as-is and does
 /// not need the structured `SchemaVersion`.
 pub fn migrate_manifest_file(path: &Path) -> anyhow::Result<Option<(String, String)>> {
     let outcome = crate::config::migrations::migrate_file_if_needed(
@@ -63,14 +69,14 @@ mod tests {
         let parsed: toml::Value = toml::from_str(&out).unwrap();
 
         assert_eq!(old, "legacy");
-        assert_eq!(new, "v1alpha1");
-        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha1");
-        assert!(out.starts_with("version = \"v1alpha1\""), "{out}");
+        assert_eq!(new, "v1alpha2");
+        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha2");
+        assert!(out.starts_with("version = \"v1alpha2\""), "{out}");
         assert!(out.contains("# keep me"), "{out}");
     }
 
     #[test]
-    fn current_manifest_migration_is_noop() {
+    fn migrates_v1alpha1_manifest_to_v1alpha2() {
         let temp = tempdir().unwrap();
         let path = temp.path().join("jackin.role.toml");
         std::fs::write(
@@ -79,7 +85,23 @@ mod tests {
         )
         .unwrap();
 
+        let (old, new) = migrate_manifest_file(&path).unwrap().unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(old, "v1alpha1");
+        assert_eq!(new, "v1alpha2");
+        assert!(out.starts_with("version = \"v1alpha2\""), "{out}");
+    }
+
+    #[test]
+    fn current_manifest_migration_is_noop() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("jackin.role.toml");
+        let manifest = "version = \"v1alpha2\"\ndockerfile = \"Dockerfile\"\n";
+        std::fs::write(&path, manifest).unwrap();
+
         assert!(migrate_manifest_file(&path).unwrap().is_none());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), manifest);
     }
 
     #[test]
@@ -94,14 +116,14 @@ mod tests {
 
         let err = migrate_manifest_file(&path).unwrap_err();
         assert!(
-            err.to_string().contains("only understands up to v1alpha1"),
+            err.to_string().contains("only understands up to v1alpha2"),
             "{err}"
         );
     }
 
     #[test]
     fn validate_manifest_version_accepts_current() {
-        let doc: DocumentMut = "version = \"v1alpha1\"\n".parse().unwrap();
+        let doc: DocumentMut = "version = \"v1alpha2\"\n".parse().unwrap();
         validate_manifest_version(&doc, "test-role").unwrap();
     }
 
@@ -120,7 +142,7 @@ mod tests {
         let doc: DocumentMut = "version = \"v2alpha1\"\n".parse().unwrap();
         let err = validate_manifest_version(&doc, "test-role").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("only understands up to v1alpha1"), "{msg}");
+        assert!(msg.contains("only understands up to v1alpha2"), "{msg}");
     }
 
     #[test]

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -221,7 +221,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -253,7 +253,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -273,7 +273,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -293,7 +293,7 @@ model = "gpt-5"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "foo"]
 
@@ -346,7 +346,7 @@ plugins = []
 
         let err = RoleManifest::load(temp.path()).unwrap_err();
         let chain = format!("{err:#}");
-        assert!(chain.contains("only understands up to v1alpha1"), "{chain}");
+        assert!(chain.contains("only understands up to v1alpha2"), "{chain}");
     }
 
     #[test]
@@ -354,7 +354,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -376,7 +376,7 @@ plugins = ["code-review@claude-plugins-official"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -410,7 +410,7 @@ sparse = ["plugins", ".claude-plugin"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -440,7 +440,7 @@ source = "jackin-project/jackin-marketplace"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -462,7 +462,7 @@ source = "obra/superpowers-marketplace"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -484,7 +484,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -506,7 +506,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -525,7 +525,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -548,7 +548,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -567,7 +567,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 unknown_field = true
 
@@ -587,7 +587,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -607,7 +607,7 @@ typo = "oops"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -664,7 +664,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -691,7 +691,7 @@ preflight = "hooks/preflight.sh"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -710,7 +710,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -732,7 +732,7 @@ post_launch = "bad"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -757,7 +757,7 @@ default = "docker"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -784,7 +784,7 @@ options = ["project1", "project2"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -814,7 +814,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -839,7 +839,7 @@ prompt = "API key (optional):"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -858,7 +858,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/manifest/validate.rs
+++ b/src/manifest/validate.rs
@@ -257,7 +257,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = []
 
@@ -276,7 +276,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -295,7 +295,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "amp"]
 
@@ -314,7 +314,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -336,7 +336,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 
@@ -360,7 +360,7 @@ model = "gpt-5"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 
@@ -385,7 +385,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -407,7 +407,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -430,7 +430,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -455,7 +455,7 @@ options = ["a", "b"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -481,7 +481,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -507,7 +507,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -538,7 +538,7 @@ prompt = "B:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -568,7 +568,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -602,7 +602,7 @@ default = "main"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -626,7 +626,7 @@ default = "docker"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -657,7 +657,7 @@ default = "sidecar"
             std::fs::write(
                 temp.path().join("jackin.role.toml"),
                 format!(
-                    r#"version = "v1alpha1"
+                    r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -686,7 +686,7 @@ default = "override"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -711,7 +711,7 @@ prompt = "This is ignored"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -736,7 +736,7 @@ skippable = true
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -767,7 +767,7 @@ default = "feature/${env.PROJECT}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -793,7 +793,7 @@ prompt = "Branch for ${env.NONEXISTENT}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -825,7 +825,7 @@ prompt = "Branch for ${env.PROJECT}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -852,7 +852,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -876,7 +876,7 @@ default = "value"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -900,7 +900,7 @@ default = "value"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -929,7 +929,7 @@ default = "c"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -966,7 +966,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -991,7 +991,7 @@ prompt = "Value (use ${other.THING} for other):"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1024,7 +1024,7 @@ default = "feature/${env.PROJECT}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1055,7 +1055,7 @@ prompt = "Label for ${env.PROJECT} in ${env.MISSING}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1080,7 +1080,7 @@ prompt = "Value: ${env.}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1111,7 +1111,7 @@ prompt = "Value: ${env.MY-VAR}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1137,7 +1137,7 @@ default = "prefix-${env.}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1163,7 +1163,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1194,7 +1194,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -226,7 +226,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -245,7 +245,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "../Dockerfile"
 
 [claude]
@@ -268,7 +268,7 @@ plugins = []
         std::os::unix::fs::symlink(outside.path(), temp.path().join("escape")).unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "escape/Dockerfile"
 
 [claude]
@@ -293,7 +293,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -331,7 +331,7 @@ echo hello
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -374,7 +374,7 @@ preflight = "hooks/preflight.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -406,7 +406,7 @@ preflight = "hooks/preflight.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -433,7 +433,7 @@ preflight = "../escape.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -460,7 +460,7 @@ preflight = "hooks/missing.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -507,7 +507,7 @@ preflight = "/etc/evil.sh"
         std::fs::write(
             temp.path().join("jackin.role.toml"),
             format!(
-                r#"version = "v1alpha1"
+                r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -541,7 +541,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -2702,7 +2702,7 @@ mod tests {
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -2755,7 +2755,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -2825,7 +2825,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -2877,7 +2877,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -2920,7 +2920,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -2971,7 +2971,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -3015,7 +3015,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -3065,7 +3065,7 @@ agents = ["amp"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -3471,7 +3471,7 @@ echo "pulled $2"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3548,7 +3548,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3637,7 +3637,7 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3690,7 +3690,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3767,7 +3767,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3852,7 +3852,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -3936,7 +3936,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -3989,7 +3989,7 @@ agents = ["codex"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4061,7 +4061,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4129,7 +4129,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4176,7 +4176,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4226,7 +4226,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -4276,7 +4276,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -4335,7 +4335,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4409,7 +4409,7 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4479,7 +4479,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4583,7 +4583,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4688,7 +4688,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4755,7 +4755,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -4809,7 +4809,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -4869,7 +4869,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -4928,7 +4928,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4981,7 +4981,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5085,7 +5085,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5157,7 +5157,7 @@ dst = "/workspace"
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5260,7 +5260,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [env.OPERATOR_SMOKE]
@@ -5340,7 +5340,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5437,7 +5437,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -621,7 +621,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -663,7 +663,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -694,7 +694,7 @@ plugins = []
                 .unwrap();
                 std::fs::write(
                     repo_dir_clone.join("jackin.role.toml"),
-                    r#"version = "v1alpha1"
+                    r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -736,7 +736,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -781,7 +781,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -821,7 +821,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -844,7 +844,7 @@ plugins = []
                 .unwrap();
                 std::fs::write(
                     repo_dir_clone.join("jackin.role.toml"),
-                    r#"version = "v1alpha1"
+                    r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -885,7 +885,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -982,7 +982,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha1"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/tests/agent_validation.rs
+++ b/tests/agent_validation.rs
@@ -6,7 +6,7 @@ fn rejects_supported_agent_without_corresponding_table() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -33,7 +33,7 @@ fn legacy_manifest_passes_validation() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -56,7 +56,7 @@ fn codex_only_manifest_with_codex_table_passes() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -79,7 +79,7 @@ fn amp_only_manifest_with_amp_table_passes() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 

--- a/tests/amp_launch.rs
+++ b/tests/amp_launch.rs
@@ -83,7 +83,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -181,7 +181,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -80,7 +80,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -189,7 +189,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 

--- a/tests/dind_e2e.rs
+++ b/tests/dind_e2e.rs
@@ -156,7 +156,7 @@ fn seed_agent_smith_role_repo(path: &Path) {
     std::fs::write(path.join("fake-curl"), fake_curl()).unwrap();
     std::fs::write(
         path.join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 

--- a/tests/fixtures/migrations/config/from-legacy/after.toml
+++ b/tests/fixtures/migrations/config/from-legacy/after.toml
@@ -1,5 +1,5 @@
-version = "v1alpha1"
-# Sample operator config carried through the legacy -> v1alpha1 migration test.
+version = "v1alpha2"
+# Sample operator config carried through the legacy migration chain.
 
 [roles.agent-smith]
 git = "https://github.com/jackin-project/jackin-agent-smith.git"

--- a/tests/fixtures/migrations/config/from-legacy/before.toml
+++ b/tests/fixtures/migrations/config/from-legacy/before.toml
@@ -1,4 +1,4 @@
-# Sample operator config carried through the legacy -> v1alpha1 migration test.
+# Sample operator config carried through the legacy migration chain.
 
 [roles.agent-smith]
 git = "https://github.com/jackin-project/jackin-agent-smith.git"

--- a/tests/fixtures/migrations/config/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/config/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
 target_version = "v1alpha1"
 target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\". Comments and existing keys are preserved."
+summary = "Adds version = \"v1alpha1\" as the first line. Comments and existing keys are preserved."

--- a/tests/fixtures/migrations/config/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/config/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
-target_version = "v1alpha1"
-target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\" as the first line. Comments and existing keys are preserved."
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Migrates legacy config through v1alpha1 to v1alpha2. Comments and existing keys are preserved, with version written first."

--- a/tests/fixtures/migrations/config/from-v1alpha1/after.toml
+++ b/tests/fixtures/migrations/config/from-v1alpha1/after.toml
@@ -1,0 +1,6 @@
+version = "v1alpha2"
+data_dir = "/tmp/jackin"
+
+[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true

--- a/tests/fixtures/migrations/config/from-v1alpha1/before.toml
+++ b/tests/fixtures/migrations/config/from-v1alpha1/before.toml
@@ -1,0 +1,6 @@
+data_dir = "/tmp/jackin"
+version = "v1alpha1"
+
+[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+trusted = true

--- a/tests/fixtures/migrations/config/from-v1alpha1/meta.toml
+++ b/tests/fixtures/migrations/config/from-v1alpha1/meta.toml
@@ -1,0 +1,4 @@
+from_version = "v1alpha1"
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Restamps config as v1alpha2 and moves version to the first line."

--- a/tests/fixtures/migrations/manifest/from-legacy/after.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/after.toml
@@ -1,5 +1,5 @@
-version = "v1alpha1"
-# Sample role manifest carried through the legacy -> v1alpha1 migration test.
+version = "v1alpha2"
+# Sample role manifest carried through the legacy migration chain.
 
 dockerfile = "Dockerfile"
 agents = ["claude"]

--- a/tests/fixtures/migrations/manifest/from-legacy/after.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/after.toml
@@ -1,8 +1,8 @@
+version = "v1alpha1"
 # Sample role manifest carried through the legacy -> v1alpha1 migration test.
 
 dockerfile = "Dockerfile"
 agents = ["claude"]
-version = "v1alpha1"
 
 [claude]
 plugins = []

--- a/tests/fixtures/migrations/manifest/from-legacy/before.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/before.toml
@@ -1,4 +1,4 @@
-# Sample role manifest carried through the legacy -> v1alpha1 migration test.
+# Sample role manifest carried through the legacy migration chain.
 
 dockerfile = "Dockerfile"
 agents = ["claude"]

--- a/tests/fixtures/migrations/manifest/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
 target_version = "v1alpha1"
 target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\". Comments and existing keys are preserved. Run `jackin-validate --migrate <role-repo-path>` to apply."
+summary = "Adds version = \"v1alpha1\" as the first line. Comments and existing keys are preserved. Run `jackin-validate --migrate <role-repo-path>` to apply."

--- a/tests/fixtures/migrations/manifest/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
-target_version = "v1alpha1"
-target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\" as the first line. Comments and existing keys are preserved. Run `jackin-validate --migrate <role-repo-path>` to apply."
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Migrates legacy role manifest through v1alpha1 to v1alpha2. Comments and existing keys are preserved, with version written first. Run `jackin-validate --migrate <role-repo-path>` to apply."

--- a/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
@@ -1,0 +1,6 @@
+version = "v1alpha2"
+dockerfile = "Dockerfile"
+agents = ["claude"]
+
+[claude]
+plugins = []

--- a/tests/fixtures/migrations/manifest/from-v1alpha1/before.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha1/before.toml
@@ -1,0 +1,6 @@
+dockerfile = "Dockerfile"
+agents = ["claude"]
+version = "v1alpha1"
+
+[claude]
+plugins = []

--- a/tests/fixtures/migrations/manifest/from-v1alpha1/meta.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha1/meta.toml
@@ -1,0 +1,4 @@
+from_version = "v1alpha1"
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Restamps role manifest as v1alpha2 and moves version to the first line."

--- a/tests/fixtures/migrations/workspace/from-legacy/after.toml
+++ b/tests/fixtures/migrations/workspace/from-legacy/after.toml
@@ -1,7 +1,7 @@
+version = "v1alpha1"
 # Sample per-workspace file carried through the legacy -> v1alpha1 migration test.
 
 workdir = "/workspace/prod"
-version = "v1alpha1"
 
 [[mounts]]
 src = "/home/operator/projects/prod"

--- a/tests/fixtures/migrations/workspace/from-legacy/before.toml
+++ b/tests/fixtures/migrations/workspace/from-legacy/before.toml
@@ -1,4 +1,4 @@
-# Sample per-workspace file carried through the legacy -> v1alpha1 migration test.
+# Sample per-workspace file carried through the legacy migration chain.
 
 workdir = "/workspace/prod"
 

--- a/tests/fixtures/migrations/workspace/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/workspace/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
-target_version = "v1alpha1"
-target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\" as the first line. Comments, existing keys, mounts, and env tables are preserved."
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Migrates legacy workspace config through v1alpha1 to v1alpha2. Comments, existing keys, mounts, and env tables are preserved, with version written first."

--- a/tests/fixtures/migrations/workspace/from-legacy/meta.toml
+++ b/tests/fixtures/migrations/workspace/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
 target_version = "v1alpha1"
 target_version_shipped = "2026-05-10"
-summary = "Adds version = \"v1alpha1\". Comments, existing keys, mounts, and env tables are preserved."
+summary = "Adds version = \"v1alpha1\" as the first line. Comments, existing keys, mounts, and env tables are preserved."

--- a/tests/fixtures/migrations/workspace/from-v1alpha1/after.toml
+++ b/tests/fixtures/migrations/workspace/from-v1alpha1/after.toml
@@ -1,11 +1,8 @@
 version = "v1alpha2"
-# Sample per-workspace file carried through the legacy migration chain.
-
 workdir = "/workspace/prod"
+allowed_roles = ["the-architect"]
+last_role = "the-architect"
 
 [[mounts]]
 src = "/home/operator/projects/prod"
 dst = "/workspace/prod"
-
-[env]
-LOCAL_ENV = "only-prod"

--- a/tests/fixtures/migrations/workspace/from-v1alpha1/before.toml
+++ b/tests/fixtures/migrations/workspace/from-v1alpha1/before.toml
@@ -1,0 +1,8 @@
+workdir = "/workspace/prod"
+allowed_roles = ["the-architect"]
+last_role = "the-architect"
+version = "v1alpha1"
+
+[[mounts]]
+src = "/home/operator/projects/prod"
+dst = "/workspace/prod"

--- a/tests/fixtures/migrations/workspace/from-v1alpha1/meta.toml
+++ b/tests/fixtures/migrations/workspace/from-v1alpha1/meta.toml
@@ -1,0 +1,4 @@
+from_version = "v1alpha1"
+target_version = "v1alpha2"
+target_version_shipped = "2026-05-11"
+summary = "Restamps workspace config as v1alpha2 and moves version to the first line."

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -12,7 +12,7 @@ fn validate_passes_for_valid_agent_repo() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -41,7 +41,7 @@ fn validate_fails_for_wrong_base_image() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -70,7 +70,7 @@ fn validate_allows_missing_dockerignore() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -98,7 +98,7 @@ fn validate_fails_for_invalid_manifest() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 unknown_field = true
 
@@ -129,7 +129,7 @@ fn validate_passes_when_manifest_uses_dockerfile_in_subdirectory() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -156,7 +156,7 @@ fn validate_fails_for_invalid_preflight_hook() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha1"
+        r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [hooks]
@@ -206,7 +206,7 @@ fn validate_migrate_accepts_flag_after_path() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest legacy -> v1alpha1",
+            "Migrated manifest legacy -> v1alpha2",
         ));
 }
 
@@ -220,7 +220,7 @@ fn validate_migrate_is_noop_for_current_manifest() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        "version = \"v1alpha1\"\ndockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
+        "version = \"v1alpha2\"\ndockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
     )
     .unwrap();
 
@@ -253,7 +253,7 @@ fn validate_migrate_rejects_newer_manifest_version() {
         .args(["--migrate", temp.path().to_str().unwrap()])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("only understands up to v1alpha1"));
+        .stderr(predicate::str::contains("only understands up to v1alpha2"));
 }
 
 #[test]
@@ -323,10 +323,10 @@ fn validate_migrate_updates_legacy_manifest() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest legacy -> v1alpha1",
+            "Migrated manifest legacy -> v1alpha2",
         ))
         .stdout(predicate::str::contains("All checks passed"));
 
     let out = std::fs::read_to_string(temp.path().join("jackin.role.toml")).unwrap();
-    assert!(out.contains(r#"version = "v1alpha1""#), "{out}");
+    assert!(out.contains(r#"version = "v1alpha2""#), "{out}");
 }


### PR DESCRIPTION
## Summary

This adds the next schema migration after the existing `v1alpha1` stamp. Config files, workspace files, and role manifests now migrate sequentially from `legacy` to `v1alpha1` to `v1alpha2`, and the `v1alpha2` migration rewrites the top-level `version` key as the first line.

The docs and fixtures now treat `v1alpha2` as current, keep `v1alpha1` documented as the historical first stamp, and update role manifest examples so current snippets start with `version = "v1alpha2"`.

## Verify locally

### Checkout

```sh
export TIRITH=0
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/role-manifest-version-snippets:refs/remotes/origin/docs/role-manifest-version-snippets
git checkout -B docs/role-manifest-version-snippets refs/remotes/origin/docs/role-manifest-version-snippets
```

### Static Checks

```sh
cargo fmt --check
git diff --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo test
cargo test --test migration_fixtures -- --nocapture
cargo test validate_migrate -- --nocapture
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run build
```

## Migration notes

Existing `v1alpha1` files migrate to `v1alpha2`. This is intentionally sequential so operators with already-stamped `v1alpha1` files where `version` sits below other top-level keys get a normal upgrade path instead of another manual edit.
