### PR TITLE
feat(codex): enable goals by default

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -114,7 +114,7 @@ case "${JACKIN_AGENT:?JACKIN_AGENT must be set}" in
         cp /jackin/codex/auth.json /home/agent/.codex/auth.json
         chmod 600 /home/agent/.codex/auth.json
     fi
-    LAUNCH=(codex --dangerously-bypass-approvals-and-sandbox)
+    LAUNCH=(codex --enable goals --dangerously-bypass-approvals-and-sandbox)
     if [ "$#" -gt 0 ]; then
         LAUNCH+=("$@")
     fi

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -507,7 +507,10 @@ mod tests {
             .split(";;")
             .next()
             .unwrap();
-        assert!(codex_section.contains("codex --dangerously-bypass-approvals-and-sandbox"));
+        assert!(
+            codex_section
+                .contains("codex --enable goals --dangerously-bypass-approvals-and-sandbox")
+        );
         assert!(codex_section.contains("LAUNCH+=(\"$@\")"));
         assert!(!codex_section.contains("config.toml"));
     }


### PR DESCRIPTION
## Summary

Codex launches from jackin now enable the experimental goals feature by default, so operators can use `/goal` inside every jackin-managed Codex session without first changing Codex settings by hand. The launch path keeps the behavior scoped to the containerized Codex process and updates the embedded-entrypoint assertion that pins the command shape.

## Hard rule: host-side state stays untouched

This change honors the “Never mutate the host machine silently” rule from AGENTS.md: jackin enables goals with Codex's launch-time feature flag instead of writing to the operator's host-side `~/.codex/config.toml` or mounting a generated config file into the session.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/enable-codex-goals:refs/remotes/origin/jackin/enable-codex-goals
git checkout -B jackin/enable-codex-goals refs/remotes/origin/jackin/enable-codex-goals
```

### Static checks

```sh
cargo fmt --check
```

### Tests

```sh
cargo test --test codex_launch
cargo test entrypoint_codex_branch_uses_cli_flags_not_generated_config
```

These tests cover Codex launch argument construction and the embedded runtime entrypoint command used by derived images.

### User smoke

```sh
cargo run --bin jackin -- load the-architect . --agent codex --debug
```

In the launched Codex session, run `/goal` and confirm Codex recognizes the command without requiring `/experimental` or a host-side Codex config edit first.

## Migration notes

None.
