### PR TITLE
fix(runtime): move entrypoint into runtime dir

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -121,7 +121,7 @@ distinction is enforced in `docs/astro.config.ts`, not in URLs.
 | `docker/construct/Dockerfile` | Shared base image all roles extend |
 | `docker/construct/README.md` | `construct` image documentation |
 | `docker/construct/zshrc` | Shell config injected into containers |
-| `docker/runtime/entrypoint.sh` | Container entrypoint at runtime |
+| `docker/runtime/entrypoint.sh` | Source for the runtime entrypoint copied into derived images at `/jackin/runtime/entrypoint.sh` |
 
 For what each piece does at runtime, see
 [The Construct Image](https://jackin.tailrocks.com/developing/construct-image/)

--- a/docker/construct/README.md
+++ b/docker/construct/README.md
@@ -14,7 +14,7 @@ For full details — including what's installed, how it is built, the image laye
 | `zshrc` | Shell configuration — sets up mise shims, starship prompt, and security tool shell hooks |
 | `versions.env` | Pinned versions for security tools (tirith, shellfirm) used as Docker build-args |
 
-The runtime entrypoint that launches the selected agent is at [`docker/runtime/entrypoint.sh`](../runtime/entrypoint.sh) — it configures git identity, authenticates with GitHub, runs agent-specific setup, and starts Claude or Codex.
+The runtime entrypoint source that launches the selected agent is at [`docker/runtime/entrypoint.sh`](../runtime/entrypoint.sh). jackin copies it into derived images at `/jackin/runtime/entrypoint.sh`, where it configures git identity, authenticates with GitHub, runs agent-specific setup, and starts Claude or Codex.
 
 ## Image Layer Architecture
 

--- a/docs/src/content/docs/reference/codebase-map.mdx
+++ b/docs/src/content/docs/reference/codebase-map.mdx
@@ -26,7 +26,7 @@ sends readers here for the actual module-level detail.
 |---|---|
 | `src/` | Rust CLI binary — every command jackin' implements |
 | `docker/construct/` | Source for the shared base Docker image (`projectjackin/construct:trixie`) |
-| <RepoFile path="docker/runtime/entrypoint.sh" /> | The entrypoint script jackin' injects into every derived image |
+| <RepoFile path="docker/runtime/entrypoint.sh" /> | The entrypoint script jackin' injects into every derived image at `/jackin/runtime/entrypoint.sh` |
 | `docs/` | This documentation site (Astro + Starlight) |
 | `.github/workflows/` | CI for jackin', the construct image, and the docs site |
 | `tests/` | End-to-end and integration tests |

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -90,10 +90,10 @@ RUN current_gid=\"$(id -g agent)\" \
        fi \
     && chown -R agent:agent /home/agent
 {install_blocks}{hook_section}USER root
-COPY .jackin-runtime/entrypoint.sh /home/agent/entrypoint.sh
-RUN chmod +x /home/agent/entrypoint.sh
+COPY .jackin-runtime/entrypoint.sh /jackin/runtime/entrypoint.sh
+RUN chmod +x /jackin/runtime/entrypoint.sh
 USER agent
-ENTRYPOINT [\"/home/agent/entrypoint.sh\"]
+ENTRYPOINT [\"/jackin/runtime/entrypoint.sh\"]
 "
     )
 }
@@ -275,9 +275,9 @@ mod tests {
         assert!(dockerfile.contains("RUN curl -fsSL https://claude.ai/install.sh | bash"));
         assert!(!dockerfile.contains("WORKDIR"));
         assert!(
-            dockerfile.contains("COPY .jackin-runtime/entrypoint.sh /home/agent/entrypoint.sh")
+            dockerfile.contains("COPY .jackin-runtime/entrypoint.sh /jackin/runtime/entrypoint.sh")
         );
-        assert!(dockerfile.contains("ENTRYPOINT [\"/home/agent/entrypoint.sh\"]"));
+        assert!(dockerfile.contains("ENTRYPOINT [\"/jackin/runtime/entrypoint.sh\"]"));
     }
 
     #[test]
@@ -294,7 +294,7 @@ mod tests {
         assert!(dockerfile.contains("RUN curl -fsSL https://claude.ai/install.sh | bash"));
         assert!(dockerfile.contains("RUN claude --version"));
         assert!(
-            dockerfile.contains("COPY .jackin-runtime/entrypoint.sh /home/agent/entrypoint.sh")
+            dockerfile.contains("COPY .jackin-runtime/entrypoint.sh /jackin/runtime/entrypoint.sh")
         );
     }
 
@@ -453,7 +453,7 @@ mod tests {
 
         assert!(dockerfile.contains("/home/agent"));
         assert!(dockerfile.contains("groupmod -o -g \"$JACKIN_HOST_GID\" agent"));
-        assert!(dockerfile.contains("ENTRYPOINT [\"/home/agent/entrypoint.sh\"]"));
+        assert!(dockerfile.contains("ENTRYPOINT [\"/jackin/runtime/entrypoint.sh\"]"));
     }
 
     #[test]

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -2639,7 +2639,7 @@ mod tests {
         // Second capture: docker logs → entrypoint stderr.
         let mut runner = FakeRunner::with_capture_queue([
             "false 127 false".to_string(),
-            "/home/agent/entrypoint.sh: line 85: exec: codex: not found".to_string(),
+            "/jackin/runtime/entrypoint.sh: line 85: exec: codex: not found".to_string(),
         ]);
         let err = super::diagnose_premature_exit(&mut runner, "jackin-the-architect")
             .expect("stopped container must produce a diagnostic error");


### PR DESCRIPTION
## Summary

Jackin now copies its generated runtime entrypoint into `/jackin/runtime/entrypoint.sh` instead of placing it in the agent user's home directory. This keeps Jackin-owned runtime wiring under the `/jackin/runtime` namespace while preserving the existing image-baked copy model, and the documentation now states both the source script path and the in-container destination.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/runtime-entrypoint-path:refs/remotes/origin/fix/runtime-entrypoint-path
git checkout -B fix/runtime-entrypoint-path refs/remotes/origin/fix/runtime-entrypoint-path
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --all-targets
```

### Tests

```sh
cargo nextest run --all-features
```

The test suite covers the derived Dockerfile rendering assertions, runtime diagnostic fixture, and the surrounding CLI/runtime behavior.

### User smoke

```sh
cargo run --bin jackin -- load jackin-the-architect . --debug
```

Inside the launched runtime, `ls /jackin/runtime/entrypoint.sh` should show the copied entrypoint and `ls /home/agent/entrypoint.sh` should report that the old home-directory path is absent.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/codebase-map/**  
UPDATED reference page. Confirm the repository layout table says the entrypoint is injected at `/jackin/runtime/entrypoint.sh`.
