### PR TITLE
feat(runtime): source hooks from zsh exec shells

### DIFF
--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -24,6 +24,7 @@ pub fn render_derived_dockerfile(
     use std::fmt::Write as _;
 
     let mut hook_section = String::new();
+    let source_hook_declared = hooks.and_then(|hooks| hooks.source.as_ref()).is_some();
     let mut entries = hooks.into_iter().flat_map(HooksConfig::entries).peekable();
     if entries.peek().is_some() {
         // chown only /jackin/state — agent writes the marker here.
@@ -48,6 +49,22 @@ RUN chmod +x /jackin/runtime/hooks/{dst}
                 dst = entry.filename,
             )
             .expect("writing to String is infallible");
+        }
+        if source_hook_declared {
+            hook_section.push_str(
+                "\
+RUN printf '%s\\n' \\
+    'if [ -z \"",
+            );
+            hook_section.push('$');
+            hook_section.push_str(
+                "\
+{JACKIN_SOURCE_HOOK_LOADED:-}\" ] && [ -f /jackin/runtime/hooks/source.sh ]; then' \\
+    '  export JACKIN_SOURCE_HOOK_LOADED=1' \\
+    '  source /jackin/runtime/hooks/source.sh' \\
+    'fi' >> /home/agent/.zshenv
+",
+            );
         }
     }
 
@@ -339,6 +356,9 @@ mod tests {
         assert!(dockerfile.contains(
             "COPY --chown=agent:agent hooks/preflight.sh /jackin/runtime/hooks/preflight.sh"
         ));
+        assert!(dockerfile.contains(">> /home/agent/.zshenv"));
+        assert!(dockerfile.contains("JACKIN_SOURCE_HOOK_LOADED"));
+        assert!(dockerfile.contains("source /jackin/runtime/hooks/source.sh"));
     }
 
     #[test]
@@ -355,6 +375,7 @@ mod tests {
         assert!(!dockerfile.contains("preflight.sh"));
         assert!(!dockerfile.contains("/jackin/runtime/hooks"));
         assert!(!dockerfile.contains("/jackin/state/hooks"));
+        assert!(!dockerfile.contains("/home/agent/.zshenv"));
     }
 
     #[test]
@@ -688,6 +709,8 @@ mod tests {
                 "COPY --chown=agent:agent hooks/source.sh /jackin/runtime/hooks/source.sh"
             )
         );
+        assert!(dockerfile.contains(">> /home/agent/.zshenv"));
+        assert!(dockerfile.contains("source /jackin/runtime/hooks/source.sh"));
         assert!(!dockerfile.contains("setup-once.sh"));
         assert!(!dockerfile.contains("preflight.sh"));
         assert_eq!(
@@ -696,6 +719,25 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn source_hook_zshenv_shim_is_not_rendered_for_non_source_hooks() {
+        let dockerfile = render_derived_dockerfile(
+            "FROM projectjackin/construct:trixie\n",
+            Some(&HooksConfig {
+                setup_once: Some("hooks/setup-once.sh".to_string()),
+                source: None,
+                preflight: Some("hooks/preflight.sh".to_string()),
+            }),
+            &[Agent::Claude],
+            None,
+        );
+
+        assert!(dockerfile.contains("/jackin/runtime/hooks/setup-once.sh"));
+        assert!(dockerfile.contains("/jackin/runtime/hooks/preflight.sh"));
+        assert!(!dockerfile.contains(">> /home/agent/.zshenv"));
+        assert!(!dockerfile.contains("JACKIN_SOURCE_HOOK_LOADED"));
     }
 
     #[test]

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -24,7 +24,7 @@ pub fn render_derived_dockerfile(
     use std::fmt::Write as _;
 
     let mut hook_section = String::new();
-    let source_hook_declared = hooks.and_then(|hooks| hooks.source.as_ref()).is_some();
+    let source_hook_declared = hooks.is_some_and(|h| h.source.is_some());
     let mut entries = hooks.into_iter().flat_map(HooksConfig::entries).peekable();
     if entries.peek().is_some() {
         // chown only /jackin/state — agent writes the marker here.
@@ -51,20 +51,33 @@ RUN chmod +x /jackin/runtime/hooks/{dst}
             .expect("writing to String is infallible");
         }
         if source_hook_declared {
-            hook_section.push_str(
-                "\
-RUN printf '%s\\n' \\
-    'if [ -z \"",
-            );
-            hook_section.push('$');
-            hook_section.push_str(
-                "\
-{JACKIN_SOURCE_HOOK_LOADED:-}\" ] && [ -f /jackin/runtime/hooks/source.sh ]; then' \\
-    '  export JACKIN_SOURCE_HOOK_LOADED=1' \\
-    '  source /jackin/runtime/hooks/source.sh' \\
+            // `docker exec zsh` inherits the image ENV but none of PID 1's
+            // runtime exports, so operator shells miss the source-hook
+            // exports the entrypoint applied to the agent. The marker is
+            // namespaced and exported only after a successful source so a
+            // failed hook does not leave a sticky guard that hides
+            // re-source attempts from nested subshells (mirrors the rc
+            // capture + `trap - ERR` clear the entrypoint does at
+            // docker/runtime/entrypoint.sh:172-181). The outer
+            // `grep -q ... ||` keeps the file single-shimmed across
+            // derived-from-derived builds via `base_image_override`.
+            #[allow(clippy::literal_string_with_formatting_args)] // shell ${...}, not a Rust format arg
+            const ZSHENV_SOURCE_SHIM: &str = "\
+RUN grep -q '__JACKIN_ZSHENV_SOURCE_LOADED' /home/agent/.zshenv 2>/dev/null \\
+    || printf '%s\\n' \\
+    'if [ -z \"${__JACKIN_ZSHENV_SOURCE_LOADED:-}\" ] && [ -f /jackin/runtime/hooks/source.sh ]; then' \\
+    '  __jackin_rc=0' \\
+    '  source /jackin/runtime/hooks/source.sh || __jackin_rc=$?' \\
+    '  trap - ERR' \\
+    '  if [ \"$__jackin_rc\" -ne 0 ]; then' \\
+    '    print -u2 \"[zshenv] jackin source hook returned non-zero (exit $__jackin_rc); environment may be incomplete\"' \\
+    '  else' \\
+    '    export __JACKIN_ZSHENV_SOURCE_LOADED=1' \\
+    '  fi' \\
+    '  unset __jackin_rc' \\
     'fi' >> /home/agent/.zshenv
-",
-            );
+";
+            hook_section.push_str(ZSHENV_SOURCE_SHIM);
         }
     }
 
@@ -356,9 +369,31 @@ mod tests {
         assert!(dockerfile.contains(
             "COPY --chown=agent:agent hooks/preflight.sh /jackin/runtime/hooks/preflight.sh"
         ));
-        assert!(dockerfile.contains(">> /home/agent/.zshenv"));
-        assert!(dockerfile.contains("JACKIN_SOURCE_HOOK_LOADED"));
-        assert!(dockerfile.contains("source /jackin/runtime/hooks/source.sh"));
+        // Structural shape: the four load-bearing fragments must appear
+        // in order — guard test, rc capture, source call, success-only
+        // export, file append. A regression that drops the guard, the rc
+        // check, or the `fi` terminator breaks this ordering.
+        let copy_pos = dockerfile
+            .find("COPY --chown=agent:agent hooks/source.sh")
+            .unwrap();
+        let guard_pos = dockerfile
+            .find("if [ -z \"${__JACKIN_ZSHENV_SOURCE_LOADED:-}\"")
+            .unwrap();
+        let source_pos = dockerfile
+            .find("source /jackin/runtime/hooks/source.sh || __jackin_rc=$?")
+            .unwrap();
+        let export_pos = dockerfile
+            .find("export __JACKIN_ZSHENV_SOURCE_LOADED=1")
+            .unwrap();
+        let append_pos = dockerfile.find(">> /home/agent/.zshenv").unwrap();
+        assert!(copy_pos < guard_pos);
+        assert!(guard_pos < source_pos);
+        assert!(source_pos < export_pos);
+        assert!(export_pos < append_pos);
+        assert!(dockerfile.contains("trap - ERR"));
+        // Single emission — derived-from-derived rebuilds must not stack
+        // duplicate shim blocks in /home/agent/.zshenv.
+        assert_eq!(dockerfile.matches(">> /home/agent/.zshenv").count(), 1);
     }
 
     #[test]
@@ -737,7 +772,7 @@ mod tests {
         assert!(dockerfile.contains("/jackin/runtime/hooks/setup-once.sh"));
         assert!(dockerfile.contains("/jackin/runtime/hooks/preflight.sh"));
         assert!(!dockerfile.contains(">> /home/agent/.zshenv"));
-        assert!(!dockerfile.contains("JACKIN_SOURCE_HOOK_LOADED"));
+        assert!(!dockerfile.contains("__JACKIN_ZSHENV_SOURCE_LOADED"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This makes role `hooks.source` exports available to interactive `docker exec ... zsh` sessions by generating a guarded `/home/agent/.zshenv` shim in derived role images when a source hook is declared. The launched agent already inherited source-hook exports from the runtime entrypoint; this extends the same role-level environment setup to operator-opened zsh shells inside the running container without mutating the host, in line with `AGENTS.md` and the PR workflow in `PULL_REQUESTS.md`.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/source-hook-zshenv:refs/remotes/origin/feature/source-hook-zshenv
git checkout -B feature/source-hook-zshenv refs/remotes/origin/feature/source-hook-zshenv
```

### Static Checks

```sh
cargo fmt --check
cargo clippy --lib
```

### Tests

```sh
cargo test derived_image
```

### User Smoke

Use a role that declares `hooks.source`, such as ChainArgos Agent Brown, then rebuild/load it from this checkout. The important check is an interactive zsh shell, because raw `docker exec ... env` still bypasses shell startup files and can only see env values present at container creation time.

```sh
cargo run --bin jackin -- load chainargos/agent-brown --debug
```

In another terminal after the container starts:

```sh
docker exec -ti jackin-chainargos__agent-brown zsh -lc 'env | grep POSTGRESQL_DB_HOST'
```

Expected output includes `POSTGRESQL_DB_HOST=jackin-chainargos__agent-brown-dind`.

## Migration notes

None. Existing role manifests do not change. Roles with a `source` hook get the zsh shim on the next derived image rebuild; roles without a `source` hook are unchanged.
