### PR TITLE
docs: tighten desktop hub goal scope

### DIFF
--- a/docs/src/content/docs/reference/goals/jackin-desktop-agent-hub.mdx
+++ b/docs/src/content/docs/reference/goals/jackin-desktop-agent-hub.mdx
@@ -21,12 +21,18 @@ Source of truth:
 ## Goal prompt
 
 ```text
-/goal Research and design the Jackin Desktop Agent Hub, then implement the first safe slice.
+/goal Implement the Jackin Desktop Agent Hub end to end as a long-running staged program.
 
 Context:
-- Work in the jackin repo on the daemon PR branch. PR 283 is an editable draft:
-  if the Desktop goal reveals daemon API changes that should land there, update
-  that PR directly before stacking later Desktop PRs.
+- Build the full desktop experience described in the roadmap: daemon APIs,
+  native macOS status bar, native desktop app/window, Ghostty workspace
+  launch/focus actions, GitHub PR inbox, account/token status for
+  Claude/Codex/Amp, and notification/attention support.
+- Work in the jackin repo. PR 283 is an editable daemon draft: if the Desktop
+  goal reveals daemon API changes that should land there, update that PR
+  directly before stacking later Desktop PRs. New agent-created PRs still target
+  `main` unless the operator explicitly names a different base branch; follow
+  PULL_REQUESTS.md for the base-branch rule.
 - Read the roadmap source of truth first. If implementation details conflict
   with these docs, update the relevant roadmap doc in the same PR or an earlier
   stacked PR before coding around the conflict:
@@ -49,13 +55,14 @@ Context:
   organization, local git status caching.
 
 Product goal:
-Build Jackin toward a native macOS desktop companion that keeps the agent TUI as
-the primary agent UI. Desktop must be an operator control surface: active Jackin
+Build the complete native macOS desktop companion while keeping the agent TUI as
+the primary agent UI. Desktop must be an operator control surface with
+daemon-backed state, native status bar, native desktop window, active Jackin
 workspaces, simple Ghostty launches, recently active GitHub projects, workspace
 repositories, running isolated agents, PR jump links, newest-first open PRs
 authored by the operator, org/project-filtered PR inbox views, account/quota
-status for Claude/Codex/Amp, and daemon-driven attention/ready-for-review
-events.
+status for Claude/Codex/Amp, and daemon-driven notifications plus
+attention/ready-for-review events.
 
 Constraints:
 - Native macOS only for the app: SwiftUI/AppKit, MenuBarExtra or NSStatusItem,
@@ -82,6 +89,11 @@ Constraints:
 - Do not create one huge pull request. Implement the goal as small sequential
   PRs. Each PR must be reviewable, tested, and mergeable before the next PR
   becomes the main review target.
+- Keep implementing the full staged plan until every Desktop Agent Hub stage is
+  represented by reviewable PRs: daemon, status bar, desktop window, GitHub PR
+  views, account status, Ghostty actions, notifications, and attention routing.
+  Do not stop after the first slice unless blocked by CI, credentials, conflicts,
+  or a roadmap contradiction that must be resolved first.
 - Open every planned PR without waiting for operator approval, but never merge
   any PR. The operator will review and merge gradually.
 - Stack each next PR by branching from the previous PR branch. If an earlier PR
@@ -107,7 +119,7 @@ Sequential PR plan:
 11. Desktop Workspaces launch-only view and Running Agents view.
 12. Attention/ready-for-review promotion and notification click routing.
 
-First implementation slice:
+Start with this implementation slice:
 1. Strengthen PR 283 daemon protocol with a hello/capabilities response.
 2. Add the smallest endpoint scaffolding needed to prove versioned requests and
    responses without implementing the whole Desktop backend in one PR.

--- a/docs/src/content/docs/reference/roadmap/jackin-desktop-agent-hub.mdx
+++ b/docs/src/content/docs/reference/roadmap/jackin-desktop-agent-hub.mdx
@@ -5,7 +5,7 @@ import { Aside } from '@astrojs/starlight/components'
 import RepoFile from '../../../../components/RepoFile.astro'
 
 
-**Status**: Open — design proposal (Reactive daemon program / operator surface)
+**Status**: Open — implementation program (daemon, native macOS status bar, desktop app, notifications)
 
 ## Problem
 
@@ -21,6 +21,11 @@ agent UI remains the agent's own TUI. Jackin Desktop should be the Mac-native
 control surface around those agents: start workspaces, see active containers,
 jump to pull requests, monitor token/account state, and receive attention
 prompts when an agent is blocked or finished.
+
+This roadmap targets the complete Desktop Agent Hub experience: daemon-backed
+state, native macOS status bar, native desktop window, Ghostty workspace
+launch/focus, GitHub PR inbox, account/token status, and notification/attention
+routing. The phased plan below is the review strategy, not a reduced scope.
 
 ## Existing local foundation
 
@@ -456,10 +461,19 @@ not as one large feature branch. The agent running the goal should keep building
 without asking for step-by-step approval, but every externally reviewed unit
 must be a small pull request.
 
+The phases are delivery slices for review, not optional scope reductions. The
+long-running goal should continue through daemon APIs, menu bar, desktop window,
+notifications, and attention routing unless blocked by a documented design issue
+or repository constraint that must be resolved first.
+
 Delivery rules:
 
 - Create sequential pull requests, not one large PR. Each PR should be
   reviewable on its own and should leave the repo in a useful state.
+- The implementation track is complete only when all major stages have been
+  delivered as separate reviewable PRs: daemon contract, daemon data endpoints,
+  native status bar, PR/project inbox, account status, Ghostty actions, desktop
+  window, notifications, and attention routing.
 - Implement all PRs without waiting for operator approval, but do not merge any
   of them. The operator owns merge decisions and will explicitly ask for fixes
   when a reviewed PR needs changes.


### PR DESCRIPTION
## Summary

Tightens the Jackin Desktop Agent Hub goal prompt and roadmap so the requested work is clearly the full desktop experience, not just a first safe slice. The goal now explicitly covers daemon APIs, native macOS status bar, native desktop window, Ghostty launch/focus actions, GitHub PR inbox, Claude/Codex/Amp account status, notifications, and attention routing.

The roadmap now states that phases are delivery slices for review, not optional scope reductions, and that the implementation track is complete only when every major stage has been delivered as separate reviewable PRs.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/tighten-desktop-hub-goal:refs/remotes/origin/docs/tighten-desktop-hub-goal
git checkout -B docs/tighten-desktop-hub-goal refs/remotes/origin/docs/tighten-desktop-hub-goal
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/goals/jackin-desktop-agent-hub/**  
UPDATED page. Confirm the `/goal` opening now says to implement the Desktop Agent Hub end to end, names daemon/status bar/app/Ghostty/GitHub/account/notification/attention scope, preserves PR 283 as an editable daemon draft, and says new agent PRs target `main` unless explicitly told otherwise.

**http://localhost:4321/reference/roadmap/jackin-desktop-agent-hub/**  
UPDATED page. Confirm the status and phasing language now describe the full implementation program and state that each major Desktop stage must land as separate reviewable PRs.

## Migration notes

None.
