### PR TITLE
feat(mounts): surface global mounts in workspace views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
  "directories",
  "dockerfile-parser-rs",
  "fs2",
+ "nix 0.29.0",
  "open",
  "owo-colors",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.20"
 owo-colors = { version = "4", features = ["supports-colors"] }
 ratatui = { version = "0.30", features = ["unstable-widget-ref"] }
 crossterm = "0.29"
+nix = { version = "0.29", features = ["term"] }
 ratatui-textarea = "0.9"
 tui-widget-list = "0.15"
 dialoguer = "0.12"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -333,7 +333,6 @@ export default defineConfig({
                   collapsed: true,
                   items: [
                     { label: 'Config versioning and migration', slug: 'reference/roadmap/config-versioning-migration' },
-                    { label: 'Global mount visibility', slug: 'reference/roadmap/global-mount-visibility' },
                   ],
                 },
                 {
@@ -345,6 +344,7 @@ export default defineConfig({
                     { label: 'DinD hostname env var', slug: 'reference/roadmap/dind-hostname-env-var' },
                     { label: 'DinD TLS', slug: 'reference/roadmap/dind-tls' },
                     { label: 'Env var interpolation', slug: 'reference/roadmap/env-var-interpolation' },
+                    { label: 'Global mount visibility', slug: 'reference/roadmap/global-mount-visibility' },
                     { label: 'JACKIN_DEBUG env var', slug: 'reference/roadmap/jackin-debug-env-var' },
                     { label: 'Orphaned DinD cleanup', slug: 'reference/roadmap/orphaned-dind-cleanup' },
                     { label: 'Per-mount isolation', slug: 'reference/roadmap/per-mount-isolation' },

--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -14,9 +14,9 @@ This is the core of jackin's security model: **agents can only access what you e
 <Aside type="tip">
 Workspace mounts are managed through `jackin workspace …` flags or
 the operator console's workspace editor. **Global mounts** (the
-`jackin config mount` family) are CLI-only today and are not yet
-reachable from the console. Either way, you should not need to
-hand-edit a configuration file to add, remove, or change a mount.
+`jackin config mount` family) can also be managed from the console's
+**Global config → Global mounts** screen. Either way, you should not
+need to hand-edit a configuration file to add, remove, or change a mount.
 </Aside>
 
 ## Mount spec format
@@ -121,6 +121,10 @@ jackin config mount list
 # Remove a global mount
 jackin config mount remove gradle-cache
 ```
+
+In the console, press `G` from the workspace list to open **Global config → Global mounts**. That screen lists every global mount with its name, source, destination, mode, scope, and source type. It supports adding mounts, editing source and destination, toggling read-only mode, changing scope, renaming, and removing mounts. Changes stay pending until you explicitly save the global config; workspace screens never write global mounts.
+
+Workspace views show global mounts separately from workspace mounts. When jackin can determine the selected role for a workspace, role-scoped global mounts are included in the global section. When multiple roles are possible, workspace views explain that the selected role affects global mount visibility.
 
 ## Mount precedence
 

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -39,6 +39,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 - [Worktree cleanup on container removal](/reference/roadmap/worktree-cleanup-assessment/) — orphaned host-side worktrees no longer accumulate
 - [Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/) — `shared | worktree | clone` modes implemented in V1
 - [Split `config.toml` into per-workspace files](/reference/roadmap/split-workspace-config-files/) — `~/.config/jackin/workspaces/<name>.toml` layout shipped; per-file `version` stamps and migration land via the config-versioning item below
+- [Global mount visibility and editing](/reference/roadmap/global-mount-visibility/) — workspace views show applicable global mounts separately, and the console has a dedicated global mounts editor for `~/.config/jackin/config.toml`
 
 ## Partially implemented
 
@@ -86,10 +87,6 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 - **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
 - **[Cargo workspace split](/reference/roadmap/cargo-workspace-split/)** — deferred multi-crate Cargo workspace plan for when LOC, compile time, or external-consumer triggers make crate boundaries worth the overhead (status: deferred to Phase 3 — trigger not yet met, but architecture is ready)
 - **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see <RepoFile path="AGENTS.md" /> → "Code review & automated scanning").
-
-### Configuration ergonomics
-
-- **[Global mount visibility and editing](/reference/roadmap/global-mount-visibility/)** — show applicable global mounts in workspace surfaces, keep them visually separate from saved workspace mounts, and add a dedicated global-config TUI page for viewing and editing `jackin config mount` entries (status: open — implementation-ready goal)
 
 ### Documentation infrastructure
 

--- a/docs/src/content/docs/reference/roadmap/global-mount-visibility.mdx
+++ b/docs/src/content/docs/reference/roadmap/global-mount-visibility.mdx
@@ -3,168 +3,30 @@ title: "Global Mount Visibility"
 ---
 import RepoFile from '../../../../components/RepoFile.astro'
 
-**Status**: Open — implementation-ready goal
+**Status**: Resolved — shipped in the CLI and console. See the [Mounts guide](/guides/mounts/) for operator-facing usage.
 
-## Problem
+## Shipped Behavior
 
-`jackin config mount list` shows global mounts, but workspace-oriented surfaces do not show the global mounts that will be applied when that workspace launches.
+Workspace inspection now separates saved workspace mounts from applicable global mounts. `jackin workspace show <name>` prints a **Workspace mounts** section and a **Global mounts** section when the workspace has enough role context to decide which scoped mounts apply. When multiple roles can launch a workspace, the CLI and console explain that the selected role affects global mount visibility instead of pretending the effective set is fixed.
 
-That makes a valid setup look incomplete. For example, an operator can configure global `Gradle` and `Cargo` caches under `[docker.mounts]`, then open `jackin workspace show chainargos` or the console workspace panel and see only the saved workspace mounts. The effective launch will still mount the global caches, but the operator has no visual proof from the workspace view.
+The console workspace overview and workspace editor mirror that split. Workspace editor mount actions remain scoped to workspace-owned rows; global rows are read-only orientation rows and point operators to the global config surface for edits.
 
-## Why It Matters
+The console now has a dedicated **Global config → Global mounts** surface reached from the workspace list. It lists every configured global mount with name, source, destination, mode, scope, and source type, and supports add, edit source, edit destination, toggle readonly, edit scope, rename, remove, and explicit save.
 
-- Operators use workspace views to answer "what will this container see?" Global mounts are part of that answer.
-- Cache mounts such as `/home/agent/.gradle/caches`, `/home/agent/.gradle/wrapper`, `/home/agent/.gradle/jdks`, `/home/agent/.cargo/registry`, and `/home/agent/.cargo/git` are most useful as global mounts, but their absence from workspace views makes them easy to misdiagnose as missing.
-- The console currently puts workspace mounts and role choices next to the launch action. Hiding global mounts there means the launch summary is less complete than the operator expects.
+## Host-side Effects
 
-## Desired Behavior
+The implementation reads `~/.config/jackin/config.toml` to display global mounts. It writes that file only when the operator explicitly saves from the dedicated global mounts console surface or uses `jackin config mount`; workspace show, workspace overview, and workspace edit screens do not write global config.
 
-Show effective mounts in workspace inspection and workspace-edit surfaces while preserving the distinction between where each mount is configured.
+## Notes
 
-### CLI
-
-`jackin workspace show <name>` must display workspace mounts and applicable global mounts in separate groups:
-
-```text
-Workspace mounts:
-  ~/Projects/app -> ~/Projects/app  rw  clone
-
-Global mounts:
-  ~/.cache/jackin/global/gradle/caches -> /home/agent/.gradle/caches  rw
-  ~/.cache/jackin/global/cargo/registry -> /home/agent/.cargo/registry  rw
-```
-
-The global group must include role-scoped global mounts only when the workspace has enough role context to decide applicability:
-
-- If the workspace has one allowed/default/last role, show mounts for that role and label the scope.
-- If multiple roles can launch the workspace, show a role-filtered subsection per role or print a short note that global mounts depend on the selected role.
-
-### Console
-
-The workspace panel and the workspace editor's **Mounts** tab must separate mount origins visually. A single mixed table is too easy to misread because global mounts are not edited from the workspace editor.
-
-Required shape:
-
-- Keep the existing **Mounts** panel for saved workspace mounts.
-- Add a **Global mounts** panel below it, or add a section break inside the panel with a clear label.
-- Include the global mount scope when it is not unscoped, for example `global` or `chainargos/*`.
-- Treat global mounts as not editable from the workspace editor. Editing them belongs to `jackin config mount` today and to the dedicated global-config TUI page delivered by this goal.
-
-### Workspace editor
-
-In `edit workspace -> Mounts`, global rows must be visible for orientation but excluded from workspace-edit actions:
-
-- `D remove` applies only to saved workspace mounts.
-- `R toggle ro/rw` applies only to saved workspace mounts.
-- `I cycle isolation` applies only to saved workspace mounts.
-- `+ Add mount` continues to add a workspace mount, not a global mount.
-- Selecting a global mount must show disabled action hints or a short status message such as `global mount — edit from config mounts`.
-
-The visual grouping matters here even more than in the read-only workspace panel because the footer lists mutating actions. The operator must be able to tell which rows those actions can affect before pressing a key.
-
-## Global Mounts TUI
-
-Global mounts need their own first-class TUI surface. They are operator configuration, not workspace configuration, and they apply across many workspaces depending on scope.
-
-### Design direction
-
-Target the latest Apple UI/UX direction, not older macOS admin-tool patterns. The design reference is the current Apple Human Interface Guidelines and the macOS Tahoe / iOS 26 design language: content first, clear sidebars and toolbars, thoughtful control grouping, instantly familiar navigation, and a distinct control layer that does not bury the operator's task.
-
-For jackin's terminal UI, this means adapting the intent rather than copying visual effects the terminal cannot render:
-
-- Prefer a clean sidebar + detail layout over nested modal flows for primary navigation.
-- Use grouped controls and concise footer actions; avoid dense command lists that read like legacy terminal admin screens.
-- Keep global config visually separate from workspace config, matching Apple's emphasis on clear context and familiar navigation.
-- Use current-system mental models: **Settings** / **Global config**, sidebars, tabs, segmented choices, disabled states, and clear detail panels.
-- Do not optimize for old macOS conventions or backwards-looking UI compatibility. The target is the latest Apple platform behavior and expectations.
-
-Required placement:
-
-- Add a top-level console area outside the workspace editor, for example a left-nav item named **Global config** or **Settings**.
-- Inside that area, add a **Global mounts** tab.
-- Keep workspace editing focused on workspace-owned fields; do not make the workspace editor the place where global config is changed.
-
-### Global mounts list
-
-The global mounts page must show every configured global mount with:
-
-- Name
-- Source
-- Destination
-- Mode (`rw` / `ro`)
-- Scope (`global`, `chainargos/*`, `scentbird/*`, etc.)
-- Type (`folder`, `file`, `missing source`, sensitive path warning when applicable)
-
-Required table shape:
-
-```text
-Global mounts
-
-Name               Source                                  Destination                       Mode  Scope
-gradle-caches      ~/.cache/jackin/global/gradle/caches    /home/agent/.gradle/caches        rw    global
-gradle-properties  ~/.cache/jackin/global/gradle.properties /home/agent/.gradle/gradle.properties ro global
-team-secrets       ~/.company/secrets                      /secrets                          ro    chainargos/*
-```
-
-### Editing operations
-
-The global mounts page must support the same conceptual operations as `jackin config mount`:
-
-- Add global mount
-- Edit source
-- Edit destination
-- Toggle `readonly`
-- Edit scope
-- Rename mount
-- Remove mount
-
-The editor must validate the same rules as the CLI:
-
-- Source must exist before saving.
-- Destination must be absolute.
-- Duplicate destinations within the same effective scope must be rejected before launch.
-- Sensitive source paths must use the same warning-and-confirm flow as other mount entry points.
-
-### Scope editing
-
-Scope needs a deliberate UI because it is the main difference between a workspace mount and a global mount.
-
-Required control:
-
-- A segmented choice for `All roles` vs `Scoped`.
-- When `Scoped` is selected, show a text input for the glob pattern.
-- Preserve the current CLI semantics: examples include `chainargos/*` and `chainargos/agent-brown`.
-
-The global mounts list must keep scope visible in the main table so an operator can immediately see why a mount applies to one workspace but not another.
-
-### Relationship to workspace views
-
-Workspace screens consume global mount data, but do not own it:
-
-- Workspace overview: show applicable global mounts in a separate read-only section.
-- Workspace editor: show applicable global mounts in a separate read-only section or panel; workspace edit actions do not affect them.
-- Global mounts page: the only TUI place where global mounts are created, changed, or removed.
-
-This mirrors the CLI split: `jackin workspace ...` manages workspace config, while `jackin config mount ...` manages global mounts.
-
-## Host-side effects
-
-This feature intentionally writes host-side jackin operator configuration only when the operator explicitly saves changes from the dedicated global mounts TUI. The save target is `~/.config/jackin/config.toml`, the same file managed by `jackin config mount`; workspace screens remain read-only for global mounts and must not mutate global config as a side effect of inspecting or editing a workspace.
-
-## Implementation Notes
-
-- The runtime already resolves global + workspace + load-time mounts for launch. Reuse that resolver for display, but keep display rows tagged with their source: `global`, `workspace`, or `load-time` when relevant.
-- Conflict behavior stays unchanged: duplicate destinations still fail rather than letting one mount silently win.
-- The console must not offer edit actions for global mounts inside the workspace editor unless it explicitly switches to a global-config editing flow.
-- The global mounts TUI must call through the same config editor primitives used by `jackin config mount add/list/remove` rather than introducing a second persistence path.
-- Because global mounts live in `~/.config/jackin/config.toml`, saving from the global mounts page is a global config write, not a workspace file write. The save confirmation and dirty-state prompt must say that explicitly.
+Duplicate effective destinations still fail instead of shadowing. Existing launch resolution remains the source of truth for the final mount set, and workspace displays use the same global mount role-scoping semantics as launch.
 
 ## Related Files
 
-- <RepoFile path="src/config/mounts.rs" /> — global mount config model
+- <RepoFile path="src/config/mounts.rs" /> — global mount config model and role-scoped resolution
 - <RepoFile path="src/config/editor.rs" /> — config mutation helpers
 - <RepoFile path="src/workspace/resolve.rs" /> — launch-time workspace resolution
-- <RepoFile path="src/config/workspaces.rs" /> — `workspace show` rendering
+- <RepoFile path="src/config/workspaces.rs" /> — workspace config validation and mutation
 - <RepoFile path="src/console/manager/mod.rs" /> — console workspace manager
-- <RepoFile path="src/console/manager/state.rs" /> — console workspace state
+- <RepoFile path="src/console/manager/state.rs" /> — console workspace and global mount state
 - [Mounts](/guides/mounts/) — operator-facing mount concepts

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -350,7 +350,7 @@ pub(crate) fn prompt_agent_choice_if_needed(
 /// default set, single-agent role, or unreadable manifest). Split from
 /// the prompting wrapper so the gating logic is unit-testable without
 /// stdin / dialoguer scaffolding.
-fn supported_agents_requiring_prompt(
+pub(crate) fn supported_agents_requiring_prompt(
     paths: &JackinPaths,
     selector: &RoleSelector,
     workspace_default: Option<crate::agent::Agent>,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1371,9 +1371,20 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
         isolation: String,
     }
     #[derive(Tabled)]
-    struct GlobalMountRow {
+    struct GlobalMountRowWithScope {
         #[tabled(rename = "Scope")]
         scope: String,
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Source")]
+        src: String,
+        #[tabled(rename = "Destination")]
+        dst: String,
+        #[tabled(rename = "Mode")]
+        mode: String,
+    }
+    #[derive(Tabled)]
+    struct GlobalMountRow {
         #[tabled(rename = "Name")]
         name: String,
         #[tabled(rename = "Source")]
@@ -1444,21 +1455,22 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
     match config.workspace_applicable_mount_rows(workspace) {
         crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
             if !rows.is_empty() {
-                let global_rows: Vec<GlobalMountRow> = rows
-                    .iter()
-                    .map(|row| GlobalMountRow {
+                let mut global_table = if rows.iter().any(|row| row.scope.is_some()) {
+                    Table::new(rows.iter().map(|row| GlobalMountRowWithScope {
                         scope: row.scope.as_deref().unwrap_or("global").to_string(),
                         name: row.name.clone(),
                         src: tui::shorten_home(&row.mount.src),
                         dst: row.mount.dst.clone(),
-                        mode: if row.mount.readonly {
-                            "read-only".to_string()
-                        } else {
-                            "read-write".to_string()
-                        },
-                    })
-                    .collect();
-                let mut global_table = Table::new(global_rows);
+                        mode: mount_mode(row.mount.readonly),
+                    }))
+                } else {
+                    Table::new(rows.iter().map(|row| GlobalMountRow {
+                        name: row.name.clone(),
+                        src: tui::shorten_home(&row.mount.src),
+                        dst: row.mount.dst.clone(),
+                        mode: mount_mode(row.mount.readonly),
+                    }))
+                };
                 global_table.with(Style::modern_rounded());
                 let _ = writeln!(out);
                 let _ = writeln!(out, "Global mounts ({role}):");
@@ -1482,6 +1494,14 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
     }
 
     out
+}
+
+fn mount_mode(readonly: bool) -> String {
+    if readonly {
+        "read-only".to_string()
+    } else {
+        "read-write".to_string()
+    }
 }
 
 #[cfg(test)]
@@ -1590,6 +1610,7 @@ mod auth_set_tests {
         assert!(out.contains("Workspace mounts:"), "{out}");
         assert!(out.contains("Global mounts (agent-smith):"), "{out}");
         assert!(out.contains("gradle-cache"), "{out}");
+        assert!(!out.contains("│ Scope"), "{out}");
     }
 
     #[test]
@@ -1626,6 +1647,40 @@ mod auth_set_tests {
 
         assert!(out.contains("selected role"), "{out}");
         assert!(!out.contains("team-secrets"), "{out}");
+    }
+
+    #[test]
+    fn workspace_show_keeps_scope_column_for_scoped_global_mounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let global_src = temp.path().join("secrets");
+        std::fs::create_dir_all(&global_src).unwrap();
+        let mut config = AppConfig::default();
+        config.roles.insert(
+            "chainargos/agent-brown".into(),
+            crate::config::RoleSource::default(),
+        );
+        config.add_mount(
+            "team-secrets",
+            crate::workspace::MountConfig {
+                src: global_src.display().to_string(),
+                dst: "/secrets".into(),
+                readonly: true,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            Some("chainargos/*"),
+        );
+        let ws = crate::workspace::WorkspaceConfig {
+            version: crate::config::CURRENT_WORKSPACE_VERSION.to_string(),
+            workdir: "/workspace/jackin".into(),
+            mounts: vec![],
+            allowed_roles: vec!["chainargos/agent-brown".into()],
+            ..Default::default()
+        };
+
+        let out = render_workspace_show(&config, "jackin", &ws);
+
+        assert!(out.contains("│ Scope"), "{out}");
+        assert!(out.contains("chainargos/*"), "{out}");
     }
 
     /// Test fake for [`crate::operator_env::OpWriteRunner`] used by

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -275,7 +275,15 @@ pub fn run(cli: Cli) -> Result<()> {
                     {
                         anyhow::bail!("aborted — sensitive mount paths were not confirmed");
                     }
-                    let mut candidate_rows = config.list_mount_rows();
+                    let existing = config
+                        .list_mount_rows()
+                        .into_iter()
+                        .find(|row| row.name == name && row.scope == scope);
+                    let mut candidate_rows: Vec<crate::config::GlobalMountRow> = config
+                        .list_mount_rows()
+                        .into_iter()
+                        .filter(|row| !(row.name == name && row.scope == scope))
+                        .collect();
                     candidate_rows.push(crate::config::GlobalMountRow {
                         scope: scope.clone(),
                         name: name.clone(),
@@ -285,7 +293,16 @@ pub fn run(cli: Cli) -> Result<()> {
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     editor.add_mount(&name, mount, scope.as_deref());
                     editor.save()?;
-                    println!("Added mount {name:?} ({scope_label}):\n  {dst}\n  host: {src}{ro}");
+                    if let Some(prev) = existing {
+                        println!(
+                            "Replaced mount {name:?} ({scope_label}):\n  was: {} -> {}\n  now: {} -> {}{ro}",
+                            prev.mount.src, prev.mount.dst, src, dst
+                        );
+                    } else {
+                        println!(
+                            "Added mount {name:?} ({scope_label}):\n  {dst}\n  host: {src}{ro}"
+                        );
+                    }
                     Ok(())
                 }
                 cli::MountCommand::Remove { name, scope } => {
@@ -1462,11 +1479,7 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
             .iter()
             .map(|m| MountRow {
                 mount: mount_display(&m.src, &m.dst),
-                mode: if m.readonly {
-                    "read-only".to_string()
-                } else {
-                    "read-write".to_string()
-                },
+                mode: mount_mode(m.readonly),
                 isolation: m.isolation.as_str().to_string(),
                 kind: crate::console::manager::mount_info::inspect(&m.src).label(),
             })
@@ -1478,44 +1491,55 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
         let _ = writeln!(out, "{mount_table}");
     }
 
+    let render_unscoped_table = |out: &mut String, rows: &[&crate::config::GlobalMountRow]| {
+        if rows.is_empty() {
+            return;
+        }
+        let mut table = Table::new(rows.iter().map(|row| GlobalMountRow {
+            name: row.name.clone(),
+            mount: mount_display(&row.mount.src, &row.mount.dst),
+            mode: mount_mode(row.mount.readonly),
+        }));
+        table.with(Style::modern_rounded());
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Global mounts:");
+        let _ = writeln!(out, "{table}");
+    };
+
     match config.workspace_applicable_mount_rows(workspace) {
         crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
-            if !rows.is_empty() {
-                let has_scoped_rows = rows.iter().any(|row| row.scope.is_some());
-                let mut global_table = if has_scoped_rows {
-                    Table::new(rows.iter().map(|row| GlobalMountRowWithScope {
-                        scope: row.scope.as_deref().unwrap_or("global").to_string(),
-                        name: row.name.clone(),
-                        mount: mount_display(&row.mount.src, &row.mount.dst),
-                        mode: mount_mode(row.mount.readonly),
-                    }))
-                } else {
-                    Table::new(rows.iter().map(|row| GlobalMountRow {
-                        name: row.name.clone(),
-                        mount: mount_display(&row.mount.src, &row.mount.dst),
-                        mode: mount_mode(row.mount.readonly),
-                    }))
-                };
-                global_table.with(Style::modern_rounded());
-                let _ = writeln!(out);
-                if has_scoped_rows {
-                    let _ = writeln!(out, "Global mounts ({role}):");
-                } else {
-                    let _ = writeln!(out, "Global mounts:");
-                }
-                let _ = writeln!(out, "{global_table}");
+            if rows.is_empty() {
+                return out;
             }
+            let has_scoped_rows = rows.iter().any(|row| row.scope.is_some());
+            if !has_scoped_rows {
+                render_unscoped_table(&mut out, &rows.iter().collect::<Vec<_>>());
+                return out;
+            }
+            let mut table = Table::new(rows.iter().map(|row| GlobalMountRowWithScope {
+                scope: row.scope.as_deref().unwrap_or("global").to_string(),
+                name: row.name.clone(),
+                mount: mount_display(&row.mount.src, &row.mount.dst),
+                mode: mount_mode(row.mount.readonly),
+            }));
+            table.with(Style::modern_rounded());
+            let _ = writeln!(out);
+            let _ = writeln!(out, "Global mounts ({role}):");
+            let _ = writeln!(out, "{table}");
         }
         crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
-            if config
-                .list_mount_rows()
-                .iter()
-                .any(|row| row.scope.is_some())
-            {
+            // Unscoped global mounts apply regardless of role — render
+            // them even when the role is ambiguous. Only the scoped
+            // subset depends on role selection.
+            let all_rows = config.list_mount_rows();
+            let unscoped: Vec<&crate::config::GlobalMountRow> =
+                all_rows.iter().filter(|row| row.scope.is_none()).collect();
+            render_unscoped_table(&mut out, &unscoped);
+            if all_rows.iter().any(|row| row.scope.is_some()) {
                 let _ = writeln!(out);
                 let _ = writeln!(
                     out,
-                    "Global mounts: role-scoped mounts depend on selected role ({})",
+                    "Role-scoped global mounts depend on selected role ({})",
                     candidates.join(", ")
                 );
             }
@@ -1526,11 +1550,7 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
 }
 
 fn mount_mode(readonly: bool) -> String {
-    if readonly {
-        "read-only".to_string()
-    } else {
-        "read-write".to_string()
-    }
+    if readonly { "read-only" } else { "read-write" }.to_string()
 }
 
 fn mount_display(src: &str, dst: &str) -> String {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -280,7 +280,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     editor.add_mount(&name, mount, scope.as_deref());
                     editor.save()?;
-                    println!("Added mount {name:?} ({scope_label}): {src} -> {dst}{ro}");
+                    println!("Added mount {name:?} ({scope_label}):\n  {dst}\n  host: {src}{ro}");
                     Ok(())
                 }
                 cli::MountCommand::Remove { name, scope } => {
@@ -307,10 +307,8 @@ pub fn run(cli: Cli) -> Result<()> {
                             scope: String,
                             #[tabled(rename = "Name")]
                             name: String,
-                            #[tabled(rename = "Source")]
-                            src: String,
-                            #[tabled(rename = "Destination")]
-                            dst: String,
+                            #[tabled(rename = "Mount")]
+                            mount: String,
                             #[tabled(rename = "Mode")]
                             mode: String,
                         }
@@ -319,8 +317,7 @@ pub fn run(cli: Cli) -> Result<()> {
                             .map(|(scope, name, m)| Row {
                                 scope: scope.clone(),
                                 name: name.clone(),
-                                src: tui::shorten_home(&m.src),
-                                dst: m.dst.clone(),
+                                mount: mount_display(&m.src, &m.dst),
                                 mode: if m.readonly {
                                     "read-only".to_string()
                                 } else {
@@ -1361,10 +1358,8 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
 
     #[derive(Tabled)]
     struct MountRow {
-        #[tabled(rename = "Source")]
-        src: String,
-        #[tabled(rename = "Destination")]
-        dst: String,
+        #[tabled(rename = "Mount")]
+        mount: String,
         #[tabled(rename = "Mode")]
         mode: String,
         #[tabled(rename = "Isolation")]
@@ -1376,10 +1371,8 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
         scope: String,
         #[tabled(rename = "Name")]
         name: String,
-        #[tabled(rename = "Source")]
-        src: String,
-        #[tabled(rename = "Destination")]
-        dst: String,
+        #[tabled(rename = "Mount")]
+        mount: String,
         #[tabled(rename = "Mode")]
         mode: String,
     }
@@ -1387,10 +1380,8 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
     struct GlobalMountRow {
         #[tabled(rename = "Name")]
         name: String,
-        #[tabled(rename = "Source")]
-        src: String,
-        #[tabled(rename = "Destination")]
-        dst: String,
+        #[tabled(rename = "Mount")]
+        mount: String,
         #[tabled(rename = "Mode")]
         mode: String,
     }
@@ -1435,8 +1426,7 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
             .mounts
             .iter()
             .map(|m| MountRow {
-                src: tui::shorten_home(&m.src),
-                dst: tui::shorten_home(&m.dst),
+                mount: mount_display(&m.src, &m.dst),
                 mode: if m.readonly {
                     "read-only".to_string()
                 } else {
@@ -1459,15 +1449,13 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
                     Table::new(rows.iter().map(|row| GlobalMountRowWithScope {
                         scope: row.scope.as_deref().unwrap_or("global").to_string(),
                         name: row.name.clone(),
-                        src: tui::shorten_home(&row.mount.src),
-                        dst: row.mount.dst.clone(),
+                        mount: mount_display(&row.mount.src, &row.mount.dst),
                         mode: mount_mode(row.mount.readonly),
                     }))
                 } else {
                     Table::new(rows.iter().map(|row| GlobalMountRow {
                         name: row.name.clone(),
-                        src: tui::shorten_home(&row.mount.src),
-                        dst: row.mount.dst.clone(),
+                        mount: mount_display(&row.mount.src, &row.mount.dst),
                         mode: mount_mode(row.mount.readonly),
                     }))
                 };
@@ -1501,6 +1489,15 @@ fn mount_mode(readonly: bool) -> String {
         "read-only".to_string()
     } else {
         "read-write".to_string()
+    }
+}
+
+fn mount_display(src: &str, dst: &str) -> String {
+    let short_dst = tui::shorten_home(dst);
+    if src == dst {
+        short_dst
+    } else {
+        format!("{}\nhost: {}", short_dst, tui::shorten_home(src))
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -142,7 +142,9 @@ pub fn run(cli: Cli) -> Result<()> {
             runner.debug = debug;
             tui::set_debug_mode(debug);
             let cwd = std::env::current_dir()?;
-            let Some((class, workspace)) = console::run_console(config, &paths, &cwd)? else {
+            let Some((class, workspace, selected_agent)) =
+                console::run_console(config, &paths, &cwd)?
+            else {
                 return Ok(());
             };
 
@@ -156,7 +158,10 @@ pub fn run(cli: Cli) -> Result<()> {
             }
 
             let mut opts = runtime::LoadOptions::for_launch(debug);
-            opts.agent = prompt_agent_choice_if_needed(&paths, &class, workspace.default_agent)?;
+            opts.agent = match selected_agent {
+                Some(agent) => Some(agent),
+                None => prompt_agent_choice_if_needed(&paths, &class, workspace.default_agent)?,
+            };
             runtime::reconcile_keep_awake(&paths, &mut runner);
             let result =
                 runtime::load_role(&paths, &mut config, &class, &workspace, &mut runner, &opts);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1364,6 +1364,8 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
         mode: String,
         #[tabled(rename = "Isolation")]
         isolation: String,
+        #[tabled(rename = "Type")]
+        kind: String,
     }
     #[derive(Tabled)]
     struct GlobalMountRowWithScope {
@@ -1433,6 +1435,7 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
                     "read-write".to_string()
                 },
                 isolation: m.isolation.as_str().to_string(),
+                kind: crate::console::manager::mount_info::inspect(&m.src).label(),
             })
             .collect();
         let mut mount_table = Table::new(mount_rows);
@@ -1531,18 +1534,23 @@ mod auth_set_tests {
 
     #[test]
     fn workspace_show_includes_isolation_column() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree_src = temp.path().join("x");
+        let cache_src = temp.path().join("cache");
+        std::fs::create_dir_all(&worktree_src).unwrap();
+        std::fs::create_dir_all(&cache_src).unwrap();
         let ws = crate::workspace::WorkspaceConfig {
             version: crate::config::CURRENT_WORKSPACE_VERSION.to_string(),
             workdir: "/workspace/jackin".into(),
             mounts: vec![
                 crate::workspace::MountConfig {
-                    src: "/tmp/x".into(),
+                    src: worktree_src.display().to_string(),
                     dst: "/workspace/jackin".into(),
                     readonly: false,
                     isolation: crate::isolation::MountIsolation::Worktree,
                 },
                 crate::workspace::MountConfig {
-                    src: "/tmp/cache".into(),
+                    src: cache_src.display().to_string(),
                     dst: "/workspace/cache".into(),
                     readonly: false,
                     isolation: crate::isolation::MountIsolation::Shared,
@@ -1564,6 +1572,8 @@ mod auth_set_tests {
         };
         let out = render_workspace_show(&AppConfig::default(), "jackin", &ws);
         assert!(out.contains("Isolation"));
+        assert!(out.contains("Type"));
+        assert!(out.contains("folder"));
         assert!(out.contains("worktree"));
         assert!(out.contains("shared"));
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -295,12 +295,21 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 }
                 cli::MountCommand::List => {
-                    let mounts = config.list_mounts();
+                    let mounts = config.list_mount_rows();
                     if mounts.is_empty() {
                         println!("No mounts configured.");
                     } else {
                         use tabled::settings::Style;
                         use tabled::{Table, Tabled};
+                        #[derive(Tabled)]
+                        struct GlobalRow {
+                            #[tabled(rename = "Name")]
+                            name: String,
+                            #[tabled(rename = "Mount")]
+                            mount: String,
+                            #[tabled(rename = "Mode")]
+                            mode: String,
+                        }
                         #[derive(Tabled)]
                         struct Row {
                             #[tabled(rename = "Scope")]
@@ -312,22 +321,41 @@ pub fn run(cli: Cli) -> Result<()> {
                             #[tabled(rename = "Mode")]
                             mode: String,
                         }
-                        let rows: Vec<Row> = mounts
-                            .iter()
-                            .map(|(scope, name, m)| Row {
-                                scope: scope.clone(),
-                                name: name.clone(),
-                                mount: mount_display(&m.src, &m.dst),
-                                mode: if m.readonly {
-                                    "read-only".to_string()
-                                } else {
-                                    "read-write".to_string()
-                                },
-                            })
-                            .collect();
-                        let mut table = Table::new(rows);
-                        table.with(Style::modern_rounded());
-                        println!("{table}");
+                        let (global, scoped): (Vec<_>, Vec<_>) =
+                            mounts.iter().partition(|row| row.scope.is_none());
+                        let has_global = !global.is_empty();
+                        if !global.is_empty() {
+                            let rows: Vec<GlobalRow> = global
+                                .into_iter()
+                                .map(|row| GlobalRow {
+                                    name: row.name.clone(),
+                                    mount: mount_display(&row.mount.src, &row.mount.dst),
+                                    mode: mount_mode(row.mount.readonly),
+                                })
+                                .collect();
+                            let mut table = Table::new(rows);
+                            table.with(Style::modern_rounded());
+                            println!("Global mounts:");
+                            println!("{table}");
+                        }
+                        if !scoped.is_empty() {
+                            if has_global {
+                                println!();
+                            }
+                            let rows: Vec<Row> = scoped
+                                .into_iter()
+                                .map(|row| Row {
+                                    scope: row.scope.clone().unwrap_or_default(),
+                                    name: row.name.clone(),
+                                    mount: mount_display(&row.mount.src, &row.mount.dst),
+                                    mode: mount_mode(row.mount.readonly),
+                                })
+                                .collect();
+                            let mut table = Table::new(rows);
+                            table.with(Style::modern_rounded());
+                            println!("Scoped global mounts:");
+                            println!("{table}");
+                        }
                     }
                     Ok(())
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -275,15 +275,14 @@ pub fn run(cli: Cli) -> Result<()> {
                     {
                         anyhow::bail!("aborted — sensitive mount paths were not confirmed");
                     }
-                    let existing = config
+                    let (matched, mut candidate_rows): (
+                        Vec<crate::config::GlobalMountRow>,
+                        Vec<crate::config::GlobalMountRow>,
+                    ) = config
                         .list_mount_rows()
                         .into_iter()
-                        .find(|row| row.name == name && row.scope == scope);
-                    let mut candidate_rows: Vec<crate::config::GlobalMountRow> = config
-                        .list_mount_rows()
-                        .into_iter()
-                        .filter(|row| !(row.name == name && row.scope == scope))
-                        .collect();
+                        .partition(|row| row.name == name && row.scope == scope);
+                    let existing = matched.into_iter().next();
                     candidate_rows.push(crate::config::GlobalMountRow {
                         scope: scope.clone(),
                         name: name.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1448,7 +1448,8 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
     match config.workspace_applicable_mount_rows(workspace) {
         crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
             if !rows.is_empty() {
-                let mut global_table = if rows.iter().any(|row| row.scope.is_some()) {
+                let has_scoped_rows = rows.iter().any(|row| row.scope.is_some());
+                let mut global_table = if has_scoped_rows {
                     Table::new(rows.iter().map(|row| GlobalMountRowWithScope {
                         scope: row.scope.as_deref().unwrap_or("global").to_string(),
                         name: row.name.clone(),
@@ -1464,7 +1465,11 @@ fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceCo
                 };
                 global_table.with(Style::modern_rounded());
                 let _ = writeln!(out);
-                let _ = writeln!(out, "Global mounts ({role}):");
+                if has_scoped_rows {
+                    let _ = writeln!(out, "Global mounts ({role}):");
+                } else {
+                    let _ = writeln!(out, "Global mounts:");
+                }
                 let _ = writeln!(out, "{global_table}");
             }
         }
@@ -1615,7 +1620,8 @@ mod auth_set_tests {
         let out = render_workspace_show(&config, "jackin", &ws);
 
         assert!(out.contains("Workspace mounts:"), "{out}");
-        assert!(out.contains("Global mounts (agent-smith):"), "{out}");
+        assert!(out.contains("Global mounts:"), "{out}");
+        assert!(!out.contains("Global mounts (agent-smith):"), "{out}");
         assert!(out.contains("gradle-cache"), "{out}");
         assert!(!out.contains("│ Scope"), "{out}");
     }
@@ -1686,6 +1692,10 @@ mod auth_set_tests {
 
         let out = render_workspace_show(&config, "jackin", &ws);
 
+        assert!(
+            out.contains("Global mounts (chainargos/agent-brown):"),
+            "{out}"
+        );
         assert!(out.contains("│ Scope"), "{out}");
         assert!(out.contains("chainargos/*"), "{out}");
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -262,6 +262,21 @@ pub fn run(cli: Cli) -> Result<()> {
                         readonly,
                         isolation: crate::isolation::MountIsolation::Shared,
                     };
+                    crate::workspace::validate_mounts(std::slice::from_ref(&mount))?;
+                    let sensitive =
+                        crate::workspace::find_sensitive_mounts(std::slice::from_ref(&mount));
+                    if !sensitive.is_empty()
+                        && !crate::workspace::confirm_sensitive_mounts(&sensitive)?
+                    {
+                        anyhow::bail!("aborted — sensitive mount paths were not confirmed");
+                    }
+                    let mut candidate_rows = config.list_mount_rows();
+                    candidate_rows.push(crate::config::GlobalMountRow {
+                        scope: scope.clone(),
+                        name: name.clone(),
+                        mount: mount.clone(),
+                    });
+                    AppConfig::validate_global_mount_rows(&candidate_rows)?;
                     let mut editor = crate::config::ConfigEditor::open(&paths)?;
                     editor.add_mount(&name, mount, scope.as_deref());
                     editor.save()?;
@@ -585,7 +600,7 @@ pub fn run(cli: Cli) -> Result<()> {
             }
             WorkspaceCommand::Show { name } => {
                 let workspace = config.require_workspace(&name)?;
-                print!("{}", render_workspace_show(&name, workspace));
+                print!("{}", render_workspace_show(&config, &name, workspace));
                 Ok(())
             }
             WorkspaceCommand::Edit {
@@ -1338,7 +1353,8 @@ fn render_auth_show(config: &AppConfig) -> String {
 /// trailing mounts table with one row per mount. The mounts table renders the
 /// canonical lowercase isolation name (`shared`/`worktree`/`clone`) so the output
 /// matches TOML/CLI input verbatim.
-fn render_workspace_show(name: &str, workspace: &WorkspaceConfig) -> String {
+#[allow(clippy::too_many_lines)]
+fn render_workspace_show(config: &AppConfig, name: &str, workspace: &WorkspaceConfig) -> String {
     use std::fmt::Write as _;
     use tabled::settings::Style;
     use tabled::{Table, Tabled};
@@ -1353,6 +1369,19 @@ fn render_workspace_show(name: &str, workspace: &WorkspaceConfig) -> String {
         mode: String,
         #[tabled(rename = "Isolation")]
         isolation: String,
+    }
+    #[derive(Tabled)]
+    struct GlobalMountRow {
+        #[tabled(rename = "Scope")]
+        scope: String,
+        #[tabled(rename = "Name")]
+        name: String,
+        #[tabled(rename = "Source")]
+        src: String,
+        #[tabled(rename = "Destination")]
+        dst: String,
+        #[tabled(rename = "Mode")]
+        mode: String,
     }
 
     let allowed = if workspace.allowed_roles.is_empty() {
@@ -1408,8 +1437,48 @@ fn render_workspace_show(name: &str, workspace: &WorkspaceConfig) -> String {
         let mut mount_table = Table::new(mount_rows);
         mount_table.with(Style::modern_rounded());
         let _ = writeln!(out);
-        let _ = writeln!(out, "Mounts:");
+        let _ = writeln!(out, "Workspace mounts:");
         let _ = writeln!(out, "{mount_table}");
+    }
+
+    match config.workspace_applicable_mount_rows(workspace) {
+        crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
+            if !rows.is_empty() {
+                let global_rows: Vec<GlobalMountRow> = rows
+                    .iter()
+                    .map(|row| GlobalMountRow {
+                        scope: row.scope.as_deref().unwrap_or("global").to_string(),
+                        name: row.name.clone(),
+                        src: tui::shorten_home(&row.mount.src),
+                        dst: row.mount.dst.clone(),
+                        mode: if row.mount.readonly {
+                            "read-only".to_string()
+                        } else {
+                            "read-write".to_string()
+                        },
+                    })
+                    .collect();
+                let mut global_table = Table::new(global_rows);
+                global_table.with(Style::modern_rounded());
+                let _ = writeln!(out);
+                let _ = writeln!(out, "Global mounts ({role}):");
+                let _ = writeln!(out, "{global_table}");
+            }
+        }
+        crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
+            if config
+                .list_mount_rows()
+                .iter()
+                .any(|row| row.scope.is_some())
+            {
+                let _ = writeln!(out);
+                let _ = writeln!(
+                    out,
+                    "Global mounts: role-scoped mounts depend on selected role ({})",
+                    candidates.join(", ")
+                );
+            }
+        }
     }
 
     out
@@ -1476,10 +1545,87 @@ mod auth_set_tests {
             github: None,
             git_pull_on_entry: false,
         };
-        let out = render_workspace_show("jackin", &ws);
+        let out = render_workspace_show(&AppConfig::default(), "jackin", &ws);
         assert!(out.contains("Isolation"));
         assert!(out.contains("worktree"));
         assert!(out.contains("shared"));
+    }
+
+    #[test]
+    fn workspace_show_splits_workspace_and_global_mount_groups() {
+        let temp = tempfile::tempdir().unwrap();
+        let global_src = temp.path().join("gradle");
+        std::fs::create_dir_all(&global_src).unwrap();
+        let work_src = temp.path().join("work");
+        std::fs::create_dir_all(&work_src).unwrap();
+        let mut config = AppConfig::default();
+        config
+            .roles
+            .insert("agent-smith".into(), crate::config::RoleSource::default());
+        config.add_mount(
+            "gradle-cache",
+            crate::workspace::MountConfig {
+                src: global_src.display().to_string(),
+                dst: "/home/agent/.gradle/caches".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            None,
+        );
+        let ws = crate::workspace::WorkspaceConfig {
+            version: crate::config::CURRENT_WORKSPACE_VERSION.to_string(),
+            workdir: "/workspace/jackin".into(),
+            mounts: vec![crate::workspace::MountConfig {
+                src: work_src.display().to_string(),
+                dst: "/workspace/jackin".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }],
+            allowed_roles: vec!["agent-smith".into()],
+            ..Default::default()
+        };
+
+        let out = render_workspace_show(&config, "jackin", &ws);
+
+        assert!(out.contains("Workspace mounts:"), "{out}");
+        assert!(out.contains("Global mounts (agent-smith):"), "{out}");
+        assert!(out.contains("gradle-cache"), "{out}");
+    }
+
+    #[test]
+    fn workspace_show_explains_ambiguous_role_scoped_global_mounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let global_src = temp.path().join("secrets");
+        std::fs::create_dir_all(&global_src).unwrap();
+        let mut config = AppConfig::default();
+        config
+            .roles
+            .insert("alpha".into(), crate::config::RoleSource::default());
+        config
+            .roles
+            .insert("beta".into(), crate::config::RoleSource::default());
+        config.add_mount(
+            "team-secrets",
+            crate::workspace::MountConfig {
+                src: global_src.display().to_string(),
+                dst: "/secrets".into(),
+                readonly: true,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            Some("alpha"),
+        );
+        let ws = crate::workspace::WorkspaceConfig {
+            version: crate::config::CURRENT_WORKSPACE_VERSION.to_string(),
+            workdir: "/workspace/jackin".into(),
+            mounts: vec![],
+            allowed_roles: vec!["alpha".into(), "beta".into()],
+            ..Default::default()
+        };
+
+        let out = render_workspace_show(&config, "jackin", &ws);
+
+        assert!(out.contains("selected role"), "{out}");
+        assert!(!out.contains("team-secrets"), "{out}");
     }
 
     /// Test fake for [`crate::operator_env::OpWriteRunner`] used by

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,8 +17,10 @@ pub use migrations::{
     CURRENT_CONFIG_VERSION, CURRENT_WORKSPACE_VERSION, migrate_config_file_if_needed,
     migrate_workspace_file_if_needed,
 };
-pub use mounts::DockerMounts;
 pub(crate) use mounts::MountEntry;
+pub use mounts::{
+    DockerMounts, GlobalMountRow, WorkspaceGlobalMountRows, WorkspaceMountRoleContext,
+};
 pub use roles::{build_github_env_layers, resolve_github_mode, resolve_mode};
 pub use workspaces::{DriftDetection, detect_workspace_edit_drift};
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,9 +18,7 @@ pub use migrations::{
     migrate_workspace_file_if_needed,
 };
 pub(crate) use mounts::MountEntry;
-pub use mounts::{
-    DockerMounts, GlobalMountRow, WorkspaceGlobalMountRows, WorkspaceMountRoleContext,
-};
+pub use mounts::{DockerMounts, GlobalMountRow, WorkspaceGlobalMountRows};
 pub use roles::{build_github_env_layers, resolve_github_mode, resolve_mode};
 pub use workspaces::{DriftDetection, detect_workspace_edit_drift};
 

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -6,19 +6,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Wire format for global mounts (top-level `[[mounts]]` and scoped
-/// `[mounts.<scope>]` entries). Mirrors `MountConfig` minus the
-/// `isolation` field, which is a workspace-mount concept only.
-/// Rejects unknown fields so an operator who tries to set `isolation`
-/// directly on this struct gets a serde "unknown field" error.
-///
-/// Note: at the actual wire path (`AppConfig` → `DockerMounts` →
-/// `MountEntry`), `MountEntry` is `#[serde(untagged)]`, so the error
-/// surfaces as "data did not match any variant of untagged enum
-/// `MountEntry`" rather than a clean "unknown field `isolation`"
-/// message. This is acceptable; a custom `Deserialize` for
-/// `MountEntry` could improve the message but is not implemented
-/// here.
+/// Wire format for `[[mounts]]` / `[mounts.<scope>]` entries. Lacks
+/// the `isolation` field (workspace-only) and rejects unknown fields so
+/// setting `isolation` here fails deserialization with the generic
+/// `MountEntry` untagged-enum error.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalMountConfig {
@@ -71,45 +62,39 @@ impl DockerMounts {
 }
 
 impl AppConfig {
-    pub fn workspace_mount_role_context(
-        &self,
-        workspace: &crate::workspace::WorkspaceConfig,
-    ) -> WorkspaceMountRoleContext {
-        let mut candidates: Vec<String> = workspace.allowed_roles.clone();
-        if let Some(default) = &workspace.default_role
-            && !candidates.iter().any(|role| role == default)
-        {
-            candidates.push(default.clone());
-        }
-        if let Some(last) = &workspace.last_role
-            && !candidates.iter().any(|role| role == last)
-        {
-            candidates.push(last.clone());
-        }
-        candidates.sort();
-        candidates.dedup();
-
-        if candidates.len() == 1 {
-            return WorkspaceMountRoleContext::Selected(candidates.remove(0));
-        }
-        if candidates.is_empty()
-            && self.roles.len() == 1
-            && let Some(role) = self.roles.keys().next()
-        {
-            return WorkspaceMountRoleContext::Selected(role.clone());
-        }
-        if candidates.is_empty() {
-            candidates = self.roles.keys().cloned().collect();
-        }
-        WorkspaceMountRoleContext::Ambiguous(candidates)
-    }
-
+    /// Determine which role drives role-scoped global mounts for this
+    /// workspace. Returns `Applicable` (with the resolved role + merged
+    /// rows) when role is determinable; `Ambiguous` (with candidates)
+    /// otherwise. Role candidates merge `allowed_roles`, `default_role`,
+    /// and `last_role`; if none is set and the config has exactly one
+    /// role, that one is used.
     pub fn workspace_applicable_mount_rows(
         &self,
         workspace: &crate::workspace::WorkspaceConfig,
     ) -> WorkspaceGlobalMountRows {
-        match self.workspace_mount_role_context(workspace) {
-            WorkspaceMountRoleContext::Selected(role) => RoleSelector::parse(&role).map_or_else(
+        let mut candidates: Vec<String> = workspace.allowed_roles.clone();
+        for extra in workspace
+            .default_role
+            .iter()
+            .chain(workspace.last_role.iter())
+        {
+            if !candidates.iter().any(|role| role == extra) {
+                candidates.push(extra.clone());
+            }
+        }
+        candidates.sort();
+        candidates.dedup();
+
+        let resolved_role = if candidates.len() == 1 {
+            Some(candidates.remove(0))
+        } else if candidates.is_empty() && self.roles.len() == 1 {
+            self.roles.keys().next().cloned()
+        } else {
+            None
+        };
+
+        if let Some(role) = resolved_role {
+            return RoleSelector::parse(&role).map_or_else(
                 |_| WorkspaceGlobalMountRows::Ambiguous {
                     candidates: vec![role],
                 },
@@ -117,11 +102,13 @@ impl AppConfig {
                     role: selector.key(),
                     rows: self.resolve_mount_rows(&selector),
                 },
-            ),
-            WorkspaceMountRoleContext::Ambiguous(candidates) => {
-                WorkspaceGlobalMountRows::Ambiguous { candidates }
-            }
+            );
         }
+
+        if candidates.is_empty() {
+            candidates = self.roles.keys().cloned().collect();
+        }
+        WorkspaceGlobalMountRows::Ambiguous { candidates }
     }
 
     pub fn resolve_mount_rows(&self, selector: &RoleSelector) -> Vec<GlobalMountRow> {
@@ -191,14 +178,9 @@ impl AppConfig {
         Ok(expanded)
     }
 
-    // pub(crate): test-only affordance for in-memory AppConfig setup in tests
-    // (launch/preview.rs, workspace/resolve.rs). Production callers use ConfigEditor.
+    // Test-only; production writes go through ConfigEditor.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn add_mount(&mut self, name: &str, mount: MountConfig, scope: Option<&str>) {
-        // Global mounts cannot carry isolation; the wire format
-        // (`GlobalMountConfig`) doesn't have the field. Convert
-        // explicitly to make the lossy projection visible at the
-        // call site rather than hidden behind `Into`.
         debug_assert!(
             matches!(mount.isolation, crate::isolation::MountIsolation::Shared),
             "global mounts cannot carry isolation"
@@ -229,19 +211,6 @@ impl AppConfig {
         }
     }
 
-    pub fn list_mounts(&self) -> Vec<(String, String, MountConfig)> {
-        self.list_mount_rows()
-            .into_iter()
-            .map(|row| {
-                (
-                    row.scope.unwrap_or_else(|| "(global)".to_string()),
-                    row.name,
-                    row.mount,
-                )
-            })
-            .collect()
-    }
-
     pub fn list_mount_rows(&self) -> Vec<GlobalMountRow> {
         let mut result = Vec::new();
         for (key, entry) in self.docker.mounts.iter() {
@@ -263,17 +232,6 @@ impl AppConfig {
             }
         }
         result
-    }
-
-    pub fn global_mounts(&self) -> Vec<MountConfig> {
-        self.docker
-            .mounts
-            .iter()
-            .filter_map(|(_, entry)| match entry {
-                MountEntry::Mount(m) => Some(MountConfig::from(m.clone())),
-                MountEntry::Scoped(_) => None,
-            })
-            .collect()
     }
 
     pub fn validate_effective_mount_destinations(
@@ -336,12 +294,6 @@ pub struct GlobalMountRow {
     pub scope: Option<String>,
     pub name: String,
     pub mount: MountConfig,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WorkspaceMountRoleContext {
-    Selected(String),
-    Ambiguous(Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -1,9 +1,10 @@
 use super::{AppConfig, MountConfig};
 use crate::selector::RoleSelector;
 use crate::workspace::expand_tilde;
+use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Wire format for global mounts (top-level `[[mounts]]` and scoped
 /// `[mounts.<scope>]` entries). Mirrors `MountConfig` minus the
@@ -70,42 +71,108 @@ impl DockerMounts {
 }
 
 impl AppConfig {
-    pub fn resolve_mounts(&self, selector: &RoleSelector) -> Vec<(String, MountConfig)> {
-        let mut by_name: BTreeMap<String, MountConfig> = BTreeMap::new();
+    pub fn workspace_mount_role_context(
+        &self,
+        workspace: &crate::workspace::WorkspaceConfig,
+    ) -> WorkspaceMountRoleContext {
+        let mut candidates: Vec<String> = workspace.allowed_roles.clone();
+        if let Some(default) = &workspace.default_role
+            && !candidates.iter().any(|role| role == default)
+        {
+            candidates.push(default.clone());
+        }
+        if let Some(last) = &workspace.last_role
+            && !candidates.iter().any(|role| role == last)
+        {
+            candidates.push(last.clone());
+        }
+        candidates.sort();
+        candidates.dedup();
 
-        // Priority order: global < wildcard < exact (later inserts override earlier)
+        if candidates.len() == 1 {
+            return WorkspaceMountRoleContext::Selected(candidates.remove(0));
+        }
+        if candidates.is_empty()
+            && self.roles.len() == 1
+            && let Some(role) = self.roles.keys().next()
+        {
+            return WorkspaceMountRoleContext::Selected(role.clone());
+        }
+        if candidates.is_empty() {
+            candidates = self.roles.keys().cloned().collect();
+        }
+        WorkspaceMountRoleContext::Ambiguous(candidates)
+    }
+
+    pub fn workspace_applicable_mount_rows(
+        &self,
+        workspace: &crate::workspace::WorkspaceConfig,
+    ) -> WorkspaceGlobalMountRows {
+        match self.workspace_mount_role_context(workspace) {
+            WorkspaceMountRoleContext::Selected(role) => RoleSelector::parse(&role).map_or_else(
+                |_| WorkspaceGlobalMountRows::Ambiguous {
+                    candidates: vec![role],
+                },
+                |selector| WorkspaceGlobalMountRows::Applicable {
+                    role: selector.key(),
+                    rows: self.resolve_mount_rows(&selector),
+                },
+            ),
+            WorkspaceMountRoleContext::Ambiguous(candidates) => {
+                WorkspaceGlobalMountRows::Ambiguous { candidates }
+            }
+        }
+    }
+
+    pub fn resolve_mount_rows(&self, selector: &RoleSelector) -> Vec<GlobalMountRow> {
+        let mut by_name: BTreeMap<String, GlobalMountRow> = BTreeMap::new();
         let scopes = [
-            None,                                                    // global
-            selector.namespace.as_ref().map(|ns| format!("{ns}/*")), // wildcard
-            Some(selector.key()),                                    // exact
+            None,
+            selector.namespace.as_ref().map(|ns| format!("{ns}/*")),
+            Some(selector.key()),
         ];
 
         for scope in &scopes {
-            let entries: BTreeMap<String, MountConfig> = match scope {
+            match scope {
                 None => {
-                    let mut map = BTreeMap::new();
                     for (name, entry) in self.docker.mounts.iter() {
                         if let MountEntry::Mount(m) = entry {
-                            map.insert(name.clone(), MountConfig::from(m.clone()));
+                            by_name.insert(
+                                name.clone(),
+                                GlobalMountRow {
+                                    scope: None,
+                                    name: name.clone(),
+                                    mount: MountConfig::from(m.clone()),
+                                },
+                            );
                         }
                     }
-                    map
                 }
-                Some(scope_key) => match self.docker.mounts.get(scope_key) {
-                    Some(MountEntry::Scoped(scope_map)) => scope_map
-                        .iter()
-                        .map(|(name, m)| (name.clone(), MountConfig::from(m.clone())))
-                        .collect(),
-                    _ => continue,
-                },
-            };
-
-            for (name, mount) in entries {
-                by_name.insert(name, mount);
+                Some(scope_key) => {
+                    if let Some(MountEntry::Scoped(scope_map)) = self.docker.mounts.get(scope_key) {
+                        for (name, m) in scope_map {
+                            by_name.insert(
+                                name.clone(),
+                                GlobalMountRow {
+                                    scope: Some(scope_key.clone()),
+                                    name: name.clone(),
+                                    mount: MountConfig::from(m.clone()),
+                                },
+                            );
+                        }
+                    }
+                }
             }
         }
 
-        by_name.into_iter().collect()
+        by_name.into_values().collect()
+    }
+
+    pub fn resolve_mounts(&self, selector: &RoleSelector) -> Vec<(String, MountConfig)> {
+        self.resolve_mount_rows(selector)
+            .into_iter()
+            .map(|row| (row.name, row.mount))
+            .collect()
     }
 
     pub fn expand_and_validate_named_mounts(
@@ -163,19 +230,34 @@ impl AppConfig {
     }
 
     pub fn list_mounts(&self) -> Vec<(String, String, MountConfig)> {
+        self.list_mount_rows()
+            .into_iter()
+            .map(|row| {
+                (
+                    row.scope.unwrap_or_else(|| "(global)".to_string()),
+                    row.name,
+                    row.mount,
+                )
+            })
+            .collect()
+    }
+
+    pub fn list_mount_rows(&self) -> Vec<GlobalMountRow> {
         let mut result = Vec::new();
         for (key, entry) in self.docker.mounts.iter() {
             match entry {
-                MountEntry::Mount(m) => {
-                    result.push((
-                        "(global)".to_string(),
-                        key.clone(),
-                        MountConfig::from(m.clone()),
-                    ));
-                }
+                MountEntry::Mount(m) => result.push(GlobalMountRow {
+                    scope: None,
+                    name: key.clone(),
+                    mount: MountConfig::from(m.clone()),
+                }),
                 MountEntry::Scoped(map) => {
                     for (name, m) in map {
-                        result.push((key.clone(), name.clone(), MountConfig::from(m.clone())));
+                        result.push(GlobalMountRow {
+                            scope: Some(key.clone()),
+                            name: name.clone(),
+                            mount: MountConfig::from(m.clone()),
+                        });
                     }
                 }
             }
@@ -193,6 +275,103 @@ impl AppConfig {
             })
             .collect()
     }
+
+    pub fn validate_effective_mount_destinations(
+        workspace: &crate::workspace::WorkspaceConfig,
+        rows: &[GlobalMountRow],
+    ) -> anyhow::Result<()> {
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        for mount in &workspace.mounts {
+            if !seen.insert(mount.dst.as_str()) {
+                anyhow::bail!("duplicate mount destination: {}", mount.dst);
+            }
+        }
+        for row in rows {
+            if !seen.insert(row.mount.dst.as_str()) {
+                anyhow::bail!(
+                    "global mount destination conflicts with workspace destination: {}",
+                    row.mount.dst
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub fn validate_global_mount_rows(rows: &[GlobalMountRow]) -> anyhow::Result<()> {
+        let expanded: Vec<GlobalMountRow> = rows
+            .iter()
+            .map(|row| GlobalMountRow {
+                scope: row.scope.clone(),
+                name: row.name.clone(),
+                mount: MountConfig {
+                    src: expand_tilde(&row.mount.src),
+                    dst: row.mount.dst.clone(),
+                    readonly: row.mount.readonly,
+                    isolation: row.mount.isolation,
+                },
+            })
+            .collect();
+
+        for row in &expanded {
+            crate::workspace::validate_mounts(std::slice::from_ref(&row.mount))
+                .with_context(|| format!("validating global mount {}", row.name))?;
+        }
+        for (idx, left) in expanded.iter().enumerate() {
+            for right in expanded.iter().skip(idx + 1) {
+                if left.name != right.name
+                    && left.mount.dst == right.mount.dst
+                    && scopes_overlap(left.scope.as_ref(), right.scope.as_ref())
+                {
+                    anyhow::bail!(
+                        "duplicate global mount destination in overlapping scope: {}",
+                        left.mount.dst
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalMountRow {
+    pub scope: Option<String>,
+    pub name: String,
+    pub mount: MountConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceMountRoleContext {
+    Selected(String),
+    Ambiguous(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceGlobalMountRows {
+    Applicable {
+        role: String,
+        rows: Vec<GlobalMountRow>,
+    },
+    Ambiguous {
+        candidates: Vec<String>,
+    },
+}
+
+fn scopes_overlap(left: Option<&String>, right: Option<&String>) -> bool {
+    match (left.map(String::as_str), right.map(String::as_str)) {
+        (None, _) | (_, None) => true,
+        (Some(a), Some(b)) if a == b => true,
+        (Some(a), Some(b)) => wildcard_scope_matches(a, b) || wildcard_scope_matches(b, a),
+    }
+}
+
+fn wildcard_scope_matches(wildcard: &str, concrete: &str) -> bool {
+    let Some(prefix) = wildcard.strip_suffix("/*") else {
+        return false;
+    };
+    concrete
+        .strip_prefix(prefix)
+        .is_some_and(|rest| rest.starts_with('/'))
 }
 
 #[cfg(test)]
@@ -369,6 +548,98 @@ shared = { src = "/tmp/specific", dst = "/data" }
         ];
         let err = AppConfig::expand_and_validate_named_mounts(&mounts).unwrap_err();
         assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn validate_global_mount_rows_rejects_overlapping_scope_duplicate_dst() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().display().to_string();
+        let rows = vec![
+            GlobalMountRow {
+                scope: Some("chainargos/*".into()),
+                name: "a".into(),
+                mount: MountConfig {
+                    src: src.clone(),
+                    dst: "/cache".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+            GlobalMountRow {
+                scope: Some("chainargos/the-architect".into()),
+                name: "b".into(),
+                mount: MountConfig {
+                    src,
+                    dst: "/cache".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+        ];
+
+        let err = AppConfig::validate_global_mount_rows(&rows).unwrap_err();
+
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn validate_global_mount_rows_allows_disjoint_scope_duplicate_dst() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().display().to_string();
+        let rows = vec![
+            GlobalMountRow {
+                scope: Some("chainargos/*".into()),
+                name: "a".into(),
+                mount: MountConfig {
+                    src: src.clone(),
+                    dst: "/cache".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+            GlobalMountRow {
+                scope: Some("scentbird/*".into()),
+                name: "b".into(),
+                mount: MountConfig {
+                    src,
+                    dst: "/cache".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+        ];
+
+        AppConfig::validate_global_mount_rows(&rows).unwrap();
+    }
+
+    #[test]
+    fn validate_global_mount_rows_allows_same_name_override_duplicate_dst() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().display().to_string();
+        let rows = vec![
+            GlobalMountRow {
+                scope: None,
+                name: "cache".into(),
+                mount: MountConfig {
+                    src: src.clone(),
+                    dst: "/cache".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+            GlobalMountRow {
+                scope: Some("chainargos/*".into()),
+                name: "cache".into(),
+                mount: MountConfig {
+                    src,
+                    dst: "/cache".into(),
+                    readonly: true,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+        ];
+
+        AppConfig::validate_global_mount_rows(&rows).unwrap();
     }
 
     #[test]

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -288,9 +288,12 @@ impl AppConfig {
         }
         for row in rows {
             if !seen.insert(row.mount.dst.as_str()) {
+                let scope = row.scope.as_deref().unwrap_or("global");
                 anyhow::bail!(
-                    "global mount destination conflicts with workspace destination: {}",
-                    row.mount.dst
+                    "global mount destination conflicts with workspace destination: {} (from global mount {} [{}])",
+                    row.mount.dst,
+                    row.name,
+                    scope
                 );
             }
         }
@@ -298,26 +301,21 @@ impl AppConfig {
     }
 
     pub fn validate_global_mount_rows(rows: &[GlobalMountRow]) -> anyhow::Result<()> {
-        let expanded: Vec<GlobalMountRow> = rows
-            .iter()
-            .map(|row| GlobalMountRow {
-                scope: row.scope.clone(),
-                name: row.name.clone(),
-                mount: MountConfig {
-                    src: expand_tilde(&row.mount.src),
-                    dst: row.mount.dst.clone(),
-                    readonly: row.mount.readonly,
-                    isolation: row.mount.isolation,
-                },
-            })
-            .collect();
-
-        for row in &expanded {
-            crate::workspace::validate_mounts(std::slice::from_ref(&row.mount))
+        for row in rows {
+            if row.name.trim().is_empty() {
+                anyhow::bail!("global mount name cannot be empty");
+            }
+            let expanded = MountConfig {
+                src: expand_tilde(&row.mount.src),
+                dst: row.mount.dst.clone(),
+                readonly: row.mount.readonly,
+                isolation: row.mount.isolation,
+            };
+            crate::workspace::validate_mounts(std::slice::from_ref(&expanded))
                 .with_context(|| format!("validating global mount {}", row.name))?;
         }
-        for (idx, left) in expanded.iter().enumerate() {
-            for right in expanded.iter().skip(idx + 1) {
+        for (idx, left) in rows.iter().enumerate() {
+            for right in rows.iter().skip(idx + 1) {
                 if left.name != right.name
                     && left.mount.dst == right.mount.dst
                     && scopes_overlap(left.scope.as_ref(), right.scope.as_ref())
@@ -548,6 +546,25 @@ shared = { src = "/tmp/specific", dst = "/data" }
         ];
         let err = AppConfig::expand_and_validate_named_mounts(&mounts).unwrap_err();
         assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn validate_global_mount_rows_rejects_empty_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let rows = vec![GlobalMountRow {
+            scope: None,
+            name: "  ".into(),
+            mount: MountConfig {
+                src: temp.path().display().to_string(),
+                dst: "/x".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+        }];
+
+        let err = AppConfig::validate_global_mount_rows(&rows).unwrap_err();
+
+        assert!(err.to_string().contains("name cannot be empty"));
     }
 
     #[test]

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -259,9 +259,17 @@ impl AppConfig {
     }
 
     pub fn validate_global_mount_rows(rows: &[GlobalMountRow]) -> anyhow::Result<()> {
+        let mut seen_keys: BTreeSet<(Option<&str>, &str)> = BTreeSet::new();
         for row in rows {
             if row.name.trim().is_empty() {
                 anyhow::bail!("global mount name cannot be empty");
+            }
+            // Two rows with the same (scope, name) silently collapse on
+            // wire-write because `add_mount` keys the BTreeMap by name —
+            // catch it here before the editor loses one row's data.
+            if !seen_keys.insert((row.scope.as_deref(), row.name.as_str())) {
+                let scope = row.scope.as_deref().unwrap_or("global");
+                anyhow::bail!("duplicate global mount entry: {} [{}]", row.name, scope);
             }
             let expanded = MountConfig {
                 src: expand_tilde(&row.mount.src),
@@ -498,6 +506,41 @@ shared = { src = "/tmp/specific", dst = "/data" }
         ];
         let err = AppConfig::expand_and_validate_named_mounts(&mounts).unwrap_err();
         assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn validate_global_mount_rows_rejects_duplicate_scope_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().display().to_string();
+        let rows = vec![
+            GlobalMountRow {
+                scope: None,
+                name: "cache".into(),
+                mount: MountConfig {
+                    src: src.clone(),
+                    dst: "/a".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+            GlobalMountRow {
+                scope: None,
+                name: "cache".into(),
+                mount: MountConfig {
+                    src,
+                    dst: "/b".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            },
+        ];
+
+        let err = AppConfig::validate_global_mount_rows(&rows).unwrap_err();
+
+        assert!(
+            err.to_string().contains("duplicate global mount entry"),
+            "expected duplicate-entry error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -385,7 +385,20 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         // 0=Name, 1=Working dir, 2=Keep awake
         // 0=Name, 1=Working dir, 2=Keep awake, 3=Git pull
         EditorTab::General => 3,
-        EditorTab::Mounts => editor.pending.mounts.len(),
+        EditorTab::Mounts => {
+            let global_rows = match editor.mode {
+                super::super::state::EditorMode::Edit { .. } => {
+                    match config.workspace_applicable_mount_rows(&editor.pending) {
+                        crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => {
+                            rows.len()
+                        }
+                        crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => 0,
+                    }
+                }
+                super::super::state::EditorMode::Create => 0,
+            };
+            editor.pending.mounts.len() + global_rows
+        }
         // One extra sentinel row: + Add role.
         EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
@@ -2927,6 +2940,44 @@ plugins = []
             panic!("editor stage expected");
         };
         assert!(e.pending.mounts[0].readonly);
+    }
+
+    #[test]
+    fn global_mount_row_readonly_toggle_is_read_only_in_workspace_editor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("cache");
+        std::fs::create_dir_all(&src).unwrap();
+        let mut config = AppConfig::default();
+        config
+            .roles
+            .insert("agent-smith".into(), crate::config::RoleSource::default());
+        config.add_mount(
+            "cache",
+            MountConfig {
+                src: src.display().to_string(),
+                dst: "/cache".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            None,
+        );
+        let mut ws = ws_with_one_mount(false);
+        ws.allowed_roles = vec!["agent-smith".into()];
+        let mut state = editor_on_mounts_tab(ws, 2);
+
+        press(&mut state, &mut config, KeyCode::Char('R')).unwrap();
+        press(&mut state, &mut config, KeyCode::Char('D')).unwrap();
+        press(&mut state, &mut config, KeyCode::Char('I')).unwrap();
+
+        let ManagerStage::Editor(e) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert_eq!(e.pending.mounts.len(), 1);
+        assert!(!e.pending.mounts[0].readonly);
+        assert_eq!(
+            e.pending.mounts[0].isolation,
+            crate::isolation::MountIsolation::Shared
+        );
     }
 
     #[test]

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -92,10 +92,20 @@ pub(super) fn handle_editor_key(
 
     match key.code {
         KeyCode::Char('h' | 'H') if editor.active_tab == EditorTab::Mounts => {
-            editor.scroll_x = editor.scroll_x.saturating_sub(8);
+            if cursor_is_global_mount(editor, config) {
+                editor.global_mounts_scroll_x = editor.global_mounts_scroll_x.saturating_sub(8);
+            } else {
+                editor.workspace_mounts_scroll_x =
+                    editor.workspace_mounts_scroll_x.saturating_sub(8);
+            }
         }
         KeyCode::Char('l' | 'L') if editor.active_tab == EditorTab::Mounts => {
-            editor.scroll_x = editor.scroll_x.saturating_add(8);
+            if cursor_is_global_mount(editor, config) {
+                editor.global_mounts_scroll_x = editor.global_mounts_scroll_x.saturating_add(8);
+            } else {
+                editor.workspace_mounts_scroll_x =
+                    editor.workspace_mounts_scroll_x.saturating_add(8);
+            }
         }
         KeyCode::Tab | KeyCode::Right => {
             // Secrets tab `AgentHeader` absorbs `→` in both states
@@ -413,6 +423,23 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
             super::super::render::editor::auth_row_count(editor, config).saturating_sub(1)
         }
     }
+}
+
+fn cursor_is_global_mount(editor: &EditorState<'_>, config: &AppConfig) -> bool {
+    if editor.active_tab != EditorTab::Mounts {
+        return false;
+    }
+    let super::super::state::FieldFocus::Row(cursor) = editor.active_field;
+    let global_count = match editor.mode {
+        super::super::state::EditorMode::Edit { .. } => {
+            match config.workspace_applicable_mount_rows(&editor.pending) {
+                crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => rows.len(),
+                crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => 0,
+            }
+        }
+        super::super::state::EditorMode::Create => 0,
+    };
+    global_count > 0 && cursor > editor.pending.mounts.len()
 }
 
 /// Walks forward past spacer rows. Defensive fallback to `candidate`

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -91,21 +91,15 @@ pub(super) fn handle_editor_key(
     };
 
     match key.code {
-        KeyCode::Char('h' | 'H') if editor.active_tab == EditorTab::Mounts => {
-            if cursor_is_global_mount(editor, config) {
-                editor.global_mounts_scroll_x = editor.global_mounts_scroll_x.saturating_sub(8);
-            } else {
-                editor.workspace_mounts_scroll_x =
-                    editor.workspace_mounts_scroll_x.saturating_sub(8);
-            }
+        KeyCode::Char('h' | 'H')
+            if editor.active_tab == EditorTab::Mounts && editor.workspace_mounts_scroll_focused =>
+        {
+            editor.workspace_mounts_scroll_x = editor.workspace_mounts_scroll_x.saturating_sub(8);
         }
-        KeyCode::Char('l' | 'L') if editor.active_tab == EditorTab::Mounts => {
-            if cursor_is_global_mount(editor, config) {
-                editor.global_mounts_scroll_x = editor.global_mounts_scroll_x.saturating_add(8);
-            } else {
-                editor.workspace_mounts_scroll_x =
-                    editor.workspace_mounts_scroll_x.saturating_add(8);
-            }
+        KeyCode::Char('l' | 'L')
+            if editor.active_tab == EditorTab::Mounts && editor.workspace_mounts_scroll_focused =>
+        {
+            editor.workspace_mounts_scroll_x = editor.workspace_mounts_scroll_x.saturating_add(8);
         }
         KeyCode::Tab | KeyCode::Right => {
             // Secrets tab `AgentHeader` absorbs `→` in both states
@@ -401,20 +395,7 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
         // 0=Name, 1=Working dir, 2=Keep awake
         // 0=Name, 1=Working dir, 2=Keep awake, 3=Git pull
         EditorTab::General => 3,
-        EditorTab::Mounts => {
-            let global_rows = match editor.mode {
-                super::super::state::EditorMode::Edit { .. } => {
-                    match config.workspace_applicable_mount_rows(&editor.pending) {
-                        crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => {
-                            rows.len()
-                        }
-                        crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => 0,
-                    }
-                }
-                super::super::state::EditorMode::Create => 0,
-            };
-            editor.pending.mounts.len() + global_rows
-        }
+        EditorTab::Mounts => editor.pending.mounts.len(),
         // One extra sentinel row: + Add role.
         EditorTab::Roles => config.roles.len(),
         // Secrets tab is handled inline in the Down key arm; never reached here.
@@ -423,23 +404,6 @@ fn max_row_for_tab(editor: &EditorState<'_>, config: &AppConfig) -> usize {
             super::super::render::editor::auth_row_count(editor, config).saturating_sub(1)
         }
     }
-}
-
-fn cursor_is_global_mount(editor: &EditorState<'_>, config: &AppConfig) -> bool {
-    if editor.active_tab != EditorTab::Mounts {
-        return false;
-    }
-    let super::super::state::FieldFocus::Row(cursor) = editor.active_field;
-    let global_count = match editor.mode {
-        super::super::state::EditorMode::Edit { .. } => {
-            match config.workspace_applicable_mount_rows(&editor.pending) {
-                crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => rows.len(),
-                crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => 0,
-            }
-        }
-        super::super::state::EditorMode::Create => 0,
-    };
-    global_count > 0 && cursor > editor.pending.mounts.len()
 }
 
 /// Walks forward past spacer rows. Defensive fallback to `candidate`
@@ -2976,7 +2940,7 @@ plugins = []
     }
 
     #[test]
-    fn global_mount_row_readonly_toggle_is_read_only_in_workspace_editor() {
+    fn rows_beyond_workspace_mounts_are_noop_in_workspace_editor() {
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("cache");
         std::fs::create_dir_all(&src).unwrap();
@@ -2996,6 +2960,8 @@ plugins = []
         );
         let mut ws = ws_with_one_mount(false);
         ws.allowed_roles = vec!["agent-smith".into()];
+        // Global mounts are intentionally not rendered/editable here; row 2
+        // simulates stale input beyond the workspace mount + add sentinel.
         let mut state = editor_on_mounts_tab(ws, 2);
 
         press(&mut state, &mut config, KeyCode::Char('R')).unwrap();

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -91,14 +91,12 @@ pub(super) fn handle_editor_key(
     };
 
     match key.code {
-        KeyCode::Char('h' | 'H')
-            if editor.active_tab == EditorTab::Mounts && editor.workspace_mounts_scroll_focused =>
-        {
+        KeyCode::Char('h' | 'H') if editor.active_tab == EditorTab::Mounts => {
+            editor.workspace_mounts_scroll_focused = true;
             editor.workspace_mounts_scroll_x = editor.workspace_mounts_scroll_x.saturating_sub(8);
         }
-        KeyCode::Char('l' | 'L')
-            if editor.active_tab == EditorTab::Mounts && editor.workspace_mounts_scroll_focused =>
-        {
+        KeyCode::Char('l' | 'L') if editor.active_tab == EditorTab::Mounts => {
+            editor.workspace_mounts_scroll_focused = true;
             editor.workspace_mounts_scroll_x = editor.workspace_mounts_scroll_x.saturating_add(8);
         }
         KeyCode::Tab | KeyCode::Right => {

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -91,6 +91,12 @@ pub(super) fn handle_editor_key(
     };
 
     match key.code {
+        KeyCode::Char('h' | 'H') if editor.active_tab == EditorTab::Mounts => {
+            editor.scroll_x = editor.scroll_x.saturating_sub(8);
+        }
+        KeyCode::Char('l' | 'L') if editor.active_tab == EditorTab::Mounts => {
+            editor.scroll_x = editor.scroll_x.saturating_add(8);
+        }
         KeyCode::Tab | KeyCode::Right => {
             // Secrets tab `AgentHeader` absorbs `→` in both states
             // (expand or no-op) — falling through to tab-cycle on an

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -31,9 +31,15 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
             global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
         }
         KeyCode::Char('s' | 'S') => {
-            global.modal = Some(GlobalMountModal::ConfirmSave {
-                state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
-            });
+            if has_sensitive_mount(&global.pending) {
+                global.modal = Some(GlobalMountModal::ConfirmSensitive {
+                    state: ConfirmState::new("Sensitive global mount path detected. Save anyway?"),
+                });
+            } else {
+                global.modal = Some(GlobalMountModal::ConfirmSave {
+                    state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
+                });
+            }
         }
         KeyCode::Char('d' | 'D') if !global.pending.is_empty() => {
             global.modal = Some(GlobalMountModal::ConfirmRemove {
@@ -127,6 +133,15 @@ pub(super) fn handle_global_mounts_modal(
             ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
             ModalOutcome::Continue => global.modal = Some(modal),
         },
+        GlobalMountModal::ConfirmSensitive { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => {
+                global.modal = Some(GlobalMountModal::ConfirmSave {
+                    state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
+                });
+            }
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
+            ModalOutcome::Continue => global.modal = Some(modal),
+        },
     }
 }
 
@@ -216,5 +231,31 @@ fn scope_value(value: &str) -> Option<String> {
         None
     } else {
         Some(value.to_string())
+    }
+}
+
+fn has_sensitive_mount(rows: &[crate::config::GlobalMountRow]) -> bool {
+    let mounts: Vec<MountConfig> = rows.iter().map(|row| row.mount.clone()).collect();
+    !crate::workspace::find_sensitive_mounts(&mounts).is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_mount_save_detects_sensitive_sources() {
+        let rows = vec![crate::config::GlobalMountRow {
+            scope: None,
+            name: "ssh".into(),
+            mount: MountConfig {
+                src: "/home/user/.ssh".into(),
+                dst: "/ssh".into(),
+                readonly: true,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+        }];
+
+        assert!(has_sensitive_mount(&rows));
     }
 }

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -4,6 +4,11 @@ use super::super::state::{
     GlobalMountConfirm, GlobalMountDraft, GlobalMountModal, GlobalMountTextTarget, ManagerStage,
     ManagerState, Toast, ToastKind,
 };
+
+const NO_MOUNT_SELECTED: &str = "No mount selected.";
+const MOUNT_NAME_EMPTY: &str = "Mount name cannot be empty.";
+const MOUNT_GONE: &str = "Mount no longer exists; selection was cleared.";
+const ADD_DRAFT_LOST: &str = "Add-mount draft was lost; press 'a' to start over.";
 use crate::config::AppConfig;
 use crate::console::widgets::ModalOutcome;
 use crate::console::widgets::confirm::ConfirmState;
@@ -18,10 +23,7 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
             if global.is_dirty() {
-                global.modal = Some(confirm_modal(
-                    GlobalMountConfirm::Discard,
-                    "Discard unsaved global mount changes?",
-                ));
+                global.modal = Some(confirm_modal(GlobalMountConfirm::Discard));
             } else {
                 state.stage = ManagerStage::List;
             }
@@ -49,37 +51,26 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
             } else {
                 GlobalMountConfirm::Save
             };
-            global.modal = Some(confirm_modal(action, prompt_for(action)));
+            global.modal = Some(confirm_modal(action));
         }
         KeyCode::Char('d' | 'D') => {
             if global.pending.is_empty() {
                 set_toast(state, "Nothing to remove.", ToastKind::Error);
             } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
-                global.modal = Some(confirm_modal(
-                    GlobalMountConfirm::Remove,
-                    "Remove selected global mount?",
-                ));
+                global.modal = Some(confirm_modal(GlobalMountConfirm::Remove));
             }
         }
         KeyCode::Char('r' | 'R') => {
             if let Some(row) = global.pending.get_mut(global.selected) {
                 row.mount.readonly = !row.mount.readonly;
             } else {
-                set_toast(state, "No mount selected.", ToastKind::Error);
+                set_toast(state, NO_MOUNT_SELECTED, ToastKind::Error);
             }
         }
-        KeyCode::Char('n' | 'N') => {
-            open_edit_text(state, GlobalMountTextTarget::Rename, "Rename mount");
-        }
-        KeyCode::Char('1') => open_edit_text(state, GlobalMountTextTarget::Source, "Source"),
-        KeyCode::Char('2') => {
-            open_edit_text(state, GlobalMountTextTarget::Destination, "Destination");
-        }
-        KeyCode::Char('3') => open_edit_text(
-            state,
-            GlobalMountTextTarget::Scope,
-            "Scope (empty = global)",
-        ),
+        KeyCode::Char('n' | 'N') => open_edit_text(state, GlobalMountTextTarget::Rename),
+        KeyCode::Char('1') => open_edit_text(state, GlobalMountTextTarget::Source),
+        KeyCode::Char('2') => open_edit_text(state, GlobalMountTextTarget::Destination),
+        KeyCode::Char('3') => open_edit_text(state, GlobalMountTextTarget::Scope),
         _ => {}
     }
 }
@@ -137,10 +128,7 @@ fn commit_confirm(
             Err(err) => global.error = Some(err.to_string()),
         },
         GlobalMountConfirm::Sensitive => {
-            global.modal = Some(confirm_modal(
-                GlobalMountConfirm::Save,
-                prompt_for(GlobalMountConfirm::Save),
-            ));
+            global.modal = Some(confirm_modal(GlobalMountConfirm::Save));
         }
         GlobalMountConfirm::Discard => {
             global.discard();
@@ -158,98 +146,120 @@ fn commit_text(
     match target {
         GlobalMountTextTarget::AddName => {
             if trimmed.is_empty() {
-                global.error = Some("Mount name cannot be empty.".into());
+                global.error = Some(MOUNT_NAME_EMPTY.into());
                 global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
                 return;
             }
-            if let Some(draft) = global.add_draft.as_mut() {
-                draft.name = trimmed.to_string();
-                global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
-            }
+            let Some(draft) = global.add_draft.as_mut() else {
+                global.error = Some(ADD_DRAFT_LOST.into());
+                return;
+            };
+            draft.name = trimmed.to_string();
+            global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
         }
         GlobalMountTextTarget::AddSource => {
-            if let Some(draft) = global.add_draft.as_mut() {
-                draft.src = resolve_path(trimmed);
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::AddDestination,
-                    "Destination",
-                    "",
-                ));
-            }
+            let Some(draft) = global.add_draft.as_mut() else {
+                global.error = Some(ADD_DRAFT_LOST.into());
+                return;
+            };
+            draft.src = resolve_path(trimmed);
+            global.modal = Some(text_modal(
+                GlobalMountTextTarget::AddDestination,
+                "Destination",
+                "",
+            ));
         }
         GlobalMountTextTarget::AddDestination => {
-            if let Some(draft) = global.add_draft.as_mut() {
-                draft.dst = trimmed.to_string();
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::AddScope,
-                    "Scope (empty = global)",
-                    "",
-                ));
-            }
+            let Some(draft) = global.add_draft.as_mut() else {
+                global.error = Some(ADD_DRAFT_LOST.into());
+                return;
+            };
+            draft.dst = trimmed.to_string();
+            global.modal = Some(text_modal(
+                GlobalMountTextTarget::AddScope,
+                "Scope (empty = global)",
+                "",
+            ));
         }
         GlobalMountTextTarget::AddScope => {
-            if let Some(draft) = global.add_draft.take() {
-                global.pending.push(crate::config::GlobalMountRow {
-                    scope: scope_value(trimmed),
-                    name: draft.name,
-                    mount: MountConfig {
-                        src: draft.src,
-                        dst: draft.dst,
-                        readonly: false,
-                        isolation: crate::isolation::MountIsolation::Shared,
-                    },
-                });
-                global.selected = global.pending.len().saturating_sub(1);
-            }
+            let Some(draft) = global.add_draft.take() else {
+                global.error = Some(ADD_DRAFT_LOST.into());
+                return;
+            };
+            global.pending.push(crate::config::GlobalMountRow {
+                scope: scope_value(trimmed),
+                name: draft.name,
+                mount: MountConfig {
+                    src: draft.src,
+                    dst: draft.dst,
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            });
+            global.selected = global.pending.len().saturating_sub(1);
         }
         GlobalMountTextTarget::Source => {
-            if let Some(row) = global.pending.get_mut(global.selected) {
-                row.mount.src = resolve_path(trimmed);
-            }
+            let Some(row) = global.pending.get_mut(global.selected) else {
+                global.error = Some(MOUNT_GONE.into());
+                return;
+            };
+            row.mount.src = resolve_path(trimmed);
         }
         GlobalMountTextTarget::Destination => {
-            if let Some(row) = global.pending.get_mut(global.selected) {
-                row.mount.dst = trimmed.to_string();
-            }
+            let Some(row) = global.pending.get_mut(global.selected) else {
+                global.error = Some(MOUNT_GONE.into());
+                return;
+            };
+            row.mount.dst = trimmed.to_string();
         }
         GlobalMountTextTarget::Scope => {
-            if let Some(row) = global.pending.get_mut(global.selected) {
-                row.scope = scope_value(trimmed);
-            }
+            let Some(row) = global.pending.get_mut(global.selected) else {
+                global.error = Some(MOUNT_GONE.into());
+                return;
+            };
+            row.scope = scope_value(trimmed);
         }
         GlobalMountTextTarget::Rename => {
             if trimmed.is_empty() {
-                global.error = Some("Mount name cannot be empty.".into());
+                global.error = Some(MOUNT_NAME_EMPTY.into());
                 return;
             }
-            if let Some(row) = global.pending.get_mut(global.selected) {
-                row.name = trimmed.to_string();
-            }
+            let Some(row) = global.pending.get_mut(global.selected) else {
+                global.error = Some(MOUNT_GONE.into());
+                return;
+            };
+            row.name = trimmed.to_string();
         }
     }
 }
 
-fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget, label: &str) {
+fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget) {
     let ManagerStage::GlobalMounts(global) = &mut state.stage else {
         return;
     };
     let Some(row) = global.pending.get(global.selected) else {
-        set_toast(state, "No mount selected.", ToastKind::Error);
+        set_toast(state, NO_MOUNT_SELECTED, ToastKind::Error);
         return;
     };
-    let initial = match target {
-        GlobalMountTextTarget::Rename => row.name.clone(),
-        GlobalMountTextTarget::Source => row.mount.src.clone(),
-        GlobalMountTextTarget::Destination => row.mount.dst.clone(),
-        GlobalMountTextTarget::Scope => row.scope.clone().unwrap_or_default(),
-        _ => return,
+    let (label, initial) = match target {
+        GlobalMountTextTarget::Rename => ("Rename mount", row.name.clone()),
+        GlobalMountTextTarget::Source => ("Source", row.mount.src.clone()),
+        GlobalMountTextTarget::Destination => ("Destination", row.mount.dst.clone()),
+        GlobalMountTextTarget::Scope => (
+            "Scope (empty = global)",
+            row.scope.clone().unwrap_or_default(),
+        ),
+        // Add-flow targets are driven by the four-step text wizard, not this entry point.
+        GlobalMountTextTarget::AddName
+        | GlobalMountTextTarget::AddSource
+        | GlobalMountTextTarget::AddDestination
+        | GlobalMountTextTarget::AddScope => return,
     };
     global.modal = Some(text_modal(target, label, &initial));
 }
 
-/// Drain transient signals (`error`, `success`, `exit_requested`) that
-/// the `GlobalMounts` handlers set. Promote messages to toasts and pop
-/// back to the workspace list when the handlers asked for it.
+/// Promote pending error/success messages to toasts; pop back to the
+/// workspace list when the handler set `exit_requested`.
 pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
     let ManagerStage::GlobalMounts(global) = &mut state.stage else {
         return;
@@ -258,18 +268,9 @@ pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
     let success = global.success.take();
     let exit = std::mem::take(&mut global.exit_requested);
     if let Some(err) = error {
-        state.toast = Some(Toast {
-            message: err,
-            kind: ToastKind::Error,
-            shown_at: std::time::Instant::now(),
-        });
-    }
-    if let Some(msg) = success {
-        state.toast = Some(Toast {
-            message: msg,
-            kind: ToastKind::Success,
-            shown_at: std::time::Instant::now(),
-        });
+        set_toast(state, &err, ToastKind::Error);
+    } else if let Some(msg) = success {
+        set_toast(state, &msg, ToastKind::Success);
     }
     if exit {
         state.stage = ManagerStage::List;
@@ -284,19 +285,16 @@ fn set_toast(state: &mut ManagerState<'_>, msg: &str, kind: ToastKind) {
     });
 }
 
-fn confirm_modal(action: GlobalMountConfirm, prompt: &str) -> GlobalMountModal<'static> {
-    GlobalMountModal::Confirm {
-        action,
-        state: ConfirmState::new(prompt),
-    }
-}
-
-const fn prompt_for(action: GlobalMountConfirm) -> &'static str {
-    match action {
+fn confirm_modal(action: GlobalMountConfirm) -> GlobalMountModal<'static> {
+    let prompt = match action {
         GlobalMountConfirm::Save => "Save global mounts to ~/.config/jackin/config.toml?",
         GlobalMountConfirm::Sensitive => "Sensitive global mount path detected. Save anyway?",
         GlobalMountConfirm::Remove => "Remove selected global mount?",
         GlobalMountConfirm::Discard => "Discard unsaved global mount changes?",
+    };
+    GlobalMountModal::Confirm {
+        action,
+        state: ConfirmState::new(prompt),
     }
 }
 

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -1,0 +1,220 @@
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::super::state::{
+    GlobalMountDraft, GlobalMountModal, GlobalMountTextTarget, ManagerStage, ManagerState, Toast,
+    ToastKind,
+};
+use crate::config::AppConfig;
+use crate::console::widgets::ModalOutcome;
+use crate::console::widgets::confirm::ConfirmState;
+use crate::console::widgets::text_input::TextInputState;
+use crate::paths::JackinPaths;
+use crate::workspace::{MountConfig, resolve_path};
+
+pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+        return;
+    };
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
+            state.stage = ManagerStage::List;
+        }
+        KeyCode::Up | KeyCode::Char('k' | 'K') => {
+            global.selected = global.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j' | 'J') => {
+            let max = global.pending.len().saturating_sub(1);
+            global.selected = (global.selected + 1).min(max);
+        }
+        KeyCode::Char('a' | 'A') => {
+            global.add_draft = Some(GlobalMountDraft::default());
+            global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
+        }
+        KeyCode::Char('s' | 'S') => {
+            global.modal = Some(GlobalMountModal::ConfirmSave {
+                state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
+            });
+        }
+        KeyCode::Char('d' | 'D') if !global.pending.is_empty() => {
+            global.modal = Some(GlobalMountModal::ConfirmRemove {
+                state: ConfirmState::new("Remove selected global mount?"),
+            });
+        }
+        KeyCode::Char('r' | 'R') => {
+            if let Some(row) = global.pending.get_mut(global.selected) {
+                row.mount.readonly = !row.mount.readonly;
+            }
+        }
+        KeyCode::Char('n' | 'N') => {
+            if let Some(row) = global.pending.get(global.selected) {
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::Rename,
+                    "Rename mount",
+                    &row.name,
+                ));
+            }
+        }
+        KeyCode::Char('1') => {
+            if let Some(row) = global.pending.get(global.selected) {
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::Source,
+                    "Source",
+                    &row.mount.src,
+                ));
+            }
+        }
+        KeyCode::Char('2') => {
+            if let Some(row) = global.pending.get(global.selected) {
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::Destination,
+                    "Destination",
+                    &row.mount.dst,
+                ));
+            }
+        }
+        KeyCode::Char('3') => {
+            if let Some(row) = global.pending.get(global.selected) {
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::Scope,
+                    "Scope (empty = global)",
+                    row.scope.as_deref().unwrap_or(""),
+                ));
+            }
+        }
+        _ => {}
+    }
+    if let ManagerStage::GlobalMounts(global) = &mut state.stage
+        && let Some(err) = global.error.take()
+    {
+        state.toast = Some(Toast {
+            message: err,
+            kind: ToastKind::Error,
+            shown_at: std::time::Instant::now(),
+        });
+    }
+}
+
+pub(super) fn handle_global_mounts_modal(
+    global: &mut super::super::state::GlobalMountsState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    key: KeyEvent,
+) {
+    let Some(mut modal) = global.modal.take() else {
+        return;
+    };
+    match &mut modal {
+        GlobalMountModal::Text { target, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(value) => commit_text(global, target, &value),
+            ModalOutcome::Cancel => global.add_draft = None,
+            ModalOutcome::Continue => global.modal = Some(modal),
+        },
+        GlobalMountModal::ConfirmRemove { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => {
+                if global.selected < global.pending.len() {
+                    global.pending.remove(global.selected);
+                    global.selected = global.selected.min(global.pending.len().saturating_sub(1));
+                }
+            }
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
+            ModalOutcome::Continue => global.modal = Some(modal),
+        },
+        GlobalMountModal::ConfirmSave { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => match global.save_to_config(paths) {
+                Ok(saved) => *config = saved,
+                Err(err) => global.error = Some(err.to_string()),
+            },
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
+            ModalOutcome::Continue => global.modal = Some(modal),
+        },
+    }
+}
+
+fn commit_text(
+    global: &mut super::super::state::GlobalMountsState<'_>,
+    target: &GlobalMountTextTarget,
+    value: &str,
+) {
+    match target {
+        GlobalMountTextTarget::AddName => {
+            if let Some(draft) = global.add_draft.as_mut() {
+                draft.name = value.trim().to_string();
+                global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
+            }
+        }
+        GlobalMountTextTarget::AddSource => {
+            if let Some(draft) = global.add_draft.as_mut() {
+                draft.src = resolve_path(value.trim());
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::AddDestination,
+                    "Destination",
+                    "",
+                ));
+            }
+        }
+        GlobalMountTextTarget::AddDestination => {
+            if let Some(draft) = global.add_draft.as_mut() {
+                draft.dst = value.trim().to_string();
+                global.modal = Some(text_modal(
+                    GlobalMountTextTarget::AddScope,
+                    "Scope (empty = global)",
+                    "",
+                ));
+            }
+        }
+        GlobalMountTextTarget::AddScope => {
+            if let Some(draft) = global.add_draft.take() {
+                global.pending.push(crate::config::GlobalMountRow {
+                    scope: scope_value(value.trim()),
+                    name: draft.name,
+                    mount: MountConfig {
+                        src: draft.src,
+                        dst: draft.dst,
+                        readonly: false,
+                        isolation: crate::isolation::MountIsolation::Shared,
+                    },
+                });
+                global.selected = global.pending.len().saturating_sub(1);
+            }
+        }
+        GlobalMountTextTarget::Source => {
+            if let Some(row) = global.pending.get_mut(global.selected) {
+                row.mount.src = resolve_path(value.trim());
+            }
+        }
+        GlobalMountTextTarget::Destination => {
+            if let Some(row) = global.pending.get_mut(global.selected) {
+                row.mount.dst = value.trim().to_string();
+            }
+        }
+        GlobalMountTextTarget::Scope => {
+            if let Some(row) = global.pending.get_mut(global.selected) {
+                row.scope = scope_value(value.trim());
+            }
+        }
+        GlobalMountTextTarget::Rename => {
+            if let Some(row) = global.pending.get_mut(global.selected) {
+                row.name = value.trim().to_string();
+            }
+        }
+    }
+}
+
+fn text_modal(
+    target: GlobalMountTextTarget,
+    label: &str,
+    initial: &str,
+) -> GlobalMountModal<'static> {
+    GlobalMountModal::Text {
+        target,
+        state: Box::new(TextInputState::new(label, initial)),
+    }
+}
+
+fn scope_value(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -19,6 +19,12 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
             state.stage = ManagerStage::List;
         }
+        KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            global.scroll_x = global.scroll_x.saturating_sub(8);
+        }
+        KeyCode::Right | KeyCode::Char('l' | 'L') => {
+            global.scroll_x = global.scroll_x.saturating_add(8);
+        }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             global.selected = global.selected.saturating_sub(1);
         }

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -1,8 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use super::super::state::{
-    GlobalMountDraft, GlobalMountModal, GlobalMountTextTarget, ManagerStage, ManagerState, Toast,
-    ToastKind,
+    GlobalMountConfirm, GlobalMountDraft, GlobalMountModal, GlobalMountTextTarget, ManagerStage,
+    ManagerState, Toast, ToastKind,
 };
 use crate::config::AppConfig;
 use crate::console::widgets::ModalOutcome;
@@ -17,7 +17,14 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
     };
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
-            state.stage = ManagerStage::List;
+            if global.is_dirty() {
+                global.modal = Some(confirm_modal(
+                    GlobalMountConfirm::Discard,
+                    "Discard unsaved global mount changes?",
+                ));
+            } else {
+                state.stage = ManagerStage::List;
+            }
         }
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
             global.scroll_x = global.scroll_x.saturating_sub(8);
@@ -37,72 +44,43 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
             global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
         }
         KeyCode::Char('s' | 'S') => {
-            if has_sensitive_mount(&global.pending) {
-                global.modal = Some(GlobalMountModal::ConfirmSensitive {
-                    state: ConfirmState::new("Sensitive global mount path detected. Save anyway?"),
-                });
+            let action = if has_sensitive_mount(&global.pending) {
+                GlobalMountConfirm::Sensitive
             } else {
-                global.modal = Some(GlobalMountModal::ConfirmSave {
-                    state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
-                });
-            }
+                GlobalMountConfirm::Save
+            };
+            global.modal = Some(confirm_modal(action, prompt_for(action)));
         }
-        KeyCode::Char('d' | 'D') if !global.pending.is_empty() => {
-            global.modal = Some(GlobalMountModal::ConfirmRemove {
-                state: ConfirmState::new("Remove selected global mount?"),
-            });
+        KeyCode::Char('d' | 'D') => {
+            if global.pending.is_empty() {
+                set_toast(state, "Nothing to remove.", ToastKind::Error);
+            } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
+                global.modal = Some(confirm_modal(
+                    GlobalMountConfirm::Remove,
+                    "Remove selected global mount?",
+                ));
+            }
         }
         KeyCode::Char('r' | 'R') => {
             if let Some(row) = global.pending.get_mut(global.selected) {
                 row.mount.readonly = !row.mount.readonly;
+            } else {
+                set_toast(state, "No mount selected.", ToastKind::Error);
             }
         }
         KeyCode::Char('n' | 'N') => {
-            if let Some(row) = global.pending.get(global.selected) {
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::Rename,
-                    "Rename mount",
-                    &row.name,
-                ));
-            }
+            open_edit_text(state, GlobalMountTextTarget::Rename, "Rename mount");
         }
-        KeyCode::Char('1') => {
-            if let Some(row) = global.pending.get(global.selected) {
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::Source,
-                    "Source",
-                    &row.mount.src,
-                ));
-            }
-        }
+        KeyCode::Char('1') => open_edit_text(state, GlobalMountTextTarget::Source, "Source"),
         KeyCode::Char('2') => {
-            if let Some(row) = global.pending.get(global.selected) {
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::Destination,
-                    "Destination",
-                    &row.mount.dst,
-                ));
-            }
+            open_edit_text(state, GlobalMountTextTarget::Destination, "Destination");
         }
-        KeyCode::Char('3') => {
-            if let Some(row) = global.pending.get(global.selected) {
-                global.modal = Some(text_modal(
-                    GlobalMountTextTarget::Scope,
-                    "Scope (empty = global)",
-                    row.scope.as_deref().unwrap_or(""),
-                ));
-            }
-        }
+        KeyCode::Char('3') => open_edit_text(
+            state,
+            GlobalMountTextTarget::Scope,
+            "Scope (empty = global)",
+        ),
         _ => {}
-    }
-    if let ManagerStage::GlobalMounts(global) = &mut state.stage
-        && let Some(err) = global.error.take()
-    {
-        state.toast = Some(Toast {
-            message: err,
-            kind: ToastKind::Error,
-            shown_at: std::time::Instant::now(),
-        });
     }
 }
 
@@ -118,36 +96,56 @@ pub(super) fn handle_global_mounts_modal(
     match &mut modal {
         GlobalMountModal::Text { target, state } => match state.handle_key(key) {
             ModalOutcome::Commit(value) => commit_text(global, target, &value),
-            ModalOutcome::Cancel => global.add_draft = None,
-            ModalOutcome::Continue => global.modal = Some(modal),
-        },
-        GlobalMountModal::ConfirmRemove { state } => match state.handle_key(key) {
-            ModalOutcome::Commit(true) => {
-                if global.selected < global.pending.len() {
-                    global.pending.remove(global.selected);
-                    global.selected = global.selected.min(global.pending.len().saturating_sub(1));
+            ModalOutcome::Cancel => {
+                if global.add_draft.take().is_some() {
+                    global.error = Some("Add mount cancelled.".to_string());
                 }
             }
-            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
             ModalOutcome::Continue => global.modal = Some(modal),
         },
-        GlobalMountModal::ConfirmSave { state } => match state.handle_key(key) {
-            ModalOutcome::Commit(true) => match global.save_to_config(paths) {
-                Ok(saved) => *config = saved,
-                Err(err) => global.error = Some(err.to_string()),
-            },
-            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
-            ModalOutcome::Continue => global.modal = Some(modal),
-        },
-        GlobalMountModal::ConfirmSensitive { state } => match state.handle_key(key) {
-            ModalOutcome::Commit(true) => {
-                global.modal = Some(GlobalMountModal::ConfirmSave {
-                    state: ConfirmState::new("Save global mounts to ~/.config/jackin/config.toml?"),
-                });
+        GlobalMountModal::Confirm { action, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => commit_confirm(global, *action, config, paths),
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {
+                if matches!(action, GlobalMountConfirm::Sensitive) {
+                    global.error = Some("Save aborted: sensitive paths not confirmed.".into());
+                }
             }
-            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
             ModalOutcome::Continue => global.modal = Some(modal),
         },
+    }
+}
+
+fn commit_confirm(
+    global: &mut super::super::state::GlobalMountsState<'_>,
+    action: GlobalMountConfirm,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+) {
+    match action {
+        GlobalMountConfirm::Remove => {
+            if global.selected < global.pending.len() {
+                global.pending.remove(global.selected);
+                global.selected = global.selected.min(global.pending.len().saturating_sub(1));
+            }
+        }
+        GlobalMountConfirm::Save => match global.save_to_config(paths) {
+            Ok(saved) => {
+                *config = saved;
+                global.success = Some("Global mounts saved.".into());
+                global.exit_requested = true;
+            }
+            Err(err) => global.error = Some(err.to_string()),
+        },
+        GlobalMountConfirm::Sensitive => {
+            global.modal = Some(confirm_modal(
+                GlobalMountConfirm::Save,
+                prompt_for(GlobalMountConfirm::Save),
+            ));
+        }
+        GlobalMountConfirm::Discard => {
+            global.discard();
+            global.exit_requested = true;
+        }
     }
 }
 
@@ -156,16 +154,22 @@ fn commit_text(
     target: &GlobalMountTextTarget,
     value: &str,
 ) {
+    let trimmed = value.trim();
     match target {
         GlobalMountTextTarget::AddName => {
+            if trimmed.is_empty() {
+                global.error = Some("Mount name cannot be empty.".into());
+                global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
+                return;
+            }
             if let Some(draft) = global.add_draft.as_mut() {
-                draft.name = value.trim().to_string();
+                draft.name = trimmed.to_string();
                 global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
             }
         }
         GlobalMountTextTarget::AddSource => {
             if let Some(draft) = global.add_draft.as_mut() {
-                draft.src = resolve_path(value.trim());
+                draft.src = resolve_path(trimmed);
                 global.modal = Some(text_modal(
                     GlobalMountTextTarget::AddDestination,
                     "Destination",
@@ -175,7 +179,7 @@ fn commit_text(
         }
         GlobalMountTextTarget::AddDestination => {
             if let Some(draft) = global.add_draft.as_mut() {
-                draft.dst = value.trim().to_string();
+                draft.dst = trimmed.to_string();
                 global.modal = Some(text_modal(
                     GlobalMountTextTarget::AddScope,
                     "Scope (empty = global)",
@@ -186,7 +190,7 @@ fn commit_text(
         GlobalMountTextTarget::AddScope => {
             if let Some(draft) = global.add_draft.take() {
                 global.pending.push(crate::config::GlobalMountRow {
-                    scope: scope_value(value.trim()),
+                    scope: scope_value(trimmed),
                     name: draft.name,
                     mount: MountConfig {
                         src: draft.src,
@@ -200,24 +204,99 @@ fn commit_text(
         }
         GlobalMountTextTarget::Source => {
             if let Some(row) = global.pending.get_mut(global.selected) {
-                row.mount.src = resolve_path(value.trim());
+                row.mount.src = resolve_path(trimmed);
             }
         }
         GlobalMountTextTarget::Destination => {
             if let Some(row) = global.pending.get_mut(global.selected) {
-                row.mount.dst = value.trim().to_string();
+                row.mount.dst = trimmed.to_string();
             }
         }
         GlobalMountTextTarget::Scope => {
             if let Some(row) = global.pending.get_mut(global.selected) {
-                row.scope = scope_value(value.trim());
+                row.scope = scope_value(trimmed);
             }
         }
         GlobalMountTextTarget::Rename => {
+            if trimmed.is_empty() {
+                global.error = Some("Mount name cannot be empty.".into());
+                return;
+            }
             if let Some(row) = global.pending.get_mut(global.selected) {
-                row.name = value.trim().to_string();
+                row.name = trimmed.to_string();
             }
         }
+    }
+}
+
+fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget, label: &str) {
+    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+        return;
+    };
+    let Some(row) = global.pending.get(global.selected) else {
+        set_toast(state, "No mount selected.", ToastKind::Error);
+        return;
+    };
+    let initial = match target {
+        GlobalMountTextTarget::Rename => row.name.clone(),
+        GlobalMountTextTarget::Source => row.mount.src.clone(),
+        GlobalMountTextTarget::Destination => row.mount.dst.clone(),
+        GlobalMountTextTarget::Scope => row.scope.clone().unwrap_or_default(),
+        _ => return,
+    };
+    global.modal = Some(text_modal(target, label, &initial));
+}
+
+/// Drain transient signals (`error`, `success`, `exit_requested`) that
+/// the `GlobalMounts` handlers set. Promote messages to toasts and pop
+/// back to the workspace list when the handlers asked for it.
+pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
+    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+        return;
+    };
+    let error = global.error.take();
+    let success = global.success.take();
+    let exit = std::mem::take(&mut global.exit_requested);
+    if let Some(err) = error {
+        state.toast = Some(Toast {
+            message: err,
+            kind: ToastKind::Error,
+            shown_at: std::time::Instant::now(),
+        });
+    }
+    if let Some(msg) = success {
+        state.toast = Some(Toast {
+            message: msg,
+            kind: ToastKind::Success,
+            shown_at: std::time::Instant::now(),
+        });
+    }
+    if exit {
+        state.stage = ManagerStage::List;
+    }
+}
+
+fn set_toast(state: &mut ManagerState<'_>, msg: &str, kind: ToastKind) {
+    state.toast = Some(Toast {
+        message: msg.to_string(),
+        kind,
+        shown_at: std::time::Instant::now(),
+    });
+}
+
+fn confirm_modal(action: GlobalMountConfirm, prompt: &str) -> GlobalMountModal<'static> {
+    GlobalMountModal::Confirm {
+        action,
+        state: ConfirmState::new(prompt),
+    }
+}
+
+const fn prompt_for(action: GlobalMountConfirm) -> &'static str {
+    match action {
+        GlobalMountConfirm::Save => "Save global mounts to ~/.config/jackin/config.toml?",
+        GlobalMountConfirm::Sensitive => "Sensitive global mount path detected. Save anyway?",
+        GlobalMountConfirm::Remove => "Remove selected global mount?",
+        GlobalMountConfirm::Discard => "Discard unsaved global mount changes?",
     }
 }
 

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -271,10 +271,7 @@ fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
         Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
         Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
         Some(MountScrollFocus::RoleGlobal) => apply(&mut state.list_role_global_mounts_scroll_x),
-        None => {
-            state.list_scroll_focus = Some(MountScrollFocus::Workspace);
-            apply(&mut state.list_mounts_scroll_x);
-        }
+        None => {}
     }
 }
 

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -8,7 +8,7 @@ use super::super::super::widgets::{
 };
 use super::super::state::{
     EditorState, FileBrowserTarget, GlobalMountsState, ManagerListRow, ManagerStage, ManagerState,
-    Modal, MountScrollFocus, Toast, ToastKind,
+    Modal, Toast, ToastKind,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -297,27 +297,20 @@ pub(super) fn handle_inline_agent_picker(
     }
 }
 
-fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
-    let apply = |value: &mut u16| {
-        if delta.is_negative() {
-            *value = value.saturating_sub(delta.unsigned_abs());
-        } else {
-            *value = value.saturating_add(delta as u16);
-        }
+const fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
+    let Some(focus) = state.list_scroll_focus else {
+        return;
     };
-    match state.list_scroll_focus {
-        Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
-        Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
-        Some(MountScrollFocus::RoleGlobal) => apply(&mut state.list_role_global_mounts_scroll_x),
-        None => {}
+    let value = state.list_scroll_x_mut(focus);
+    if delta.is_negative() {
+        *value = value.saturating_sub(delta.unsigned_abs());
+    } else {
+        *value = value.saturating_add(delta as u16);
     }
 }
 
-const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
-    state.list_mounts_scroll_x = 0;
-    state.list_global_mounts_scroll_x = 0;
-    state.list_role_global_mounts_scroll_x = 0;
-    state.list_scroll_focus = None;
+pub(super) const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
+    state.reset_list_scroll();
 }
 
 #[cfg(test)]

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -14,6 +14,7 @@ use super::InputOutcome;
 use crate::config::AppConfig;
 use crate::paths::JackinPaths;
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn handle_list_key(
     state: &mut ManagerState<'_>,
     config: &AppConfig,
@@ -24,11 +25,21 @@ pub(super) fn handle_list_key(
     // See ManagerListRow docs for row layout.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => Ok(InputOutcome::ExitJackin),
+        KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            state.list_scroll_x = state.list_scroll_x.saturating_sub(8);
+            Ok(InputOutcome::Continue)
+        }
+        KeyCode::Right | KeyCode::Char('l' | 'L') => {
+            state.list_scroll_x = state.list_scroll_x.saturating_add(8);
+            Ok(InputOutcome::Continue)
+        }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
+            state.inline_role_picker = None;
             state.selected = state.selected.saturating_sub(1);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
+            state.inline_role_picker = None;
             state.selected = (state.selected + 1).min(state.row_count() - 1);
             Ok(InputOutcome::Continue)
         }
@@ -213,6 +224,36 @@ pub(super) fn handle_list_modal(state: &mut ManagerState<'_>, key: KeyEvent) -> 
             state.list_modal = None;
             InputOutcome::Continue
         }
+    }
+}
+
+pub(super) fn handle_inline_role_picker(
+    state: &mut ManagerState<'_>,
+    key: KeyEvent,
+) -> InputOutcome {
+    let Some(picker) = state.inline_role_picker.as_mut() else {
+        return InputOutcome::Continue;
+    };
+    match key.code {
+        KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            state.list_scroll_x = state.list_scroll_x.saturating_sub(8);
+            InputOutcome::Continue
+        }
+        KeyCode::Right | KeyCode::Char('l' | 'L') => {
+            state.list_scroll_x = state.list_scroll_x.saturating_add(8);
+            InputOutcome::Continue
+        }
+        _ => match picker.handle_key(key) {
+            ModalOutcome::Commit(role) => {
+                state.inline_role_picker = None;
+                InputOutcome::LaunchWithAgent(role)
+            }
+            ModalOutcome::Cancel => {
+                state.inline_role_picker = None;
+                InputOutcome::Continue
+            }
+            ModalOutcome::Continue => InputOutcome::Continue,
+        },
     }
 }
 

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -38,7 +38,7 @@ pub(super) fn handle_list_key(
             state.inline_agent_picker = None;
             let selected = state.selected.saturating_sub(1);
             if selected != state.selected {
-                reset_list_mount_scroll(state);
+                state.reset_list_scroll();
                 state.selected = selected;
             }
             Ok(InputOutcome::Continue)
@@ -48,7 +48,7 @@ pub(super) fn handle_list_key(
             state.inline_agent_picker = None;
             let selected = (state.selected + 1).min(state.row_count() - 1);
             if selected != state.selected {
-                reset_list_mount_scroll(state);
+                state.reset_list_scroll();
                 state.selected = selected;
             }
             Ok(InputOutcome::Continue)
@@ -307,10 +307,6 @@ const fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
     } else {
         *value = value.saturating_add(delta as u16);
     }
-}
-
-pub(super) const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
-    state.reset_list_scroll();
 }
 
 #[cfg(test)]

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -8,7 +8,7 @@ use super::super::super::widgets::{
 };
 use super::super::state::{
     EditorState, FileBrowserTarget, GlobalMountsState, ManagerListRow, ManagerStage, ManagerState,
-    Modal, Toast, ToastKind,
+    Modal, MountScrollFocus, Toast, ToastKind,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -26,20 +26,22 @@ pub(super) fn handle_list_key(
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => Ok(InputOutcome::ExitJackin),
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            state.list_mounts_scroll_x = state.list_mounts_scroll_x.saturating_sub(8);
+            scroll_focused_mount_block(state, -8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            state.list_mounts_scroll_x = state.list_mounts_scroll_x.saturating_add(8);
+            scroll_focused_mount_block(state, 8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             state.inline_role_picker = None;
+            state.list_scroll_focus = None;
             state.selected = state.selected.saturating_sub(1);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
             state.inline_role_picker = None;
+            state.list_scroll_focus = None;
             state.selected = (state.selected + 1).min(state.row_count() - 1);
             Ok(InputOutcome::Continue)
         }
@@ -236,11 +238,11 @@ pub(super) fn handle_inline_role_picker(
     };
     match key.code {
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            state.list_global_mounts_scroll_x = state.list_global_mounts_scroll_x.saturating_sub(8);
+            scroll_focused_mount_block(state, -8);
             InputOutcome::Continue
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            state.list_global_mounts_scroll_x = state.list_global_mounts_scroll_x.saturating_add(8);
+            scroll_focused_mount_block(state, 8);
             InputOutcome::Continue
         }
         _ => match picker.handle_key(key) {
@@ -254,6 +256,22 @@ pub(super) fn handle_inline_role_picker(
             }
             ModalOutcome::Continue => InputOutcome::Continue,
         },
+    }
+}
+
+fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
+    let apply = |value: &mut u16| {
+        if delta.is_negative() {
+            *value = value.saturating_sub(delta.unsigned_abs());
+        } else {
+            *value = value.saturating_add(delta as u16);
+        }
+    };
+    match state.list_scroll_focus {
+        Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
+        Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
+        Some(MountScrollFocus::RoleGlobal) => apply(&mut state.list_role_global_mounts_scroll_x),
+        None => {}
     }
 }
 

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -35,14 +35,20 @@ pub(super) fn handle_list_key(
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             state.inline_role_picker = None;
-            state.list_scroll_focus = None;
-            state.selected = state.selected.saturating_sub(1);
+            let selected = state.selected.saturating_sub(1);
+            if selected != state.selected {
+                reset_list_mount_scroll(state);
+                state.selected = selected;
+            }
             Ok(InputOutcome::Continue)
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
             state.inline_role_picker = None;
-            state.list_scroll_focus = None;
-            state.selected = (state.selected + 1).min(state.row_count() - 1);
+            let selected = (state.selected + 1).min(state.row_count() - 1);
+            if selected != state.selected {
+                reset_list_mount_scroll(state);
+                state.selected = selected;
+            }
             Ok(InputOutcome::Continue)
         }
         KeyCode::Enter => match state.selected_row() {
@@ -275,11 +281,20 @@ fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
     }
 }
 
+const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
+    state.list_mounts_scroll_x = 0;
+    state.list_global_mounts_scroll_x = 0;
+    state.list_role_global_mounts_scroll_x = 0;
+    state.list_scroll_focus = None;
+}
+
 #[cfg(test)]
 mod tests {
     //! List-stage tests: row-0 (current dir) gating, Enter routing,
     //! `o`-key resolver to GitHub URLs, and the `GithubPicker` modal.
-    use super::super::super::state::{ManagerStage, ManagerState, Modal, ToastKind};
+    use super::super::super::state::{
+        ManagerStage, ManagerState, Modal, MountScrollFocus, ToastKind,
+    };
     use super::super::test_support::{key, mount};
     use super::InputOutcome;
     use crate::config::AppConfig;
@@ -433,6 +448,38 @@ mod tests {
             InputOutcome::LaunchNamed(name) => assert_eq!(name, "alpha"),
             other => panic!("row 1 Enter must produce LaunchNamed(\"alpha\"); got {other:?}"),
         }
+    }
+
+    #[test]
+    fn moving_selection_resets_mount_scroll_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let cwd = tmp.path();
+
+        let mut config = AppConfig::default();
+        config.workspaces.insert(
+            "alpha".into(),
+            WorkspaceConfig {
+                workdir: "/alpha".into(),
+                mounts: vec![],
+                ..Default::default()
+            },
+        );
+        let mut state = ManagerState::from_config(&config, cwd);
+        state.selected = 0;
+        state.list_mounts_scroll_x = 24;
+        state.list_global_mounts_scroll_x = 16;
+        state.list_role_global_mounts_scroll_x = 8;
+        state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+
+        handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Down)).unwrap();
+
+        assert_eq!(state.selected, 1);
+        assert_eq!(state.list_mounts_scroll_x, 0);
+        assert_eq!(state.list_global_mounts_scroll_x, 0);
+        assert_eq!(state.list_role_global_mounts_scroll_x, 0);
+        assert_eq!(state.list_scroll_focus, None);
     }
 
     // ── List-view `o` key → GitHub resolver + picker ──────────────────

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -7,8 +7,8 @@ use super::super::super::widgets::{
     ModalOutcome, confirm::ConfirmState, file_browser::FileBrowserState,
 };
 use super::super::state::{
-    EditorState, FileBrowserTarget, ManagerListRow, ManagerStage, ManagerState, Modal, Toast,
-    ToastKind,
+    EditorState, FileBrowserTarget, GlobalMountsState, ManagerListRow, ManagerStage, ManagerState,
+    Modal, Toast, ToastKind,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -114,6 +114,10 @@ pub(super) fn handle_list_key(
         }
         KeyCode::Char('o' | 'O') => {
             handle_list_open_in_github(state, config);
+            Ok(InputOutcome::Continue)
+        }
+        KeyCode::Char('g' | 'G') => {
+            state.stage = ManagerStage::GlobalMounts(GlobalMountsState::from_config(config));
             Ok(InputOutcome::Continue)
         }
         _ => Ok(InputOutcome::Continue),

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -35,6 +35,7 @@ pub(super) fn handle_list_key(
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             state.inline_role_picker = None;
+            state.inline_agent_picker = None;
             let selected = state.selected.saturating_sub(1);
             if selected != state.selected {
                 reset_list_mount_scroll(state);
@@ -44,6 +45,7 @@ pub(super) fn handle_list_key(
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
             state.inline_role_picker = None;
+            state.inline_agent_picker = None;
             let selected = (state.selected + 1).min(state.row_count() - 1);
             if selected != state.selected {
                 reset_list_mount_scroll(state);
@@ -258,6 +260,36 @@ pub(super) fn handle_inline_role_picker(
             }
             ModalOutcome::Cancel => {
                 state.inline_role_picker = None;
+                InputOutcome::Continue
+            }
+            ModalOutcome::Continue => InputOutcome::Continue,
+        },
+    }
+}
+
+pub(super) fn handle_inline_agent_picker(
+    state: &mut ManagerState<'_>,
+    key: KeyEvent,
+) -> InputOutcome {
+    let Some((_, picker)) = state.inline_agent_picker.as_mut() else {
+        return InputOutcome::Continue;
+    };
+    match key.code {
+        KeyCode::Left | KeyCode::Char('h' | 'H') => {
+            scroll_focused_mount_block(state, -8);
+            InputOutcome::Continue
+        }
+        KeyCode::Right | KeyCode::Char('l' | 'L') => {
+            scroll_focused_mount_block(state, 8);
+            InputOutcome::Continue
+        }
+        _ => match picker.handle_key(key) {
+            ModalOutcome::Commit(agent) => {
+                state.inline_agent_picker = None;
+                InputOutcome::LaunchWithRuntimeAgent(agent)
+            }
+            ModalOutcome::Cancel => {
+                state.inline_agent_picker = None;
                 InputOutcome::Continue
             }
             ModalOutcome::Continue => InputOutcome::Continue,

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -271,7 +271,10 @@ fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
         Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
         Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
         Some(MountScrollFocus::RoleGlobal) => apply(&mut state.list_role_global_mounts_scroll_x),
-        None => {}
+        None => {
+            state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+            apply(&mut state.list_mounts_scroll_x);
+        }
     }
 }
 

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -26,11 +26,11 @@ pub(super) fn handle_list_key(
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => Ok(InputOutcome::ExitJackin),
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            state.list_scroll_x = state.list_scroll_x.saturating_sub(8);
+            state.list_mounts_scroll_x = state.list_mounts_scroll_x.saturating_sub(8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            state.list_scroll_x = state.list_scroll_x.saturating_add(8);
+            state.list_mounts_scroll_x = state.list_mounts_scroll_x.saturating_add(8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
@@ -236,11 +236,11 @@ pub(super) fn handle_inline_role_picker(
     };
     match key.code {
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            state.list_scroll_x = state.list_scroll_x.saturating_sub(8);
+            state.list_global_mounts_scroll_x = state.list_global_mounts_scroll_x.saturating_sub(8);
             InputOutcome::Continue
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            state.list_scroll_x = state.list_scroll_x.saturating_add(8);
+            state.list_global_mounts_scroll_x = state.list_global_mounts_scroll_x.saturating_add(8);
             InputOutcome::Continue
         }
         _ => match picker.handle_key(key) {

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -4,6 +4,7 @@
 
 pub(super) mod auth;
 pub(super) mod editor;
+pub(super) mod global_mounts;
 pub(super) mod list;
 pub(super) mod mouse;
 pub(super) mod prelude;
@@ -131,6 +132,12 @@ pub fn handle_key(
         }
         return Ok(InputOutcome::Continue);
     }
+    if let ManagerStage::GlobalMounts(global) = &mut state.stage
+        && global.modal.is_some()
+    {
+        global_mounts::handle_global_mounts_modal(global, config, paths, key);
+        return Ok(InputOutcome::Continue);
+    }
     if matches!(state.stage, ManagerStage::CreatePrelude(_)) {
         let has_modal = if let ManagerStage::CreatePrelude(p) = &state.stage {
             p.modal.is_some()
@@ -203,12 +210,14 @@ pub fn handle_key(
     enum StageDis {
         List,
         Editor,
+        GlobalMounts,
         CreatePrelude,
         ConfirmDelete,
     }
     let dis = match &state.stage {
         ManagerStage::List => StageDis::List,
         ManagerStage::Editor(_) => StageDis::Editor,
+        ManagerStage::GlobalMounts(_) => StageDis::GlobalMounts,
         ManagerStage::CreatePrelude(_) => StageDis::CreatePrelude,
         ManagerStage::ConfirmDelete { .. } => StageDis::ConfirmDelete,
     };
@@ -216,6 +225,10 @@ pub fn handle_key(
     match dis {
         StageDis::List => list::handle_list_key(state, config, paths, cwd, key),
         StageDis::Editor => editor::handle_editor_key(state, config, paths, cwd, key),
+        StageDis::GlobalMounts => {
+            global_mounts::handle_global_mounts_key(state, key);
+            Ok(InputOutcome::Continue)
+        }
         StageDis::CreatePrelude => Ok(prelude::handle_prelude_key(state, config, paths, cwd, key)),
         StageDis::ConfirmDelete => handle_confirm_delete_key(state, config, paths, cwd, key),
     }

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -144,6 +144,7 @@ pub fn handle_key(
         && global.modal.is_some()
     {
         global_mounts::handle_global_mounts_modal(global, config, paths, key);
+        global_mounts::after_global_mounts_event(state);
         return Ok(InputOutcome::Continue);
     }
     if matches!(state.stage, ManagerStage::CreatePrelude(_)) {
@@ -235,6 +236,7 @@ pub fn handle_key(
         StageDis::Editor => editor::handle_editor_key(state, config, paths, cwd, key),
         StageDis::GlobalMounts => {
             global_mounts::handle_global_mounts_key(state, key);
+            global_mounts::after_global_mounts_event(state);
             Ok(InputOutcome::Continue)
         }
         StageDis::CreatePrelude => Ok(prelude::handle_prelude_key(state, config, paths, cwd, key)),

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -59,6 +59,9 @@ pub fn handle_key(
     if state.list_modal.is_some() {
         return Ok(list::handle_list_modal(state, key));
     }
+    if state.inline_role_picker.is_some() {
+        return Ok(list::handle_inline_role_picker(state, key));
+    }
     // Modal precedence: if a modal is open, it gets the event.
     // Use a discriminant check so we can take &mut without keeping an
     // immutable borrow alive across the call.

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -19,7 +19,7 @@ use super::state::{
 use crate::config::AppConfig;
 use crate::paths::JackinPaths;
 
-pub use mouse::handle_mouse;
+pub use mouse::{handle_mouse, handle_mouse_with_config};
 
 #[derive(Debug)]
 pub enum InputOutcome {

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -40,6 +40,8 @@ pub enum InputOutcome {
     /// when the picker opened), resolves it against this role, and
     /// breaks with `Ok(Some((role, ws)))`.
     LaunchWithAgent(crate::selector::RoleSelector),
+    /// Operator committed a runtime agent after choosing a role.
+    LaunchWithRuntimeAgent(crate::agent::Agent),
 }
 
 #[allow(clippy::too_many_lines)]
@@ -58,6 +60,9 @@ pub fn handle_key(
     // `Continue`, but `AgentPicker` commit produces `LaunchWithAgent`.
     if state.list_modal.is_some() {
         return Ok(list::handle_list_modal(state, key));
+    }
+    if state.inline_agent_picker.is_some() {
+        return Ok(list::handle_inline_agent_picker(state, key));
     }
     if state.inline_role_picker.is_some() {
         return Ok(list::handle_inline_role_picker(state, key));

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -6,8 +6,8 @@ use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
 use super::super::state::{
-    DragState, EditorTab, ManagerListRow, ManagerStage, ManagerState, Modal, MountScrollFocus,
-    clamp_split,
+    DragState, EditorTab, FieldFocus, ManagerListRow, ManagerStage, ManagerState, Modal,
+    MountScrollFocus, clamp_split,
 };
 
 /// Minimum terminal width (in columns) at which the list/details seam is
@@ -27,6 +27,8 @@ const LIST_HEADER_HEIGHT: u16 = 3;
 /// Height of the footer chunk in the list-view chrome. Mirrors
 /// `Constraint::Length(2)` in `render::render`.
 const LIST_FOOTER_HEIGHT: u16 = 2;
+const EDITOR_HEADER_HEIGHT: u16 = 3;
+const EDITOR_TAB_STRIP_HEIGHT: u16 = 2;
 const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 1;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
@@ -56,6 +58,12 @@ pub fn handle_mouse_with_config(
     config: Option<&crate::config::AppConfig>,
 ) {
     if term_size.width < MIN_DRAGGABLE_WIDTH {
+        return;
+    }
+
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+        && try_select_editor_tab(state, mouse)
+    {
         return;
     }
 
@@ -145,6 +153,57 @@ pub fn handle_mouse_with_config(
         }
         _ => {}
     }
+}
+
+fn try_select_editor_tab(state: &mut ManagerState<'_>, mouse: MouseEvent) -> bool {
+    let ManagerStage::Editor(editor) = &mut state.stage else {
+        return false;
+    };
+    if editor.modal.is_some() {
+        return false;
+    }
+
+    let Some(tab) = editor_tab_at(mouse) else {
+        return false;
+    };
+
+    let was_secrets = editor.active_tab == EditorTab::Secrets;
+    editor.active_tab = tab;
+    editor.active_field = FieldFocus::Row(0);
+    editor.workspace_mounts_scroll_focused = false;
+    if editor.active_tab != EditorTab::Auth {
+        editor.auth_selected_kind = None;
+    }
+    if was_secrets && editor.active_tab != EditorTab::Secrets {
+        editor.unmasked_rows.clear();
+        editor.secrets_expanded.clear();
+    }
+    true
+}
+
+fn editor_tab_at(mouse: MouseEvent) -> Option<EditorTab> {
+    if mouse.row < EDITOR_HEADER_HEIGHT
+        || mouse.row >= EDITOR_HEADER_HEIGHT.saturating_add(EDITOR_TAB_STRIP_HEIGHT)
+    {
+        return None;
+    }
+
+    let labels = [
+        (EditorTab::General, "General"),
+        (EditorTab::Mounts, "Mounts"),
+        (EditorTab::Roles, "Roles"),
+        (EditorTab::Secrets, "Environments"),
+        (EditorTab::Auth, "Auth"),
+    ];
+    let mut x = 0u16;
+    for (tab, label) in labels {
+        let width = label.len() as u16 + 2;
+        if mouse.column >= x && mouse.column < x.saturating_add(width) {
+            return Some(tab);
+        }
+        x = x.saturating_add(width + 1);
+    }
+    None
 }
 
 fn try_drag_horizontal_scrollbar(
@@ -701,8 +760,8 @@ mod mouse_drag_tests {
     //! real terminal.
     use super::{MOUSE_HORIZONTAL_SCROLL_STEP, handle_mouse, handle_mouse_with_config};
     use crate::console::manager::state::{
-        DEFAULT_SPLIT_PCT, EditorState, MAX_SPLIT_PCT, MIN_SPLIT_PCT, ManagerStage, ManagerState,
-        Modal, MountScrollFocus,
+        DEFAULT_SPLIT_PCT, EditorState, EditorTab, MAX_SPLIT_PCT, MIN_SPLIT_PCT, ManagerStage,
+        ManagerState, Modal, MountScrollFocus, SecretsScopeTag,
     };
     use crate::workspace::{MountConfig, WorkspaceConfig};
     use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -949,6 +1008,57 @@ mod mouse_drag_tests {
             row,
             modifiers: KeyModifiers::NONE,
         }
+    }
+
+    #[test]
+    fn mouse_down_on_editor_tab_selects_tab() {
+        let mut state = list_state();
+        let ws = WorkspaceConfig {
+            workdir: "/w".into(),
+            mounts: vec![],
+            ..Default::default()
+        };
+        state.stage = ManagerStage::Editor(EditorState::new_edit("x".into(), ws));
+
+        // Rendered tab spans start at x=0:
+        // " General " (0..9), space, " Mounts " (10..18), space,
+        // " Roles " (19..26), space, " Environments " (27..41).
+        handle_mouse(&mut state, mouse_down_at(33, 3), term(100));
+
+        let ManagerStage::Editor(editor) = state.stage else {
+            panic!("expected editor stage");
+        };
+        assert_eq!(editor.active_tab, EditorTab::Secrets);
+        assert!(matches!(
+            editor.active_field,
+            crate::console::manager::state::FieldFocus::Row(0)
+        ));
+    }
+
+    #[test]
+    fn mouse_down_on_editor_tab_clears_secrets_view_when_leaving() {
+        let mut state = list_state();
+        let ws = WorkspaceConfig {
+            workdir: "/w".into(),
+            mounts: vec![],
+            ..Default::default()
+        };
+        let mut editor = EditorState::new_edit("x".into(), ws);
+        editor.active_tab = EditorTab::Secrets;
+        editor
+            .unmasked_rows
+            .insert((SecretsScopeTag::Workspace, "TOKEN".to_string()));
+        editor.secrets_expanded.insert("agent-smith".to_string());
+        state.stage = ManagerStage::Editor(editor);
+
+        handle_mouse(&mut state, mouse_down_at(3, 3), term(100));
+
+        let ManagerStage::Editor(editor) = state.stage else {
+            panic!("expected editor stage");
+        };
+        assert_eq!(editor.active_tab, EditorTab::General);
+        assert!(editor.unmasked_rows.is_empty());
+        assert!(editor.secrets_expanded.is_empty());
     }
 
     #[test]

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -280,9 +280,9 @@ fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width:
 
 fn scroll_active_panel(
     state: &mut ManagerState<'_>,
-    _mouse: MouseEvent,
-    _term_size: Rect,
-    _config: Option<&crate::config::AppConfig>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
     delta: i16,
 ) {
     let apply = |value: &mut u16| {
@@ -293,6 +293,17 @@ fn scroll_active_panel(
         }
     };
     match &mut state.stage {
+        ManagerStage::List if state.list_scroll_focus.is_none() => {
+            update_scroll_focus(state, mouse, term_size, config);
+            match state.list_scroll_focus {
+                Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
+                Some(MountScrollFocus::RoleGlobal) => {
+                    apply(&mut state.list_role_global_mounts_scroll_x);
+                }
+                Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
+                None => {}
+            }
+        }
         ManagerStage::List => match state.list_scroll_focus {
             Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
             Some(MountScrollFocus::RoleGlobal) => {
@@ -301,13 +312,18 @@ fn scroll_active_panel(
             Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
             None => {}
         },
-        ManagerStage::Editor(editor) if editor.workspace_mounts_scroll_focused => {
+        ManagerStage::Editor(editor) if !editor.workspace_mounts_scroll_focused => {
+            let area = editor_scroll_area(editor, term_size);
+            if point_in(mouse, area.area) && is_scrollable(area.area, area.content_width) {
+                editor.workspace_mounts_scroll_focused = true;
+                apply(&mut editor.workspace_mounts_scroll_x);
+            }
+        }
+        ManagerStage::Editor(editor) => {
             apply(&mut editor.workspace_mounts_scroll_x);
         }
         ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
-        ManagerStage::Editor(_)
-        | ManagerStage::CreatePrelude(_)
-        | ManagerStage::ConfirmDelete { .. } => {}
+        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
     }
 }
 
@@ -330,10 +346,22 @@ fn list_scroll_areas(
     let right_w = term_size.width.saturating_sub(seam_x);
     let body_y = LIST_HEADER_HEIGHT;
     let mounts_h = mount_block_height(workspace.mounts.as_slice());
-    let global_rows = match config.workspace_applicable_mount_rows(workspace) {
-        crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => rows,
-        crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => Vec::new(),
-    };
+    let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
+        picker
+            .list_state
+            .selected
+            .and_then(|idx| picker.filtered.get(idx).cloned())
+    });
+    let global_rows = picker_role.as_ref().map_or_else(
+        || {
+            config
+                .list_mount_rows()
+                .into_iter()
+                .filter(|row| row.scope.is_none())
+                .collect()
+        },
+        |role| config.resolve_mount_rows(role),
+    );
     let global_mounts: Vec<crate::workspace::MountConfig> = global_rows
         .iter()
         .filter(|row| row.scope.is_none())
@@ -344,10 +372,10 @@ fn list_scroll_areas(
         .filter(|row| row.scope.is_some())
         .map(|row| row.mount.clone())
         .collect();
-    let global_h = if !global_mounts.is_empty() || role_global_mounts.is_empty() {
-        mount_block_height(global_mounts.as_slice())
-    } else {
+    let global_h = if global_mounts.is_empty() {
         0
+    } else {
+        mount_block_height(global_mounts.as_slice())
     };
     let role_global_h = if role_global_mounts.is_empty() {
         0

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -146,7 +146,7 @@ pub fn handle_mouse_with_config(
                 state.inline_role_picker = None;
                 let selected = row.to_screen_index(state.workspaces.len());
                 if selected != state.selected {
-                    super::list::reset_list_mount_scroll(state);
+                    state.reset_list_scroll();
                     state.selected = selected;
                     state.inline_agent_picker = None;
                 }

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -27,7 +27,7 @@ const LIST_HEADER_HEIGHT: u16 = 3;
 /// Height of the footer chunk in the list-view chrome. Mirrors
 /// `Constraint::Length(2)` in `render::render`.
 const LIST_FOOTER_HEIGHT: u16 = 2;
-const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 4;
+const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 1;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
 /// the mouse-draggable seam between the list pane and the details pane.

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -27,7 +27,7 @@ const LIST_HEADER_HEIGHT: u16 = 3;
 /// Height of the footer chunk in the list-view chrome. Mirrors
 /// `Constraint::Length(2)` in `render::render`.
 const LIST_FOOTER_HEIGHT: u16 = 2;
-const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 8;
+const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 4;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
 /// the mouse-draggable seam between the list pane and the details pane.
@@ -127,7 +127,11 @@ pub fn handle_mouse_with_config(
             // the list pane's content area (excluding borders).
             if let Some(row) = list_content_row_index(state, mouse, term_size, seam_x) {
                 state.inline_role_picker = None;
-                state.selected = row.to_screen_index(state.workspaces.len());
+                let selected = row.to_screen_index(state.workspaces.len());
+                if selected != state.selected {
+                    reset_list_mount_scroll(state);
+                    state.selected = selected;
+                }
             }
         }
         MouseEventKind::Drag(MouseButton::Left) => {
@@ -526,6 +530,13 @@ fn current_dir_mount(state: &ManagerState<'_>) -> crate::workspace::MountConfig 
         readonly: false,
         isolation: crate::isolation::MountIsolation::Shared,
     }
+}
+
+const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
+    state.list_mounts_scroll_x = 0;
+    state.list_global_mounts_scroll_x = 0;
+    state.list_role_global_mounts_scroll_x = 0;
+    state.list_scroll_focus = None;
 }
 
 fn editor_scroll_area(

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -100,6 +100,12 @@ pub fn handle_mouse_with_config(
         _ => {}
     }
 
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+        && try_select_editor_mount_row(state, mouse, term_size)
+    {
+        return;
+    }
+
     // Editor / CreatePrelude file-browser URL click: only on Down(Left),
     // only when the modal is a FileBrowser with a resolved git URL.
     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
@@ -205,6 +211,68 @@ fn editor_tab_at(mouse: MouseEvent) -> Option<EditorTab> {
         x = x.saturating_add(width + 1);
     }
     None
+}
+
+fn try_select_editor_mount_row(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+) -> bool {
+    let ManagerStage::Editor(editor) = &mut state.stage else {
+        return false;
+    };
+    if editor.active_tab != EditorTab::Mounts || editor.modal.is_some() {
+        return false;
+    }
+
+    let area = editor_scroll_area(editor, term_size).area;
+    if mouse.column <= area.x
+        || mouse.column >= area.x.saturating_add(area.width).saturating_sub(1)
+        || mouse.row <= area.y
+        || mouse.row >= area.y.saturating_add(area.height).saturating_sub(1)
+    {
+        return false;
+    }
+
+    let row = usize::from(mouse.row.saturating_sub(area.y + 1));
+    let Some(index) = editor_mount_index_at_visual_row(editor, row) else {
+        return false;
+    };
+    editor.active_field = FieldFocus::Row(index);
+    editor.workspace_mounts_scroll_focused = true;
+    true
+}
+
+fn editor_mount_index_at_visual_row(
+    editor: &super::super::state::EditorState<'_>,
+    row: usize,
+) -> Option<usize> {
+    if row == 0 {
+        return None;
+    }
+
+    let mut visual = 1usize;
+    for (index, mount) in editor.pending.mounts.iter().enumerate() {
+        if row == visual {
+            return Some(index);
+        }
+        visual += 1;
+        if mount.src != mount.dst {
+            if row == visual {
+                return Some(index);
+            }
+            visual += 1;
+        }
+    }
+
+    if !editor.pending.mounts.is_empty() {
+        if row == visual {
+            return None;
+        }
+        visual += 1;
+    }
+
+    (row == visual).then_some(editor.pending.mounts.len())
 }
 
 fn try_drag_horizontal_scrollbar(
@@ -770,8 +838,8 @@ mod mouse_drag_tests {
     //! real terminal.
     use super::{MOUSE_HORIZONTAL_SCROLL_STEP, handle_mouse, handle_mouse_with_config};
     use crate::console::manager::state::{
-        DEFAULT_SPLIT_PCT, EditorState, EditorTab, MAX_SPLIT_PCT, MIN_SPLIT_PCT, ManagerStage,
-        ManagerState, Modal, MountScrollFocus, SecretsScopeTag,
+        DEFAULT_SPLIT_PCT, EditorState, EditorTab, FieldFocus, MAX_SPLIT_PCT, MIN_SPLIT_PCT,
+        ManagerStage, ManagerState, Modal, MountScrollFocus, SecretsScopeTag,
     };
     use crate::workspace::{MountConfig, WorkspaceConfig};
     use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -1679,5 +1747,71 @@ mod mouse_drag_tests {
             editor.workspace_mounts_scroll_x,
             MOUSE_HORIZONTAL_SCROLL_STEP
         );
+    }
+
+    #[test]
+    fn editor_mounts_tab_click_full_row_width_selects_mount() {
+        let mut state = list_state();
+        let ws = WorkspaceConfig {
+            workdir: "/w".into(),
+            mounts: vec![
+                MountConfig {
+                    src: "/host/one".into(),
+                    dst: "/host/one".into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+                MountConfig {
+                    src: "/host/two".into(),
+                    dst: "/host/two".into(),
+                    readonly: true,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                },
+            ],
+            ..Default::default()
+        };
+        let mut editor = EditorState::new_edit("x".into(), ws);
+        editor.active_tab = EditorTab::Mounts;
+        editor.active_field = FieldFocus::Row(0);
+        state.stage = ManagerStage::Editor(editor);
+
+        // Mounts editor body begins at y=5. Interior row y=6 is the
+        // header, y=7 is mount 0, y=8 is mount 1. Click far to the
+        // right in whitespace on mount 1's row, not on the path text.
+        handle_mouse_with_config(&mut state, mouse_at(95, 8), term(100), None);
+
+        let ManagerStage::Editor(editor) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(matches!(editor.active_field, FieldFocus::Row(1)));
+        assert!(editor.workspace_mounts_scroll_focused);
+    }
+
+    #[test]
+    fn editor_mounts_tab_click_host_source_continuation_selects_parent_mount() {
+        let mut state = list_state();
+        let ws = WorkspaceConfig {
+            workdir: "/w".into(),
+            mounts: vec![MountConfig {
+                src: "/host/source".into(),
+                dst: "/container/destination".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }],
+            ..Default::default()
+        };
+        let mut editor = EditorState::new_edit("x".into(), ws);
+        editor.active_tab = EditorTab::Mounts;
+        editor.active_field = FieldFocus::Row(editor.pending.mounts.len());
+        state.stage = ManagerStage::Editor(editor);
+
+        // y=8 is the host-source continuation line for the first mount.
+        handle_mouse_with_config(&mut state, mouse_at(95, 8), term(100), None);
+
+        let ManagerStage::Editor(editor) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(matches!(editor.active_field, FieldFocus::Row(0)));
+        assert!(editor.workspace_mounts_scroll_focused);
     }
 }

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -1,7 +1,7 @@
 //! Mouse event handling for the workspace manager: list/details seam drag,
 //! click-to-select in the list pane, and `FileBrowser` URL-click fallthrough.
 
-use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
@@ -27,7 +27,7 @@ const LIST_HEADER_HEIGHT: u16 = 3;
 /// Height of the footer chunk in the list-view chrome. Mirrors
 /// `Constraint::Length(2)` in `render::render`.
 const LIST_FOOTER_HEIGHT: u16 = 2;
-const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 4;
+const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 8;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
 /// the mouse-draggable seam between the list pane and the details pane.
@@ -69,7 +69,7 @@ pub fn handle_mouse_with_config(
         {
             return;
         }
-        MouseEventKind::ScrollLeft => {
+        MouseEventKind::ScrollLeft | MouseEventKind::ScrollUp => {
             scroll_active_panel(
                 state,
                 mouse,
@@ -79,27 +79,7 @@ pub fn handle_mouse_with_config(
             );
             return;
         }
-        MouseEventKind::ScrollRight => {
-            scroll_active_panel(
-                state,
-                mouse,
-                term_size,
-                config,
-                MOUSE_HORIZONTAL_SCROLL_STEP as i16,
-            );
-            return;
-        }
-        MouseEventKind::ScrollUp if mouse.modifiers.contains(KeyModifiers::SHIFT) => {
-            scroll_active_panel(
-                state,
-                mouse,
-                term_size,
-                config,
-                -(MOUSE_HORIZONTAL_SCROLL_STEP as i16),
-            );
-            return;
-        }
-        MouseEventKind::ScrollDown if mouse.modifiers.contains(KeyModifiers::SHIFT) => {
+        MouseEventKind::ScrollRight | MouseEventKind::ScrollDown => {
             scroll_active_panel(
                 state,
                 mouse,
@@ -393,10 +373,11 @@ fn scroll_active_panel(
 
 fn apply_horizontal_scroll(value: &mut u16, delta: i16, area: Rect, content_width: usize) {
     let max = max_scroll_offset(area, content_width);
+    let current = (*value).min(max);
     let next = if delta.is_negative() {
-        value.saturating_sub(delta.unsigned_abs())
+        current.saturating_sub(delta.unsigned_abs())
     } else {
-        value.saturating_add(delta as u16)
+        current.saturating_add(delta as u16)
     };
     *value = next.min(max);
 }
@@ -475,7 +456,9 @@ fn list_scroll_areas(
                 width: right_w,
                 height: mounts_h,
             },
-            content_width: mount_rows_content_width(workspace.mounts.as_slice()),
+            content_width: super::super::render::list::workspace_mounts_content_width(
+                workspace.mounts.as_slice(),
+            ),
         },
         global: ScrollArea {
             area: Rect {
@@ -484,7 +467,9 @@ fn list_scroll_areas(
                 width: right_w,
                 height: global_h,
             },
-            content_width: global_mount_configs_content_width(global_mounts.as_slice()),
+            content_width: super::super::render::list::global_mounts_content_width(
+                global_mounts.as_slice(),
+            ),
         },
         role_global: (role_global_h > 0).then(|| ScrollArea {
             area: Rect {
@@ -493,7 +478,9 @@ fn list_scroll_areas(
                 width: right_w,
                 height: role_global_h,
             },
-            content_width: global_mount_configs_content_width(role_global_mounts.as_slice()),
+            content_width: super::super::render::list::global_mounts_content_width(
+                role_global_mounts.as_slice(),
+            ),
         }),
     })
 }
@@ -514,7 +501,9 @@ fn editor_scroll_area(
             width: term_size.width,
             height: (rows as u16 + 2).min(body_h.max(4)),
         },
-        content_width: mount_rows_content_width(editor.pending.mounts.as_slice()),
+        content_width: super::super::render::list::workspace_mounts_content_width(
+            editor.pending.mounts.as_slice(),
+        ),
     }
 }
 
@@ -530,53 +519,8 @@ fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
     (data_rows + 3).min(12) as u16
 }
 
-fn mount_rows_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
-    let header = "  Destination  Mode  Isolation  Type".len();
-    mounts
-        .iter()
-        .map(|mount| {
-            let dst = crate::tui::shorten_home(&mount.dst);
-            let src = crate::tui::shorten_home(&mount.src);
-            let path_width = if mount.src == mount.dst {
-                dst.chars().count()
-            } else {
-                dst.chars()
-                    .count()
-                    .max(src.chars().count() + "host: ".len())
-            };
-            let kind_width = super::super::mount_info::inspect(&mount.src)
-                .label()
-                .chars()
-                .count();
-            2 + path_width
-                + "  ".len()
-                + "rw".len()
-                + "  ".len()
-                + "worktree".len()
-                + "  ".len()
-                + kind_width
-        })
-        .max()
-        .unwrap_or(header)
-        .max(header)
-}
-
 fn global_mount_configs_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
-    let header = "  Destination  Mode".len();
-    mounts
-        .iter()
-        .map(|mount| {
-            let dst = crate::tui::shorten_home(&mount.dst);
-            let src = crate::tui::shorten_home(&mount.src);
-            let path_width = dst
-                .chars()
-                .count()
-                .max(src.chars().count() + "host: ".len());
-            2 + path_width + "  ".len() + "rw".len()
-        })
-        .max()
-        .unwrap_or(header)
-        .max(header)
+    super::super::render::list::global_mounts_content_width(mounts)
 }
 
 fn global_mount_rows_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
@@ -1143,6 +1087,24 @@ mod mouse_drag_tests {
         state
     }
 
+    fn config_with_long_git_type_mount(source: &std::path::Path) -> crate::config::AppConfig {
+        let mut config = crate::config::AppConfig::default();
+        config.workspaces.insert(
+            "demo".into(),
+            WorkspaceConfig {
+                workdir: "/workspace/demo".into(),
+                mounts: vec![MountConfig {
+                    src: source.display().to_string(),
+                    dst: source.display().to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                }],
+                ..Default::default()
+            },
+        );
+        config
+    }
+
     #[test]
     fn click_on_first_row_sets_selected_to_zero() {
         // y=4 = first list item (index 0, "Current directory").
@@ -1314,7 +1276,7 @@ mod mouse_drag_tests {
     }
 
     #[test]
-    fn plain_vertical_mouse_wheel_does_not_change_horizontal_scroll() {
+    fn plain_vertical_mouse_wheel_scrolls_horizontally_over_mount_block() {
         let config = config_with_scrollable_workspace_and_global_mounts();
         let mut state = selected_demo_state(&config);
 
@@ -1325,8 +1287,20 @@ mod mouse_drag_tests {
             Some(&config),
         );
 
+        assert_eq!(
+            state.list_global_mounts_scroll_x,
+            MOUSE_HORIZONTAL_SCROLL_STEP
+        );
+        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollUp, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
         assert_eq!(state.list_global_mounts_scroll_x, 0);
-        assert_eq!(state.list_scroll_focus, None);
     }
 
     #[test]
@@ -1372,6 +1346,84 @@ mod mouse_drag_tests {
             state.list_global_mounts_scroll_x,
             expected_max.saturating_sub(MOUSE_HORIZONTAL_SCROLL_STEP),
             "left-scroll after overscrolling right must move immediately, not burn hidden offset"
+        );
+    }
+
+    #[test]
+    fn horizontal_mouse_wheel_reaches_rendered_workspace_width() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        std::fs::write(
+            repo.join(".git").join("HEAD"),
+            "ref: refs/heads/feat/backend-rust-gdpr-purge-normalization\n",
+        )
+        .unwrap();
+        let config = config_with_long_git_type_mount(&repo);
+        let mut state = selected_demo_state(&config);
+
+        for _ in 0..100 {
+            handle_mouse_with_config(
+                &mut state,
+                mouse_kind_at(MouseEventKind::ScrollDown, 31, 7),
+                term(100),
+                Some(&config),
+            );
+        }
+
+        let workspace = config.workspaces.get("demo").unwrap();
+        let expected_max = super::max_scroll_offset(
+            Rect {
+                x: 30,
+                y: 6,
+                width: 70,
+                height: 4,
+            },
+            super::super::super::render::list::workspace_mounts_content_width(
+                workspace.mounts.as_slice(),
+            ),
+        );
+
+        assert_eq!(
+            state.list_mounts_scroll_x, expected_max,
+            "mouse/touch scroll must clamp at the same rendered width keyboard scrolling reaches"
+        );
+    }
+
+    #[test]
+    fn horizontal_mouse_wheel_clamps_before_applying_left_delta() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+        state.list_global_mounts_scroll_x = u16::MAX;
+
+        let global_mounts: Vec<MountConfig> = config
+            .list_mount_rows()
+            .into_iter()
+            .filter(|row| row.scope.is_none())
+            .map(|row| row.mount)
+            .collect();
+        let global_area = Rect {
+            x: 30,
+            y: 11,
+            width: 70,
+            height: 5,
+        };
+        let expected_max = super::max_scroll_offset(
+            global_area,
+            super::global_mount_configs_content_width(global_mounts.as_slice()),
+        );
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollLeft, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(
+            state.list_global_mounts_scroll_x,
+            expected_max.saturating_sub(MOUSE_HORIZONTAL_SCROLL_STEP),
+            "left-scroll must first clamp stale resize/overscroll state, then move left"
         );
     }
 

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -6,7 +6,8 @@ use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
 use super::super::state::{
-    DragState, ManagerListRow, ManagerStage, ManagerState, Modal, MountScrollFocus, clamp_split,
+    DragState, EditorTab, ManagerListRow, ManagerStage, ManagerState, Modal, MountScrollFocus,
+    clamp_split,
 };
 
 /// Minimum terminal width (in columns) at which the list/details seam is
@@ -232,6 +233,10 @@ fn update_scroll_focus(
             };
         }
         ManagerStage::Editor(editor) => {
+            if editor.active_tab != EditorTab::Mounts {
+                editor.workspace_mounts_scroll_focused = false;
+                return;
+            }
             let area = editor_scroll_area(editor, term_size);
             editor.workspace_mounts_scroll_focused =
                 point_in(mouse, area.area) && is_scrollable(area.area, area.content_width);
@@ -293,7 +298,7 @@ fn scroll_active_panel(
         }
     };
     match &mut state.stage {
-        ManagerStage::List if state.list_scroll_focus.is_none() => {
+        ManagerStage::List => {
             update_scroll_focus(state, mouse, term_size, config);
             match state.list_scroll_focus {
                 Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
@@ -304,23 +309,18 @@ fn scroll_active_panel(
                 None => {}
             }
         }
-        ManagerStage::List => match state.list_scroll_focus {
-            Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
-            Some(MountScrollFocus::RoleGlobal) => {
-                apply(&mut state.list_role_global_mounts_scroll_x);
+        ManagerStage::Editor(editor) => {
+            if editor.active_tab != EditorTab::Mounts {
+                editor.workspace_mounts_scroll_focused = false;
+                return;
             }
-            Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
-            None => {}
-        },
-        ManagerStage::Editor(editor) if !editor.workspace_mounts_scroll_focused => {
             let area = editor_scroll_area(editor, term_size);
             if point_in(mouse, area.area) && is_scrollable(area.area, area.content_width) {
                 editor.workspace_mounts_scroll_focused = true;
                 apply(&mut editor.workspace_mounts_scroll_x);
+            } else {
+                editor.workspace_mounts_scroll_focused = false;
             }
-        }
-        ManagerStage::Editor(editor) => {
-            apply(&mut editor.workspace_mounts_scroll_x);
         }
         ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
@@ -616,10 +616,10 @@ mod mouse_drag_tests {
     //! These build `MouseEvent` values directly and bypass the ratatui
     //! event loop — enough to pin the seam hit-test + drag math without a
     //! real terminal.
-    use super::handle_mouse;
+    use super::{handle_mouse, handle_mouse_with_config};
     use crate::console::manager::state::{
         DEFAULT_SPLIT_PCT, EditorState, MAX_SPLIT_PCT, MIN_SPLIT_PCT, ManagerStage, ManagerState,
-        Modal,
+        Modal, MountScrollFocus,
     };
     use crate::workspace::{MountConfig, WorkspaceConfig};
     use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -979,6 +979,15 @@ mod mouse_drag_tests {
         }
     }
 
+    const fn mouse_kind_at(kind: MouseEventKind, col: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
     /// Build a list state with `n` saved workspaces (row 0 + n + spacer + sentinel).
     fn list_state_with_saved(n: usize) -> ManagerState<'static> {
         let mut config = crate::config::AppConfig::default();
@@ -994,6 +1003,45 @@ mod mouse_drag_tests {
         }
         let tmp = tempfile::tempdir().unwrap();
         ManagerState::from_config(&config, tmp.path())
+    }
+
+    fn config_with_scrollable_workspace_and_global_mounts() -> crate::config::AppConfig {
+        let mut config = crate::config::AppConfig::default();
+        config.workspaces.insert(
+            "demo".into(),
+            WorkspaceConfig {
+                workdir: "/workspace/demo".into(),
+                mounts: vec![MountConfig {
+                    src: "/host/source/with/a/very/long/path/that/forces/workspace/mount/scrolling"
+                        .into(),
+                    dst: "/container/destination/with/a/very/long/path/that/forces/workspace/mount/scrolling"
+                        .into(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                }],
+                ..Default::default()
+            },
+        );
+        config.add_mount(
+            "global-long",
+            MountConfig {
+                src: "/host/source/with/a/very/long/path/that/forces/global/mount/scrolling"
+                    .into(),
+                dst: "/container/destination/with/a/very/long/path/that/forces/global/mount/scrolling"
+                    .into(),
+                readonly: true,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            None,
+        );
+        config
+    }
+
+    fn selected_demo_state(config: &crate::config::AppConfig) -> ManagerState<'static> {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = ManagerState::from_config(config, tmp.path());
+        state.selected = 1;
+        state
     }
 
     #[test]
@@ -1088,5 +1136,95 @@ mod mouse_drag_tests {
             state.selected, 0,
             "seam-click must not change selection even when y lands on a list row"
         );
+    }
+
+    #[test]
+    fn click_scrollable_mount_block_focuses_it() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+
+        // Right pane starts at x=30 for a 100-col terminal. Workspace mounts
+        // block starts at y=6 after General's 3 rows.
+        handle_mouse_with_config(&mut state, mouse_at(31, 7), term(100), Some(&config));
+
+        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Workspace));
+    }
+
+    #[test]
+    fn click_non_scrollable_area_clears_mount_focus() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+        state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+
+        // y=4 is inside the General block, which is not a horizontal-scroll
+        // target.
+        handle_mouse_with_config(&mut state, mouse_at(31, 4), term(100), Some(&config));
+
+        assert_eq!(state.list_scroll_focus, None);
+    }
+
+    #[test]
+    fn horizontal_mouse_wheel_scrolls_block_under_pointer() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+        state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+
+        // Global mounts block starts immediately after General (3 rows) and
+        // the one-mount Workspace mounts block (5 rows): y=11.
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollRight, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(state.list_mounts_scroll_x, 0);
+        assert_eq!(state.list_global_mounts_scroll_x, 8);
+        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
+    }
+
+    #[test]
+    fn editor_mounts_tab_horizontal_wheel_requires_mounts_tab() {
+        let mut state = list_state();
+        let ws = WorkspaceConfig {
+            workdir: "/w".into(),
+            mounts: vec![MountConfig {
+                src: "/host/source/with/a/very/long/path/that/forces/editor/mount/scrolling"
+                    .into(),
+                dst: "/container/destination/with/a/very/long/path/that/forces/editor/mount/scrolling"
+                    .into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }],
+            ..Default::default()
+        };
+        let mut editor = EditorState::new_edit("x".into(), ws);
+        editor.active_tab = crate::console::manager::state::EditorTab::Mounts;
+        state.stage = ManagerStage::Editor(editor);
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollRight, 10, 6),
+            term(100),
+            None,
+        );
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(editor.workspace_mounts_scroll_focused);
+        assert_eq!(editor.workspace_mounts_scroll_x, 8);
+
+        editor.active_tab = crate::console::manager::state::EditorTab::General;
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollRight, 10, 6),
+            term(100),
+            None,
+        );
+        let ManagerStage::Editor(editor) = &state.stage else {
+            panic!("editor stage expected");
+        };
+        assert!(!editor.workspace_mounts_scroll_focused);
+        assert_eq!(editor.workspace_mounts_scroll_x, 8);
     }
 }

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -44,17 +44,31 @@ const LIST_FOOTER_HEIGHT: u16 = 2;
 /// passing the current `terminal.size()?` as `term_size` so the handler
 /// can compute the seam column as `term_size.width * list_split_pct / 100`.
 pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: Rect) {
+    handle_mouse_with_config(state, mouse, term_size, None);
+}
+
+pub fn handle_mouse_with_config(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+) {
     if term_size.width < MIN_DRAGGABLE_WIDTH {
         return;
     }
 
     match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left)
+            if try_drag_horizontal_scrollbar(state, mouse, term_size, config) =>
+        {
+            return;
+        }
         MouseEventKind::ScrollLeft => {
-            scroll_active_panel(state, -8);
+            scroll_active_panel(state, mouse, term_size, config, -8);
             return;
         }
         MouseEventKind::ScrollRight => {
-            scroll_active_panel(state, 8);
+            scroll_active_panel(state, mouse, term_size, config, 8);
             return;
         }
         _ => {}
@@ -111,7 +125,97 @@ pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: 
     }
 }
 
-fn scroll_active_panel(state: &mut ManagerState<'_>, delta: i16) {
+fn try_drag_horizontal_scrollbar(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+) -> bool {
+    match &mut state.stage {
+        ManagerStage::List => {
+            let Some((mounts, global)) = list_scroll_areas(state, term_size, config) else {
+                return false;
+            };
+            if drag_scrollbar(
+                &mut state.list_mounts_scroll_x,
+                mouse,
+                mounts.area,
+                mounts.content_width,
+            ) {
+                return true;
+            }
+            drag_scrollbar(
+                &mut state.list_global_mounts_scroll_x,
+                mouse,
+                global.area,
+                global.content_width,
+            )
+        }
+        ManagerStage::Editor(editor) => {
+            let (workspace, global) = editor_scroll_areas(editor, term_size);
+            if drag_scrollbar(
+                &mut editor.workspace_mounts_scroll_x,
+                mouse,
+                workspace.area,
+                workspace.content_width,
+            ) {
+                return true;
+            }
+            drag_scrollbar(
+                &mut editor.global_mounts_scroll_x,
+                mouse,
+                global.area,
+                global.content_width,
+            )
+        }
+        ManagerStage::GlobalMounts(global) => drag_scrollbar(
+            &mut global.scroll_x,
+            mouse,
+            Rect {
+                x: 0,
+                y: LIST_HEADER_HEIGHT,
+                width: term_size.width,
+                height: term_size
+                    .height
+                    .saturating_sub(LIST_HEADER_HEIGHT + LIST_FOOTER_HEIGHT),
+            },
+            global_mount_rows_content_width(&global.pending),
+        ),
+        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => false,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ScrollArea {
+    area: Rect,
+    content_width: usize,
+}
+
+fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width: usize) -> bool {
+    let viewport = area.width.saturating_sub(2) as usize;
+    if viewport == 0 || content_width <= viewport {
+        return false;
+    }
+    let scrollbar_y = area.y + area.height.saturating_sub(1);
+    let start_x = area.x + 1;
+    let end_x = area.x + area.width.saturating_sub(2);
+    if mouse.row != scrollbar_y || mouse.column < start_x || mouse.column > end_x {
+        return false;
+    }
+    let max_position = content_width.saturating_sub(viewport);
+    let track = usize::from(end_x.saturating_sub(start_x)).max(1);
+    let rel = usize::from(mouse.column.saturating_sub(start_x));
+    *value = ((max_position * rel) / track).min(usize::from(u16::MAX)) as u16;
+    true
+}
+
+fn scroll_active_panel(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+    delta: i16,
+) {
     let apply = |value: &mut u16| {
         if delta.is_negative() {
             *value = value.saturating_sub(delta.unsigned_abs());
@@ -120,11 +224,171 @@ fn scroll_active_panel(state: &mut ManagerState<'_>, delta: i16) {
         }
     };
     match &mut state.stage {
-        ManagerStage::List => apply(&mut state.list_scroll_x),
-        ManagerStage::Editor(editor) => apply(&mut editor.scroll_x),
+        ManagerStage::List => match list_scroll_target(state, mouse, term_size, config) {
+            ScrollTarget::GlobalMounts => apply(&mut state.list_global_mounts_scroll_x),
+            ScrollTarget::Mounts => apply(&mut state.list_mounts_scroll_x),
+        },
+        ManagerStage::Editor(editor) => match editor_scroll_target(editor, mouse, term_size) {
+            ScrollTarget::GlobalMounts => apply(&mut editor.global_mounts_scroll_x),
+            ScrollTarget::Mounts => apply(&mut editor.workspace_mounts_scroll_x),
+        },
         ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
     }
+}
+
+#[derive(Clone, Copy)]
+enum ScrollTarget {
+    Mounts,
+    GlobalMounts,
+}
+
+fn list_scroll_target(
+    state: &ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+) -> ScrollTarget {
+    let Some((_, global)) = list_scroll_areas(state, term_size, config) else {
+        return ScrollTarget::Mounts;
+    };
+    if mouse.column > seam_column(state.list_split_pct, term_size.width)
+        && mouse.row >= global.area.y
+    {
+        ScrollTarget::GlobalMounts
+    } else {
+        ScrollTarget::Mounts
+    }
+}
+
+fn editor_scroll_target(
+    editor: &super::super::state::EditorState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+) -> ScrollTarget {
+    if editor.active_tab != super::super::state::EditorTab::Mounts {
+        return ScrollTarget::Mounts;
+    }
+    let (_, global) = editor_scroll_areas(editor, term_size);
+    if mouse.row >= global.area.y {
+        ScrollTarget::GlobalMounts
+    } else {
+        ScrollTarget::Mounts
+    }
+}
+
+fn list_scroll_areas(
+    state: &ManagerState<'_>,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+) -> Option<(ScrollArea, ScrollArea)> {
+    let config = config?;
+    let summary = state.selected_workspace_summary()?;
+    let workspace = config.workspaces.get(&summary.name)?;
+    let seam_x = seam_column(state.list_split_pct, term_size.width);
+    let right_x = seam_x;
+    let right_w = term_size.width.saturating_sub(seam_x);
+    let body_y = LIST_HEADER_HEIGHT;
+    let mounts_h = mount_block_height(workspace.mounts.as_slice());
+    let global_rows = match config.workspace_applicable_mount_rows(workspace) {
+        crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => rows,
+        crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => Vec::new(),
+    };
+    let global_mounts: Vec<crate::workspace::MountConfig> =
+        global_rows.iter().map(|row| row.mount.clone()).collect();
+    let global_h = mount_block_height(global_mounts.as_slice());
+    Some((
+        ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: body_y + 3,
+                width: right_w,
+                height: mounts_h,
+            },
+            content_width: mount_rows_content_width(workspace.mounts.as_slice()),
+        },
+        ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: body_y + 3 + mounts_h,
+                width: right_w,
+                height: global_h,
+            },
+            content_width: mount_rows_content_width(global_mounts.as_slice()),
+        },
+    ))
+}
+
+fn editor_scroll_areas(
+    editor: &super::super::state::EditorState<'_>,
+    term_size: Rect,
+) -> (ScrollArea, ScrollArea) {
+    let body_y = 5;
+    let body_h = term_size.height.saturating_sub(7);
+    let workspace_rows = editor.pending.mounts.iter().fold(1usize, |acc, mount| {
+        acc + if mount.src == mount.dst { 1 } else { 2 }
+    }) + 2;
+    let workspace_h = (workspace_rows as u16 + 2).min(body_h.saturating_sub(4).max(4));
+    (
+        ScrollArea {
+            area: Rect {
+                x: 0,
+                y: body_y,
+                width: term_size.width,
+                height: workspace_h,
+            },
+            content_width: mount_rows_content_width(editor.pending.mounts.as_slice()),
+        },
+        ScrollArea {
+            area: Rect {
+                x: 0,
+                y: body_y + workspace_h,
+                width: term_size.width,
+                height: body_h.saturating_sub(workspace_h),
+            },
+            content_width: 160,
+        },
+    )
+}
+
+fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
+    let data_rows: usize = if mounts.is_empty() {
+        1
+    } else {
+        mounts
+            .iter()
+            .map(|mount| if mount.src == mount.dst { 1 } else { 2 })
+            .sum()
+    };
+    (data_rows + 3).min(12) as u16
+}
+
+fn mount_rows_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
+    let header = "  Destination  Mode  Isolation  Type".len();
+    mounts
+        .iter()
+        .map(|mount| {
+            let dst = crate::tui::shorten_home(&mount.dst);
+            let src = crate::tui::shorten_home(&mount.src);
+            let path_width = if mount.src == mount.dst {
+                dst.chars().count()
+            } else {
+                dst.chars()
+                    .count()
+                    .max(src.chars().count() + "host: ".len())
+            };
+            path_width + "  rw    worktree   ".len() + 24
+        })
+        .max()
+        .unwrap_or(header)
+        .max(header)
+}
+
+fn global_mount_rows_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
+    rows.iter()
+        .map(|row| mount_rows_content_width(std::slice::from_ref(&row.mount)))
+        .max()
+        .unwrap_or("  Name                 Destination                    Mode Scope Type".len())
 }
 
 /// If the `Editor` or `CreatePrelude` stage has an open `FileBrowser`

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -139,6 +139,7 @@ pub fn handle_mouse_with_config(
                 if selected != state.selected {
                     reset_list_mount_scroll(state);
                     state.selected = selected;
+                    state.inline_agent_picker = None;
                 }
             }
         }
@@ -478,12 +479,21 @@ fn list_scroll_areas(
     let summary = state.selected_workspace_summary()?;
     let workspace = config.workspaces.get(&summary.name)?;
     let mounts_h = mount_block_height(workspace.mounts.as_slice());
-    let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
-        picker
-            .list_state
-            .selected
-            .and_then(|idx| picker.filtered.get(idx).cloned())
-    });
+    let picker_role = state
+        .inline_role_picker
+        .as_ref()
+        .and_then(|picker| {
+            picker
+                .list_state
+                .selected
+                .and_then(|idx| picker.filtered.get(idx).cloned())
+        })
+        .or_else(|| {
+            state
+                .inline_agent_picker
+                .as_ref()
+                .map(|(role, _)| role.clone())
+        });
     let global_rows = picker_role.as_ref().map_or_else(
         || {
             config

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -48,6 +48,18 @@ pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: 
         return;
     }
 
+    match mouse.kind {
+        MouseEventKind::ScrollLeft => {
+            scroll_active_panel(state, -8);
+            return;
+        }
+        MouseEventKind::ScrollRight => {
+            scroll_active_panel(state, 8);
+            return;
+        }
+        _ => {}
+    }
+
     // Editor / CreatePrelude file-browser URL click: only on Down(Left),
     // only when the modal is a FileBrowser with a resolved git URL.
     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
@@ -82,6 +94,7 @@ pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: 
             // Otherwise, treat as click-to-select if the click lands inside
             // the list pane's content area (excluding borders).
             if let Some(row) = list_content_row_index(state, mouse, term_size, seam_x) {
+                state.inline_role_picker = None;
                 state.selected = row.to_screen_index(state.workspaces.len());
             }
         }
@@ -95,6 +108,22 @@ pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: 
             state.drag_state = None;
         }
         _ => {}
+    }
+}
+
+fn scroll_active_panel(state: &mut ManagerState<'_>, delta: i16) {
+    let apply = |value: &mut u16| {
+        if delta.is_negative() {
+            *value = value.saturating_sub(delta.unsigned_abs());
+        } else {
+            *value = value.saturating_add(delta as u16);
+        }
+    };
+    match &mut state.stage {
+        ManagerStage::List => apply(&mut state.list_scroll_x),
+        ManagerStage::Editor(editor) => apply(&mut editor.scroll_x),
+        ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
+        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
     }
 }
 

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -5,6 +5,9 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
+use super::super::render::list::{
+    global_mounts_content_width, mount_block_height, workspace_mounts_content_width,
+};
 use super::super::state::{
     DragState, EditorTab, FieldFocus, ManagerListRow, ManagerStage, ManagerState, Modal,
     MountScrollFocus, clamp_split,
@@ -143,7 +146,7 @@ pub fn handle_mouse_with_config(
                 state.inline_role_picker = None;
                 let selected = row.to_screen_index(state.workspaces.len());
                 if selected != state.selected {
-                    reset_list_mount_scroll(state);
+                    super::list::reset_list_mount_scroll(state);
                     state.selected = selected;
                     state.inline_agent_picker = None;
                 }
@@ -195,15 +198,8 @@ fn editor_tab_at(mouse: MouseEvent) -> Option<EditorTab> {
         return None;
     }
 
-    let labels = [
-        (EditorTab::General, "General"),
-        (EditorTab::Mounts, "Mounts"),
-        (EditorTab::Roles, "Roles"),
-        (EditorTab::Secrets, "Environments"),
-        (EditorTab::Auth, "Auth"),
-    ];
     let mut x = 0u16;
-    for (tab, label) in labels {
+    for &(tab, label) in super::super::render::editor::EDITOR_TAB_LABELS {
         let width = label.len() as u16 + 2;
         if mouse.column >= x && mouse.column < x.saturating_add(width) {
             return Some(tab);
@@ -442,31 +438,23 @@ fn scroll_active_panel(
                 state.list_scroll_focus = None;
                 return;
             };
-            match state.list_scroll_focus {
-                Some(MountScrollFocus::Global) => apply_horizontal_scroll(
-                    &mut state.list_global_mounts_scroll_x,
-                    delta,
-                    areas.global.area,
-                    areas.global.content_width,
-                ),
-                Some(MountScrollFocus::RoleGlobal) => {
-                    if let Some(role) = areas.role_global {
-                        apply_horizontal_scroll(
-                            &mut state.list_role_global_mounts_scroll_x,
-                            delta,
-                            role.area,
-                            role.content_width,
-                        );
-                    }
-                }
-                Some(MountScrollFocus::Workspace) => apply_horizontal_scroll(
-                    &mut state.list_mounts_scroll_x,
-                    delta,
-                    areas.workspace.area,
-                    areas.workspace.content_width,
-                ),
-                None => {}
-            }
+            let Some(focus) = state.list_scroll_focus else {
+                return;
+            };
+            let area_info = match focus {
+                MountScrollFocus::Workspace => Some(areas.workspace),
+                MountScrollFocus::Global => Some(areas.global),
+                MountScrollFocus::RoleGlobal => areas.role_global,
+            };
+            let Some(area_info) = area_info else {
+                return;
+            };
+            apply_horizontal_scroll(
+                state.list_scroll_x_mut(focus),
+                delta,
+                area_info.area,
+                area_info.content_width,
+            );
         }
         ManagerStage::Editor(editor) => {
             if editor.active_tab != EditorTab::Mounts {
@@ -562,26 +550,9 @@ fn list_scroll_areas(
                 .as_ref()
                 .map(|(role, _)| role.clone())
         });
-    let global_rows = picker_role.as_ref().map_or_else(
-        || {
-            config
-                .list_mount_rows()
-                .into_iter()
-                .filter(|row| row.scope.is_none())
-                .collect()
-        },
-        |role| config.resolve_mount_rows(role),
-    );
-    let global_mounts: Vec<crate::workspace::MountConfig> = global_rows
-        .iter()
-        .filter(|row| row.scope.is_none())
-        .map(|row| row.mount.clone())
-        .collect();
-    let role_global_mounts: Vec<crate::workspace::MountConfig> = global_rows
-        .iter()
-        .filter(|row| row.scope.is_some())
-        .map(|row| row.mount.clone())
-        .collect();
+    let global_rows = super::super::render::global_rows_for(config, picker_role.as_ref());
+    let (global_mounts, role_global_mounts) =
+        super::super::render::partition_mounts_by_scope(&global_rows);
     let global_h = if global_mounts.is_empty() {
         0
     } else {
@@ -600,9 +571,7 @@ fn list_scroll_areas(
                 width: right_w,
                 height: mounts_h,
             },
-            content_width: super::super::render::list::workspace_mounts_content_width(
-                workspace.mounts.as_slice(),
-            ),
+            content_width: workspace_mounts_content_width(workspace.mounts.as_slice()),
         },
         global: ScrollArea {
             area: Rect {
@@ -611,9 +580,7 @@ fn list_scroll_areas(
                 width: right_w,
                 height: global_h,
             },
-            content_width: super::super::render::list::global_mounts_content_width(
-                global_mounts.as_slice(),
-            ),
+            content_width: global_mounts_content_width(global_mounts.as_slice()),
         },
         role_global: (role_global_h > 0).then(|| ScrollArea {
             area: Rect {
@@ -622,9 +589,7 @@ fn list_scroll_areas(
                 width: right_w,
                 height: role_global_h,
             },
-            content_width: super::super::render::list::global_mounts_content_width(
-                role_global_mounts.as_slice(),
-            ),
+            content_width: global_mounts_content_width(role_global_mounts.as_slice()),
         }),
     })
 }
@@ -645,7 +610,7 @@ fn current_dir_scroll_areas(
                 width: right_w,
                 height: mounts_h,
             },
-            content_width: super::super::render::list::workspace_mounts_content_width(&mounts),
+            content_width: workspace_mounts_content_width(&mounts),
         },
         global: ScrollArea {
             area: Rect {
@@ -669,13 +634,6 @@ fn current_dir_mount(state: &ManagerState<'_>) -> crate::workspace::MountConfig 
     }
 }
 
-const fn reset_list_mount_scroll(state: &mut ManagerState<'_>) {
-    state.list_mounts_scroll_x = 0;
-    state.list_global_mounts_scroll_x = 0;
-    state.list_role_global_mounts_scroll_x = 0;
-    state.list_scroll_focus = None;
-}
-
 fn editor_scroll_area(
     editor: &super::super::state::EditorState<'_>,
     term_size: Rect,
@@ -692,33 +650,14 @@ fn editor_scroll_area(
             width: term_size.width,
             height: (rows as u16 + 2).min(body_h.max(4)),
         },
-        content_width: super::super::render::list::workspace_mounts_content_width(
-            editor.pending.mounts.as_slice(),
-        ),
+        content_width: workspace_mounts_content_width(editor.pending.mounts.as_slice()),
     }
 }
 
-fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
-    let data_rows: usize = if mounts.is_empty() {
-        1
-    } else {
-        mounts
-            .iter()
-            .map(|mount| if mount.src == mount.dst { 1 } else { 2 })
-            .sum()
-    };
-    (data_rows + 3).min(12) as u16
-}
-
-fn global_mount_configs_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
-    super::super::render::list::global_mounts_content_width(mounts)
-}
-
 fn global_mount_rows_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
-    rows.iter()
-        .map(|row| global_mount_configs_content_width(std::slice::from_ref(&row.mount)))
-        .max()
-        .unwrap_or("  Name                 Destination                    Mode Scope".len())
+    let mounts: Vec<crate::workspace::MountConfig> =
+        rows.iter().map(|row| row.mount.clone()).collect();
+    global_mounts_content_width(&mounts)
 }
 
 /// If the `Editor` or `CreatePrelude` stage has an open `FileBrowser`
@@ -1602,7 +1541,7 @@ mod mouse_drag_tests {
         };
         let expected_max = super::max_scroll_offset(
             global_area,
-            super::global_mount_configs_content_width(global_mounts.as_slice()),
+            super::global_mounts_content_width(global_mounts.as_slice()),
         );
         assert_eq!(state.list_global_mounts_scroll_x, expected_max);
 
@@ -1650,9 +1589,7 @@ mod mouse_drag_tests {
                 width: 70,
                 height: 4,
             },
-            super::super::super::render::list::workspace_mounts_content_width(
-                workspace.mounts.as_slice(),
-            ),
+            super::workspace_mounts_content_width(workspace.mounts.as_slice()),
         );
 
         assert_eq!(
@@ -1681,7 +1618,7 @@ mod mouse_drag_tests {
         };
         let expected_max = super::max_scroll_offset(
             global_area,
-            super::global_mount_configs_content_width(global_mounts.as_slice()),
+            super::global_mounts_content_width(global_mounts.as_slice()),
         );
 
         handle_mouse_with_config(

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -405,12 +405,15 @@ fn list_scroll_areas(
     config: Option<&crate::config::AppConfig>,
 ) -> Option<ListScrollAreas> {
     let config = config?;
-    let summary = state.selected_workspace_summary()?;
-    let workspace = config.workspaces.get(&summary.name)?;
     let seam_x = seam_column(state.list_split_pct, term_size.width);
     let right_x = seam_x;
     let right_w = term_size.width.saturating_sub(seam_x);
     let body_y = LIST_HEADER_HEIGHT;
+    if state.is_current_dir_selected() {
+        return Some(current_dir_scroll_areas(state, right_x, right_w, body_y));
+    }
+    let summary = state.selected_workspace_summary()?;
+    let workspace = config.workspaces.get(&summary.name)?;
     let mounts_h = mount_block_height(workspace.mounts.as_slice());
     let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
         picker
@@ -483,6 +486,46 @@ fn list_scroll_areas(
             ),
         }),
     })
+}
+
+fn current_dir_scroll_areas(
+    state: &ManagerState<'_>,
+    right_x: u16,
+    right_w: u16,
+    body_y: u16,
+) -> ListScrollAreas {
+    let mounts = [current_dir_mount(state)];
+    let mounts_h = mount_block_height(&mounts);
+    ListScrollAreas {
+        workspace: ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: body_y + 3,
+                width: right_w,
+                height: mounts_h,
+            },
+            content_width: super::super::render::list::workspace_mounts_content_width(&mounts),
+        },
+        global: ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: body_y + 3 + mounts_h,
+                width: right_w,
+                height: 0,
+            },
+            content_width: 0,
+        },
+        role_global: None,
+    }
+}
+
+fn current_dir_mount(state: &ManagerState<'_>) -> crate::workspace::MountConfig {
+    crate::workspace::MountConfig {
+        src: state.current_dir.clone(),
+        dst: state.current_dir.clone(),
+        readonly: false,
+        isolation: crate::isolation::MountIsolation::Shared,
+    }
 }
 
 fn editor_scroll_area(
@@ -1087,6 +1130,11 @@ mod mouse_drag_tests {
         state
     }
 
+    fn current_dir_state_at(path: &std::path::Path) -> ManagerState<'static> {
+        let config = crate::config::AppConfig::default();
+        ManagerState::from_config(&config, path)
+    }
+
     fn config_with_long_git_type_mount(source: &std::path::Path) -> crate::config::AppConfig {
         let mut config = crate::config::AppConfig::default();
         config.workspaces.insert(
@@ -1209,6 +1257,30 @@ mod mouse_drag_tests {
         handle_mouse_with_config(&mut state, mouse_at(31, 7), term(100), Some(&config));
 
         assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Workspace));
+    }
+
+    #[test]
+    fn click_current_directory_mount_block_focuses_and_scrolls_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path().join(
+            "very-long-current-directory-name-that-forces-horizontal-scrolling-in-the-preview",
+        );
+        std::fs::create_dir_all(&cwd).unwrap();
+        let config = crate::config::AppConfig::default();
+        let mut state = current_dir_state_at(&cwd);
+        assert!(state.is_current_dir_selected());
+
+        handle_mouse_with_config(&mut state, mouse_at(31, 7), term(100), Some(&config));
+        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Workspace));
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollDown, 31, 7),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(state.list_mounts_scroll_x, MOUSE_HORIZONTAL_SCROLL_STEP);
     }
 
     #[test]

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -6,7 +6,7 @@ use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
 use super::super::state::{
-    DragState, ManagerListRow, ManagerStage, ManagerState, Modal, clamp_split,
+    DragState, ManagerListRow, ManagerStage, ManagerState, Modal, MountScrollFocus, clamp_split,
 };
 
 /// Minimum terminal width (in columns) at which the list/details seam is
@@ -55,6 +55,10 @@ pub fn handle_mouse_with_config(
 ) {
     if term_size.width < MIN_DRAGGABLE_WIDTH {
         return;
+    }
+
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+        update_scroll_focus(state, mouse, term_size, config);
     }
 
     match mouse.kind {
@@ -133,40 +137,52 @@ fn try_drag_horizontal_scrollbar(
 ) -> bool {
     match &mut state.stage {
         ManagerStage::List => {
-            let Some((mounts, global)) = list_scroll_areas(state, term_size, config) else {
+            let Some(areas) = list_scroll_areas(state, term_size, config) else {
                 return false;
             };
             if drag_scrollbar(
                 &mut state.list_mounts_scroll_x,
                 mouse,
-                mounts.area,
-                mounts.content_width,
+                areas.workspace.area,
+                areas.workspace.content_width,
             ) {
+                state.list_scroll_focus = Some(MountScrollFocus::Workspace);
                 return true;
             }
-            drag_scrollbar(
+            if drag_scrollbar(
                 &mut state.list_global_mounts_scroll_x,
                 mouse,
-                global.area,
-                global.content_width,
-            )
+                areas.global.area,
+                areas.global.content_width,
+            ) {
+                state.list_scroll_focus = Some(MountScrollFocus::Global);
+                return true;
+            }
+            if let Some(role) = areas.role_global
+                && drag_scrollbar(
+                    &mut state.list_role_global_mounts_scroll_x,
+                    mouse,
+                    role.area,
+                    role.content_width,
+                )
+            {
+                state.list_scroll_focus = Some(MountScrollFocus::RoleGlobal);
+                return true;
+            }
+            false
         }
         ManagerStage::Editor(editor) => {
-            let (workspace, global) = editor_scroll_areas(editor, term_size);
-            if drag_scrollbar(
+            let workspace = editor_scroll_area(editor, term_size);
+            let dragged = drag_scrollbar(
                 &mut editor.workspace_mounts_scroll_x,
                 mouse,
                 workspace.area,
                 workspace.content_width,
-            ) {
-                return true;
+            );
+            if dragged {
+                editor.workspace_mounts_scroll_focused = true;
             }
-            drag_scrollbar(
-                &mut editor.global_mounts_scroll_x,
-                mouse,
-                global.area,
-                global.content_width,
-            )
+            dragged
         }
         ManagerStage::GlobalMounts(global) => drag_scrollbar(
             &mut global.scroll_x,
@@ -183,6 +199,59 @@ fn try_drag_horizontal_scrollbar(
         ),
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => false,
     }
+}
+
+fn update_scroll_focus(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    config: Option<&crate::config::AppConfig>,
+) {
+    match &mut state.stage {
+        ManagerStage::List => {
+            let Some(areas) = list_scroll_areas(state, term_size, config) else {
+                state.list_scroll_focus = None;
+                return;
+            };
+            state.list_scroll_focus = if point_in(mouse, areas.workspace.area)
+                && is_scrollable(areas.workspace.area, areas.workspace.content_width)
+            {
+                Some(MountScrollFocus::Workspace)
+            } else if point_in(mouse, areas.global.area)
+                && is_scrollable(areas.global.area, areas.global.content_width)
+            {
+                Some(MountScrollFocus::Global)
+            } else if let Some(role) = areas.role_global {
+                if point_in(mouse, role.area) && is_scrollable(role.area, role.content_width) {
+                    Some(MountScrollFocus::RoleGlobal)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+        }
+        ManagerStage::Editor(editor) => {
+            let area = editor_scroll_area(editor, term_size);
+            editor.workspace_mounts_scroll_focused =
+                point_in(mouse, area.area) && is_scrollable(area.area, area.content_width);
+        }
+        ManagerStage::GlobalMounts(_)
+        | ManagerStage::CreatePrelude(_)
+        | ManagerStage::ConfirmDelete { .. } => {}
+    }
+}
+
+const fn point_in(mouse: MouseEvent, area: Rect) -> bool {
+    mouse.column >= area.x
+        && mouse.column < area.x.saturating_add(area.width)
+        && mouse.row >= area.y
+        && mouse.row < area.y.saturating_add(area.height)
+}
+
+const fn is_scrollable(area: Rect, content_width: usize) -> bool {
+    let viewport = area.width.saturating_sub(2) as usize;
+    viewport > 0 && content_width > viewport
 }
 
 #[derive(Clone, Copy)]
@@ -211,9 +280,9 @@ fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width:
 
 fn scroll_active_panel(
     state: &mut ManagerState<'_>,
-    mouse: MouseEvent,
-    term_size: Rect,
-    config: Option<&crate::config::AppConfig>,
+    _mouse: MouseEvent,
+    _term_size: Rect,
+    _config: Option<&crate::config::AppConfig>,
     delta: i16,
 ) {
     let apply = |value: &mut u16| {
@@ -224,64 +293,35 @@ fn scroll_active_panel(
         }
     };
     match &mut state.stage {
-        ManagerStage::List => match list_scroll_target(state, mouse, term_size, config) {
-            ScrollTarget::GlobalMounts => apply(&mut state.list_global_mounts_scroll_x),
-            ScrollTarget::Mounts => apply(&mut state.list_mounts_scroll_x),
+        ManagerStage::List => match state.list_scroll_focus {
+            Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
+            Some(MountScrollFocus::RoleGlobal) => {
+                apply(&mut state.list_role_global_mounts_scroll_x);
+            }
+            Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
+            None => {}
         },
-        ManagerStage::Editor(editor) => match editor_scroll_target(editor, mouse, term_size) {
-            ScrollTarget::GlobalMounts => apply(&mut editor.global_mounts_scroll_x),
-            ScrollTarget::Mounts => apply(&mut editor.workspace_mounts_scroll_x),
-        },
+        ManagerStage::Editor(editor) if editor.workspace_mounts_scroll_focused => {
+            apply(&mut editor.workspace_mounts_scroll_x);
+        }
         ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
-        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
+        ManagerStage::Editor(_)
+        | ManagerStage::CreatePrelude(_)
+        | ManagerStage::ConfirmDelete { .. } => {}
     }
 }
 
-#[derive(Clone, Copy)]
-enum ScrollTarget {
-    Mounts,
-    GlobalMounts,
-}
-
-fn list_scroll_target(
-    state: &ManagerState<'_>,
-    mouse: MouseEvent,
-    term_size: Rect,
-    config: Option<&crate::config::AppConfig>,
-) -> ScrollTarget {
-    let Some((_, global)) = list_scroll_areas(state, term_size, config) else {
-        return ScrollTarget::Mounts;
-    };
-    if mouse.column > seam_column(state.list_split_pct, term_size.width)
-        && mouse.row >= global.area.y
-    {
-        ScrollTarget::GlobalMounts
-    } else {
-        ScrollTarget::Mounts
-    }
-}
-
-fn editor_scroll_target(
-    editor: &super::super::state::EditorState<'_>,
-    mouse: MouseEvent,
-    term_size: Rect,
-) -> ScrollTarget {
-    if editor.active_tab != super::super::state::EditorTab::Mounts {
-        return ScrollTarget::Mounts;
-    }
-    let (_, global) = editor_scroll_areas(editor, term_size);
-    if mouse.row >= global.area.y {
-        ScrollTarget::GlobalMounts
-    } else {
-        ScrollTarget::Mounts
-    }
+struct ListScrollAreas {
+    workspace: ScrollArea,
+    global: ScrollArea,
+    role_global: Option<ScrollArea>,
 }
 
 fn list_scroll_areas(
     state: &ManagerState<'_>,
     term_size: Rect,
     config: Option<&crate::config::AppConfig>,
-) -> Option<(ScrollArea, ScrollArea)> {
+) -> Option<ListScrollAreas> {
     let config = config?;
     let summary = state.selected_workspace_summary()?;
     let workspace = config.workspaces.get(&summary.name)?;
@@ -294,11 +334,28 @@ fn list_scroll_areas(
         crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. } => rows,
         crate::config::WorkspaceGlobalMountRows::Ambiguous { .. } => Vec::new(),
     };
-    let global_mounts: Vec<crate::workspace::MountConfig> =
-        global_rows.iter().map(|row| row.mount.clone()).collect();
-    let global_h = mount_block_height(global_mounts.as_slice());
-    Some((
-        ScrollArea {
+    let global_mounts: Vec<crate::workspace::MountConfig> = global_rows
+        .iter()
+        .filter(|row| row.scope.is_none())
+        .map(|row| row.mount.clone())
+        .collect();
+    let role_global_mounts: Vec<crate::workspace::MountConfig> = global_rows
+        .iter()
+        .filter(|row| row.scope.is_some())
+        .map(|row| row.mount.clone())
+        .collect();
+    let global_h = if !global_mounts.is_empty() || role_global_mounts.is_empty() {
+        mount_block_height(global_mounts.as_slice())
+    } else {
+        0
+    };
+    let role_global_h = if role_global_mounts.is_empty() {
+        0
+    } else {
+        mount_block_height(role_global_mounts.as_slice())
+    };
+    Some(ListScrollAreas {
+        workspace: ScrollArea {
             area: Rect {
                 x: right_x,
                 y: body_y + 3,
@@ -307,48 +364,45 @@ fn list_scroll_areas(
             },
             content_width: mount_rows_content_width(workspace.mounts.as_slice()),
         },
-        ScrollArea {
+        global: ScrollArea {
             area: Rect {
                 x: right_x,
                 y: body_y + 3 + mounts_h,
                 width: right_w,
                 height: global_h,
             },
-            content_width: mount_rows_content_width(global_mounts.as_slice()),
+            content_width: global_mount_configs_content_width(global_mounts.as_slice()),
         },
-    ))
+        role_global: (role_global_h > 0).then(|| ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: body_y + 3 + mounts_h + global_h,
+                width: right_w,
+                height: role_global_h,
+            },
+            content_width: global_mount_configs_content_width(role_global_mounts.as_slice()),
+        }),
+    })
 }
 
-fn editor_scroll_areas(
+fn editor_scroll_area(
     editor: &super::super::state::EditorState<'_>,
     term_size: Rect,
-) -> (ScrollArea, ScrollArea) {
+) -> ScrollArea {
     let body_y = 5;
     let body_h = term_size.height.saturating_sub(7);
-    let workspace_rows = editor.pending.mounts.iter().fold(1usize, |acc, mount| {
+    let rows = editor.pending.mounts.iter().fold(1usize, |acc, mount| {
         acc + if mount.src == mount.dst { 1 } else { 2 }
     }) + 2;
-    let workspace_h = (workspace_rows as u16 + 2).min(body_h.saturating_sub(4).max(4));
-    (
-        ScrollArea {
-            area: Rect {
-                x: 0,
-                y: body_y,
-                width: term_size.width,
-                height: workspace_h,
-            },
-            content_width: mount_rows_content_width(editor.pending.mounts.as_slice()),
+    ScrollArea {
+        area: Rect {
+            x: 0,
+            y: body_y,
+            width: term_size.width,
+            height: (rows as u16 + 2).min(body_h.max(4)),
         },
-        ScrollArea {
-            area: Rect {
-                x: 0,
-                y: body_y + workspace_h,
-                width: term_size.width,
-                height: body_h.saturating_sub(workspace_h),
-            },
-            content_width: 160,
-        },
-    )
+        content_width: mount_rows_content_width(editor.pending.mounts.as_slice()),
+    }
 }
 
 fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
@@ -377,7 +431,35 @@ fn mount_rows_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
                     .count()
                     .max(src.chars().count() + "host: ".len())
             };
-            path_width + "  rw    worktree   ".len() + 24
+            let kind_width = super::super::mount_info::inspect(&mount.src)
+                .label()
+                .chars()
+                .count();
+            2 + path_width
+                + "  ".len()
+                + "rw".len()
+                + "  ".len()
+                + "worktree".len()
+                + "  ".len()
+                + kind_width
+        })
+        .max()
+        .unwrap_or(header)
+        .max(header)
+}
+
+fn global_mount_configs_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
+    let header = "  Destination  Mode".len();
+    mounts
+        .iter()
+        .map(|mount| {
+            let dst = crate::tui::shorten_home(&mount.dst);
+            let src = crate::tui::shorten_home(&mount.src);
+            let path_width = dst
+                .chars()
+                .count()
+                .max(src.chars().count() + "host: ".len());
+            2 + path_width + "  ".len() + "rw".len()
         })
         .max()
         .unwrap_or(header)
@@ -386,9 +468,9 @@ fn mount_rows_content_width(mounts: &[crate::workspace::MountConfig]) -> usize {
 
 fn global_mount_rows_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
     rows.iter()
-        .map(|row| mount_rows_content_width(std::slice::from_ref(&row.mount)))
+        .map(|row| global_mount_configs_content_width(std::slice::from_ref(&row.mount)))
         .max()
-        .unwrap_or("  Name                 Destination                    Mode Scope Type".len())
+        .unwrap_or("  Name                 Destination                    Mode Scope".len())
 }
 
 /// If the `Editor` or `CreatePrelude` stage has an open `FileBrowser`

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -1,7 +1,7 @@
 //! Mouse event handling for the workspace manager: list/details seam drag,
 //! click-to-select in the list pane, and `FileBrowser` URL-click fallthrough.
 
-use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use super::super::super::widgets::file_browser::FileBrowserState;
@@ -27,6 +27,7 @@ const LIST_HEADER_HEIGHT: u16 = 3;
 /// Height of the footer chunk in the list-view chrome. Mirrors
 /// `Constraint::Length(2)` in `render::render`.
 const LIST_FOOTER_HEIGHT: u16 = 2;
+const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 4;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
 /// the mouse-draggable seam between the list pane and the details pane.
@@ -69,11 +70,43 @@ pub fn handle_mouse_with_config(
             return;
         }
         MouseEventKind::ScrollLeft => {
-            scroll_active_panel(state, mouse, term_size, config, -8);
+            scroll_active_panel(
+                state,
+                mouse,
+                term_size,
+                config,
+                -(MOUSE_HORIZONTAL_SCROLL_STEP as i16),
+            );
             return;
         }
         MouseEventKind::ScrollRight => {
-            scroll_active_panel(state, mouse, term_size, config, 8);
+            scroll_active_panel(
+                state,
+                mouse,
+                term_size,
+                config,
+                MOUSE_HORIZONTAL_SCROLL_STEP as i16,
+            );
+            return;
+        }
+        MouseEventKind::ScrollUp if mouse.modifiers.contains(KeyModifiers::SHIFT) => {
+            scroll_active_panel(
+                state,
+                mouse,
+                term_size,
+                config,
+                -(MOUSE_HORIZONTAL_SCROLL_STEP as i16),
+            );
+            return;
+        }
+        MouseEventKind::ScrollDown if mouse.modifiers.contains(KeyModifiers::SHIFT) => {
+            scroll_active_panel(
+                state,
+                mouse,
+                term_size,
+                config,
+                MOUSE_HORIZONTAL_SCROLL_STEP as i16,
+            );
             return;
         }
         _ => {}
@@ -290,22 +323,36 @@ fn scroll_active_panel(
     config: Option<&crate::config::AppConfig>,
     delta: i16,
 ) {
-    let apply = |value: &mut u16| {
-        if delta.is_negative() {
-            *value = value.saturating_sub(delta.unsigned_abs());
-        } else {
-            *value = value.saturating_add(delta as u16);
-        }
-    };
     match &mut state.stage {
         ManagerStage::List => {
             update_scroll_focus(state, mouse, term_size, config);
+            let Some(areas) = list_scroll_areas(state, term_size, config) else {
+                state.list_scroll_focus = None;
+                return;
+            };
             match state.list_scroll_focus {
-                Some(MountScrollFocus::Global) => apply(&mut state.list_global_mounts_scroll_x),
+                Some(MountScrollFocus::Global) => apply_horizontal_scroll(
+                    &mut state.list_global_mounts_scroll_x,
+                    delta,
+                    areas.global.area,
+                    areas.global.content_width,
+                ),
                 Some(MountScrollFocus::RoleGlobal) => {
-                    apply(&mut state.list_role_global_mounts_scroll_x);
+                    if let Some(role) = areas.role_global {
+                        apply_horizontal_scroll(
+                            &mut state.list_role_global_mounts_scroll_x,
+                            delta,
+                            role.area,
+                            role.content_width,
+                        );
+                    }
                 }
-                Some(MountScrollFocus::Workspace) => apply(&mut state.list_mounts_scroll_x),
+                Some(MountScrollFocus::Workspace) => apply_horizontal_scroll(
+                    &mut state.list_mounts_scroll_x,
+                    delta,
+                    areas.workspace.area,
+                    areas.workspace.content_width,
+                ),
                 None => {}
             }
         }
@@ -317,13 +364,51 @@ fn scroll_active_panel(
             let area = editor_scroll_area(editor, term_size);
             if point_in(mouse, area.area) && is_scrollable(area.area, area.content_width) {
                 editor.workspace_mounts_scroll_focused = true;
-                apply(&mut editor.workspace_mounts_scroll_x);
+                apply_horizontal_scroll(
+                    &mut editor.workspace_mounts_scroll_x,
+                    delta,
+                    area.area,
+                    area.content_width,
+                );
             } else {
                 editor.workspace_mounts_scroll_focused = false;
             }
         }
-        ManagerStage::GlobalMounts(global) => apply(&mut global.scroll_x),
+        ManagerStage::GlobalMounts(global) => apply_horizontal_scroll(
+            &mut global.scroll_x,
+            delta,
+            Rect {
+                x: 0,
+                y: LIST_HEADER_HEIGHT,
+                width: term_size.width,
+                height: term_size
+                    .height
+                    .saturating_sub(LIST_HEADER_HEIGHT + LIST_FOOTER_HEIGHT),
+            },
+            global_mount_rows_content_width(&global.pending),
+        ),
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
+    }
+}
+
+fn apply_horizontal_scroll(value: &mut u16, delta: i16, area: Rect, content_width: usize) {
+    let max = max_scroll_offset(area, content_width);
+    let next = if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    };
+    *value = next.min(max);
+}
+
+fn max_scroll_offset(area: Rect, content_width: usize) -> u16 {
+    let viewport = area.width.saturating_sub(2) as usize;
+    if viewport == 0 || content_width <= viewport {
+        0
+    } else {
+        content_width
+            .saturating_sub(viewport)
+            .min(usize::from(u16::MAX)) as u16
     }
 }
 
@@ -616,7 +701,7 @@ mod mouse_drag_tests {
     //! These build `MouseEvent` values directly and bypass the ratatui
     //! event loop — enough to pin the seam hit-test + drag math without a
     //! real terminal.
-    use super::{handle_mouse, handle_mouse_with_config};
+    use super::{MOUSE_HORIZONTAL_SCROLL_STEP, handle_mouse, handle_mouse_with_config};
     use crate::console::manager::state::{
         DEFAULT_SPLIT_PCT, EditorState, MAX_SPLIT_PCT, MIN_SPLIT_PCT, ManagerStage, ManagerState,
         Modal, MountScrollFocus,
@@ -988,6 +1073,20 @@ mod mouse_drag_tests {
         }
     }
 
+    const fn mouse_kind_with_modifiers_at(
+        kind: MouseEventKind,
+        modifiers: KeyModifiers,
+        col: u16,
+        row: u16,
+    ) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: col,
+            row,
+            modifiers,
+        }
+    }
+
     /// Build a list state with `n` saved workspaces (row 0 + n + spacer + sentinel).
     fn list_state_with_saved(n: usize) -> ManagerState<'static> {
         let mut config = crate::config::AppConfig::default();
@@ -1179,8 +1278,101 @@ mod mouse_drag_tests {
         );
 
         assert_eq!(state.list_mounts_scroll_x, 0);
-        assert_eq!(state.list_global_mounts_scroll_x, 8);
+        assert_eq!(
+            state.list_global_mounts_scroll_x,
+            MOUSE_HORIZONTAL_SCROLL_STEP
+        );
         assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
+    }
+
+    #[test]
+    fn shift_vertical_mouse_wheel_scrolls_horizontally() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_with_modifiers_at(MouseEventKind::ScrollDown, KeyModifiers::SHIFT, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(
+            state.list_global_mounts_scroll_x,
+            MOUSE_HORIZONTAL_SCROLL_STEP
+        );
+        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_with_modifiers_at(MouseEventKind::ScrollUp, KeyModifiers::SHIFT, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(state.list_global_mounts_scroll_x, 0);
+    }
+
+    #[test]
+    fn plain_vertical_mouse_wheel_does_not_change_horizontal_scroll() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollDown, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(state.list_global_mounts_scroll_x, 0);
+        assert_eq!(state.list_scroll_focus, None);
+    }
+
+    #[test]
+    fn horizontal_mouse_wheel_clamps_stored_offset_at_block_end() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+
+        for _ in 0..100 {
+            handle_mouse_with_config(
+                &mut state,
+                mouse_kind_at(MouseEventKind::ScrollRight, 31, 12),
+                term(100),
+                Some(&config),
+            );
+        }
+
+        let global_mounts: Vec<MountConfig> = config
+            .list_mount_rows()
+            .into_iter()
+            .filter(|row| row.scope.is_none())
+            .map(|row| row.mount)
+            .collect();
+        let global_area = Rect {
+            x: 30,
+            y: 11,
+            width: 70,
+            height: 5,
+        };
+        let expected_max = super::max_scroll_offset(
+            global_area,
+            super::global_mount_configs_content_width(global_mounts.as_slice()),
+        );
+        assert_eq!(state.list_global_mounts_scroll_x, expected_max);
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollLeft, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(
+            state.list_global_mounts_scroll_x,
+            expected_max.saturating_sub(MOUSE_HORIZONTAL_SCROLL_STEP),
+            "left-scroll after overscrolling right must move immediately, not burn hidden offset"
+        );
     }
 
     #[test]
@@ -1212,7 +1404,10 @@ mod mouse_drag_tests {
             panic!("editor stage expected");
         };
         assert!(editor.workspace_mounts_scroll_focused);
-        assert_eq!(editor.workspace_mounts_scroll_x, 8);
+        assert_eq!(
+            editor.workspace_mounts_scroll_x,
+            MOUSE_HORIZONTAL_SCROLL_STEP
+        );
 
         editor.active_tab = crate::console::manager::state::EditorTab::General;
         handle_mouse_with_config(
@@ -1225,6 +1420,9 @@ mod mouse_drag_tests {
             panic!("editor stage expected");
         };
         assert!(!editor.workspace_mounts_scroll_focused);
-        assert_eq!(editor.workspace_mounts_scroll_x, 8);
+        assert_eq!(
+            editor.workspace_mounts_scroll_x,
+            MOUSE_HORIZONTAL_SCROLL_STEP
+        );
     }
 }

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -685,11 +685,16 @@ fn build_confirm_save_lines(
 }
 
 fn mount_summary(m: &crate::workspace::MountConfig) -> String {
-    let src = crate::tui::shorten_home(&m.src);
+    let dst = crate::tui::shorten_home(&m.dst);
     let kind = super::super::mount_info::inspect(&m.src);
     let rw = if m.readonly { "ro" } else { "rw" };
     let isolation = m.isolation.as_str();
-    format!("{src}  ({rw}, {isolation}, {})", kind.label())
+    let host = if m.src == m.dst {
+        String::new()
+    } else {
+        format!("  host: {}", crate::tui::shorten_home(&m.src))
+    };
+    format!("{dst}{host}  ({rw}, {isolation}, {})", kind.label())
 }
 
 fn allowed_agents_summary(editor: &EditorState<'_>, config: &AppConfig) -> String {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -508,35 +508,8 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
         match config.workspace_applicable_mount_rows(workspace) {
             crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
                 lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    format!("Global mounts ({role})"),
-                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-                )));
                 let offset = state.pending.mounts.len() + 1;
-                for (i, row) in rows.iter().enumerate() {
-                    let selected = cursor == offset + i;
-                    let prefix = if selected { "▸ " } else { "  " };
-                    let src = crate::tui::shorten_home(&row.mount.src);
-                    let dst = crate::tui::shorten_home(&row.mount.dst);
-                    let path = if row.mount.src == row.mount.dst {
-                        src
-                    } else {
-                        format!("{src} \u{2192} {dst}")
-                    };
-                    let mode = if row.mount.readonly { "ro" } else { "rw" };
-                    let scope = row.scope.as_deref().unwrap_or("global");
-                    let style = if selected {
-                        Style::default()
-                            .fg(PHOSPHOR_DIM)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(PHOSPHOR_DIM)
-                    };
-                    lines.push(Line::from(vec![
-                        Span::styled(format!("{prefix}{path}  "), style),
-                        Span::styled(format!("{mode}  {scope}"), style),
-                    ]));
-                }
+                append_global_mount_lines(&mut lines, &role, &rows, cursor, offset);
             }
             crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
                 lines.push(Line::from(""));
@@ -552,6 +525,68 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
     }
 
     frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn append_global_mount_lines(
+    lines: &mut Vec<Line<'_>>,
+    role: &str,
+    rows: &[crate::config::GlobalMountRow],
+    cursor: usize,
+    offset: usize,
+) {
+    lines.push(Line::from(Span::styled(
+        format!("  Global mounts ({role})"),
+        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    )));
+    let global_rows: Vec<(String, &'static str, &'static str, String)> = rows
+        .iter()
+        .map(|row| {
+            let src = crate::tui::shorten_home(&row.mount.src);
+            let dst = crate::tui::shorten_home(&row.mount.dst);
+            let path = if row.mount.src == row.mount.dst {
+                src
+            } else {
+                format!("{src} \u{2192} {dst}")
+            };
+            let mode = if row.mount.readonly { "ro" } else { "rw" };
+            let kind = super::super::mount_info::inspect(&row.mount.src).label();
+            let kind = row
+                .scope
+                .as_ref()
+                .map_or_else(|| kind.clone(), |scope| format!("{kind} · {scope}"));
+            (path, mode, "shared", kind)
+        })
+        .collect();
+    let path_w = mount_path_width(&global_rows);
+    lines.push(render_mount_header(path_w));
+    for (i, (path, mode, iso, kind)) in global_rows.iter().enumerate() {
+        let selected = cursor == offset + i;
+        let prefix = if selected { "▸ " } else { "  " };
+        let base_style = if selected {
+            Style::default()
+                .fg(PHOSPHOR_DIM)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(PHOSPHOR_DIM)
+        };
+        let dim_style = Style::default()
+            .fg(PHOSPHOR_DIM)
+            .add_modifier(Modifier::ITALIC);
+        lines.push(Line::from(vec![
+            Span::styled(format!("{prefix}{path:<path_w$}  "), base_style),
+            Span::styled(
+                format!("{mode:<MOUNT_MODE_COL_WIDTH$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{iso:<MOUNT_ISOLATION_COL_WIDTH$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            ),
+            Span::raw("  "),
+            Span::styled(kind.clone(), dim_style),
+        ]));
+    }
 }
 
 const fn workspace_for_global_mount_context<'a>(

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -339,9 +339,8 @@ pub(in crate::console::manager) fn auth_row_count(
     auth_flat_rows(state, config).len()
 }
 
-/// Order and labels of editor tabs. Shared with mouse hit-testing
-/// (`input::mouse::editor_tab_at`) so the strip the renderer draws is
-/// the same one the click code measures against.
+/// Order/labels shared with mouse hit-testing; renderer and click code
+/// must measure the same strip.
 pub(in crate::console::manager) const EDITOR_TAB_LABELS: &[(EditorTab, &str)] = &[
     (EditorTab::General, "General"),
     (EditorTab::Mounts, "Mounts"),

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -11,6 +11,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
+use std::cmp::Ordering;
 
 use super::super::state::{EditorMode, EditorState, EditorTab, FieldFocus, SecretsScopeTag};
 use super::list::{
@@ -70,7 +71,7 @@ pub fn render_editor(
 
     match state.active_tab {
         EditorTab::General => render_general_tab(frame, chunks[2], state),
-        EditorTab::Mounts => render_mounts_tab(frame, chunks[2], state),
+        EditorTab::Mounts => render_mounts_tab(frame, chunks[2], state, config),
         EditorTab::Roles => render_roles_tab(frame, chunks[2], state, config),
         EditorTab::Secrets => render_secrets_tab(frame, chunks[2], state, config),
         EditorTab::Auth => render_auth_tab(frame, chunks[2], state, config),
@@ -153,48 +154,40 @@ fn contextual_row_items(
         }
         EditorTab::Mounts => {
             let mount_count = state.pending.mounts.len();
-            if cursor < mount_count {
-                let mut items = vec![
-                    FooterItem::Key("D"),
-                    FooterItem::Text("remove"),
-                    FooterItem::Sep,
-                    FooterItem::Key("A"),
-                    FooterItem::Text("add"),
-                ];
-                // Surface `O open in GitHub` when the cursor is on a mount
-                // whose source resolves to a GitHub-hosted git repo with a
-                // web URL. Editor-only — the list view's mounts pane is
-                // a preview, not a focus target.
-                if let Some(m) = state.pending.mounts.get(cursor)
-                    && matches!(
-                        super::super::mount_info::inspect(&m.src),
-                        super::super::mount_info::MountKind::Git {
-                            origin: Some(super::super::mount_info::GitOrigin::Github { .. }),
-                            ..
-                        }
-                    )
-                {
+            match cursor.cmp(&mount_count) {
+                Ordering::Less => {
+                    let mut items = vec![
+                        FooterItem::Key("D"),
+                        FooterItem::Text("remove"),
+                        FooterItem::Sep,
+                        FooterItem::Key("A"),
+                        FooterItem::Text("add"),
+                    ];
+                    if let Some(m) = state.pending.mounts.get(cursor)
+                        && matches!(
+                            super::super::mount_info::inspect(&m.src),
+                            super::super::mount_info::MountKind::Git {
+                                origin: Some(super::super::mount_info::GitOrigin::Github { .. }),
+                                ..
+                            }
+                        )
+                    {
+                        items.push(FooterItem::Sep);
+                        items.push(FooterItem::Key("O"));
+                        items.push(FooterItem::Text("open in GitHub"));
+                    }
                     items.push(FooterItem::Sep);
-                    items.push(FooterItem::Key("O"));
-                    items.push(FooterItem::Text("open in GitHub"));
+                    items.push(FooterItem::Key("R"));
+                    items.push(FooterItem::Text("toggle ro/rw"));
+                    items.push(FooterItem::Sep);
+                    items.push(FooterItem::Key("I"));
+                    items.push(FooterItem::Text("cycle isolation"));
+                    items
                 }
-                // `R` toggles the readonly flag on the highlighted mount row
-                // (rw ↔ ro). Sentinel row omits this hint — there's nothing
-                // to toggle yet.
-                items.push(FooterItem::Sep);
-                items.push(FooterItem::Key("R"));
-                items.push(FooterItem::Text("toggle ro/rw"));
-                // `I` cycles the per-mount isolation strategy on the
-                // highlighted row (shared ↔ worktree).
-                // Same gating as R: hidden on the `+ Add mount` sentinel.
-                items.push(FooterItem::Sep);
-                items.push(FooterItem::Key("I"));
-                items.push(FooterItem::Text("cycle isolation"));
-                items
-            } else {
-                // Sentinel "+ Add mount" row — both Enter and A invoke the
-                // same add-mount flow, so render as a single combined key.
-                vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")]
+                Ordering::Equal => vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")],
+                Ordering::Greater => vec![FooterItem::Dyn(
+                    "global mount - edit from config mounts".to_string(),
+                )],
             }
         }
         EditorTab::Roles => {
@@ -454,7 +447,7 @@ fn render_editor_row(row: usize, cursor: usize, label: &str, value: &str) -> Lin
     Line::from(spans)
 }
 
-fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
+fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(PHOSPHOR_DARK));
@@ -511,7 +504,63 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
         action_row_style(sentinel_selected),
     )));
 
+    if let Some(workspace) = workspace_for_global_mount_context(state) {
+        match config.workspace_applicable_mount_rows(workspace) {
+            crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("Global mounts ({role})"),
+                    Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+                )));
+                let offset = state.pending.mounts.len() + 1;
+                for (i, row) in rows.iter().enumerate() {
+                    let selected = cursor == offset + i;
+                    let prefix = if selected { "▸ " } else { "  " };
+                    let src = crate::tui::shorten_home(&row.mount.src);
+                    let dst = crate::tui::shorten_home(&row.mount.dst);
+                    let path = if row.mount.src == row.mount.dst {
+                        src
+                    } else {
+                        format!("{src} \u{2192} {dst}")
+                    };
+                    let mode = if row.mount.readonly { "ro" } else { "rw" };
+                    let scope = row.scope.as_deref().unwrap_or("global");
+                    let style = if selected {
+                        Style::default()
+                            .fg(PHOSPHOR_DIM)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(PHOSPHOR_DIM)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("{prefix}{path}  "), style),
+                        Span::styled(format!("{mode}  {scope}"), style),
+                    ]));
+                }
+            }
+            crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "Global mounts: selected role affects visibility ({})",
+                        candidates.join(", ")
+                    ),
+                    Style::default().fg(PHOSPHOR_DIM),
+                )));
+            }
+        }
+    }
+
     frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+const fn workspace_for_global_mount_context<'a>(
+    state: &'a EditorState<'_>,
+) -> Option<&'a crate::workspace::WorkspaceConfig> {
+    match state.mode {
+        EditorMode::Edit { .. } => Some(&state.pending),
+        EditorMode::Create => None,
+    }
 }
 
 fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -15,8 +15,8 @@ use std::cmp::Ordering;
 
 use super::super::state::{EditorMode, EditorState, EditorTab, FieldFocus, SecretsScopeTag};
 use super::list::{
-    MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, format_mount_rows, mount_path_width,
-    render_mount_header,
+    MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, MountDisplayRow, format_mount_rows,
+    mount_display_paths, mount_path_width, render_mount_header,
 };
 use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
@@ -461,7 +461,7 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
     // with data rows regardless of path width.
     let mut lines: Vec<Line> = vec![render_mount_header(path_w)];
 
-    lines.extend(rows.iter().enumerate().map(|(i, (path, mode, iso, kind))| {
+    for (i, row) in rows.iter().enumerate() {
         let selected = i == cursor;
         let prefix = if selected { "▸ " } else { "  " };
         let base_style = if selected {
@@ -474,23 +474,32 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
         let dim_style = Style::default()
             .fg(PHOSPHOR_DIM)
             .add_modifier(Modifier::ITALIC);
-        Line::from(vec![
-            Span::styled(format!("{prefix}{path:<path_w$}  "), base_style),
+        lines.push(Line::from(vec![
             Span::styled(
-                format!("{mode:<MOUNT_MODE_COL_WIDTH$}"),
+                format!("{prefix}{:<path_w$}  ", row.destination),
+                base_style,
+            ),
+            Span::styled(
+                format!("{:<MOUNT_MODE_COL_WIDTH$}", row.mode),
                 Style::default().fg(PHOSPHOR_DIM),
             ),
             // Two-space gap before the iso column — matches the header.
             Span::raw("  "),
             Span::styled(
-                format!("{iso:<MOUNT_ISOLATION_COL_WIDTH$}"),
+                format!("{:<MOUNT_ISOLATION_COL_WIDTH$}", row.isolation),
                 Style::default().fg(PHOSPHOR_DIM),
             ),
             // Two-space gap before the type column — matches the header.
             Span::raw("  "),
-            Span::styled(kind.clone(), dim_style),
-        ])
-    }));
+            Span::styled(row.kind.clone(), dim_style),
+        ]));
+        if let Some(host_source) = &row.host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {host_source:<path_w$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
+    }
 
     // Sentinel row: + Add mount — selectable, styled distinctly from mounts.
     let sentinel_idx = state.pending.mounts.len();
@@ -538,28 +547,28 @@ fn append_global_mount_lines(
         format!("  Global mounts ({role})"),
         Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
     )));
-    let global_rows: Vec<(String, &'static str, &'static str, String)> = rows
+    let global_rows: Vec<MountDisplayRow> = rows
         .iter()
         .map(|row| {
-            let src = crate::tui::shorten_home(&row.mount.src);
-            let dst = crate::tui::shorten_home(&row.mount.dst);
-            let path = if row.mount.src == row.mount.dst {
-                src
-            } else {
-                format!("{src} \u{2192} {dst}")
-            };
+            let (destination, host_source) = mount_display_paths(&row.mount);
             let mode = if row.mount.readonly { "ro" } else { "rw" };
             let kind = super::super::mount_info::inspect(&row.mount.src).label();
             let kind = row
                 .scope
                 .as_ref()
                 .map_or_else(|| kind.clone(), |scope| format!("{kind} · {scope}"));
-            (path, mode, "shared", kind)
+            MountDisplayRow {
+                destination,
+                host_source,
+                mode,
+                isolation: "shared",
+                kind,
+            }
         })
         .collect();
     let path_w = mount_path_width(&global_rows);
     lines.push(render_mount_header(path_w));
-    for (i, (path, mode, iso, kind)) in global_rows.iter().enumerate() {
+    for (i, row) in global_rows.iter().enumerate() {
         let selected = cursor == offset + i;
         let prefix = if selected { "▸ " } else { "  " };
         let base_style = if selected {
@@ -573,19 +582,28 @@ fn append_global_mount_lines(
             .fg(PHOSPHOR_DIM)
             .add_modifier(Modifier::ITALIC);
         lines.push(Line::from(vec![
-            Span::styled(format!("{prefix}{path:<path_w$}  "), base_style),
             Span::styled(
-                format!("{mode:<MOUNT_MODE_COL_WIDTH$}"),
+                format!("{prefix}{:<path_w$}  ", row.destination),
+                base_style,
+            ),
+            Span::styled(
+                format!("{:<MOUNT_MODE_COL_WIDTH$}", row.mode),
                 Style::default().fg(PHOSPHOR_DIM),
             ),
             Span::raw("  "),
             Span::styled(
-                format!("{iso:<MOUNT_ISOLATION_COL_WIDTH$}"),
+                format!("{:<MOUNT_ISOLATION_COL_WIDTH$}", row.isolation),
                 Style::default().fg(PHOSPHOR_DIM),
             ),
             Span::raw("  "),
-            Span::styled(kind.clone(), dim_style),
+            Span::styled(row.kind.clone(), dim_style),
         ]));
+        if let Some(host_source) = &row.host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {host_source:<path_w$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
     }
 }
 

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -182,12 +182,24 @@ fn contextual_row_items(
                     items.push(FooterItem::Sep);
                     items.push(FooterItem::Key("I"));
                     items.push(FooterItem::Text("cycle isolation"));
+                    items.push(FooterItem::Sep);
+                    items.push(FooterItem::Key("H/L"));
+                    items.push(FooterItem::Text("scroll"));
                     items
                 }
-                Ordering::Equal => vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")],
-                Ordering::Greater => vec![FooterItem::Dyn(
-                    "global mount - edit from config mounts".to_string(),
-                )],
+                Ordering::Equal => vec![
+                    FooterItem::Key("Enter/A"),
+                    FooterItem::Text("add"),
+                    FooterItem::Sep,
+                    FooterItem::Key("H/L"),
+                    FooterItem::Text("scroll"),
+                ],
+                Ordering::Greater => vec![
+                    FooterItem::Dyn("global mount - edit from config mounts".to_string()),
+                    FooterItem::Sep,
+                    FooterItem::Key("H/L"),
+                    FooterItem::Text("scroll"),
+                ],
             }
         }
         EditorTab::Roles => {
@@ -447,10 +459,8 @@ fn render_editor_row(row: usize, cursor: usize, label: &str, value: &str) -> Lin
     Line::from(spans)
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK));
     let FieldFocus::Row(cursor) = state.active_field;
 
     // Build aligned table rows for all mounts.
@@ -513,40 +523,77 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
         action_row_style(sentinel_selected),
     )));
 
-    if let Some(workspace) = workspace_for_global_mount_context(state) {
-        match config.workspace_applicable_mount_rows(workspace) {
-            crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
-                lines.push(Line::from(""));
-                let offset = state.pending.mounts.len() + 1;
-                append_global_mount_lines(&mut lines, &role, &rows, cursor, offset);
-            }
-            crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
-                lines.push(Line::from(""));
-                lines.push(Line::from(Span::styled(
-                    format!(
-                        "Global mounts: selected role affects visibility ({})",
-                        candidates.join(", ")
-                    ),
-                    Style::default().fg(PHOSPHOR_DIM),
-                )));
-            }
+    let workspace_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            " Workspace mounts ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+
+    let Some(workspace) = workspace_for_global_mount_context(state) else {
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(workspace_block)
+                .scroll((0, state.scroll_x)),
+            area,
+        );
+        return;
+    };
+
+    let workspace_height = (lines.len() as u16 + 2).min(area.height.saturating_sub(4).max(4));
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(workspace_height), Constraint::Min(4)])
+        .split(area);
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(workspace_block)
+            .scroll((0, state.scroll_x)),
+        chunks[0],
+    );
+
+    let mut global_lines = Vec::new();
+    let mut global_title = " Global mounts ".to_string();
+    match config.workspace_applicable_mount_rows(workspace) {
+        crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
+            global_title = format!(" Global mounts · {role} ");
+            let offset = state.pending.mounts.len() + 1;
+            append_global_mount_lines(&mut global_lines, &rows, cursor, offset);
+        }
+        crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
+            global_lines.push(Line::from(Span::styled(
+                format!(
+                    "  selected role affects visibility ({})",
+                    candidates.join(", ")
+                ),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
         }
     }
 
-    frame.render_widget(Paragraph::new(lines).block(block), area);
+    let global_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            global_title,
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    frame.render_widget(
+        Paragraph::new(global_lines)
+            .block(global_block)
+            .scroll((0, state.scroll_x)),
+        chunks[1],
+    );
 }
 
 fn append_global_mount_lines(
     lines: &mut Vec<Line<'_>>,
-    role: &str,
     rows: &[crate::config::GlobalMountRow],
     cursor: usize,
     offset: usize,
 ) {
-    lines.push(Line::from(Span::styled(
-        format!("  Global mounts ({role})"),
-        Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-    )));
     let global_rows: Vec<MountDisplayRow> = rows
         .iter()
         .map(|row| {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -182,11 +182,9 @@ fn contextual_row_items(
                     items.push(FooterItem::Sep);
                     items.push(FooterItem::Key("I"));
                     items.push(FooterItem::Text("cycle isolation"));
-                    if state.workspace_mounts_scroll_focused {
-                        items.push(FooterItem::Sep);
-                        items.push(FooterItem::Key("H/L"));
-                        items.push(FooterItem::Text("scroll focused block"));
-                    }
+                    items.push(FooterItem::Sep);
+                    items.push(FooterItem::Key("H/L"));
+                    items.push(FooterItem::Text("scroll"));
                     items
                 }
                 Ordering::Equal => vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")],

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -15,8 +15,8 @@ use std::cmp::Ordering;
 
 use super::super::state::{EditorMode, EditorState, EditorTab, FieldFocus, SecretsScopeTag};
 use super::list::{
-    MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, MountDisplayRow, format_mount_rows,
-    mount_display_paths, mount_path_width, render_global_mount_header, render_mount_header,
+    MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, format_mount_rows, mount_path_width,
+    render_mount_header,
 };
 use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
@@ -182,24 +182,15 @@ fn contextual_row_items(
                     items.push(FooterItem::Sep);
                     items.push(FooterItem::Key("I"));
                     items.push(FooterItem::Text("cycle isolation"));
-                    items.push(FooterItem::Sep);
-                    items.push(FooterItem::Key("H/L"));
-                    items.push(FooterItem::Text("scroll"));
+                    if state.workspace_mounts_scroll_focused {
+                        items.push(FooterItem::Sep);
+                        items.push(FooterItem::Key("H/L"));
+                        items.push(FooterItem::Text("scroll focused block"));
+                    }
                     items
                 }
-                Ordering::Equal => vec![
-                    FooterItem::Key("Enter/A"),
-                    FooterItem::Text("add"),
-                    FooterItem::Sep,
-                    FooterItem::Key("H/L"),
-                    FooterItem::Text("scroll"),
-                ],
-                Ordering::Greater => vec![
-                    FooterItem::Dyn("global mount - edit from config mounts".to_string()),
-                    FooterItem::Sep,
-                    FooterItem::Key("H/L"),
-                    FooterItem::Text("scroll"),
-                ],
+                Ordering::Equal => vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")],
+                Ordering::Greater => Vec::new(),
             }
         }
         EditorTab::Roles => {
@@ -459,8 +450,7 @@ fn render_editor_row(row: usize, cursor: usize, label: &str, value: &str) -> Lin
     Line::from(spans)
 }
 
-#[allow(clippy::too_many_lines)]
-fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
+fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, _config: &AppConfig) {
     let FieldFocus::Row(cursor) = state.active_field;
 
     // Build aligned table rows for all mounts.
@@ -525,144 +515,31 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
 
     let workspace_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .border_style(
+            Style::default().fg(if state.workspace_mounts_scroll_focused {
+                PHOSPHOR_GREEN
+            } else {
+                PHOSPHOR_DARK
+            }),
+        )
         .title(Span::styled(
             " Workspace mounts ",
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
 
-    let Some(workspace) = workspace_for_global_mount_context(state) else {
-        let content_width = super::max_line_width(&lines);
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(workspace_block)
-                .scroll((0, state.workspace_mounts_scroll_x)),
-            area,
-        );
-        super::render_horizontal_scrollbar(
-            frame,
-            area,
-            content_width,
-            state.workspace_mounts_scroll_x,
-        );
-        return;
-    };
-
-    let workspace_height = (lines.len() as u16 + 2).min(area.height.saturating_sub(4).max(4));
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(workspace_height), Constraint::Min(4)])
-        .split(area);
-
     let workspace_content_width = super::max_line_width(&lines);
+    let scroll_x = super::effective_scroll_x(
+        workspace_content_width,
+        area.width.saturating_sub(2) as usize,
+        state.workspace_mounts_scroll_x,
+    );
     frame.render_widget(
         Paragraph::new(lines)
             .block(workspace_block)
-            .scroll((0, state.workspace_mounts_scroll_x)),
-        chunks[0],
+            .scroll((0, scroll_x)),
+        area,
     );
-    super::render_horizontal_scrollbar(
-        frame,
-        chunks[0],
-        workspace_content_width,
-        state.workspace_mounts_scroll_x,
-    );
-
-    let mut global_lines = Vec::new();
-    let mut global_title = " Global mounts ".to_string();
-    match config.workspace_applicable_mount_rows(workspace) {
-        crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
-            if rows.iter().any(|row| row.scope.is_some()) {
-                global_title = format!(" Role global mounts · {role} ");
-            }
-            let offset = state.pending.mounts.len() + 1;
-            append_global_mount_lines(&mut global_lines, &rows, cursor, offset);
-        }
-        crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates } => {
-            global_lines.push(Line::from(Span::styled(
-                format!(
-                    "  selected role affects visibility ({})",
-                    candidates.join(", ")
-                ),
-                Style::default().fg(PHOSPHOR_DIM),
-            )));
-        }
-    }
-
-    let global_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(Span::styled(
-            global_title,
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-    let global_content_width = super::max_line_width(&global_lines);
-    frame.render_widget(
-        Paragraph::new(global_lines)
-            .block(global_block)
-            .scroll((0, state.global_mounts_scroll_x)),
-        chunks[1],
-    );
-    super::render_horizontal_scrollbar(
-        frame,
-        chunks[1],
-        global_content_width,
-        state.global_mounts_scroll_x,
-    );
-}
-
-fn append_global_mount_lines(
-    lines: &mut Vec<Line<'_>>,
-    rows: &[crate::config::GlobalMountRow],
-    cursor: usize,
-    offset: usize,
-) {
-    let global_rows: Vec<MountDisplayRow> = rows
-        .iter()
-        .map(|row| {
-            let (destination, host_source) = mount_display_paths(&row.mount);
-            let mode = if row.mount.readonly { "ro" } else { "rw" };
-            MountDisplayRow {
-                destination,
-                host_source,
-                mode,
-                isolation: "shared",
-                kind: String::new(),
-            }
-        })
-        .collect();
-    let path_w = mount_path_width(&global_rows);
-    lines.push(render_global_mount_header(path_w));
-    for (i, row) in global_rows.iter().enumerate() {
-        let selected = cursor == offset + i;
-        let prefix = if selected { "▸ " } else { "  " };
-        let style = if selected {
-            Style::default()
-                .fg(PHOSPHOR_DIM)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(PHOSPHOR_DIM)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(format!("{prefix}{:<path_w$}  ", row.destination), style),
-            Span::styled(row.mode, Style::default().fg(PHOSPHOR_DIM)),
-        ]));
-        if let Some(host_source) = &row.host_source {
-            lines.push(Line::from(Span::styled(
-                format!("  {host_source:<path_w$}"),
-                Style::default().fg(PHOSPHOR_DIM),
-            )));
-        }
-    }
-}
-
-const fn workspace_for_global_mount_context<'a>(
-    state: &'a EditorState<'_>,
-) -> Option<&'a crate::workspace::WorkspaceConfig> {
-    match state.mode {
-        EditorMode::Edit { .. } => Some(&state.pending),
-        EditorMode::Create => None,
-    }
+    super::render_horizontal_scrollbar(frame, area, workspace_content_width, scroll_x);
 }
 
 fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -572,7 +572,9 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
     let mut global_title = " Global mounts ".to_string();
     match config.workspace_applicable_mount_rows(workspace) {
         crate::config::WorkspaceGlobalMountRows::Applicable { role, rows } => {
-            global_title = format!(" Global mounts · {role} ");
+            if rows.iter().any(|row| row.scope.is_some()) {
+                global_title = format!(" Role global mounts · {role} ");
+            }
             let offset = state.pending.mounts.len() + 1;
             append_global_mount_lines(&mut global_lines, &rows, cursor, offset);
         }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -16,7 +16,7 @@ use std::cmp::Ordering;
 use super::super::state::{EditorMode, EditorState, EditorTab, FieldFocus, SecretsScopeTag};
 use super::list::{
     MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, MountDisplayRow, format_mount_rows,
-    mount_display_paths, mount_path_width, render_mount_header,
+    mount_display_paths, mount_path_width, render_global_mount_header, render_mount_header,
 };
 use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
@@ -620,51 +620,30 @@ fn append_global_mount_lines(
         .map(|row| {
             let (destination, host_source) = mount_display_paths(&row.mount);
             let mode = if row.mount.readonly { "ro" } else { "rw" };
-            let kind = super::super::mount_info::inspect(&row.mount.src).label();
-            let kind = row
-                .scope
-                .as_ref()
-                .map_or_else(|| kind.clone(), |scope| format!("{kind} · {scope}"));
             MountDisplayRow {
                 destination,
                 host_source,
                 mode,
                 isolation: "shared",
-                kind,
+                kind: String::new(),
             }
         })
         .collect();
     let path_w = mount_path_width(&global_rows);
-    lines.push(render_mount_header(path_w));
+    lines.push(render_global_mount_header(path_w));
     for (i, row) in global_rows.iter().enumerate() {
         let selected = cursor == offset + i;
         let prefix = if selected { "▸ " } else { "  " };
-        let base_style = if selected {
+        let style = if selected {
             Style::default()
                 .fg(PHOSPHOR_DIM)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(PHOSPHOR_DIM)
         };
-        let dim_style = Style::default()
-            .fg(PHOSPHOR_DIM)
-            .add_modifier(Modifier::ITALIC);
         lines.push(Line::from(vec![
-            Span::styled(
-                format!("{prefix}{:<path_w$}  ", row.destination),
-                base_style,
-            ),
-            Span::styled(
-                format!("{:<MOUNT_MODE_COL_WIDTH$}", row.mode),
-                Style::default().fg(PHOSPHOR_DIM),
-            ),
-            Span::raw("  "),
-            Span::styled(
-                format!("{:<MOUNT_ISOLATION_COL_WIDTH$}", row.isolation),
-                Style::default().fg(PHOSPHOR_DIM),
-            ),
-            Span::raw("  "),
-            Span::styled(row.kind.clone(), dim_style),
+            Span::styled(format!("{prefix}{:<path_w$}  ", row.destination), style),
+            Span::styled(row.mode, Style::default().fg(PHOSPHOR_DIM)),
         ]));
         if let Some(host_source) = &row.host_source {
             lines.push(Line::from(Span::styled(

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -71,7 +71,7 @@ pub fn render_editor(
 
     match state.active_tab {
         EditorTab::General => render_general_tab(frame, chunks[2], state),
-        EditorTab::Mounts => render_mounts_tab(frame, chunks[2], state, config),
+        EditorTab::Mounts => render_mounts_tab(frame, chunks[2], state),
         EditorTab::Roles => render_roles_tab(frame, chunks[2], state, config),
         EditorTab::Secrets => render_secrets_tab(frame, chunks[2], state, config),
         EditorTab::Auth => render_auth_tab(frame, chunks[2], state, config),
@@ -339,16 +339,20 @@ pub(in crate::console::manager) fn auth_row_count(
     auth_flat_rows(state, config).len()
 }
 
+/// Order and labels of editor tabs. Shared with mouse hit-testing
+/// (`input::mouse::editor_tab_at`) so the strip the renderer draws is
+/// the same one the click code measures against.
+pub(in crate::console::manager) const EDITOR_TAB_LABELS: &[(EditorTab, &str)] = &[
+    (EditorTab::General, "General"),
+    (EditorTab::Mounts, "Mounts"),
+    (EditorTab::Roles, "Roles"),
+    (EditorTab::Secrets, "Environments"),
+    (EditorTab::Auth, "Auth"),
+];
+
 fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
-    let labels = [
-        (EditorTab::General, "General"),
-        (EditorTab::Mounts, "Mounts"),
-        (EditorTab::Roles, "Roles"),
-        (EditorTab::Secrets, "Environments"),
-        (EditorTab::Auth, "Auth"),
-    ];
     let mut spans = Vec::new();
-    for (tab, label) in labels {
+    for &(tab, label) in EDITOR_TAB_LABELS {
         let style = if tab == active {
             Style::default()
                 .bg(PHOSPHOR_GREEN)
@@ -448,7 +452,7 @@ fn render_editor_row(row: usize, cursor: usize, label: &str, value: &str) -> Lin
     Line::from(spans)
 }
 
-fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, _config: &AppConfig) {
+fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
     let FieldFocus::Row(cursor) = state.active_field;
 
     // Build aligned table rows for all mounts.

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -532,11 +532,18 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
         ));
 
     let Some(workspace) = workspace_for_global_mount_context(state) else {
+        let content_width = super::max_line_width(&lines);
         frame.render_widget(
             Paragraph::new(lines)
                 .block(workspace_block)
-                .scroll((0, state.scroll_x)),
+                .scroll((0, state.workspace_mounts_scroll_x)),
             area,
+        );
+        super::render_horizontal_scrollbar(
+            frame,
+            area,
+            content_width,
+            state.workspace_mounts_scroll_x,
         );
         return;
     };
@@ -547,11 +554,18 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
         .constraints([Constraint::Length(workspace_height), Constraint::Min(4)])
         .split(area);
 
+    let workspace_content_width = super::max_line_width(&lines);
     frame.render_widget(
         Paragraph::new(lines)
             .block(workspace_block)
-            .scroll((0, state.scroll_x)),
+            .scroll((0, state.workspace_mounts_scroll_x)),
         chunks[0],
+    );
+    super::render_horizontal_scrollbar(
+        frame,
+        chunks[0],
+        workspace_content_width,
+        state.workspace_mounts_scroll_x,
     );
 
     let mut global_lines = Vec::new();
@@ -580,11 +594,18 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, con
             global_title,
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
+    let global_content_width = super::max_line_width(&global_lines);
     frame.render_widget(
         Paragraph::new(global_lines)
             .block(global_block)
-            .scroll((0, state.scroll_x)),
+            .scroll((0, state.global_mounts_scroll_x)),
         chunks[1],
+    );
+    super::render_horizontal_scrollbar(
+        frame,
+        chunks[1],
+        global_content_width,
+        state.global_mounts_scroll_x,
     );
 }
 

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -1,0 +1,133 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+use super::{
+    FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
+};
+use crate::console::manager::state::{GlobalMountModal, GlobalMountsState};
+
+pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<'_>) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(10),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    render_header(frame, chunks[0], "global config · mounts");
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            " Global mounts ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    let mut lines = vec![Line::from(Span::styled(
+        "  Name                 Source                         Destination                    Mode Scope Type",
+        Style::default().fg(WHITE),
+    ))];
+    if state.pending.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none)",
+            Style::default().fg(PHOSPHOR_DIM),
+        )));
+    }
+    for (i, row) in state.pending.iter().enumerate() {
+        let selected = i == state.selected;
+        let prefix = if selected { "▸ " } else { "  " };
+        let style = if selected {
+            Style::default()
+                .fg(PHOSPHOR_GREEN)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(PHOSPHOR_GREEN)
+        };
+        let mode = if row.mount.readonly { "ro" } else { "rw" };
+        let scope = row.scope.as_deref().unwrap_or("global");
+        let kind = crate::console::manager::mount_info::inspect(&row.mount.src).label();
+        lines.push(Line::from(Span::styled(
+            format!(
+                "{prefix}{:<20} {:<30} {:<30} {:<4} {:<16} {}",
+                truncate(&row.name, 20),
+                truncate(&crate::tui::shorten_home(&row.mount.src), 30),
+                truncate(&row.mount.dst, 30),
+                mode,
+                truncate(scope, 16),
+                kind
+            ),
+            style,
+        )));
+    }
+    if let Some(err) = &state.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {err}"),
+            Style::default().fg(ratatui::style::Color::Rgb(255, 94, 122)),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines).block(block), chunks[1]);
+
+    let mut items = vec![
+        FooterItem::Key("A"),
+        FooterItem::Text("add"),
+        FooterItem::Sep,
+        FooterItem::Key("N"),
+        FooterItem::Text("rename"),
+        FooterItem::Sep,
+        FooterItem::Key("1"),
+        FooterItem::Text("source"),
+        FooterItem::Sep,
+        FooterItem::Key("2"),
+        FooterItem::Text("destination"),
+        FooterItem::Sep,
+        FooterItem::Key("3"),
+        FooterItem::Text("scope"),
+        FooterItem::Sep,
+        FooterItem::Key("R"),
+        FooterItem::Text("ro/rw"),
+        FooterItem::Sep,
+        FooterItem::Key("D"),
+        FooterItem::Text("remove"),
+        FooterItem::GroupSep,
+        FooterItem::Key("S"),
+        FooterItem::Text("save global config"),
+    ];
+    if state.is_dirty() {
+        items.push(FooterItem::Dyn("(unsaved)".to_string()));
+    }
+    items.extend([
+        FooterItem::GroupSep,
+        FooterItem::Key("Esc"),
+        FooterItem::Text("back"),
+    ]);
+    render_footer(frame, chunks[2], &items);
+}
+
+pub(super) fn render_global_mount_modal(frame: &mut Frame, modal: &mut GlobalMountModal<'_>) {
+    let area = super::centered_rect_fixed(frame.area(), 70, 7);
+    match modal {
+        GlobalMountModal::Text { state, .. } => {
+            crate::console::widgets::text_input::render(frame, area, state);
+        }
+        GlobalMountModal::ConfirmRemove { state } | GlobalMountModal::ConfirmSave { state } => {
+            crate::console::widgets::confirm::render(frame, area, state);
+        }
+    }
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    let mut out: String = value.chars().take(width).collect();
+    if value.chars().count() > width && width > 1 {
+        out.pop();
+        out.push('…');
+    }
+    out
+}

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -81,12 +81,14 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
             Style::default().fg(ratatui::style::Color::Rgb(255, 94, 122)),
         )));
     }
+    let content_width = super::max_line_width(&lines);
     frame.render_widget(
         Paragraph::new(lines)
             .block(block)
             .scroll((0, state.scroll_x)),
         chunks[1],
     );
+    super::render_horizontal_scrollbar(frame, chunks[1], content_width, state.scroll_x);
 
     let mut items = vec![
         FooterItem::Key("A"),

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -42,7 +42,7 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             format!("  {err}"),
-            Style::default().fg(ratatui::style::Color::Rgb(255, 94, 122)),
+            Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
         )));
     }
     let content_width = super::max_line_width(&lines);
@@ -149,9 +149,7 @@ pub(super) fn render_global_mount_modal(frame: &mut Frame, modal: &mut GlobalMou
         GlobalMountModal::Text { state, .. } => {
             crate::console::widgets::text_input::render(frame, area, state);
         }
-        GlobalMountModal::ConfirmRemove { state }
-        | GlobalMountModal::ConfirmSave { state }
-        | GlobalMountModal::ConfirmSensitive { state } => {
+        GlobalMountModal::Confirm { state, .. } => {
             crate::console::widgets::confirm::render(frame, area, state);
         }
     }

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -33,7 +33,7 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let mut lines = vec![Line::from(Span::styled(
-        "  Name                 Destination                    Mode Scope Type",
+        "  Name                 Destination                    Mode Scope",
         Style::default().fg(WHITE),
     ))];
     if state.pending.is_empty() {
@@ -54,16 +54,14 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         };
         let mode = if row.mount.readonly { "ro" } else { "rw" };
         let scope = row.scope.as_deref().unwrap_or("global");
-        let kind = crate::console::manager::mount_info::inspect(&row.mount.src).label();
         let (destination, host_source) = mount_display_paths(&row.mount);
         lines.push(Line::from(Span::styled(
             format!(
-                "{prefix}{:<20} {:<30} {:<4} {:<16} {}",
+                "{prefix}{:<20} {:<30} {:<4} {:<16}",
                 truncate(&row.name, 20),
                 truncate(&destination, 30),
                 mode,
-                truncate(scope, 16),
-                kind
+                truncate(scope, 16)
             ),
             style,
         )));

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -12,6 +12,11 @@ use super::{
 use crate::console::manager::render::list::mount_display_paths;
 use crate::console::manager::state::{GlobalMountModal, GlobalMountsState};
 
+pub(super) fn global_mounts_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
+    let lines = global_mount_lines(rows, None);
+    super::max_line_width(&lines)
+}
+
 #[allow(clippy::too_many_lines)]
 pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<'_>) {
     let area = frame.area();
@@ -32,46 +37,7 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
             " Global mounts ",
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
-    let mut lines = vec![Line::from(Span::styled(
-        "  Name                 Destination                    Mode Scope",
-        Style::default().fg(WHITE),
-    ))];
-    if state.pending.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  (none)",
-            Style::default().fg(PHOSPHOR_DIM),
-        )));
-    }
-    for (i, row) in state.pending.iter().enumerate() {
-        let selected = i == state.selected;
-        let prefix = if selected { "▸ " } else { "  " };
-        let style = if selected {
-            Style::default()
-                .fg(PHOSPHOR_GREEN)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(PHOSPHOR_GREEN)
-        };
-        let mode = if row.mount.readonly { "ro" } else { "rw" };
-        let scope = row.scope.as_deref().unwrap_or("global");
-        let (destination, host_source) = mount_display_paths(&row.mount);
-        lines.push(Line::from(Span::styled(
-            format!(
-                "{prefix}{:<20} {:<30} {:<4} {:<16}",
-                truncate(&row.name, 20),
-                truncate(&destination, 30),
-                mode,
-                truncate(scope, 16)
-            ),
-            style,
-        )));
-        if let Some(host_source) = host_source {
-            lines.push(Line::from(Span::styled(
-                format!("  {:<20} {}", "", truncate(&host_source, 64)),
-                Style::default().fg(PHOSPHOR_DIM),
-            )));
-        }
-    }
+    let mut lines = global_mount_lines(&state.pending, Some(state.selected));
     if let Some(err) = &state.error {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -128,6 +94,53 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         FooterItem::Text("back"),
     ]);
     render_footer(frame, chunks[2], &items);
+}
+
+fn global_mount_lines(
+    rows: &[crate::config::GlobalMountRow],
+    selected: Option<usize>,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "  Name                 Destination                    Mode Scope",
+        Style::default().fg(WHITE),
+    ))];
+    if rows.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none)",
+            Style::default().fg(PHOSPHOR_DIM),
+        )));
+    }
+    for (i, row) in rows.iter().enumerate() {
+        let is_selected = selected == Some(i);
+        let prefix = if is_selected { "▸ " } else { "  " };
+        let style = if is_selected {
+            Style::default()
+                .fg(PHOSPHOR_GREEN)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(PHOSPHOR_GREEN)
+        };
+        let mode = if row.mount.readonly { "ro" } else { "rw" };
+        let scope = row.scope.as_deref().unwrap_or("global");
+        let (destination, host_source) = mount_display_paths(&row.mount);
+        lines.push(Line::from(Span::styled(
+            format!(
+                "{prefix}{:<20} {:<30} {:<4} {:<16}",
+                truncate(&row.name, 20),
+                truncate(&destination, 30),
+                mode,
+                truncate(scope, 16)
+            ),
+            style,
+        )));
+        if let Some(host_source) = host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {:<20} {}", "", truncate(&host_source, 64)),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
+    }
+    lines
 }
 
 pub(super) fn render_global_mount_modal(frame: &mut Frame, modal: &mut GlobalMountModal<'_>) {

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -117,7 +117,9 @@ pub(super) fn render_global_mount_modal(frame: &mut Frame, modal: &mut GlobalMou
         GlobalMountModal::Text { state, .. } => {
             crate::console::widgets::text_input::render(frame, area, state);
         }
-        GlobalMountModal::ConfirmRemove { state } | GlobalMountModal::ConfirmSave { state } => {
+        GlobalMountModal::ConfirmRemove { state }
+        | GlobalMountModal::ConfirmSave { state }
+        | GlobalMountModal::ConfirmSensitive { state } => {
             crate::console::widgets::confirm::render(frame, area, state);
         }
     }

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -81,7 +81,12 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
             Style::default().fg(ratatui::style::Color::Rgb(255, 94, 122)),
         )));
     }
-    frame.render_widget(Paragraph::new(lines).block(block), chunks[1]);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .scroll((0, state.scroll_x)),
+        chunks[1],
+    );
 
     let mut items = vec![
         FooterItem::Key("A"),
@@ -107,6 +112,9 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         FooterItem::GroupSep,
         FooterItem::Key("S"),
         FooterItem::Text("save global config"),
+        FooterItem::GroupSep,
+        FooterItem::Key("←/→"),
+        FooterItem::Text("scroll"),
     ];
     if state.is_dirty() {
         items.push(FooterItem::Dyn("(unsaved)".to_string()));

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -9,8 +9,10 @@ use ratatui::{
 use super::{
     FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
 };
+use crate::console::manager::render::list::mount_display_paths;
 use crate::console::manager::state::{GlobalMountModal, GlobalMountsState};
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<'_>) {
     let area = frame.area();
     let chunks = Layout::default()
@@ -31,7 +33,7 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let mut lines = vec![Line::from(Span::styled(
-        "  Name                 Source                         Destination                    Mode Scope Type",
+        "  Name                 Destination                    Mode Scope Type",
         Style::default().fg(WHITE),
     ))];
     if state.pending.is_empty() {
@@ -53,18 +55,24 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         let mode = if row.mount.readonly { "ro" } else { "rw" };
         let scope = row.scope.as_deref().unwrap_or("global");
         let kind = crate::console::manager::mount_info::inspect(&row.mount.src).label();
+        let (destination, host_source) = mount_display_paths(&row.mount);
         lines.push(Line::from(Span::styled(
             format!(
-                "{prefix}{:<20} {:<30} {:<30} {:<4} {:<16} {}",
+                "{prefix}{:<20} {:<30} {:<4} {:<16} {}",
                 truncate(&row.name, 20),
-                truncate(&crate::tui::shorten_home(&row.mount.src), 30),
-                truncate(&row.mount.dst, 30),
+                truncate(&destination, 30),
                 mode,
                 truncate(scope, 16),
                 kind
             ),
             style,
         )));
+        if let Some(host_source) = host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {:<20} {}", "", truncate(&host_source, 64)),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
     }
     if let Some(err) = &state.error {
         lines.push(Line::from(""));

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -80,13 +80,16 @@ pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<
         )));
     }
     let content_width = super::max_line_width(&lines);
+    let scroll_x = super::effective_scroll_x(
+        content_width,
+        chunks[1].width.saturating_sub(2) as usize,
+        state.scroll_x,
+    );
     frame.render_widget(
-        Paragraph::new(lines)
-            .block(block)
-            .scroll((0, state.scroll_x)),
+        Paragraph::new(lines).block(block).scroll((0, scroll_x)),
         chunks[1],
     );
-    super::render_horizontal_scrollbar(frame, chunks[1], content_width, state.scroll_x);
+    super::render_horizontal_scrollbar(frame, chunks[1], content_width, scroll_x);
 
     let mut items = vec![
         FooterItem::Key("A"),

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -17,7 +17,6 @@ pub(super) fn global_mounts_content_width(rows: &[crate::config::GlobalMountRow]
     super::max_line_width(&lines)
 }
 
-#[allow(clippy::too_many_lines)]
 pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<'_>) {
     let area = frame.area();
     let chunks = Layout::default()

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -55,10 +55,13 @@ pub(super) fn render_list_body(
         }
     }
 
-    if let Some(picker) = state.inline_role_picker.as_ref()
-        && let Some(summary) = state.selected_workspace_summary()
-    {
-        render_role_picker_sidebar(frame, list_area, &summary.name, picker);
+    if let Some((role, picker)) = state.inline_agent_picker.as_ref() {
+        render_agent_picker_sidebar(frame, list_area, &role.key(), picker);
+    } else if let Some(picker) = state.inline_role_picker.as_ref() {
+        let title = state
+            .selected_workspace_summary()
+            .map_or("Current directory", |summary| summary.name.as_str());
+        render_role_picker_sidebar(frame, list_area, title, picker);
     } else {
         // Left: [Current directory] + saved workspaces + blank spacer +
         // [+ New workspace]. The spacer is visual-only; state keeps logical row
@@ -132,6 +135,43 @@ fn render_role_picker_sidebar(
         .highlight_symbol("▸ ");
     let mut list_state = ListState::default();
     list_state.select(picker.list_state.selected);
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_agent_picker_sidebar(
+    frame: &mut Frame,
+    area: Rect,
+    role_name: &str,
+    picker: &crate::console::widgets::agent_choice::AgentChoiceState,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            format!(" {role_name} "),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    let items: Vec<ListItem> = picker
+        .choices
+        .iter()
+        .map(|agent| {
+            ListItem::new(Line::from(
+                crate::console::widgets::agent_choice::agent_picker_label(*agent),
+            ))
+        })
+        .collect();
+    let list = List::new(items)
+        .block(block)
+        .style(Style::default().fg(PHOSPHOR_GREEN))
+        .highlight_style(Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black))
+        .highlight_symbol("▸ ");
+    let mut list_state = ListState::default();
+    list_state.select(
+        picker
+            .choices
+            .iter()
+            .position(|agent| *agent == picker.focused),
+    );
     frame.render_stateful_widget(list, area, &mut list_state);
 }
 
@@ -340,7 +380,13 @@ fn render_details_pane(
     let picker_role = state
         .inline_role_picker
         .as_ref()
-        .and_then(selected_picker_role);
+        .and_then(selected_picker_role)
+        .or_else(|| {
+            state
+                .inline_agent_picker
+                .as_ref()
+                .map(|(role, _)| role.clone())
+        });
     let global_display = ws_config.and_then(|_| {
         let rows = picker_role.as_ref().map_or_else(
             || {
@@ -359,7 +405,9 @@ fn render_details_pane(
             rows,
         })
     });
-    let agent_count = if state.inline_role_picker.is_some() {
+    let inline_picker_active =
+        state.inline_role_picker.is_some() || state.inline_agent_picker.is_some();
+    let agent_count = if inline_picker_active {
         0
     } else {
         agents_block_agent_count(ws_config, config)
@@ -378,7 +426,7 @@ fn render_details_pane(
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
     }
-    if state.inline_role_picker.is_none() {
+    if !inline_picker_active {
         constraints.push(Constraint::Length(agents_block_height(agent_count)));
     }
 
@@ -413,7 +461,7 @@ fn render_details_pane(
         render_environments_subpanel(frame, rows[idx], ws_config);
         idx += 1;
     }
-    if state.inline_role_picker.is_none() {
+    if !inline_picker_active {
         render_agents_subpanel(frame, rows[idx], ws_config, config);
     }
 }

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -226,12 +226,23 @@ pub(super) fn render_mount_lines(
 fn render_details_pane(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary, config: &AppConfig) {
     let ws_config = config.workspaces.get(&ws.name);
     let mounts = ws_config.map_or(&[][..], |w| w.mounts.as_slice());
+    let global_display = ws_config.map(|w| config.workspace_applicable_mount_rows(w));
+    let global_mounts: Vec<crate::workspace::MountConfig> = match &global_display {
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. }) => {
+            rows.iter().map(|row| row.mount.clone()).collect()
+        }
+        _ => Vec::new(),
+    };
     let agent_count = agents_block_agent_count(ws_config, config);
     let show_envs = ws_config.is_some_and(workspace_has_any_env);
 
     let mut constraints = vec![
         Constraint::Length(3),
         Constraint::Length(mount_block_height(mounts)),
+        Constraint::Length(global_mount_block_height(
+            global_display.as_ref(),
+            &global_mounts,
+        )),
     ];
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
@@ -248,6 +259,8 @@ fn render_details_pane(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary, con
     idx += 1;
     render_mounts_subpanel(frame, rows[idx], mounts);
     idx += 1;
+    render_global_mounts_subpanel(frame, rows[idx], global_display.as_ref(), &global_mounts);
+    idx += 1;
     if show_envs {
         render_environments_subpanel(frame, rows[idx], ws_config);
         idx += 1;
@@ -262,6 +275,18 @@ fn workspace_has_any_env(ws: &crate::workspace::WorkspaceConfig) -> bool {
 fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
     let data_rows = if mounts.is_empty() { 1 } else { mounts.len() };
     (data_rows + 2 + 1).min(12) as u16
+}
+
+fn global_mount_block_height(
+    display: Option<&crate::config::WorkspaceGlobalMountRows>,
+    mounts: &[crate::workspace::MountConfig],
+) -> u16 {
+    match display {
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => {
+            mount_block_height(mounts)
+        }
+        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { .. }) | None => 4,
+    }
 }
 
 /// Caller is expected to have gated on `workspace_has_any_env` —
@@ -491,6 +516,67 @@ fn render_mounts_subpanel(frame: &mut Frame, area: Rect, mounts: &[crate::worksp
         let path_w = mount_path_width(&rows);
         lines.push(render_mount_header(path_w));
         lines.extend(render_mount_lines(&rows, path_w));
+    }
+
+    let p = Paragraph::new(lines)
+        .block(block)
+        .style(Style::default().fg(PHOSPHOR_GREEN));
+    frame.render_widget(p, area);
+}
+
+fn render_global_mounts_subpanel(
+    frame: &mut Frame,
+    area: Rect,
+    display: Option<&crate::config::WorkspaceGlobalMountRows>,
+    mounts: &[crate::workspace::MountConfig],
+) {
+    let title = match display {
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, .. }) => {
+            format!(" Global mounts · {role} ")
+        }
+        _ => " Global mounts ".to_string(),
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            title,
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+
+    let mut lines: Vec<Line> = Vec::new();
+    match display {
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => {
+            if mounts.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "  (none)",
+                    Style::default().fg(PHOSPHOR_DIM),
+                )));
+            } else {
+                let rows = format_mount_rows(mounts);
+                let path_w = mount_path_width(&rows);
+                lines.push(render_mount_header(path_w));
+                lines.extend(render_mount_lines(&rows, path_w));
+            }
+        }
+        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates }) => {
+            let suffix = if candidates.is_empty() {
+                "selected role affects global mount visibility".to_string()
+            } else {
+                format!(
+                    "selected role affects global mount visibility: {}",
+                    candidates.join(", ")
+                )
+            };
+            lines.push(Line::from(Span::styled(
+                format!("  {suffix}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
+        None => lines.push(Line::from(Span::styled(
+            "  (workspace missing)",
+            Style::default().fg(PHOSPHOR_DIM),
+        ))),
     }
 
     let p = Paragraph::new(lines)

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -50,7 +50,7 @@ pub(super) fn render_list_body(
         }
         ManagerListRow::SavedWorkspace(i) => {
             if let Some(ws) = state.workspaces.get(i) {
-                render_details_pane(frame, columns[1], ws, config);
+                render_details_pane(frame, columns[1], ws, config, state);
             }
         }
     }
@@ -247,10 +247,28 @@ pub(super) fn render_mount_lines(rows: &[MountDisplayRow], path_w: usize) -> Vec
     lines
 }
 
-fn render_details_pane(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary, config: &AppConfig) {
+fn render_details_pane(
+    frame: &mut Frame,
+    area: Rect,
+    ws: &WorkspaceSummary,
+    config: &AppConfig,
+    state: &ManagerState<'_>,
+) {
     let ws_config = config.workspaces.get(&ws.name);
     let mounts = ws_config.map_or(&[][..], |w| w.mounts.as_slice());
-    let global_display = ws_config.map(|w| config.workspace_applicable_mount_rows(w));
+    let picker_role = state
+        .inline_role_picker
+        .as_ref()
+        .and_then(selected_picker_role);
+    let global_display = ws_config.map(|w| {
+        picker_role.as_ref().map_or_else(
+            || config.workspace_applicable_mount_rows(w),
+            |role| crate::config::WorkspaceGlobalMountRows::Applicable {
+                role: role.key(),
+                rows: config.resolve_mount_rows(role),
+            },
+        )
+    });
     let global_mounts: Vec<crate::workspace::MountConfig> = match &global_display {
         Some(crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. }) => {
             rows.iter().map(|row| row.mount.clone()).collect()
@@ -281,15 +299,34 @@ fn render_details_pane(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary, con
     let mut idx = 0;
     render_general_subpanel(frame, rows[idx], ws);
     idx += 1;
-    render_mounts_subpanel(frame, rows[idx], mounts);
+    render_mounts_subpanel(frame, rows[idx], mounts, state.list_scroll_x);
     idx += 1;
-    render_global_mounts_subpanel(frame, rows[idx], global_display.as_ref(), &global_mounts);
+    render_global_mounts_subpanel(
+        frame,
+        rows[idx],
+        global_display.as_ref(),
+        &global_mounts,
+        state.list_scroll_x,
+    );
     idx += 1;
     if show_envs {
         render_environments_subpanel(frame, rows[idx], ws_config);
         idx += 1;
     }
-    render_agents_subpanel(frame, rows[idx], ws_config, config);
+    if let Some(picker) = state.inline_role_picker.as_ref() {
+        render_role_picker_subpanel(frame, rows[idx], picker);
+    } else {
+        render_agents_subpanel(frame, rows[idx], ws_config, config);
+    }
+}
+
+fn selected_picker_role(
+    picker: &crate::console::widgets::role_picker::RolePickerState,
+) -> Option<crate::selector::RoleSelector> {
+    picker
+        .list_state
+        .selected
+        .and_then(|idx| picker.filtered.get(idx).cloned())
 }
 
 fn workspace_has_any_env(ws: &crate::workspace::WorkspaceConfig) -> bool {
@@ -408,7 +445,7 @@ fn render_current_dir_details_pane(
         rows[0],
     );
 
-    render_mounts_subpanel(frame, rows[1], &mounts);
+    render_mounts_subpanel(frame, rows[1], &mounts, 0);
 
     // Roles block — reuse the no-`ws_config` branch of the shared renderer,
     // which lists every globally-configured role (without per-role
@@ -521,7 +558,12 @@ fn render_general_subpanel(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary)
 /// `subpanel_content_column_alignment` in the visual regression tests.
 const SUBPANEL_CONTENT_INDENT: usize = 2;
 
-fn render_mounts_subpanel(frame: &mut Frame, area: Rect, mounts: &[crate::workspace::MountConfig]) {
+fn render_mounts_subpanel(
+    frame: &mut Frame,
+    area: Rect,
+    mounts: &[crate::workspace::MountConfig],
+    scroll_x: u16,
+) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(PHOSPHOR_DARK))
@@ -551,6 +593,7 @@ fn render_mounts_subpanel(frame: &mut Frame, area: Rect, mounts: &[crate::worksp
 
     let p = Paragraph::new(lines)
         .block(block)
+        .scroll((0, scroll_x))
         .style(Style::default().fg(PHOSPHOR_GREEN));
     frame.render_widget(p, area);
 }
@@ -560,6 +603,7 @@ fn render_global_mounts_subpanel(
     area: Rect,
     display: Option<&crate::config::WorkspaceGlobalMountRows>,
     mounts: &[crate::workspace::MountConfig],
+    scroll_x: u16,
 ) {
     let title = match display {
         Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, .. }) => {
@@ -612,8 +656,51 @@ fn render_global_mounts_subpanel(
 
     let p = Paragraph::new(lines)
         .block(block)
+        .scroll((0, scroll_x))
         .style(Style::default().fg(PHOSPHOR_GREEN));
     frame.render_widget(p, area);
+}
+
+fn render_role_picker_subpanel(
+    frame: &mut Frame,
+    area: Rect,
+    picker: &crate::console::widgets::role_picker::RolePickerState,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            " Select role ",
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    let mut lines = Vec::new();
+    if !picker.filter.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!("  Filter: {}", picker.filter),
+            Style::default().fg(PHOSPHOR_DIM),
+        )));
+    }
+    for (i, role) in picker.filtered.iter().enumerate() {
+        let selected = Some(i) == picker.list_state.selected;
+        let prefix = if selected { "▸ " } else { "  " };
+        let style = if selected {
+            Style::default()
+                .fg(PHOSPHOR_GREEN)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(WHITE)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{prefix}{}", role.key()),
+            style,
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Enter launch · Esc cancel",
+        Style::default().fg(PHOSPHOR_DIM),
+    )));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
 /// One row in the flat Environments preview list.
@@ -1167,7 +1254,7 @@ mod subpanel_padding_tests {
         let backend = TestBackend::new(40, 4);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[]);
+            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[], 0);
         })
         .unwrap();
         let mounts_col = first_content_indent(&term).expect("mounts has content");
@@ -2018,8 +2105,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
+        let state = crate::console::manager::state::ManagerState::from_config(
+            &cfg,
+            std::path::Path::new("/tmp"),
+        );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
         })
         .unwrap();
 
@@ -2066,8 +2157,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
+        let state = crate::console::manager::state::ManagerState::from_config(
+            &cfg,
+            std::path::Path::new("/tmp"),
+        );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
         })
         .unwrap();
 
@@ -2118,8 +2213,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
+        let state = crate::console::manager::state::ManagerState::from_config(
+            &cfg,
+            std::path::Path::new("/tmp"),
+        );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
         })
         .unwrap();
 
@@ -2177,8 +2276,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
+        let state = crate::console::manager::state::ManagerState::from_config(
+            &cfg,
+            std::path::Path::new("/tmp"),
+        );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
         })
         .unwrap();
 

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -330,12 +330,6 @@ fn render_details_pane(
             },
         )
     });
-    let global_mounts: Vec<crate::workspace::MountConfig> = match &global_display {
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. }) => {
-            rows.iter().map(|row| row.mount.clone()).collect()
-        }
-        _ => Vec::new(),
-    };
     let agent_count = if state.inline_role_picker.is_some() {
         0
     } else {
@@ -346,10 +340,7 @@ fn render_details_pane(
     let mut constraints = vec![
         Constraint::Length(3),
         Constraint::Length(mount_block_height(mounts)),
-        Constraint::Length(global_mount_block_height(
-            global_display.as_ref(),
-            &global_mounts,
-        )),
+        Constraint::Length(global_mount_block_height(global_display.as_ref())),
     ];
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
@@ -372,7 +363,6 @@ fn render_details_pane(
         frame,
         rows[idx],
         global_display.as_ref(),
-        &global_mounts,
         state.list_global_mounts_scroll_x,
     );
     idx += 1;
@@ -410,16 +400,35 @@ fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
     (data_rows + 2 + 1).min(12) as u16
 }
 
-fn global_mount_block_height(
-    display: Option<&crate::config::WorkspaceGlobalMountRows>,
-    mounts: &[crate::workspace::MountConfig],
-) -> u16 {
+fn global_mount_block_height(display: Option<&crate::config::WorkspaceGlobalMountRows>) -> u16 {
     match display {
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => {
-            mount_block_height(mounts)
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. }) => {
+            let (global, scoped) = split_global_mount_rows(rows);
+            let mut h = 0;
+            if !global.is_empty() || scoped.is_empty() {
+                h += global_mount_rows_height(global.len());
+            }
+            if !scoped.is_empty() {
+                h += global_mount_rows_height(scoped.len());
+            }
+            h
         }
         Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { .. }) | None => 4,
     }
+}
+
+fn global_mount_rows_height(count: usize) -> u16 {
+    let rows = if count == 0 { 1 } else { count * 2 };
+    (rows + 3).min(12) as u16
+}
+
+fn split_global_mount_rows(
+    rows: &[crate::config::GlobalMountRow],
+) -> (
+    Vec<&crate::config::GlobalMountRow>,
+    Vec<&crate::config::GlobalMountRow>,
+) {
+    rows.iter().partition(|row| row.scope.is_none())
 }
 
 /// Caller is expected to have gated on `workspace_has_any_env` —
@@ -669,38 +678,41 @@ fn render_global_mounts_subpanel(
     frame: &mut Frame,
     area: Rect,
     display: Option<&crate::config::WorkspaceGlobalMountRows>,
-    mounts: &[crate::workspace::MountConfig],
     scroll_x: u16,
 ) {
-    let title = match display {
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, .. }) => {
-            format!(" Global mounts · {role} ")
+    if let Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, rows }) = display {
+        let (global, scoped) = split_global_mount_rows(rows);
+        let mut sections = Vec::new();
+        if !global.is_empty() || scoped.is_empty() {
+            sections.push((" Global mounts ".to_string(), global));
         }
-        _ => " Global mounts ".to_string(),
-    };
+        if !scoped.is_empty() {
+            sections.push((format!(" Role global mounts · {role} "), scoped));
+        }
+        let constraints: Vec<Constraint> = sections
+            .iter()
+            .map(|(_, rows)| Constraint::Length(global_mount_rows_height(rows.len())))
+            .collect();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(area);
+        for ((title, rows), chunk) in sections.into_iter().zip(chunks.iter()) {
+            render_global_mount_rows_section(frame, *chunk, &title, &rows, scroll_x);
+        }
+        return;
+    }
+
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(PHOSPHOR_DARK))
         .title(Span::styled(
-            title,
+            " Global mounts ",
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
 
     let mut lines: Vec<Line> = Vec::new();
     match display {
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => {
-            if mounts.is_empty() {
-                lines.push(Line::from(Span::styled(
-                    "  (none)",
-                    Style::default().fg(PHOSPHOR_DIM),
-                )));
-            } else {
-                let rows = format_mount_rows(mounts);
-                let path_w = mount_path_width(&rows);
-                lines.push(render_global_mount_header(path_w));
-                lines.extend(render_global_mount_lines(&rows, path_w));
-            }
-        }
         Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates }) => {
             let suffix = if candidates.is_empty() {
                 "selected role affects global mount visibility".to_string()
@@ -719,8 +731,46 @@ fn render_global_mounts_subpanel(
             "  (workspace missing)",
             Style::default().fg(PHOSPHOR_DIM),
         ))),
+        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => unreachable!(),
     }
 
+    let content_width = super::max_line_width(&lines);
+    let p = Paragraph::new(lines)
+        .block(block)
+        .scroll((0, scroll_x))
+        .style(Style::default().fg(PHOSPHOR_GREEN));
+    frame.render_widget(p, area);
+    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
+}
+
+fn render_global_mount_rows_section(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    rows: &[&crate::config::GlobalMountRow],
+    scroll_x: u16,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            title.to_string(),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    let mut lines = Vec::new();
+    if rows.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none)",
+            Style::default().fg(PHOSPHOR_DIM),
+        )));
+    } else {
+        let mounts: Vec<crate::workspace::MountConfig> =
+            rows.iter().map(|row| row.mount.clone()).collect();
+        let display_rows = format_mount_rows(&mounts);
+        let path_w = mount_path_width(&display_rows);
+        lines.push(render_global_mount_header(path_w));
+        lines.extend(render_global_mount_lines(&display_rows, path_w));
+    }
     let content_width = super::max_line_width(&lines);
     let p = Paragraph::new(lines)
         .block(block)

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -10,7 +10,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
 
-use super::super::state::{ManagerListRow, ManagerState, WorkspaceSummary};
+use super::super::state::{ManagerListRow, ManagerState, MountScrollFocus, WorkspaceSummary};
 use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 use crate::config::AppConfig;
 
@@ -357,13 +357,21 @@ fn render_details_pane(
     let mut idx = 0;
     render_general_subpanel(frame, rows[idx], ws);
     idx += 1;
-    render_mounts_subpanel(frame, rows[idx], mounts, state.list_mounts_scroll_x);
+    render_mounts_subpanel(
+        frame,
+        rows[idx],
+        mounts,
+        state.list_mounts_scroll_x,
+        state.list_scroll_focus == Some(MountScrollFocus::Workspace),
+    );
     idx += 1;
     render_global_mounts_subpanel(
         frame,
         rows[idx],
         global_display.as_ref(),
         state.list_global_mounts_scroll_x,
+        state.list_role_global_mounts_scroll_x,
+        state.list_scroll_focus,
     );
     idx += 1;
     if show_envs {
@@ -519,7 +527,7 @@ fn render_current_dir_details_pane(
         rows[0],
     );
 
-    render_mounts_subpanel(frame, rows[1], &mounts, 0);
+    render_mounts_subpanel(frame, rows[1], &mounts, 0, false);
 
     // Roles block — reuse the no-`ws_config` branch of the shared renderer,
     // which lists every globally-configured role (without per-role
@@ -637,10 +645,16 @@ fn render_mounts_subpanel(
     area: Rect,
     mounts: &[crate::workspace::MountConfig],
     scroll_x: u16,
+    focused: bool,
 ) {
+    let border = if focused {
+        PHOSPHOR_GREEN
+    } else {
+        PHOSPHOR_DARK
+    };
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .border_style(Style::default().fg(border))
         .title(Span::styled(
             " Mounts ",
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
@@ -666,6 +680,11 @@ fn render_mounts_subpanel(
     }
 
     let content_width = super::max_line_width(&lines);
+    let scroll_x = super::effective_scroll_x(
+        content_width,
+        area.width.saturating_sub(2) as usize,
+        scroll_x,
+    );
     let p = Paragraph::new(lines)
         .block(block)
         .scroll((0, scroll_x))
@@ -678,7 +697,9 @@ fn render_global_mounts_subpanel(
     frame: &mut Frame,
     area: Rect,
     display: Option<&crate::config::WorkspaceGlobalMountRows>,
-    scroll_x: u16,
+    global_scroll_x: u16,
+    role_scroll_x: u16,
+    focused: Option<MountScrollFocus>,
 ) {
     if let Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, rows }) = display {
         let (global, scoped) = split_global_mount_rows(rows);
@@ -698,14 +719,39 @@ fn render_global_mounts_subpanel(
             .constraints(constraints)
             .split(area);
         for ((title, rows), chunk) in sections.into_iter().zip(chunks.iter()) {
-            render_global_mount_rows_section(frame, *chunk, &title, &rows, scroll_x);
+            let is_role = title.starts_with(" Role global mounts ");
+            let scroll_x = if is_role {
+                role_scroll_x
+            } else {
+                global_scroll_x
+            };
+            let section_focused = focused
+                == Some(if is_role {
+                    MountScrollFocus::RoleGlobal
+                } else {
+                    MountScrollFocus::Global
+                });
+            render_global_mount_rows_section(
+                frame,
+                *chunk,
+                &title,
+                &rows,
+                scroll_x,
+                section_focused,
+            );
         }
         return;
     }
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .border_style(
+            Style::default().fg(if focused == Some(MountScrollFocus::Global) {
+                PHOSPHOR_GREEN
+            } else {
+                PHOSPHOR_DARK
+            }),
+        )
         .title(Span::styled(
             " Global mounts ",
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
@@ -735,6 +781,11 @@ fn render_global_mounts_subpanel(
     }
 
     let content_width = super::max_line_width(&lines);
+    let scroll_x = super::effective_scroll_x(
+        content_width,
+        area.width.saturating_sub(2) as usize,
+        global_scroll_x,
+    );
     let p = Paragraph::new(lines)
         .block(block)
         .scroll((0, scroll_x))
@@ -749,10 +800,15 @@ fn render_global_mount_rows_section(
     title: &str,
     rows: &[&crate::config::GlobalMountRow],
     scroll_x: u16,
+    focused: bool,
 ) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .border_style(Style::default().fg(if focused {
+            PHOSPHOR_GREEN
+        } else {
+            PHOSPHOR_DARK
+        }))
         .title(Span::styled(
             title.to_string(),
             Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
@@ -772,6 +828,11 @@ fn render_global_mount_rows_section(
         lines.extend(render_global_mount_lines(&display_rows, path_w));
     }
     let content_width = super::max_line_width(&lines);
+    let scroll_x = super::effective_scroll_x(
+        content_width,
+        area.width.saturating_sub(2) as usize,
+        scroll_x,
+    );
     let p = Paragraph::new(lines)
         .block(block)
         .scroll((0, scroll_x))
@@ -1331,7 +1392,7 @@ mod subpanel_padding_tests {
         let backend = TestBackend::new(40, 4);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[], 0);
+            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[], 0, false);
         })
         .unwrap();
         let mounts_col = first_content_indent(&term).expect("mounts has content");

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -55,50 +55,84 @@ pub(super) fn render_list_body(
         }
     }
 
-    // Left: [Current directory] + saved workspaces + blank spacer +
-    // [+ New workspace]. The spacer is visual-only; state keeps logical row
-    // indices without it.
-    // The cwd path itself is shown on the right-pane `workdir` line; keep the
-    // list row label short to avoid duplicate visual load.
-    let has_saved_workspaces = saved_count > 0;
-    let mut items: Vec<ListItem> =
-        Vec::with_capacity(saved_count + 2 + usize::from(has_saved_workspaces));
-    items.push(ListItem::new(Line::from(Span::styled(
-        "Current directory",
-        Style::default().fg(WHITE),
-    ))));
-    items.extend(
-        state
-            .workspaces
-            .iter()
-            .map(|w| ListItem::new(Line::from(w.name.as_str()))),
-    );
-    if has_saved_workspaces {
-        items.push(ListItem::new(Line::from("")));
+    if let Some(picker) = state.inline_role_picker.as_ref()
+        && let Some(summary) = state.selected_workspace_summary()
+    {
+        render_role_picker_sidebar(frame, list_area, &summary.name, picker);
+    } else {
+        // Left: [Current directory] + saved workspaces + blank spacer +
+        // [+ New workspace]. The spacer is visual-only; state keeps logical row
+        // indices without it.
+        // The cwd path itself is shown on the right-pane `workdir` line; keep the
+        // list row label short to avoid duplicate visual load.
+        let has_saved_workspaces = saved_count > 0;
+        let mut items: Vec<ListItem> =
+            Vec::with_capacity(saved_count + 2 + usize::from(has_saved_workspaces));
+        items.push(ListItem::new(Line::from(Span::styled(
+            "Current directory",
+            Style::default().fg(WHITE),
+        ))));
+        items.extend(
+            state
+                .workspaces
+                .iter()
+                .map(|w| ListItem::new(Line::from(w.name.as_str()))),
+        );
+        if has_saved_workspaces {
+            items.push(ListItem::new(Line::from("")));
+        }
+        items.push(ListItem::new(Line::from(Span::styled(
+            "+ New workspace",
+            Style::default().fg(WHITE),
+        ))));
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(PHOSPHOR_DARK)),
+            )
+            .style(Style::default().fg(PHOSPHOR_GREEN))
+            .highlight_style(Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black))
+            .highlight_symbol("▸ ");
+
+        let mut ls = ListState::default();
+        ls.select(Some(state.visual_selected()));
+        frame.render_stateful_widget(list, list_area, &mut ls);
     }
-    items.push(ListItem::new(Line::from(Span::styled(
-        "+ New workspace",
-        Style::default().fg(WHITE),
-    ))));
-
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(PHOSPHOR_DARK)),
-        )
-        .style(Style::default().fg(PHOSPHOR_GREEN))
-        .highlight_style(Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black))
-        .highlight_symbol("▸ ");
-
-    let mut ls = ListState::default();
-    ls.select(Some(state.visual_selected()));
-    frame.render_stateful_widget(list, list_area, &mut ls);
 
     // Toast overlay — rendered last so it appears on top.
     if let Some(toast) = &state.toast {
         render_toast(frame, area, toast);
     }
+}
+
+fn render_role_picker_sidebar(
+    frame: &mut Frame,
+    area: Rect,
+    workspace_name: &str,
+    picker: &crate::console::widgets::role_picker::RolePickerState,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .title(Span::styled(
+            format!(" {workspace_name} "),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    let items: Vec<ListItem> = picker
+        .filtered
+        .iter()
+        .map(|role| ListItem::new(Line::from(role.key())))
+        .collect();
+    let list = List::new(items)
+        .block(block)
+        .style(Style::default().fg(PHOSPHOR_GREEN))
+        .highlight_style(Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black))
+        .highlight_symbol("▸ ");
+    let mut list_state = ListState::default();
+    list_state.select(picker.list_state.selected);
+    frame.render_stateful_widget(list, area, &mut list_state);
 }
 
 fn render_toast(frame: &mut Frame, area: Rect, toast: &super::super::state::Toast) {
@@ -247,6 +281,33 @@ pub(super) fn render_mount_lines(rows: &[MountDisplayRow], path_w: usize) -> Vec
     lines
 }
 
+pub(super) fn render_global_mount_header(path_w: usize) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {path:<path_w$}  Mode", path = "Destination"),
+        Style::default().fg(WHITE),
+    ))
+}
+
+pub(super) fn render_global_mount_lines(
+    rows: &[MountDisplayRow],
+    path_w: usize,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for row in rows {
+        lines.push(Line::from(vec![
+            Span::raw(format!("  {:<path_w$}  ", row.destination)),
+            Span::styled(row.mode, Style::default().fg(PHOSPHOR_DIM)),
+        ]));
+        if let Some(host_source) = &row.host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {host_source:<path_w$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
+    }
+    lines
+}
+
 fn render_details_pane(
     frame: &mut Frame,
     area: Rect,
@@ -275,7 +336,11 @@ fn render_details_pane(
         }
         _ => Vec::new(),
     };
-    let agent_count = agents_block_agent_count(ws_config, config);
+    let agent_count = if state.inline_role_picker.is_some() {
+        0
+    } else {
+        agents_block_agent_count(ws_config, config)
+    };
     let show_envs = ws_config.is_some_and(workspace_has_any_env);
 
     let mut constraints = vec![
@@ -289,7 +354,9 @@ fn render_details_pane(
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
     }
-    constraints.push(Constraint::Length(agents_block_height(agent_count)));
+    if state.inline_role_picker.is_none() {
+        constraints.push(Constraint::Length(agents_block_height(agent_count)));
+    }
 
     let rows = Layout::default()
         .direction(Direction::Vertical)
@@ -313,9 +380,7 @@ fn render_details_pane(
         render_environments_subpanel(frame, rows[idx], ws_config);
         idx += 1;
     }
-    if let Some(picker) = state.inline_role_picker.as_ref() {
-        render_role_picker_subpanel(frame, rows[idx], picker);
-    } else {
+    if state.inline_role_picker.is_none() {
         render_agents_subpanel(frame, rows[idx], ws_config, config);
     }
 }
@@ -632,8 +697,8 @@ fn render_global_mounts_subpanel(
             } else {
                 let rows = format_mount_rows(mounts);
                 let path_w = mount_path_width(&rows);
-                lines.push(render_mount_header(path_w));
-                lines.extend(render_mount_lines(&rows, path_w));
+                lines.push(render_global_mount_header(path_w));
+                lines.extend(render_global_mount_lines(&rows, path_w));
             }
         }
         Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates }) => {
@@ -663,48 +728,6 @@ fn render_global_mounts_subpanel(
         .style(Style::default().fg(PHOSPHOR_GREEN));
     frame.render_widget(p, area);
     super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
-}
-
-fn render_role_picker_subpanel(
-    frame: &mut Frame,
-    area: Rect,
-    picker: &crate::console::widgets::role_picker::RolePickerState,
-) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(Span::styled(
-            " Select role ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-    let mut lines = Vec::new();
-    if !picker.filter.is_empty() {
-        lines.push(Line::from(Span::styled(
-            format!("  Filter: {}", picker.filter),
-            Style::default().fg(PHOSPHOR_DIM),
-        )));
-    }
-    for (i, role) in picker.filtered.iter().enumerate() {
-        let selected = Some(i) == picker.list_state.selected;
-        let prefix = if selected { "▸ " } else { "  " };
-        let style = if selected {
-            Style::default()
-                .fg(PHOSPHOR_GREEN)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(WHITE)
-        };
-        lines.push(Line::from(Span::styled(
-            format!("{prefix}{}", role.key()),
-            style,
-        )));
-    }
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "  Enter launch · Esc cancel",
-        Style::default().fg(PHOSPHOR_DIM),
-    )));
-    frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
 /// One row in the flat Environments preview list.

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -204,8 +204,8 @@ fn render_toast(frame: &mut Frame, area: Rect, toast: &super::super::state::Toas
     frame.render_widget(Paragraph::new(line), banner_area);
 }
 
-/// Build aligned 4-column mount rows. The path column renders destination
-/// first, then host source on a continuation line when the paths differ.
+/// Pre-formatted mount row. `host_source` is `Some` only when src != dst
+/// (rendered as a continuation line).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct MountDisplayRow {
     pub(super) destination: String,
@@ -256,17 +256,11 @@ pub(super) const MOUNT_MODE_COL_WIDTH: usize = 4;
 /// the downstream `Type` column shifting.
 pub(super) const MOUNT_ISOLATION_COL_WIDTH: usize = 9;
 
-/// Compute the width used for the `Path` column so that header and data rows
-/// align. Derived from both the "Path" header label and the widest row path,
-/// with a minimum floor so short-path tables still look tabular.
+/// Width of the `Destination` column, sized to fit the widest path plus
+/// the header label. Floored at 10 so short-path tables still look tabular.
 pub(super) fn mount_path_width(rows: &[MountDisplayRow]) -> usize {
     rows.iter()
-        .flat_map(|row| {
-            [
-                &row.destination,
-                row.host_source.as_ref().unwrap_or(&row.destination),
-            ]
-        })
+        .flat_map(|row| std::iter::once(&row.destination).chain(row.host_source.as_ref()))
         .map(|p| p.chars().count())
         .max()
         .unwrap_or(0)
@@ -275,9 +269,8 @@ pub(super) fn mount_path_width(rows: &[MountDisplayRow]) -> usize {
 }
 
 pub(super) fn render_mount_header(path_w: usize) -> Line<'static> {
-    // Format: "  <destination padded>  <mode padded>  <iso padded>  Type"
-    // Leading two-space gutter + two-space gap between every column matches
-    // the data-row format so columns never run into each other.
+    // Two-space gutter + two-space gaps match the data-row format so
+    // columns never run into each other.
     let mode_col = format!("{:<mw$}", "Mode", mw = MOUNT_MODE_COL_WIDTH);
     let iso_col = format!("{:<iw$}", "Isolation", iw = MOUNT_ISOLATION_COL_WIDTH);
     Line::from(Span::styled(
@@ -387,24 +380,15 @@ fn render_details_pane(
                 .as_ref()
                 .map(|(role, _)| role.clone())
         });
-    let global_display = ws_config.and_then(|_| {
-        let rows = picker_role.as_ref().map_or_else(
-            || {
-                config
-                    .list_mount_rows()
-                    .into_iter()
-                    .filter(|row| row.scope.is_none())
-                    .collect()
-            },
-            |role| config.resolve_mount_rows(role),
-        );
-        (!rows.is_empty()).then(|| crate::config::WorkspaceGlobalMountRows::Applicable {
-            role: picker_role
-                .as_ref()
-                .map_or_else(String::new, crate::selector::RoleSelector::key),
-            rows,
-        })
-    });
+    let global_rows: Vec<crate::config::GlobalMountRow> = if ws_config.is_some() {
+        super::global_rows_for(config, picker_role.as_ref())
+    } else {
+        Vec::new()
+    };
+    let role_label = picker_role
+        .as_ref()
+        .map_or_else(String::new, crate::selector::RoleSelector::key);
+    let has_global = !global_rows.is_empty();
     let inline_picker_active =
         state.inline_role_picker.is_some() || state.inline_agent_picker.is_some();
     let agent_count = if inline_picker_active {
@@ -418,10 +402,8 @@ fn render_details_pane(
         Constraint::Length(3),
         Constraint::Length(mount_block_height(mounts)),
     ];
-    if global_display.is_some() {
-        constraints.push(Constraint::Length(global_mount_block_height(
-            global_display.as_ref(),
-        )));
+    if has_global {
+        constraints.push(Constraint::Length(global_mount_block_height(&global_rows)));
     }
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
@@ -446,11 +428,12 @@ fn render_details_pane(
         state.list_scroll_focus == Some(MountScrollFocus::Workspace),
     );
     idx += 1;
-    if global_display.is_some() {
+    if has_global {
         render_global_mounts_subpanel(
             frame,
             rows[idx],
-            global_display.as_ref(),
+            &role_label,
+            &global_rows,
             state.list_global_mounts_scroll_x,
             state.list_role_global_mounts_scroll_x,
             state.list_scroll_focus,
@@ -479,7 +462,9 @@ fn workspace_has_any_env(ws: &crate::workspace::WorkspaceConfig) -> bool {
     !ws.env.is_empty() || ws.roles.values().any(|o| !o.env.is_empty())
 }
 
-fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
+pub(in crate::console::manager) fn mount_block_height(
+    mounts: &[crate::workspace::MountConfig],
+) -> u16 {
     let data_rows = if mounts.is_empty() {
         1
     } else {
@@ -491,22 +476,16 @@ fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
     (data_rows + 2 + 1).min(12) as u16
 }
 
-fn global_mount_block_height(display: Option<&crate::config::WorkspaceGlobalMountRows>) -> u16 {
-    match display {
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { rows, .. }) => {
-            let (global, scoped) = split_global_mount_rows(rows);
-            let mut h = 0;
-            if !global.is_empty() || scoped.is_empty() {
-                h += global_mount_rows_height(global.len());
-            }
-            if !scoped.is_empty() {
-                h += global_mount_rows_height(scoped.len());
-            }
-            h
-        }
-        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { .. }) => 4,
-        None => 0,
+fn global_mount_block_height(rows: &[crate::config::GlobalMountRow]) -> u16 {
+    let (global, scoped) = split_global_mount_rows(rows);
+    let mut h = 0;
+    if !global.is_empty() || scoped.is_empty() {
+        h += global_mount_rows_height(global.len());
     }
+    if !scoped.is_empty() {
+        h += global_mount_rows_height(scoped.len());
+    }
+    h
 }
 
 fn global_mount_rows_height(count: usize) -> u16 {
@@ -787,102 +766,53 @@ fn render_mounts_subpanel(
 fn render_global_mounts_subpanel(
     frame: &mut Frame,
     area: Rect,
-    display: Option<&crate::config::WorkspaceGlobalMountRows>,
+    role: &str,
+    rows: &[crate::config::GlobalMountRow],
     global_scroll_x: u16,
     role_scroll_x: u16,
     focused: Option<MountScrollFocus>,
 ) {
-    if let Some(crate::config::WorkspaceGlobalMountRows::Applicable { role, rows }) = display {
-        let (global, scoped) = split_global_mount_rows(rows);
-        let mut sections = Vec::new();
-        if !global.is_empty() || scoped.is_empty() {
-            sections.push((" Global mounts ".to_string(), global));
-        }
-        if !scoped.is_empty() {
-            sections.push((format!(" Role global mounts · {role} "), scoped));
-        }
-        let constraints: Vec<Constraint> = sections
-            .iter()
-            .map(|(_, rows)| Constraint::Length(global_mount_rows_height(rows.len())))
-            .collect();
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(constraints)
-            .split(area);
-        for ((title, rows), chunk) in sections.into_iter().zip(chunks.iter()) {
-            let is_role = title.starts_with(" Role global mounts ");
-            let scroll_x = if is_role {
-                role_scroll_x
-            } else {
-                global_scroll_x
-            };
-            let section_focused = focused
-                == Some(if is_role {
-                    MountScrollFocus::RoleGlobal
-                } else {
-                    MountScrollFocus::Global
-                });
-            render_global_mount_rows_section(
-                frame,
-                *chunk,
-                &title,
-                &rows,
-                scroll_x,
-                section_focused,
-            );
-        }
-        return;
-    }
-
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(
-            Style::default().fg(if focused == Some(MountScrollFocus::Global) {
-                PHOSPHOR_GREEN
-            } else {
-                PHOSPHOR_DARK
-            }),
-        )
-        .title(Span::styled(
-            " Global mounts ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+    let (global, scoped) = split_global_mount_rows(rows);
+    let mut sections: Vec<(
+        String,
+        Vec<&crate::config::GlobalMountRow>,
+        MountScrollFocus,
+        u16,
+    )> = Vec::new();
+    if !global.is_empty() || scoped.is_empty() {
+        sections.push((
+            " Global mounts ".to_string(),
+            global,
+            MountScrollFocus::Global,
+            global_scroll_x,
         ));
-
-    let mut lines: Vec<Line> = Vec::new();
-    match display {
-        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { candidates }) => {
-            let suffix = if candidates.is_empty() {
-                "selected role affects global mount visibility".to_string()
-            } else {
-                format!(
-                    "selected role affects global mount visibility: {}",
-                    candidates.join(", ")
-                )
-            };
-            lines.push(Line::from(Span::styled(
-                format!("  {suffix}"),
-                Style::default().fg(PHOSPHOR_DIM),
-            )));
-        }
-        None => lines.push(Line::from(Span::styled(
-            "  (workspace missing)",
-            Style::default().fg(PHOSPHOR_DIM),
-        ))),
-        Some(crate::config::WorkspaceGlobalMountRows::Applicable { .. }) => unreachable!(),
     }
-
-    let content_width = super::max_line_width(&lines);
-    let scroll_x = super::effective_scroll_x(
-        content_width,
-        area.width.saturating_sub(2) as usize,
-        global_scroll_x,
-    );
-    let p = Paragraph::new(lines)
-        .block(block)
-        .scroll((0, scroll_x))
-        .style(Style::default().fg(PHOSPHOR_GREEN));
-    frame.render_widget(p, area);
-    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
+    if !scoped.is_empty() {
+        sections.push((
+            format!(" Role global mounts · {role} "),
+            scoped,
+            MountScrollFocus::RoleGlobal,
+            role_scroll_x,
+        ));
+    }
+    let constraints: Vec<Constraint> = sections
+        .iter()
+        .map(|(_, rows, _, _)| Constraint::Length(global_mount_rows_height(rows.len())))
+        .collect();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+    for ((title, rows, section_focus, scroll_x), chunk) in sections.into_iter().zip(chunks.iter()) {
+        render_global_mount_rows_section(
+            frame,
+            *chunk,
+            &title,
+            &rows,
+            scroll_x,
+            focused == Some(section_focus),
+        );
+    }
 }
 
 fn render_global_mount_rows_section(

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -385,9 +385,6 @@ fn render_details_pane(
     } else {
         Vec::new()
     };
-    let role_label = picker_role
-        .as_ref()
-        .map_or_else(String::new, crate::selector::RoleSelector::key);
     let has_global = !global_rows.is_empty();
     let inline_picker_active =
         state.inline_role_picker.is_some() || state.inline_agent_picker.is_some();
@@ -429,6 +426,9 @@ fn render_details_pane(
     );
     idx += 1;
     if has_global {
+        let role_label = picker_role
+            .as_ref()
+            .map_or_else(String::new, crate::selector::RoleSelector::key);
         render_global_mounts_subpanel(
             frame,
             rows[idx],

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -130,27 +130,44 @@ fn render_toast(frame: &mut Frame, area: Rect, toast: &super::super::state::Toas
     frame.render_widget(Paragraph::new(line), banner_area);
 }
 
-/// Build aligned 4-column mount rows: (`path_display`, mode, `iso_label`,
-/// `kind_label`). `iso_label` is the canonical spelling of the mount's
-/// isolation strategy ("shared" / "worktree") — rendered for every
-/// mount including `shared` per the per-mount-isolation spec.
-pub(super) fn format_mount_rows(
-    mounts: &[crate::workspace::MountConfig],
-) -> Vec<(String, &'static str, &'static str, String)> {
+/// Build aligned 4-column mount rows. The path column renders destination
+/// first, then host source on a continuation line when the paths differ.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct MountDisplayRow {
+    pub(super) destination: String,
+    pub(super) host_source: Option<String>,
+    pub(super) mode: &'static str,
+    pub(super) isolation: &'static str,
+    pub(super) kind: String,
+}
+
+pub(super) fn mount_display_paths(
+    mount: &crate::workspace::MountConfig,
+) -> (String, Option<String>) {
+    let src = crate::tui::shorten_home(&mount.src);
+    let dst = crate::tui::shorten_home(&mount.dst);
+    if mount.src == mount.dst {
+        (dst, None)
+    } else {
+        (dst, Some(format!("host: {src}")))
+    }
+}
+
+pub(super) fn format_mount_rows(mounts: &[crate::workspace::MountConfig]) -> Vec<MountDisplayRow> {
     mounts
         .iter()
         .map(|m| {
-            let src = crate::tui::shorten_home(&m.src);
-            let dst = crate::tui::shorten_home(&m.dst);
-            let path = if m.src == m.dst {
-                src
-            } else {
-                format!("{src} \u{2192} {dst}")
-            };
+            let (destination, host_source) = mount_display_paths(m);
             let mode: &'static str = if m.readonly { "ro" } else { "rw" };
             let iso: &'static str = m.isolation.as_str();
             let kind = super::super::mount_info::inspect(&m.src).label();
-            (path, mode, iso, kind)
+            MountDisplayRow {
+                destination,
+                host_source,
+                mode,
+                isolation: iso,
+                kind,
+            }
         })
         .collect()
 }
@@ -168,17 +185,23 @@ pub(super) const MOUNT_ISOLATION_COL_WIDTH: usize = 9;
 /// Compute the width used for the `Path` column so that header and data rows
 /// align. Derived from both the "Path" header label and the widest row path,
 /// with a minimum floor so short-path tables still look tabular.
-pub(super) fn mount_path_width(rows: &[(String, &str, &str, String)]) -> usize {
+pub(super) fn mount_path_width(rows: &[MountDisplayRow]) -> usize {
     rows.iter()
-        .map(|(p, _, _, _)| p.chars().count())
+        .flat_map(|row| {
+            [
+                &row.destination,
+                row.host_source.as_ref().unwrap_or(&row.destination),
+            ]
+        })
+        .map(|p| p.chars().count())
         .max()
         .unwrap_or(0)
         .max(10)
-        .max("Path".len())
+        .max("Destination".len())
 }
 
 pub(super) fn render_mount_header(path_w: usize) -> Line<'static> {
-    // Format: "  <path padded to path_w>  <mode padded>  <iso padded>  Type"
+    // Format: "  <destination padded>  <mode padded>  <iso padded>  Type"
     // Leading two-space gutter + two-space gap between every column matches
     // the data-row format so columns never run into each other.
     let mode_col = format!("{:<mw$}", "Mode", mw = MOUNT_MODE_COL_WIDTH);
@@ -186,41 +209,42 @@ pub(super) fn render_mount_header(path_w: usize) -> Line<'static> {
     Line::from(Span::styled(
         format!(
             "  {path:<path_w$}  {mode_col}  {iso_col}  Type",
-            path = "Path"
+            path = "Destination"
         ),
         Style::default().fg(WHITE),
     ))
 }
 
-pub(super) fn render_mount_lines(
-    rows: &[(String, &str, &str, String)],
-    path_w: usize,
-) -> Vec<Line<'static>> {
-    rows.iter()
-        .map(|(path, mode, iso, kind)| {
-            Line::from(vec![
-                Span::raw(format!("  {path:<path_w$}  ")),
-                Span::styled(
-                    format!("{mode:<MOUNT_MODE_COL_WIDTH$}"),
-                    Style::default().fg(PHOSPHOR_DIM),
-                ),
-                // Two-space gap before the iso column — matches the header.
-                Span::raw("  "),
-                Span::styled(
-                    format!("{iso:<MOUNT_ISOLATION_COL_WIDTH$}"),
-                    Style::default().fg(PHOSPHOR_DIM),
-                ),
-                // Two-space gap before the type column — matches the header.
-                Span::raw("  "),
-                Span::styled(
-                    kind.clone(),
-                    Style::default()
-                        .fg(PHOSPHOR_DIM)
-                        .add_modifier(Modifier::ITALIC),
-                ),
-            ])
-        })
-        .collect()
+pub(super) fn render_mount_lines(rows: &[MountDisplayRow], path_w: usize) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for row in rows {
+        lines.push(Line::from(vec![
+            Span::raw(format!("  {:<path_w$}  ", row.destination)),
+            Span::styled(
+                format!("{:<MOUNT_MODE_COL_WIDTH$}", row.mode),
+                Style::default().fg(PHOSPHOR_DIM),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{:<MOUNT_ISOLATION_COL_WIDTH$}", row.isolation),
+                Style::default().fg(PHOSPHOR_DIM),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                row.kind.clone(),
+                Style::default()
+                    .fg(PHOSPHOR_DIM)
+                    .add_modifier(Modifier::ITALIC),
+            ),
+        ]));
+        if let Some(host_source) = &row.host_source {
+            lines.push(Line::from(Span::styled(
+                format!("  {host_source:<path_w$}"),
+                Style::default().fg(PHOSPHOR_DIM),
+            )));
+        }
+    }
+    lines
 }
 
 fn render_details_pane(frame: &mut Frame, area: Rect, ws: &WorkspaceSummary, config: &AppConfig) {
@@ -273,7 +297,14 @@ fn workspace_has_any_env(ws: &crate::workspace::WorkspaceConfig) -> bool {
 }
 
 fn mount_block_height(mounts: &[crate::workspace::MountConfig]) -> u16 {
-    let data_rows = if mounts.is_empty() { 1 } else { mounts.len() };
+    let data_rows = if mounts.is_empty() {
+        1
+    } else {
+        mounts
+            .iter()
+            .map(|mount| if mount.src == mount.dst { 1 } else { 2 })
+            .sum()
+    };
     (data_rows + 2 + 1).min(12) as u16
 }
 
@@ -790,8 +821,8 @@ fn render_agents_subpanel(
 #[cfg(test)]
 mod mount_table_tests {
     use super::{
-        MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, format_mount_rows, mount_path_width,
-        render_mount_header, render_mount_lines,
+        MOUNT_ISOLATION_COL_WIDTH, MOUNT_MODE_COL_WIDTH, MountDisplayRow, format_mount_rows,
+        mount_path_width, render_mount_header, render_mount_lines,
     };
     use crate::workspace::MountConfig;
 
@@ -838,16 +869,31 @@ mod mount_table_tests {
         panic!("mode column not found in line: {s:?}");
     }
 
+    fn mount_row(
+        destination: &str,
+        mode: &'static str,
+        isolation: &'static str,
+        kind: &str,
+    ) -> MountDisplayRow {
+        MountDisplayRow {
+            destination: destination.into(),
+            host_source: None,
+            mode,
+            isolation,
+            kind: kind.into(),
+        }
+    }
+
     #[test]
     fn header_and_data_rows_share_path_column_width() {
         // Short path + long path forces path_w to be the length of the long one.
-        let rows: Vec<(String, &str, &str, String)> = vec![
-            ("~/short".into(), "rw", "shared", "git · main".into()),
-            (
-                "~/Projects/very/deeply/nested/directory".into(),
+        let rows = vec![
+            mount_row("~/short", "rw", "shared", "git · main"),
+            mount_row(
+                "~/Projects/very/deeply/nested/directory",
                 "ro",
                 "worktree",
-                "dir".into(),
+                "dir",
             ),
         ];
         let path_w = mount_path_width(&rows);
@@ -874,11 +920,11 @@ mod mount_table_tests {
     fn single_row_still_uses_minimum_column_width() {
         // Single short mount — path_w should stay at the floor so the
         // table is still visibly tabular.
-        let rows: Vec<(String, &str, &str, String)> = vec![(
-            "~/Projects/ChainArgos/blockchain-nodes".into(),
+        let rows = vec![mount_row(
+            "~/Projects/ChainArgos/blockchain-nodes",
             "rw",
             "shared",
-            "git · main".into(),
+            "git · main",
         )];
         let path_w = mount_path_width(&rows);
         assert_eq!(path_w, "~/Projects/ChainArgos/blockchain-nodes".len());
@@ -893,12 +939,12 @@ mod mount_table_tests {
         // Empty case: header should still render with the floor width and
         // include the two-space gap between every column.
         let path_w = mount_path_width(&[]);
-        assert_eq!(path_w, 10);
+        assert_eq!(path_w, "Destination".len());
         let header = render_mount_header(path_w);
         // "  <path padded>  <mode padded>  <iso padded>  Type"
         let expected = format!(
             "  {path:<path_w$}  {mode:<mw$}  {iso:<iw$}  Type",
-            path = "Path",
+            path = "Destination",
             mode = "Mode",
             iso = "Isolation",
             path_w = path_w,
@@ -918,8 +964,7 @@ mod mount_table_tests {
         // kind. Additionally pins the type-column alignment: the `Type`
         // header label must start at the same character offset as the data
         // row's kind label.
-        let rows: Vec<(String, &str, &str, String)> =
-            vec![("~/p".into(), "rw", "shared", "folder".into())];
+        let rows = vec![mount_row("~/p", "rw", "shared", "folder")];
         let path_w = mount_path_width(&rows);
         let header = render_mount_header(path_w);
         let data = render_mount_lines(&rows, path_w);

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -321,14 +321,23 @@ fn render_details_pane(
         .inline_role_picker
         .as_ref()
         .and_then(selected_picker_role);
-    let global_display = ws_config.map(|w| {
-        picker_role.as_ref().map_or_else(
-            || config.workspace_applicable_mount_rows(w),
-            |role| crate::config::WorkspaceGlobalMountRows::Applicable {
-                role: role.key(),
-                rows: config.resolve_mount_rows(role),
+    let global_display = ws_config.and_then(|_| {
+        let rows = picker_role.as_ref().map_or_else(
+            || {
+                config
+                    .list_mount_rows()
+                    .into_iter()
+                    .filter(|row| row.scope.is_none())
+                    .collect()
             },
-        )
+            |role| config.resolve_mount_rows(role),
+        );
+        (!rows.is_empty()).then(|| crate::config::WorkspaceGlobalMountRows::Applicable {
+            role: picker_role
+                .as_ref()
+                .map_or_else(String::new, crate::selector::RoleSelector::key),
+            rows,
+        })
     });
     let agent_count = if state.inline_role_picker.is_some() {
         0
@@ -340,8 +349,12 @@ fn render_details_pane(
     let mut constraints = vec![
         Constraint::Length(3),
         Constraint::Length(mount_block_height(mounts)),
-        Constraint::Length(global_mount_block_height(global_display.as_ref())),
     ];
+    if global_display.is_some() {
+        constraints.push(Constraint::Length(global_mount_block_height(
+            global_display.as_ref(),
+        )));
+    }
     if show_envs {
         constraints.push(Constraint::Length(env_block_height(ws_config)));
     }
@@ -365,15 +378,17 @@ fn render_details_pane(
         state.list_scroll_focus == Some(MountScrollFocus::Workspace),
     );
     idx += 1;
-    render_global_mounts_subpanel(
-        frame,
-        rows[idx],
-        global_display.as_ref(),
-        state.list_global_mounts_scroll_x,
-        state.list_role_global_mounts_scroll_x,
-        state.list_scroll_focus,
-    );
-    idx += 1;
+    if global_display.is_some() {
+        render_global_mounts_subpanel(
+            frame,
+            rows[idx],
+            global_display.as_ref(),
+            state.list_global_mounts_scroll_x,
+            state.list_role_global_mounts_scroll_x,
+            state.list_scroll_focus,
+        );
+        idx += 1;
+    }
     if show_envs {
         render_environments_subpanel(frame, rows[idx], ws_config);
         idx += 1;
@@ -421,7 +436,8 @@ fn global_mount_block_height(display: Option<&crate::config::WorkspaceGlobalMoun
             }
             h
         }
-        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { .. }) | None => 4,
+        Some(crate::config::WorkspaceGlobalMountRows::Ambiguous { .. }) => 4,
+        None => 0,
     }
 }
 
@@ -1034,6 +1050,19 @@ fn render_agents_subpanel(
         if is_default {
             spans.push(Span::styled(" \u{2605}", star_style));
         }
+        if let Ok(selector) = crate::selector::RoleSelector::parse(role) {
+            let scoped_count = config
+                .resolve_mount_rows(&selector)
+                .into_iter()
+                .filter(|row| row.scope.is_some())
+                .count();
+            if scoped_count > 0 {
+                spans.push(Span::styled(
+                    format!("    +{scoped_count} role mounts"),
+                    Style::default().fg(PHOSPHOR_DIM),
+                ));
+            }
+        }
         lines.push(Line::from(spans));
     }
 
@@ -1314,6 +1343,7 @@ mod subpanel_padding_tests {
     use crate::workspace::WorkspaceConfig;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
     /// Scan the first content row inside a sub-panel block (y = 1, skipping
@@ -1338,6 +1368,18 @@ mod subpanel_padding_tests {
             return Some((x - border_x - 1) as usize);
         }
         None
+    }
+
+    fn buffer_text(buf: &Buffer) -> String {
+        let area = buf.area;
+        let mut joined = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                joined.push_str(buf[(x, y)].symbol());
+            }
+            joined.push('\n');
+        }
+        joined
     }
 
     fn summary() -> WorkspaceSummary {
@@ -2269,6 +2311,55 @@ mod subpanel_padding_tests {
             !joined.contains("(no environment variables)"),
             "the placeholder line must NOT appear (block is omitted entirely); got {joined}"
         );
+    }
+
+    #[test]
+    fn preview_shows_unscoped_global_mounts_without_role_ambiguity_text() {
+        let ws = ws_config_with_allowed(&["alpha", "beta"], None);
+        let mut cfg = AppConfig::default();
+        cfg.workspaces.insert("demo".into(), ws);
+        cfg.roles
+            .insert("alpha".into(), crate::config::RoleSource::default());
+        cfg.roles
+            .insert("beta".into(), crate::config::RoleSource::default());
+        cfg.add_mount(
+            "cargo",
+            crate::workspace::MountConfig {
+                src: "/tmp/cargo".into(),
+                dst: "/home/agent/.cargo".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            None,
+        );
+        cfg.add_mount(
+            "beta-only",
+            crate::workspace::MountConfig {
+                src: "/tmp/beta".into(),
+                dst: "/beta".into(),
+                readonly: true,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            Some("beta"),
+        );
+
+        let backend = TestBackend::new(72, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let state = crate::console::manager::state::ManagerState::from_config(
+            &cfg,
+            std::path::Path::new("/tmp"),
+        );
+        term.draw(|f| {
+            super::render_details_pane(f, Rect::new(0, 0, 72, 24), &summary(), &cfg, &state);
+        })
+        .unwrap();
+
+        let joined = buffer_text(term.backend().buffer());
+        assert!(joined.contains("Global mounts"), "{joined}");
+        assert!(joined.contains(".cargo"), "{joined}");
+        assert!(!joined.contains("selected role affects"), "{joined}");
+        assert!(!joined.contains("/beta"), "{joined}");
+        assert!(joined.contains("+1 role mounts"), "{joined}");
     }
 
     /// The Environments block appears as soon as ANY env entry exists

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -308,6 +308,26 @@ pub(super) fn render_global_mount_lines(
     lines
 }
 
+pub(in crate::console::manager) fn workspace_mounts_content_width(
+    mounts: &[crate::workspace::MountConfig],
+) -> usize {
+    let rows = format_mount_rows(mounts);
+    let path_w = mount_path_width(&rows);
+    let mut lines = vec![render_mount_header(path_w)];
+    lines.extend(render_mount_lines(&rows, path_w));
+    super::max_line_width(&lines)
+}
+
+pub(in crate::console::manager) fn global_mounts_content_width(
+    mounts: &[crate::workspace::MountConfig],
+) -> usize {
+    let rows = format_mount_rows(mounts);
+    let path_w = mount_path_width(&rows);
+    let mut lines = vec![render_global_mount_header(path_w)];
+    lines.extend(render_global_mount_lines(&rows, path_w));
+    super::max_line_width(&lines)
+}
+
 fn render_details_pane(
     frame: &mut Frame,
     area: Rect,

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -43,7 +43,7 @@ pub(super) fn render_list_body(
 
     match state.selected_row() {
         ManagerListRow::CurrentDirectory => {
-            render_current_dir_details_pane(frame, columns[1], cwd, config);
+            render_current_dir_details_pane(frame, columns[1], cwd, config, state);
         }
         ManagerListRow::NewWorkspace => {
             render_sentinel_description_pane(frame, columns[1]);
@@ -514,6 +514,7 @@ fn render_current_dir_details_pane(
     area: Rect,
     cwd: &std::path::Path,
     config: &AppConfig,
+    state: &ManagerState<'_>,
 ) {
     let cwd_str = cwd.display().to_string();
     let workdir_short = crate::tui::shorten_home(&cwd_str);
@@ -563,7 +564,13 @@ fn render_current_dir_details_pane(
         rows[0],
     );
 
-    render_mounts_subpanel(frame, rows[1], &mounts, 0, false);
+    render_mounts_subpanel(
+        frame,
+        rows[1],
+        &mounts,
+        state.list_mounts_scroll_x,
+        state.list_scroll_focus == Some(MountScrollFocus::Workspace),
+    );
 
     // Roles block — reuse the no-`ws_config` branch of the shared renderer,
     // which lists every globally-configured role (without per-role

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -299,14 +299,14 @@ fn render_details_pane(
     let mut idx = 0;
     render_general_subpanel(frame, rows[idx], ws);
     idx += 1;
-    render_mounts_subpanel(frame, rows[idx], mounts, state.list_scroll_x);
+    render_mounts_subpanel(frame, rows[idx], mounts, state.list_mounts_scroll_x);
     idx += 1;
     render_global_mounts_subpanel(
         frame,
         rows[idx],
         global_display.as_ref(),
         &global_mounts,
-        state.list_scroll_x,
+        state.list_global_mounts_scroll_x,
     );
     idx += 1;
     if show_envs {
@@ -591,11 +591,13 @@ fn render_mounts_subpanel(
         lines.extend(render_mount_lines(&rows, path_w));
     }
 
+    let content_width = super::max_line_width(&lines);
     let p = Paragraph::new(lines)
         .block(block)
         .scroll((0, scroll_x))
         .style(Style::default().fg(PHOSPHOR_GREEN));
     frame.render_widget(p, area);
+    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
 }
 
 fn render_global_mounts_subpanel(
@@ -654,11 +656,13 @@ fn render_global_mounts_subpanel(
         ))),
     }
 
+    let content_width = super::max_line_width(&lines);
     let p = Paragraph::new(lines)
         .block(block)
         .scroll((0, scroll_x))
         .style(Style::default().fg(PHOSPHOR_GREEN));
     frame.render_widget(p, area);
+    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
 }
 
 fn render_role_picker_subpanel(

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
 use super::state::{ManagerListRow, ManagerStage, ManagerState};
@@ -83,6 +83,48 @@ pub(super) fn render_footer(frame: &mut Frame, area: Rect, items: &[FooterItem])
     let line = Line::from(footer_spans(items));
     let p = Paragraph::new(line).alignment(Alignment::Center);
     frame.render_widget(p, area);
+}
+
+pub(super) fn line_width(line: &Line<'_>) -> usize {
+    line.spans
+        .iter()
+        .map(|span| span.content.chars().count())
+        .sum()
+}
+
+pub(super) fn max_line_width(lines: &[Line<'_>]) -> usize {
+    lines.iter().map(line_width).max().unwrap_or(0)
+}
+
+pub(super) fn render_horizontal_scrollbar(
+    frame: &mut Frame,
+    block_area: Rect,
+    content_width: usize,
+    scroll_x: u16,
+) {
+    let viewport = block_area.width.saturating_sub(2) as usize;
+    if viewport == 0 || content_width <= viewport {
+        return;
+    }
+    let max_position = content_width.saturating_sub(viewport);
+    let position = usize::from(scroll_x).min(max_position);
+    let mut state = ScrollbarState::new(content_width)
+        .position(position)
+        .viewport_content_length(viewport);
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .track_symbol(Some("─"))
+        .thumb_symbol("█")
+        .track_style(Style::default().fg(PHOSPHOR_DARK))
+        .thumb_style(Style::default().fg(WHITE));
+    let area = Rect {
+        x: block_area.x + 1,
+        y: block_area.y + block_area.height.saturating_sub(1),
+        width: block_area.width.saturating_sub(2),
+        height: 1,
+    };
+    frame.render_stateful_widget(scrollbar, area, &mut state);
 }
 
 #[allow(clippy::too_many_lines)]

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -159,52 +159,70 @@ pub fn render(
 
         let footer_items: Vec<FooterItem> = match &state.stage {
             ManagerStage::List => {
-                // Surface "o open in GitHub" on rows whose workspace has at
-                // least one GitHub-hosted mount with a resolvable web URL.
-                // See `ManagerListRow` docs for row layout — current-dir and
-                // the "+ New workspace" sentinel skip the hint entirely.
-                let show_open_hint =
-                    matches!(state.selected_row(), ManagerListRow::SavedWorkspace(_))
-                        && state
-                            .selected_workspace_summary()
-                            .and_then(|s| config.workspaces.get(&s.name))
-                            .is_some_and(|ws| {
-                                !super::github_mounts::resolve_for_workspace(ws).is_empty()
-                            });
+                if state.inline_role_picker.is_some() {
+                    vec![
+                        FooterItem::Key("\u{2191}\u{2193}"),
+                        FooterItem::Sep,
+                        FooterItem::Key("Enter"),
+                        FooterItem::Text("launch"),
+                        FooterItem::GroupSep,
+                        FooterItem::Key("Esc"),
+                        FooterItem::Text("return to workspaces"),
+                        FooterItem::GroupSep,
+                        FooterItem::Key("←/→"),
+                        FooterItem::Text("scroll"),
+                        FooterItem::GroupSep,
+                        FooterItem::Key("Q"),
+                        FooterItem::Text("quit"),
+                    ]
+                } else {
+                    // Surface "o open in GitHub" on rows whose workspace has at
+                    // least one GitHub-hosted mount with a resolvable web URL.
+                    // See `ManagerListRow` docs for row layout — current-dir and
+                    // the "+ New workspace" sentinel skip the hint entirely.
+                    let show_open_hint =
+                        matches!(state.selected_row(), ManagerListRow::SavedWorkspace(_))
+                            && state
+                                .selected_workspace_summary()
+                                .and_then(|s| config.workspaces.get(&s.name))
+                                .is_some_and(|ws| {
+                                    !super::github_mounts::resolve_for_workspace(ws).is_empty()
+                                });
 
-                let mut items = vec![
-                    // Navigation group
-                    FooterItem::Key("\u{2191}\u{2193}"),
-                    FooterItem::Sep,
-                    FooterItem::Key("Enter"),
-                    FooterItem::Text("launch"),
-                    FooterItem::GroupSep,
-                    // Per-row actions
-                    FooterItem::Key("E"),
-                    FooterItem::Text("edit"),
-                    FooterItem::Sep,
-                    FooterItem::Key("N"),
-                    FooterItem::Text("new"),
-                    FooterItem::Sep,
-                    FooterItem::Key("D"),
-                    FooterItem::Text("delete"),
-                    FooterItem::Sep,
-                    FooterItem::Key("G"),
-                    FooterItem::Text("global config"),
-                ];
-                if show_open_hint {
-                    items.push(FooterItem::Sep);
-                    items.push(FooterItem::Key("O"));
-                    items.push(FooterItem::Text("open in GitHub"));
+                    let mut items = vec![
+                        // Navigation group
+                        FooterItem::Key("\u{2191}\u{2193}"),
+                        FooterItem::Sep,
+                        FooterItem::Key("Enter"),
+                        FooterItem::Text("launch"),
+                        FooterItem::GroupSep,
+                        // Per-row actions
+                        FooterItem::Key("E"),
+                        FooterItem::Text("edit"),
+                        FooterItem::Sep,
+                        FooterItem::Key("N"),
+                        FooterItem::Text("new"),
+                        FooterItem::Sep,
+                        FooterItem::Key("D"),
+                        FooterItem::Text("delete"),
+                        FooterItem::Sep,
+                        FooterItem::Key("G"),
+                        FooterItem::Text("global config"),
+                    ];
+                    if show_open_hint {
+                        items.push(FooterItem::Sep);
+                        items.push(FooterItem::Key("O"));
+                        items.push(FooterItem::Text("open in GitHub"));
+                    }
+                    items.push(FooterItem::GroupSep);
+                    items.push(FooterItem::Key("←/→"));
+                    items.push(FooterItem::Text("scroll"));
+                    items.push(FooterItem::GroupSep);
+                    // Exit
+                    items.push(FooterItem::Key("Q"));
+                    items.push(FooterItem::Text("quit"));
+                    items
                 }
-                items.push(FooterItem::GroupSep);
-                items.push(FooterItem::Key("←/→"));
-                items.push(FooterItem::Text("scroll"));
-                items.push(FooterItem::GroupSep);
-                // Exit
-                items.push(FooterItem::Key("Q"));
-                items.push(FooterItem::Text("quit"));
-                items
             }
             ManagerStage::CreatePrelude(_) => vec![
                 FooterItem::Dyn("Create workspace — follow the prompts".to_string()),

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -156,6 +156,9 @@ pub fn render(
                     items.push(FooterItem::Text("open in GitHub"));
                 }
                 items.push(FooterItem::GroupSep);
+                items.push(FooterItem::Key("←/→"));
+                items.push(FooterItem::Text("scroll"));
+                items.push(FooterItem::GroupSep);
                 // Exit
                 items.push(FooterItem::Key("Q"));
                 items.push(FooterItem::Text("quit"));

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -106,18 +106,17 @@ pub(super) fn render_horizontal_scrollbar(
     if viewport == 0 || content_width <= viewport {
         return;
     }
-    let max_position = content_width.saturating_sub(viewport);
-    let position = usize::from(scroll_x).min(max_position);
+    let position = usize::from(effective_scroll_x(content_width, viewport, scroll_x));
     let mut state = ScrollbarState::new(content_width)
         .position(position)
         .viewport_content_length(viewport);
     let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
         .begin_symbol(None)
         .end_symbol(None)
-        .track_symbol(Some("─"))
-        .thumb_symbol("█")
+        .track_symbol(Some("·"))
+        .thumb_symbol("━")
         .track_style(Style::default().fg(PHOSPHOR_DARK))
-        .thumb_style(Style::default().fg(WHITE));
+        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
     let area = Rect {
         x: block_area.x + 1,
         y: block_area.y + block_area.height.saturating_sub(1),
@@ -125,6 +124,18 @@ pub(super) fn render_horizontal_scrollbar(
         height: 1,
     };
     frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+pub(super) fn effective_scroll_x(content_width: usize, viewport: usize, scroll_x: u16) -> u16 {
+    if viewport == 0 || content_width <= viewport {
+        0
+    } else {
+        scroll_x.min(
+            content_width
+                .saturating_sub(viewport)
+                .min(usize::from(u16::MAX)) as u16,
+        )
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -160,7 +171,7 @@ pub fn render(
         let footer_items: Vec<FooterItem> = match &state.stage {
             ManagerStage::List => {
                 if state.inline_role_picker.is_some() {
-                    vec![
+                    let mut items = vec![
                         FooterItem::Key("\u{2191}\u{2193}"),
                         FooterItem::Sep,
                         FooterItem::Key("Enter"),
@@ -168,13 +179,16 @@ pub fn render(
                         FooterItem::GroupSep,
                         FooterItem::Key("Esc"),
                         FooterItem::Text("return to workspaces"),
-                        FooterItem::GroupSep,
-                        FooterItem::Key("←/→"),
-                        FooterItem::Text("scroll"),
-                        FooterItem::GroupSep,
-                        FooterItem::Key("Q"),
-                        FooterItem::Text("quit"),
-                    ]
+                    ];
+                    if state.list_scroll_focus.is_some() {
+                        items.push(FooterItem::GroupSep);
+                        items.push(FooterItem::Key("←/→"));
+                        items.push(FooterItem::Text("scroll focused block"));
+                    }
+                    items.push(FooterItem::GroupSep);
+                    items.push(FooterItem::Key("Q"));
+                    items.push(FooterItem::Text("quit"));
+                    items
                 } else {
                     // Surface "o open in GitHub" on rows whose workspace has at
                     // least one GitHub-hosted mount with a resolvable web URL.
@@ -214,9 +228,11 @@ pub fn render(
                         items.push(FooterItem::Key("O"));
                         items.push(FooterItem::Text("open in GitHub"));
                     }
-                    items.push(FooterItem::GroupSep);
-                    items.push(FooterItem::Key("←/→"));
-                    items.push(FooterItem::Text("scroll"));
+                    if state.list_scroll_focus.is_some() {
+                        items.push(FooterItem::GroupSep);
+                        items.push(FooterItem::Key("←/→"));
+                        items.push(FooterItem::Text("scroll focused block"));
+                    }
                     items.push(FooterItem::GroupSep);
                     // Exit
                     items.push(FooterItem::Key("Q"));

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -106,7 +106,7 @@ pub(super) fn render_horizontal_scrollbar(
     if viewport == 0 || content_width <= viewport {
         return;
     }
-    let position = usize::from(effective_scroll_x(content_width, viewport, scroll_x));
+    let position = scrollbar_position(content_width, viewport, scroll_x);
     let mut state = ScrollbarState::new(content_width)
         .position(position)
         .viewport_content_length(viewport);
@@ -136,6 +136,15 @@ pub(super) fn effective_scroll_x(content_width: usize, viewport: usize, scroll_x
                 .min(usize::from(u16::MAX)) as u16,
         )
     }
+}
+
+fn scrollbar_position(content_width: usize, viewport: usize, scroll_x: u16) -> usize {
+    let scroll_x = usize::from(effective_scroll_x(content_width, viewport, scroll_x));
+    let max_scroll = content_width.saturating_sub(viewport);
+    scroll_x
+        .saturating_mul(content_width.saturating_sub(1))
+        .checked_div(max_scroll)
+        .unwrap_or(0)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -330,6 +339,23 @@ pub(super) fn centered_rect_fixed(outer: Rect, pct_w: u16, rows: u16) -> Rect {
         y: outer.y + outer.height.saturating_sub(h) / 2,
         width: w,
         height: h,
+    }
+}
+
+#[cfg(test)]
+mod horizontal_scrollbar_tests {
+    use super::scrollbar_position;
+
+    #[test]
+    fn text_scroll_end_maps_to_scrollbar_end() {
+        assert_eq!(scrollbar_position(100, 60, 0), 0);
+        assert_eq!(scrollbar_position(100, 60, 20), 49);
+        assert_eq!(scrollbar_position(100, 60, 40), 99);
+    }
+
+    #[test]
+    fn scrollbar_position_clamps_overscroll_to_end() {
+        assert_eq!(scrollbar_position(100, 60, 400), 99);
     }
 }
 

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -188,7 +188,23 @@ pub fn render(
 
         let footer_items: Vec<FooterItem> = match &state.stage {
             ManagerStage::List => {
-                if state.inline_role_picker.is_some() {
+                if state.inline_agent_picker.is_some() {
+                    let mut items = vec![
+                        FooterItem::Key("\u{2191}\u{2193}"),
+                        FooterItem::Sep,
+                        FooterItem::Key("Enter"),
+                        FooterItem::Text("launch"),
+                        FooterItem::GroupSep,
+                        FooterItem::Key("Esc"),
+                        FooterItem::Text("return to workspaces"),
+                    ];
+                    if state.list_scroll_focus.is_some() {
+                        items.push(FooterItem::GroupSep);
+                        items.push(FooterItem::Key("←/→"));
+                        items.push(FooterItem::Text("scroll focused block"));
+                    }
+                    items
+                } else if state.inline_role_picker.is_some() {
                     let mut items = vec![
                         FooterItem::Key("\u{2191}\u{2193}"),
                         FooterItem::Sep,

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -160,7 +160,6 @@ pub fn render(
     config: &AppConfig,
     cwd: &std::path::Path,
 ) {
-    // Phase 1: render the base stage (Editor full-screen OR List chrome).
     if let ManagerStage::Editor(editor) = &mut state.stage {
         clamp_editor_scroll_for_frame(frame.area(), editor);
         editor::render_editor(frame, editor, config, state.op_available);
@@ -168,7 +167,6 @@ pub fn render(
         clamp_global_mounts_scroll_for_frame(frame.area(), global);
         global_mounts::render_global_mounts(frame, global);
     } else {
-        // List / CreatePrelude / ConfirmDelete share the list-like chrome.
         let area = frame.area();
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -224,10 +222,8 @@ pub fn render(
                     items.push(FooterItem::Text("quit"));
                     items
                 } else {
-                    // Surface "o open in GitHub" on rows whose workspace has at
-                    // least one GitHub-hosted mount with a resolvable web URL.
-                    // See `ManagerListRow` docs for row layout — current-dir and
-                    // the "+ New workspace" sentinel skip the hint entirely.
+                    // Hidden on current-dir and "+ New workspace" rows because
+                    // they have no workspace config.
                     let show_open_hint =
                         matches!(state.selected_row(), ManagerListRow::SavedWorkspace(_))
                             && state
@@ -238,13 +234,11 @@ pub fn render(
                                 });
 
                     let mut items = vec![
-                        // Navigation group
                         FooterItem::Key("\u{2191}\u{2193}"),
                         FooterItem::Sep,
                         FooterItem::Key("Enter"),
                         FooterItem::Text("launch"),
                         FooterItem::GroupSep,
-                        // Per-row actions
                         FooterItem::Key("E"),
                         FooterItem::Text("edit"),
                         FooterItem::Sep,
@@ -268,7 +262,6 @@ pub fn render(
                         items.push(FooterItem::Text("scroll focused block"));
                     }
                     items.push(FooterItem::GroupSep);
-                    // Exit
                     items.push(FooterItem::Key("Q"));
                     items.push(FooterItem::Text("quit"));
                     items
@@ -296,12 +289,9 @@ pub fn render(
         render_footer(frame, chunks[2], &footer_items);
     }
 
-    // Phase 2: overlay any active modal.
-    //
-    // The list-anchored modal lives on `ManagerState` itself rather
-    // than on a stage variant, so its borrow has to be split off
-    // separately from the stage-anchored modals to keep the borrow
-    // checker happy with the shared `state` argument.
+    // List-anchored modal lives on `ManagerState`, not on a stage
+    // variant, so the borrow splits separately from stage-anchored
+    // modals.
     let is_list_stage = matches!(state.stage, ManagerStage::List);
     if is_list_stage {
         if let Some(modal) = &mut state.list_modal {
@@ -413,6 +403,7 @@ fn clamp_list_scroll_for_area(
             );
             state.list_global_mounts_scroll_x = 0;
             state.list_role_global_mounts_scroll_x = 0;
+            state.list_scroll_focus = None;
         }
         ManagerListRow::SavedWorkspace(i) => {
             let Some(summary) = state.workspaces.get(i) else {
@@ -426,40 +417,21 @@ fn clamp_list_scroll_for_area(
                 viewport,
                 &mut state.list_mounts_scroll_x,
             );
-
             let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
                 picker
                     .list_state
                     .selected
                     .and_then(|idx| picker.filtered.get(idx).cloned())
             });
-            let global_rows = picker_role.as_ref().map_or_else(
-                || {
-                    config
-                        .list_mount_rows()
-                        .into_iter()
-                        .filter(|row| row.scope.is_none())
-                        .collect()
-                },
-                |role| config.resolve_mount_rows(role),
-            );
-            let global_mounts: Vec<_> = global_rows
-                .iter()
-                .filter(|row| row.scope.is_none())
-                .map(|row| row.mount.clone())
-                .collect();
-            let role_global_mounts: Vec<_> = global_rows
-                .iter()
-                .filter(|row| row.scope.is_some())
-                .map(|row| row.mount.clone())
-                .collect();
+            let global_rows = global_rows_for(config, picker_role.as_ref());
+            let (global, scoped) = partition_mounts_by_scope(&global_rows);
             clamp_scroll_x(
-                list::global_mounts_content_width(&global_mounts),
+                list::global_mounts_content_width(&global),
                 viewport,
                 &mut state.list_global_mounts_scroll_x,
             );
             clamp_scroll_x(
-                list::global_mounts_content_width(&role_global_mounts),
+                list::global_mounts_content_width(&scoped),
                 viewport,
                 &mut state.list_role_global_mounts_scroll_x,
             );
@@ -470,6 +442,42 @@ fn clamp_list_scroll_for_area(
             state.list_role_global_mounts_scroll_x = 0;
         }
     }
+}
+
+/// Resolve global mount rows for the workspace's effective role, falling
+/// back to unscoped-only when the role is undecided.
+pub(super) fn global_rows_for(
+    config: &AppConfig,
+    picker_role: Option<&crate::selector::RoleSelector>,
+) -> Vec<crate::config::GlobalMountRow> {
+    picker_role.map_or_else(
+        || {
+            config
+                .list_mount_rows()
+                .into_iter()
+                .filter(|row| row.scope.is_none())
+                .collect()
+        },
+        |role| config.resolve_mount_rows(role),
+    )
+}
+
+pub(super) fn partition_mounts_by_scope(
+    rows: &[crate::config::GlobalMountRow],
+) -> (
+    Vec<crate::workspace::MountConfig>,
+    Vec<crate::workspace::MountConfig>,
+) {
+    let mut global = Vec::new();
+    let mut scoped = Vec::new();
+    for row in rows {
+        if row.scope.is_none() {
+            global.push(row.mount.clone());
+        } else {
+            scoped.push(row.mount.clone());
+        }
+    }
+    (global, scoped)
 }
 
 pub(super) fn render_header(frame: &mut Frame, area: Rect, title: &str) {

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -444,8 +444,7 @@ fn clamp_list_scroll_for_area(
     }
 }
 
-/// Resolve global mount rows for the workspace's effective role, falling
-/// back to unscoped-only when the role is undecided.
+/// `None` role → unscoped rows only; `Some(role)` → merged scoped + unscoped.
 pub(super) fn global_rows_for(
     config: &AppConfig,
     picker_role: Option<&crate::selector::RoleSelector>,

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -12,6 +12,7 @@ use super::state::{ManagerListRow, ManagerStage, ManagerState};
 use crate::config::AppConfig;
 
 pub mod editor;
+mod global_mounts;
 pub(super) mod list;
 pub(super) mod modal;
 
@@ -94,6 +95,8 @@ pub fn render(
     // Phase 1: render the base stage (Editor full-screen OR List chrome).
     if let ManagerStage::Editor(editor) = &state.stage {
         editor::render_editor(frame, editor, config, state.op_available);
+    } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
+        global_mounts::render_global_mounts(frame, global);
     } else {
         // List / CreatePrelude / ConfirmDelete share the list-like chrome.
         let area = frame.area();
@@ -143,6 +146,9 @@ pub fn render(
                     FooterItem::Sep,
                     FooterItem::Key("D"),
                     FooterItem::Text("delete"),
+                    FooterItem::Sep,
+                    FooterItem::Key("G"),
+                    FooterItem::Text("global config"),
                 ];
                 if show_open_hint {
                     items.push(FooterItem::Sep);
@@ -172,6 +178,7 @@ pub fn render(
                 FooterItem::Text("cancel"),
             ],
             ManagerStage::Editor(_) => unreachable!("Editor has its own render path"),
+            ManagerStage::GlobalMounts(_) => unreachable!("Global mounts has its own render path"),
         };
         render_footer(frame, chunks[2], &footer_items);
     }
@@ -211,6 +218,11 @@ pub fn render(
             }
             ManagerStage::List => {
                 // Handled above via the `is_list_stage` early branch.
+            }
+            ManagerStage::GlobalMounts(global) => {
+                if let Some(modal) = &mut global.modal {
+                    global_mounts::render_global_mount_modal(frame, modal);
+                }
             }
         }
     }

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -138,6 +138,12 @@ pub(super) fn effective_scroll_x(content_width: usize, viewport: usize, scroll_x
     }
 }
 
+pub(super) fn clamp_scroll_x(content_width: usize, viewport: usize, scroll_x: &mut u16) -> u16 {
+    let effective = effective_scroll_x(content_width, viewport, *scroll_x);
+    *scroll_x = effective;
+    effective
+}
+
 fn scrollbar_position(content_width: usize, viewport: usize, scroll_x: u16) -> usize {
     let scroll_x = usize::from(effective_scroll_x(content_width, viewport, scroll_x));
     let max_scroll = content_width.saturating_sub(viewport);
@@ -155,9 +161,11 @@ pub fn render(
     cwd: &std::path::Path,
 ) {
     // Phase 1: render the base stage (Editor full-screen OR List chrome).
-    if let ManagerStage::Editor(editor) = &state.stage {
+    if let ManagerStage::Editor(editor) = &mut state.stage {
+        clamp_editor_scroll_for_frame(frame.area(), editor);
         editor::render_editor(frame, editor, config, state.op_available);
     } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
+        clamp_global_mounts_scroll_for_frame(frame.area(), global);
         global_mounts::render_global_mounts(frame, global);
     } else {
         // List / CreatePrelude / ConfirmDelete share the list-like chrome.
@@ -174,6 +182,7 @@ pub fn render(
         render_header(frame, chunks[0], "workspaces");
 
         if matches!(&state.stage, ManagerStage::List) {
+            clamp_list_scroll_for_area(chunks[1], state, config, cwd);
             list::render_list_body(frame, chunks[1], state, config, cwd);
         }
 
@@ -316,6 +325,137 @@ pub fn render(
     }
 }
 
+fn clamp_editor_scroll_for_frame(area: Rect, editor: &mut super::state::EditorState<'_>) {
+    if editor.active_tab != super::state::EditorTab::Mounts {
+        return;
+    }
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Min(8),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    clamp_scroll_x(
+        list::workspace_mounts_content_width(&editor.pending.mounts),
+        chunks[2].width.saturating_sub(2) as usize,
+        &mut editor.workspace_mounts_scroll_x,
+    );
+}
+
+fn clamp_global_mounts_scroll_for_frame(
+    area: Rect,
+    global: &mut super::state::GlobalMountsState<'_>,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(10),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    clamp_scroll_x(
+        global_mounts::global_mounts_content_width(&global.pending),
+        chunks[1].width.saturating_sub(2) as usize,
+        &mut global.scroll_x,
+    );
+}
+
+fn clamp_list_scroll_for_area(
+    area: Rect,
+    state: &mut ManagerState<'_>,
+    config: &AppConfig,
+    cwd: &std::path::Path,
+) {
+    let left_pct = state.list_split_pct;
+    let right_pct = 100u16.saturating_sub(left_pct);
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(left_pct),
+            Constraint::Percentage(right_pct),
+        ])
+        .split(area);
+    let viewport = columns[1].width.saturating_sub(2) as usize;
+
+    match state.selected_row() {
+        ManagerListRow::CurrentDirectory => {
+            let cwd = cwd.display().to_string();
+            let mounts = [crate::workspace::MountConfig {
+                src: cwd.clone(),
+                dst: cwd,
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }];
+            clamp_scroll_x(
+                list::workspace_mounts_content_width(&mounts),
+                viewport,
+                &mut state.list_mounts_scroll_x,
+            );
+            state.list_global_mounts_scroll_x = 0;
+            state.list_role_global_mounts_scroll_x = 0;
+        }
+        ManagerListRow::SavedWorkspace(i) => {
+            let Some(summary) = state.workspaces.get(i) else {
+                return;
+            };
+            let Some(workspace) = config.workspaces.get(&summary.name) else {
+                return;
+            };
+            clamp_scroll_x(
+                list::workspace_mounts_content_width(&workspace.mounts),
+                viewport,
+                &mut state.list_mounts_scroll_x,
+            );
+
+            let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
+                picker
+                    .list_state
+                    .selected
+                    .and_then(|idx| picker.filtered.get(idx).cloned())
+            });
+            let global_rows = picker_role.as_ref().map_or_else(
+                || {
+                    config
+                        .list_mount_rows()
+                        .into_iter()
+                        .filter(|row| row.scope.is_none())
+                        .collect()
+                },
+                |role| config.resolve_mount_rows(role),
+            );
+            let global_mounts: Vec<_> = global_rows
+                .iter()
+                .filter(|row| row.scope.is_none())
+                .map(|row| row.mount.clone())
+                .collect();
+            let role_global_mounts: Vec<_> = global_rows
+                .iter()
+                .filter(|row| row.scope.is_some())
+                .map(|row| row.mount.clone())
+                .collect();
+            clamp_scroll_x(
+                list::global_mounts_content_width(&global_mounts),
+                viewport,
+                &mut state.list_global_mounts_scroll_x,
+            );
+            clamp_scroll_x(
+                list::global_mounts_content_width(&role_global_mounts),
+                viewport,
+                &mut state.list_role_global_mounts_scroll_x,
+            );
+        }
+        ManagerListRow::NewWorkspace => {
+            state.list_mounts_scroll_x = 0;
+            state.list_global_mounts_scroll_x = 0;
+            state.list_role_global_mounts_scroll_x = 0;
+        }
+    }
+}
+
 pub(super) fn render_header(frame: &mut Frame, area: Rect, title: &str) {
     let line = Line::from(vec![
         Span::styled("▓▓▓▓ ", Style::default().fg(PHOSPHOR_GREEN)),
@@ -344,7 +484,7 @@ pub(super) fn centered_rect_fixed(outer: Rect, pct_w: u16, rows: u16) -> Rect {
 
 #[cfg(test)]
 mod horizontal_scrollbar_tests {
-    use super::scrollbar_position;
+    use super::{clamp_scroll_x, scrollbar_position};
 
     #[test]
     fn text_scroll_end_maps_to_scrollbar_end() {
@@ -356,6 +496,19 @@ mod horizontal_scrollbar_tests {
     #[test]
     fn scrollbar_position_clamps_overscroll_to_end() {
         assert_eq!(scrollbar_position(100, 60, 400), 99);
+    }
+
+    #[test]
+    fn stored_scroll_offset_clamps_to_visible_end() {
+        let mut scroll_x = 400;
+
+        let effective = clamp_scroll_x(100, 60, &mut scroll_x);
+
+        assert_eq!(effective, 40);
+        assert_eq!(scroll_x, 40);
+
+        scroll_x = scroll_x.saturating_sub(8);
+        assert_eq!(scroll_x, 32);
     }
 }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -131,9 +131,7 @@ pub struct GlobalMountsState<'a> {
     pub error: Option<String>,
     pub success: Option<String>,
     pub scroll_x: u16,
-    /// Set by Discard or Save commit to signal the dispatcher to pop
-    /// back to the workspace list. Acted on (and reset) by
-    /// `after_global_mounts_event` in the input dispatcher.
+    /// Dispatcher pops back to the workspace list when set.
     pub exit_requested: bool,
 }
 
@@ -643,10 +641,10 @@ impl WorkspaceSummary {
 }
 
 impl ManagerState<'_> {
-    /// Mutable scroll-offset slot for the named focus. Centralizes the
-    /// "which list-stage scroll field to mutate" switch so handlers
-    /// don't reimplement the match.
-    pub const fn list_scroll_x_mut(&mut self, focus: MountScrollFocus) -> &mut u16 {
+    pub(in crate::console::manager) const fn list_scroll_x_mut(
+        &mut self,
+        focus: MountScrollFocus,
+    ) -> &mut u16 {
         match focus {
             MountScrollFocus::Workspace => &mut self.list_mounts_scroll_x,
             MountScrollFocus::Global => &mut self.list_global_mounts_scroll_x,
@@ -654,7 +652,7 @@ impl ManagerState<'_> {
         }
     }
 
-    pub const fn reset_list_scroll(&mut self) {
+    pub(in crate::console::manager) const fn reset_list_scroll(&mut self) {
         self.list_mounts_scroll_x = 0;
         self.list_global_mounts_scroll_x = 0;
         self.list_role_global_mounts_scroll_x = 0;

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -643,6 +643,24 @@ impl WorkspaceSummary {
 }
 
 impl ManagerState<'_> {
+    /// Mutable scroll-offset slot for the named focus. Centralizes the
+    /// "which list-stage scroll field to mutate" switch so handlers
+    /// don't reimplement the match.
+    pub const fn list_scroll_x_mut(&mut self, focus: MountScrollFocus) -> &mut u16 {
+        match focus {
+            MountScrollFocus::Workspace => &mut self.list_mounts_scroll_x,
+            MountScrollFocus::Global => &mut self.list_global_mounts_scroll_x,
+            MountScrollFocus::RoleGlobal => &mut self.list_role_global_mounts_scroll_x,
+        }
+    }
+
+    pub const fn reset_list_scroll(&mut self) {
+        self.list_mounts_scroll_x = 0;
+        self.list_global_mounts_scroll_x = 0;
+        self.list_role_global_mounts_scroll_x = 0;
+        self.list_scroll_focus = None;
+    }
+
     /// Allocates a fresh empty cache and assumes `op` unavailable —
     /// production reset paths use the `_with_cache_and_op` variant to
     /// preserve the `ConsoleState`-owned cache.

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -129,7 +129,12 @@ pub struct GlobalMountsState<'a> {
     pub modal: Option<GlobalMountModal<'a>>,
     pub add_draft: Option<GlobalMountDraft>,
     pub error: Option<String>,
+    pub success: Option<String>,
     pub scroll_x: u16,
+    /// Set by Discard or Save commit to signal the dispatcher to pop
+    /// back to the workspace list. Acted on (and reset) by
+    /// `after_global_mounts_event` in the input dispatcher.
+    pub exit_requested: bool,
 }
 
 #[derive(Debug, Default)]
@@ -146,15 +151,18 @@ pub enum GlobalMountModal<'a> {
         target: GlobalMountTextTarget,
         state: Box<TextInputState<'a>>,
     },
-    ConfirmRemove {
+    Confirm {
+        action: GlobalMountConfirm,
         state: ConfirmState,
     },
-    ConfirmSave {
-        state: ConfirmState,
-    },
-    ConfirmSensitive {
-        state: ConfirmState,
-    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalMountConfirm {
+    Remove,
+    Save,
+    Sensitive,
+    Discard,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -308,13 +316,23 @@ impl GlobalMountsState<'_> {
             modal: None,
             add_draft: None,
             error: None,
+            success: None,
             scroll_x: 0,
+            exit_requested: false,
         }
     }
 
     #[must_use]
     pub fn is_dirty(&self) -> bool {
         self.pending != self.original
+    }
+
+    pub fn discard(&mut self) {
+        self.pending = self.original.clone();
+        self.selected = self.selected.min(self.pending.len().saturating_sub(1));
+        self.add_draft = None;
+        self.error = None;
+        self.success = None;
     }
 
     pub fn save_to_config(

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -56,6 +56,7 @@ impl ManagerListRow {
 pub struct ManagerState<'a> {
     pub stage: ManagerStage<'a>,
     pub workspaces: Vec<WorkspaceSummary>,
+    pub current_dir: String,
     pub selected: usize,
     pub toast: Option<Toast>,
     /// Modal slot at the list level (e.g. `Modal::GithubPicker`); the
@@ -659,6 +660,7 @@ impl ManagerState<'_> {
         Self {
             stage: ManagerStage::List,
             workspaces,
+            current_dir: cwd.display().to_string(),
             selected,
             toast: None,
             list_modal: None,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -64,6 +64,8 @@ pub struct ManagerState<'a> {
     pub inline_role_picker: Option<RolePickerState>,
     pub list_mounts_scroll_x: u16,
     pub list_global_mounts_scroll_x: u16,
+    pub list_role_global_mounts_scroll_x: u16,
+    pub list_scroll_focus: Option<MountScrollFocus>,
     pub list_split_pct: u16,
     pub drag_state: Option<DragState>,
     /// Process-lifetime cache of `op` structural metadata, threaded
@@ -74,6 +76,13 @@ pub struct ManagerState<'a> {
     /// startup) so the Secrets-tab editor can disable the
     /// source-picker's 1Password choice without re-probing.
     pub op_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountScrollFocus {
+    Workspace,
+    Global,
+    RoleGlobal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -226,7 +235,7 @@ pub struct EditorState<'a> {
     /// `input::auth` for the recovery path on stash desync.
     pub pending_auth_form_return: Option<AuthFormReturnPath>,
     pub workspace_mounts_scroll_x: u16,
-    pub global_mounts_scroll_x: u16,
+    pub workspace_mounts_scroll_focused: bool,
 }
 
 /// Captured auth-form context to re-mount the form after a side
@@ -656,6 +665,8 @@ impl ManagerState<'_> {
             inline_role_picker: None,
             list_mounts_scroll_x: 0,
             list_global_mounts_scroll_x: 0,
+            list_role_global_mounts_scroll_x: 0,
+            list_scroll_focus: None,
             list_split_pct: DEFAULT_SPLIT_PCT,
             drag_state: None,
             op_cache,
@@ -787,7 +798,7 @@ impl EditorState<'_> {
             pending_picker_value: None,
             pending_auth_form_return: None,
             workspace_mounts_scroll_x: 0,
-            global_mounts_scroll_x: 0,
+            workspace_mounts_scroll_focused: false,
         }
     }
 
@@ -812,7 +823,7 @@ impl EditorState<'_> {
             pending_picker_value: None,
             pending_auth_form_return: None,
             workspace_mounts_scroll_x: 0,
-            global_mounts_scroll_x: 0,
+            workspace_mounts_scroll_focused: false,
         }
     }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -61,6 +61,8 @@ pub struct ManagerState<'a> {
     /// Modal slot at the list level (e.g. `Modal::GithubPicker`); the
     /// Editor / `CreatePrelude` stages own their own modal slots.
     pub list_modal: Option<Modal<'a>>,
+    pub inline_role_picker: Option<RolePickerState>,
+    pub list_scroll_x: u16,
     pub list_split_pct: u16,
     pub drag_state: Option<DragState>,
     /// Process-lifetime cache of `op` structural metadata, threaded
@@ -112,6 +114,7 @@ pub struct GlobalMountsState<'a> {
     pub modal: Option<GlobalMountModal<'a>>,
     pub add_draft: Option<GlobalMountDraft>,
     pub error: Option<String>,
+    pub scroll_x: u16,
 }
 
 #[derive(Debug, Default)]
@@ -221,6 +224,7 @@ pub struct EditorState<'a> {
     /// touch this slot — see `AUTH00x` debug tags in
     /// `input::auth` for the recovery path on stash desync.
     pub pending_auth_form_return: Option<AuthFormReturnPath>,
+    pub scroll_x: u16,
 }
 
 /// Captured auth-form context to re-mount the form after a side
@@ -288,6 +292,7 @@ impl GlobalMountsState<'_> {
             modal: None,
             add_draft: None,
             error: None,
+            scroll_x: 0,
         }
     }
 
@@ -646,6 +651,8 @@ impl ManagerState<'_> {
             selected,
             toast: None,
             list_modal: None,
+            inline_role_picker: None,
+            list_scroll_x: 0,
             list_split_pct: DEFAULT_SPLIT_PCT,
             drag_state: None,
             op_cache,
@@ -776,6 +783,7 @@ impl EditorState<'_> {
             pending_picker_target: None,
             pending_picker_value: None,
             pending_auth_form_return: None,
+            scroll_x: 0,
         }
     }
 
@@ -799,6 +807,7 @@ impl EditorState<'_> {
             pending_picker_target: None,
             pending_picker_value: None,
             pending_auth_form_return: None,
+            scroll_x: 0,
         }
     }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -63,6 +63,10 @@ pub struct ManagerState<'a> {
     /// Editor / `CreatePrelude` stages own their own modal slots.
     pub list_modal: Option<Modal<'a>>,
     pub inline_role_picker: Option<RolePickerState>,
+    pub inline_agent_picker: Option<(
+        crate::selector::RoleSelector,
+        crate::console::widgets::agent_choice::AgentChoiceState,
+    )>,
     pub list_mounts_scroll_x: u16,
     pub list_global_mounts_scroll_x: u16,
     pub list_role_global_mounts_scroll_x: u16,
@@ -665,6 +669,7 @@ impl ManagerState<'_> {
             toast: None,
             list_modal: None,
             inline_role_picker: None,
+            inline_agent_picker: None,
             list_mounts_scroll_x: 0,
             list_global_mounts_scroll_x: 0,
             list_role_global_mounts_scroll_x: 0,

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -62,7 +62,8 @@ pub struct ManagerState<'a> {
     /// Editor / `CreatePrelude` stages own their own modal slots.
     pub list_modal: Option<Modal<'a>>,
     pub inline_role_picker: Option<RolePickerState>,
-    pub list_scroll_x: u16,
+    pub list_mounts_scroll_x: u16,
+    pub list_global_mounts_scroll_x: u16,
     pub list_split_pct: u16,
     pub drag_state: Option<DragState>,
     /// Process-lifetime cache of `op` structural metadata, threaded
@@ -224,7 +225,8 @@ pub struct EditorState<'a> {
     /// touch this slot — see `AUTH00x` debug tags in
     /// `input::auth` for the recovery path on stash desync.
     pub pending_auth_form_return: Option<AuthFormReturnPath>,
-    pub scroll_x: u16,
+    pub workspace_mounts_scroll_x: u16,
+    pub global_mounts_scroll_x: u16,
 }
 
 /// Captured auth-form context to re-mount the form after a side
@@ -652,7 +654,8 @@ impl ManagerState<'_> {
             toast: None,
             list_modal: None,
             inline_role_picker: None,
-            list_scroll_x: 0,
+            list_mounts_scroll_x: 0,
+            list_global_mounts_scroll_x: 0,
             list_split_pct: DEFAULT_SPLIT_PCT,
             drag_state: None,
             op_cache,
@@ -783,7 +786,8 @@ impl EditorState<'_> {
             pending_picker_target: None,
             pending_picker_value: None,
             pending_auth_form_return: None,
-            scroll_x: 0,
+            workspace_mounts_scroll_x: 0,
+            global_mounts_scroll_x: 0,
         }
     }
 
@@ -807,7 +811,8 @@ impl EditorState<'_> {
             pending_picker_target: None,
             pending_picker_value: None,
             pending_auth_form_return: None,
-            scroll_x: 0,
+            workspace_mounts_scroll_x: 0,
+            global_mounts_scroll_x: 0,
         }
     }
 

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -134,6 +134,9 @@ pub enum GlobalMountModal<'a> {
     ConfirmSave {
         state: ConfirmState,
     },
+    ConfirmSensitive {
+        state: ConfirmState,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -99,8 +99,53 @@ pub const fn clamp_split(pct: u16) -> u16 {
 pub enum ManagerStage<'a> {
     List,
     Editor(EditorState<'a>),
+    GlobalMounts(GlobalMountsState<'a>),
     CreatePrelude(CreatePreludeState<'a>),
     ConfirmDelete { name: String, state: ConfirmState },
+}
+
+#[derive(Debug)]
+pub struct GlobalMountsState<'a> {
+    pub selected: usize,
+    pub pending: Vec<crate::config::GlobalMountRow>,
+    pub original: Vec<crate::config::GlobalMountRow>,
+    pub modal: Option<GlobalMountModal<'a>>,
+    pub add_draft: Option<GlobalMountDraft>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct GlobalMountDraft {
+    pub name: String,
+    pub src: String,
+    pub dst: String,
+    pub scope: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum GlobalMountModal<'a> {
+    Text {
+        target: GlobalMountTextTarget,
+        state: Box<TextInputState<'a>>,
+    },
+    ConfirmRemove {
+        state: ConfirmState,
+    },
+    ConfirmSave {
+        state: ConfirmState,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GlobalMountTextTarget {
+    AddName,
+    AddSource,
+    AddDestination,
+    AddScope,
+    Source,
+    Destination,
+    Scope,
+    Rename,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +272,42 @@ impl EditorSaveFlow {
         } else {
             None
         }
+    }
+}
+
+impl GlobalMountsState<'_> {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let rows = config.list_mount_rows();
+        Self {
+            selected: 0,
+            pending: rows.clone(),
+            original: rows,
+            modal: None,
+            add_draft: None,
+            error: None,
+        }
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.pending != self.original
+    }
+
+    pub fn save_to_config(
+        &mut self,
+        paths: &crate::paths::JackinPaths,
+    ) -> anyhow::Result<AppConfig> {
+        AppConfig::validate_global_mount_rows(&self.pending)?;
+        let mut editor = crate::config::ConfigEditor::open(paths)?;
+        for row in &self.original {
+            editor.remove_mount(&row.name, row.scope.as_deref());
+        }
+        for row in &self.pending {
+            editor.add_mount(&row.name, row.mount.clone(), row.scope.as_deref());
+        }
+        let config = editor.save()?;
+        self.original = self.pending.clone();
+        Ok(config)
     }
 }
 
@@ -1368,6 +1449,59 @@ mod tests {
         state.selected = ManagerListRow::NewWorkspace.to_screen_index(1);
         assert!(state.selected_workspace_summary().is_none());
         assert!(state.is_new_workspace_selected());
+    }
+
+    #[test]
+    fn global_mounts_state_persists_add_edit_remove_rename_scope_readonly() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = crate::paths::JackinPaths::for_tests(temp.path());
+        paths.ensure_base_dirs().unwrap();
+        std::fs::write(&paths.config_file, "").unwrap();
+        let source_a = temp.path().join("cache-a");
+        let source_b = temp.path().join("cache-b");
+        std::fs::create_dir_all(&source_a).unwrap();
+        std::fs::create_dir_all(&source_b).unwrap();
+
+        let mut state = GlobalMountsState::from_config(&AppConfig::default());
+        state.pending.push(crate::config::GlobalMountRow {
+            scope: None,
+            name: "gradle".into(),
+            mount: MountConfig {
+                src: source_a.display().to_string(),
+                dst: "/home/agent/.gradle/caches".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+        });
+        state.save_to_config(&paths).unwrap();
+
+        state.pending[0].name = "cargo".into();
+        state.pending[0].mount.src = source_b.display().to_string();
+        state.pending[0].mount.dst = "/home/agent/.cargo/registry".into();
+        state.pending[0].mount.readonly = true;
+        state.pending[0].scope = Some("chainargos/*".into());
+        state.pending.push(crate::config::GlobalMountRow {
+            scope: None,
+            name: "remove-me".into(),
+            mount: MountConfig {
+                src: source_a.display().to_string(),
+                dst: "/remove-me".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+        });
+        state.pending.retain(|row| row.name != "remove-me");
+        let saved = state.save_to_config(&paths).unwrap();
+
+        let rows = saved.list_mount_rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "cargo");
+        assert_eq!(rows[0].scope.as_deref(), Some("chainargos/*"));
+        assert!(rows[0].mount.readonly);
+        assert_eq!(rows[0].mount.dst, "/home/agent/.cargo/registry");
+        let raw = std::fs::read_to_string(&paths.config_file).unwrap();
+        assert!(raw.contains("[docker.mounts.\"chainargos/*\"]"), "{raw}");
+        assert!(!raw.contains("remove-me"), "{raw}");
     }
 
     // ── cycle_isolation_for_selected_mount ─────────────────────────────

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -255,7 +255,7 @@ fn key_debug_name(state: &ConsoleState, key: crossterm::event::KeyEvent) -> Stri
     }
 }
 
-const fn should_debug_log_mouse(mouse: &crossterm::event::MouseEvent) -> bool {
+const fn should_debug_log_mouse(mouse: crossterm::event::MouseEvent) -> bool {
     !matches!(
         mouse.kind,
         crossterm::event::MouseEventKind::ScrollDown
@@ -280,7 +280,7 @@ fn drain_pending_terminal_events_until_quiet(limit: usize, quiet_for: std::time:
             if elapsed >= max {
                 break;
             }
-            quiet_for.min(max - elapsed)
+            quiet_for.min(max.saturating_sub(elapsed))
         };
         match crossterm::event::poll(poll_for) {
             Ok(true) => {
@@ -566,7 +566,7 @@ pub fn run_console(
                 }
                 Event::Mouse(mouse) => {
                     last_mouse_event_at = Some(std::time::Instant::now());
-                    if should_debug_log_mouse(&mouse) {
+                    if should_debug_log_mouse(mouse) {
                         crate::debug_log!(
                             "tui",
                             "mouse={mouse:?} location={}",

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -31,7 +31,8 @@ impl ConsoleState {
         config: &AppConfig,
         cwd: &std::path::Path,
         input: LoadWorkspaceInput,
-    ) -> anyhow::Result<Option<(RoleSelector, ResolvedWorkspace)>> {
+    ) -> anyhow::Result<Option<(RoleSelector, ResolvedWorkspace, Option<crate::agent::Agent>)>>
+    {
         let Some(choice) = build_workspace_choice(config, cwd, &input)? else {
             // Workspace was deleted between keypress and dispatch.
             return Ok(None);
@@ -44,7 +45,8 @@ impl ConsoleState {
         {
             let workspace = preview::resolve_selected_workspace(config, cwd, &choice, &role)?;
             self.pending_launch = None;
-            return Ok(Some((role, workspace)));
+            self.pending_launch_role = None;
+            return Ok(Some((role, workspace, None)));
         }
 
         match roles.len() {
@@ -60,18 +62,21 @@ impl ConsoleState {
                     });
                 }
                 self.pending_launch = None;
+                self.pending_launch_role = None;
                 Ok(None)
             }
             1 => {
                 let role = roles.swap_remove(0);
                 let workspace = preview::resolve_selected_workspace(config, cwd, &choice, &role)?;
                 self.pending_launch = None;
-                Ok(Some((role, workspace)))
+                self.pending_launch_role = None;
+                Ok(Some((role, workspace, None)))
             }
             _ => {
                 // Multiple eligible: pin `pending_launch` so the
                 // `LaunchWithAgent` arm rebuilds the choice on commit.
                 self.pending_launch = Some(input);
+                self.pending_launch_role = None;
                 if let ConsoleStage::Manager(ms) = &mut self.stage {
                     ms.inline_role_picker = Some(
                         crate::console::widgets::role_picker::RolePickerState::with_confirm_label(
@@ -316,12 +321,36 @@ fn disable_console_mouse_capture<W: std::io::Write>(out: &mut W) -> std::io::Res
     out.flush()
 }
 
+fn maybe_open_inline_agent_picker(
+    state: &mut ConsoleState,
+    paths: &JackinPaths,
+    role: RoleSelector,
+    workspace: &ResolvedWorkspace,
+) -> bool {
+    let Some(agents) = crate::app::context::supported_agents_requiring_prompt(
+        paths,
+        &role,
+        workspace.default_agent,
+    ) else {
+        return false;
+    };
+
+    let ConsoleStage::Manager(ms) = &mut state.stage;
+    ms.inline_agent_picker = Some((
+        role.clone(),
+        crate::console::widgets::agent_choice::AgentChoiceState::with_choices(agents),
+    ));
+    ms.inline_role_picker = None;
+    state.pending_launch_role = Some(role);
+    true
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run_console(
     mut config: AppConfig,
     paths: &JackinPaths,
     cwd: &std::path::Path,
-) -> anyhow::Result<Option<(RoleSelector, ResolvedWorkspace)>> {
+) -> anyhow::Result<Option<(RoleSelector, ResolvedWorkspace, Option<crate::agent::Agent>)>> {
     use std::time::Duration;
 
     use crossterm::ExecutableCommand;
@@ -449,23 +478,43 @@ pub fn run_console(
                             break 'main Ok(None);
                         }
                         manager::InputOutcome::LaunchNamed(name) => {
-                            match state.dispatch_launch_for_workspace(
-                                &config,
-                                cwd,
-                                LoadWorkspaceInput::Saved(name),
-                            ) {
-                                Ok(Some(outcome)) => break 'main Ok(Some(outcome)),
+                            let input = LoadWorkspaceInput::Saved(name);
+                            match state.dispatch_launch_for_workspace(&config, cwd, input.clone()) {
+                                Ok(Some((role, workspace, agent))) => {
+                                    if agent.is_none()
+                                        && maybe_open_inline_agent_picker(
+                                            &mut state,
+                                            paths,
+                                            role.clone(),
+                                            &workspace,
+                                        )
+                                    {
+                                        state.pending_launch = Some(input);
+                                    } else {
+                                        break 'main Ok(Some((role, workspace, agent)));
+                                    }
+                                }
                                 Ok(None) => {}
                                 Err(e) => break 'main Err(e),
                             }
                         }
                         manager::InputOutcome::LaunchCurrentDir => {
-                            match state.dispatch_launch_for_workspace(
-                                &config,
-                                cwd,
-                                LoadWorkspaceInput::CurrentDir,
-                            ) {
-                                Ok(Some(outcome)) => break 'main Ok(Some(outcome)),
+                            let input = LoadWorkspaceInput::CurrentDir;
+                            match state.dispatch_launch_for_workspace(&config, cwd, input.clone()) {
+                                Ok(Some((role, workspace, agent))) => {
+                                    if agent.is_none()
+                                        && maybe_open_inline_agent_picker(
+                                            &mut state,
+                                            paths,
+                                            role.clone(),
+                                            &workspace,
+                                        )
+                                    {
+                                        state.pending_launch = Some(input);
+                                    } else {
+                                        break 'main Ok(Some((role, workspace, agent)));
+                                    }
+                                }
                                 Ok(None) => {}
                                 Err(e) => break 'main Err(e),
                             }
@@ -480,7 +529,35 @@ pub fn run_console(
                                 match preview::resolve_selected_workspace(
                                     &config, cwd, &choice, &role,
                                 ) {
-                                    Ok(workspace) => break 'main Ok(Some((role, workspace))),
+                                    Ok(workspace) => {
+                                        if maybe_open_inline_agent_picker(
+                                            &mut state,
+                                            paths,
+                                            role.clone(),
+                                            &workspace,
+                                        ) {
+                                            state.pending_launch = Some(input);
+                                        } else {
+                                            state.pending_launch_role = None;
+                                            break 'main Ok(Some((role, workspace, None)));
+                                        }
+                                    }
+                                    Err(e) => break 'main Err(e),
+                                }
+                            }
+                        }
+                        manager::InputOutcome::LaunchWithRuntimeAgent(agent) => {
+                            if let (Some(input), Some(role)) = (
+                                state.pending_launch.take(),
+                                state.pending_launch_role.take(),
+                            ) && let Some(choice) = build_workspace_choice(&config, cwd, &input)?
+                            {
+                                match preview::resolve_selected_workspace(
+                                    &config, cwd, &choice, &role,
+                                ) {
+                                    Ok(workspace) => {
+                                        break 'main Ok(Some((role, workspace, Some(agent))));
+                                    }
                                     Err(e) => break 'main Err(e),
                                 }
                             }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -402,7 +402,12 @@ pub fn run_console(
                         console_location_debug(&state)
                     );
                     if let ConsoleStage::Manager(ms) = &mut state.stage {
-                        manager::input::handle_mouse(ms, mouse, term_size);
+                        manager::input::handle_mouse_with_config(
+                            ms,
+                            mouse,
+                            term_size,
+                            Some(&config),
+                        );
                     }
                 }
                 _ => {}

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -212,6 +212,9 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
                 crate::console::manager::state::GlobalMountModal::ConfirmSave { .. } => {
                     "confirm-save"
                 }
+                crate::console::manager::state::GlobalMountModal::ConfirmSensitive { .. } => {
+                    "confirm-sensitive"
+                }
             });
             format!("global-mounts selected={} modal={modal}", global.selected)
         }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -88,6 +88,10 @@ impl ConsoleState {
 /// 20 Hz: spinner stays fluid and op results surface within ~50ms
 /// without hot-spinning. <16ms wastes cycles, >100ms stutters.
 const TICK_MS: u64 = 50;
+const MAX_EVENTS_PER_TICK: usize = 256;
+const MAX_TEARDOWN_DRAIN_EVENTS: usize = 16_384;
+const TEARDOWN_DRAIN_QUIET_MS: u64 = 30;
+const TEARDOWN_DRAIN_MAX_MS: u64 = 250;
 
 fn quit_confirm_area(
     frame: ratatui::layout::Rect,
@@ -245,6 +249,72 @@ fn key_debug_name(state: &ConsoleState, key: crossterm::event::KeyEvent) -> Stri
     }
 }
 
+const fn should_debug_log_mouse(mouse: &crossterm::event::MouseEvent) -> bool {
+    !matches!(
+        mouse.kind,
+        crossterm::event::MouseEventKind::ScrollDown
+            | crossterm::event::MouseEventKind::ScrollUp
+            | crossterm::event::MouseEventKind::ScrollLeft
+            | crossterm::event::MouseEventKind::ScrollRight
+    )
+}
+
+fn drain_pending_terminal_events(limit: usize) {
+    drain_pending_terminal_events_until_quiet(limit, std::time::Duration::ZERO);
+}
+
+fn drain_pending_terminal_events_until_quiet(limit: usize, quiet_for: std::time::Duration) {
+    let started = std::time::Instant::now();
+    for _ in 0..limit {
+        let poll_for = if quiet_for.is_zero() {
+            std::time::Duration::ZERO
+        } else {
+            let elapsed = started.elapsed();
+            let max = std::time::Duration::from_millis(TEARDOWN_DRAIN_MAX_MS);
+            if elapsed >= max {
+                break;
+            }
+            quiet_for.min(max - elapsed)
+        };
+        match crossterm::event::poll(poll_for) {
+            Ok(true) => {
+                let _ = crossterm::event::read();
+            }
+            Ok(false) | Err(_) => break,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn flush_terminal_input_queue() {
+    if let Ok(tty) = std::fs::File::options()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+    {
+        let _ = nix::sys::termios::tcflush(&tty, nix::sys::termios::FlushArg::TCIFLUSH);
+    }
+}
+
+#[cfg(not(unix))]
+fn flush_terminal_input_queue() {}
+
+fn enable_console_mouse_capture<W: std::io::Write>(out: &mut W) -> std::io::Result<()> {
+    // Crossterm's EnableMouseCapture includes ?1003h "any-event"
+    // tracking. That reports plain pointer motion and can flood the pty
+    // under touchpad inertia. Jackin needs press/release, drag, scroll,
+    // and SGR coordinates, so enable only those modes.
+    out.write_all(b"\x1b[?1000h\x1b[?1002h\x1b[?1015h\x1b[?1006h")?;
+    out.flush()
+}
+
+fn disable_console_mouse_capture<W: std::io::Write>(out: &mut W) -> std::io::Result<()> {
+    // Disable the exact modes we enable, plus ?1003l defensively in case
+    // an older build or another library enabled any-event tracking.
+    out.write_all(b"\x1b[?1006l\x1b[?1015l\x1b[?1003l\x1b[?1002l\x1b[?1000l")?;
+    out.flush()
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn run_console(
     mut config: AppConfig,
@@ -254,9 +324,7 @@ pub fn run_console(
     use std::time::Duration;
 
     use crossterm::ExecutableCommand;
-    use crossterm::event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    };
+    use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
     use crossterm::terminal::{EnterAlternateScreen, enable_raw_mode};
 
     // EnableMouseCapture disables native text selection; operators
@@ -264,9 +332,15 @@ pub fn run_console(
     struct TerminalGuard;
     impl Drop for TerminalGuard {
         fn drop(&mut self) {
-            let _ = crossterm::terminal::disable_raw_mode();
             let mut stdout = std::io::stdout();
-            let _ = stdout.execute(DisableMouseCapture);
+            drain_pending_terminal_events_until_quiet(
+                MAX_TEARDOWN_DRAIN_EVENTS,
+                std::time::Duration::from_millis(TEARDOWN_DRAIN_QUIET_MS),
+            );
+            let _ = disable_console_mouse_capture(&mut stdout);
+            drain_pending_terminal_events(MAX_TEARDOWN_DRAIN_EVENTS);
+            flush_terminal_input_queue();
+            let _ = crossterm::terminal::disable_raw_mode();
             let _ = stdout.execute(crossterm::terminal::LeaveAlternateScreen);
             let _ = stdout.execute(crossterm::cursor::Show);
             crate::tui::end_debug_buffering();
@@ -279,11 +353,11 @@ pub fn run_console(
     let guard = TerminalGuard;
     crate::tui::begin_debug_buffering();
     stdout.execute(EnterAlternateScreen)?;
-    stdout.execute(EnableMouseCapture)?;
+    enable_console_mouse_capture(&mut stdout)?;
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
 
-    let result = loop {
+    let result = 'main: loop {
         // Auto-expire manager toasts after 3 seconds.
         if let ConsoleStage::Manager(ms) = &mut state.stage
             && let Some(toast) = &ms.toast
@@ -312,7 +386,15 @@ pub fn run_console(
 
         // Non-blocking poll: a TICK_MS timeout falls through to advance
         // the spinner and drain worker channels even when idle.
-        if event::poll(Duration::from_millis(TICK_MS))? {
+        let mut events_processed = 0;
+        while events_processed < MAX_EVENTS_PER_TICK
+            && event::poll(if events_processed == 0 {
+                Duration::from_millis(TICK_MS)
+            } else {
+                Duration::ZERO
+            })?
+        {
+            events_processed += 1;
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     crate::debug_log!(
@@ -324,7 +406,7 @@ pub fn run_console(
                     if let Some(confirm) = state.quit_confirm.as_mut() {
                         use crate::console::widgets::ModalOutcome;
                         match confirm.handle_key(key) {
-                            ModalOutcome::Commit(true) => break Ok(None),
+                            ModalOutcome::Commit(true) => break 'main Ok(None),
                             ModalOutcome::Commit(false) | ModalOutcome::Cancel => {
                                 state.quit_confirm = None;
                             }
@@ -354,7 +436,7 @@ pub fn run_console(
                     match outcome {
                         manager::InputOutcome::Continue => {}
                         manager::InputOutcome::ExitJackin => {
-                            break Ok(None);
+                            break 'main Ok(None);
                         }
                         manager::InputOutcome::LaunchNamed(name) => {
                             match state.dispatch_launch_for_workspace(
@@ -362,9 +444,9 @@ pub fn run_console(
                                 cwd,
                                 LoadWorkspaceInput::Saved(name),
                             ) {
-                                Ok(Some(outcome)) => break Ok(Some(outcome)),
+                                Ok(Some(outcome)) => break 'main Ok(Some(outcome)),
                                 Ok(None) => {}
-                                Err(e) => break Err(e),
+                                Err(e) => break 'main Err(e),
                             }
                         }
                         manager::InputOutcome::LaunchCurrentDir => {
@@ -373,9 +455,9 @@ pub fn run_console(
                                 cwd,
                                 LoadWorkspaceInput::CurrentDir,
                             ) {
-                                Ok(Some(outcome)) => break Ok(Some(outcome)),
+                                Ok(Some(outcome)) => break 'main Ok(Some(outcome)),
                                 Ok(None) => {}
-                                Err(e) => break Err(e),
+                                Err(e) => break 'main Err(e),
                             }
                         }
                         manager::InputOutcome::LaunchWithAgent(role) => {
@@ -388,19 +470,21 @@ pub fn run_console(
                                 match preview::resolve_selected_workspace(
                                     &config, cwd, &choice, &role,
                                 ) {
-                                    Ok(workspace) => break Ok(Some((role, workspace))),
-                                    Err(e) => break Err(e),
+                                    Ok(workspace) => break 'main Ok(Some((role, workspace))),
+                                    Err(e) => break 'main Err(e),
                                 }
                             }
                         }
                     }
                 }
                 Event::Mouse(mouse) => {
-                    crate::debug_log!(
-                        "tui",
-                        "mouse={mouse:?} location={}",
-                        console_location_debug(&state)
-                    );
+                    if should_debug_log_mouse(&mouse) {
+                        crate::debug_log!(
+                            "tui",
+                            "mouse={mouse:?} location={}",
+                            console_location_debug(&state)
+                        );
+                    }
                     if let ConsoleStage::Manager(ms) = &mut state.stage {
                         manager::input::handle_mouse_with_config(
                             ms,

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -92,6 +92,7 @@ const MAX_EVENTS_PER_TICK: usize = 256;
 const MAX_TEARDOWN_DRAIN_EVENTS: usize = 16_384;
 const TEARDOWN_DRAIN_QUIET_MS: u64 = 30;
 const TEARDOWN_DRAIN_MAX_MS: u64 = 250;
+const MOUSE_ESCAPE_GRACE_MS: u64 = 150;
 
 fn quit_confirm_area(
     frame: ratatui::layout::Rect,
@@ -356,6 +357,7 @@ pub fn run_console(
     enable_console_mouse_capture(&mut stdout)?;
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
+    let mut last_mouse_event_at: Option<std::time::Instant> = None;
 
     let result = 'main: loop {
         // Auto-expire manager toasts after 3 seconds.
@@ -397,6 +399,14 @@ pub fn run_console(
             events_processed += 1;
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    if matches!(key.code, KeyCode::Esc)
+                        && key.modifiers.is_empty()
+                        && last_mouse_event_at.is_some_and(|at| {
+                            at.elapsed() <= Duration::from_millis(MOUSE_ESCAPE_GRACE_MS)
+                        })
+                    {
+                        continue;
+                    }
                     crate::debug_log!(
                         "tui",
                         "key={} location={}",
@@ -478,6 +488,7 @@ pub fn run_console(
                     }
                 }
                 Event::Mouse(mouse) => {
+                    last_mouse_event_at = Some(std::time::Instant::now());
                     if should_debug_log_mouse(&mouse) {
                         crate::debug_log!(
                             "tui",

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -73,11 +73,11 @@ impl ConsoleState {
                 // `LaunchWithAgent` arm rebuilds the choice on commit.
                 self.pending_launch = Some(input);
                 if let ConsoleStage::Manager(ms) = &mut self.stage {
-                    ms.list_modal = Some(crate::console::manager::state::Modal::RolePicker {
-                        state: crate::console::widgets::role_picker::RolePickerState::with_confirm_label(
+                    ms.inline_role_picker = Some(
+                        crate::console::widgets::role_picker::RolePickerState::with_confirm_label(
                             roles, "launch",
                         ),
-                    });
+                    );
                 }
                 Ok(None)
             }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -117,7 +117,7 @@ const fn is_on_main_screen(state: &ConsoleState) -> bool {
 /// Modals that consume letters (`TextInput`, pickers with filter-as-
 /// you-type) must shadow the Q-intercept so `Q` types the letter.
 const fn consumes_letter_input(state: &ConsoleState) -> bool {
-    use crate::console::manager::state::{ManagerStage, Modal};
+    use crate::console::manager::state::{GlobalMountModal, ManagerStage, Modal};
     let ConsoleStage::Manager(ms) = &state.stage;
 
     if let Some(modal) = &ms.list_modal
@@ -142,6 +142,12 @@ const fn consumes_letter_input(state: &ConsoleState) -> bool {
     if let ManagerStage::CreatePrelude(p) = &ms.stage
         && let Some(modal) = &p.modal
         && matches!(modal, Modal::TextInput { .. })
+    {
+        return true;
+    }
+    if let ManagerStage::GlobalMounts(global) = &ms.stage
+        && let Some(modal) = &global.modal
+        && matches!(modal, GlobalMountModal::Text { .. })
     {
         return true;
     }
@@ -196,6 +202,18 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
         }
         crate::console::manager::state::ManagerStage::ConfirmDelete { .. } => {
             "confirm-delete".to_string()
+        }
+        crate::console::manager::state::ManagerStage::GlobalMounts(global) => {
+            let modal = global.modal.as_ref().map_or("none", |modal| match modal {
+                crate::console::manager::state::GlobalMountModal::Text { .. } => "text-input",
+                crate::console::manager::state::GlobalMountModal::ConfirmRemove { .. } => {
+                    "confirm-remove"
+                }
+                crate::console::manager::state::GlobalMountModal::ConfirmSave { .. } => {
+                    "confirm-save"
+                }
+            });
+            format!("global-mounts selected={} modal={modal}", global.selected)
         }
     };
     format!("{location}{list_modal}")

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -216,14 +216,19 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
         crate::console::manager::state::ManagerStage::GlobalMounts(global) => {
             let modal = global.modal.as_ref().map_or("none", |modal| match modal {
                 crate::console::manager::state::GlobalMountModal::Text { .. } => "text-input",
-                crate::console::manager::state::GlobalMountModal::ConfirmRemove { .. } => {
-                    "confirm-remove"
-                }
-                crate::console::manager::state::GlobalMountModal::ConfirmSave { .. } => {
-                    "confirm-save"
-                }
-                crate::console::manager::state::GlobalMountModal::ConfirmSensitive { .. } => {
-                    "confirm-sensitive"
+                crate::console::manager::state::GlobalMountModal::Confirm { action, .. } => {
+                    match action {
+                        crate::console::manager::state::GlobalMountConfirm::Remove => {
+                            "confirm-remove"
+                        }
+                        crate::console::manager::state::GlobalMountConfirm::Save => "confirm-save",
+                        crate::console::manager::state::GlobalMountConfirm::Sensitive => {
+                            "confirm-sensitive"
+                        }
+                        crate::console::manager::state::GlobalMountConfirm::Discard => {
+                            "confirm-discard"
+                        }
+                    }
                 }
             });
             format!("global-mounts selected={} modal={modal}", global.selected)

--- a/src/console/state.rs
+++ b/src/console/state.rs
@@ -33,6 +33,7 @@ pub struct ConsoleState {
     /// its `WorkspaceChoice` from current config — manager edits flow
     /// through immediately.
     pub pending_launch: Option<LoadWorkspaceInput>,
+    pub pending_launch_role: Option<RoleSelector>,
     /// Process-lifetime `op` metadata cache. `Rc<RefCell<_>>` because
     /// the TUI event loop is single-threaded.
     pub op_cache: Rc<RefCell<OpCache>>,
@@ -61,6 +62,7 @@ impl ConsoleState {
                 ),
             ),
             pending_launch: None,
+            pending_launch_role: None,
             op_cache,
             op_available,
             quit_confirm: None,

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -17,29 +17,38 @@ const WHITE: Color = Color::Rgb(255, 255, 255);
 
 #[derive(Debug, Clone)]
 pub struct AgentChoiceState {
+    pub choices: Vec<Agent>,
     pub focused: Agent,
 }
 
 impl AgentChoiceState {
-    pub const fn new() -> Self {
-        Self {
-            focused: Agent::Claude,
-        }
+    pub fn new() -> Self {
+        Self::with_choices(Agent::ALL.to_vec())
+    }
+
+    pub fn with_choices(choices: Vec<Agent>) -> Self {
+        let choices = if choices.is_empty() {
+            Agent::ALL.to_vec()
+        } else {
+            choices
+        };
+        let focused = choices[0];
+        Self { choices, focused }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<Agent> {
         match key.code {
             KeyCode::Down | KeyCode::Char('j') => {
-                let idx = focus_index(self.focused);
-                if idx + 1 < Agent::ALL.len() {
-                    self.focused = Agent::ALL[idx + 1];
+                let idx = focus_index_in(&self.choices, self.focused);
+                if idx + 1 < self.choices.len() {
+                    self.focused = self.choices[idx + 1];
                 }
                 ModalOutcome::Continue
             }
             KeyCode::Up | KeyCode::Char('k') => {
-                let idx = focus_index(self.focused);
+                let idx = focus_index_in(&self.choices, self.focused);
                 if idx > 0 {
-                    self.focused = Agent::ALL[idx - 1];
+                    self.focused = self.choices[idx - 1];
                 }
                 ModalOutcome::Continue
             }
@@ -50,14 +59,11 @@ impl AgentChoiceState {
     }
 }
 
-fn focus_index(agent: Agent) -> usize {
-    Agent::ALL
-        .iter()
-        .position(|a| *a == agent)
-        .expect("Agent::ALL contains every Agent variant")
+fn focus_index_in(choices: &[Agent], agent: Agent) -> usize {
+    choices.iter().position(|a| *a == agent).unwrap_or(0)
 }
 
-const fn agent_picker_label(agent: Agent) -> &'static str {
+pub const fn agent_picker_label(agent: Agent) -> &'static str {
     match agent {
         Agent::Claude => "Claude",
         Agent::Codex => "Codex",
@@ -103,7 +109,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AgentChoiceState) {
         ])
         .split(inner);
 
-    let lines: Vec<Line> = Agent::ALL
+    let lines: Vec<Line> = state
+        .choices
         .iter()
         .map(|a| make_row(*a, agent_picker_label(*a)))
         .collect();
@@ -168,6 +175,18 @@ mod tests {
             ModalOutcome::Commit(a) => assert_eq!(a, Agent::Codex),
             other => panic!("expected commit, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn with_choices_limits_navigation_and_default_focus() {
+        let mut s = AgentChoiceState::with_choices(vec![Agent::Codex, Agent::Amp]);
+        assert_eq!(s.focused, Agent::Codex);
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.focused, Agent::Amp);
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.focused, Agent::Amp);
+        let _ = s.handle_key(key(KeyCode::Up));
+        assert_eq!(s.focused, Agent::Codex);
     }
 
     #[test]

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -190,6 +190,13 @@ mod tests {
     }
 
     #[test]
+    fn empty_choices_falls_back_to_agent_all() {
+        let s = AgentChoiceState::with_choices(Vec::new());
+        assert_eq!(s.choices, Agent::ALL.to_vec());
+        assert_eq!(s.focused, Agent::ALL[0]);
+    }
+
+    #[test]
     fn esc_cancels() {
         let mut s = AgentChoiceState::new();
         assert!(matches!(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,6 +6,7 @@ use std::sync::{
 static DEBUG_MODE: AtomicBool = AtomicBool::new(false);
 static DEBUG_BUFFER_ACTIVE: AtomicBool = AtomicBool::new(false);
 static DEBUG_BUFFER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+const DEBUG_BUFFER_LIMIT: usize = 2048;
 
 pub fn set_debug_mode(enabled: bool) {
     DEBUG_MODE.store(enabled, Ordering::Relaxed);
@@ -52,6 +53,10 @@ pub fn emit_debug_line(category: &str, message: &str) {
         let mut guard = debug_buffer()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if guard.len() >= DEBUG_BUFFER_LIMIT {
+            let keep_from = guard.len() / 2;
+            guard.drain(..keep_from);
+        }
         guard.push(line);
     } else {
         eprintln!("{line}");

--- a/src/workspace/resolve.rs
+++ b/src/workspace/resolve.rs
@@ -166,9 +166,13 @@ pub fn resolve_load_workspace(
     validate_mount_paths(&workspace.mounts)?;
 
     let mut mounts = workspace.mounts.clone();
-    let global_mounts = crate::config::AppConfig::expand_and_validate_named_mounts(
-        &config.resolve_mounts(selector),
-    )?;
+    let global_rows = config.resolve_mount_rows(selector);
+    crate::config::AppConfig::validate_effective_mount_destinations(&workspace, &global_rows)?;
+    let global_mounts: Vec<(String, MountConfig)> = global_rows
+        .into_iter()
+        .map(|row| (row.name, row.mount))
+        .collect();
+    let global_mounts = crate::config::AppConfig::expand_and_validate_named_mounts(&global_mounts)?;
 
     for mount in global_mounts {
         if mounts.iter().any(|existing| existing.dst == mount.dst) {
@@ -619,6 +623,55 @@ mod tests {
             error
                 .to_string()
                 .contains("ad-hoc mount destination conflicts")
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_duplicate_effective_global_workspace_destination() {
+        let temp = tempdir().unwrap();
+        let workspace_src = temp.path().join("project");
+        let global_src = temp.path().join("cache");
+        std::fs::create_dir_all(&workspace_src).unwrap();
+        std::fs::create_dir_all(&global_src).unwrap();
+
+        let mut config = crate::config::AppConfig::default();
+        config.add_mount(
+            "cache",
+            MountConfig {
+                src: global_src.display().to_string(),
+                dst: "/workspace/project".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            },
+            None,
+        );
+        config.workspaces.insert(
+            "my-ws".to_string(),
+            WorkspaceConfig {
+                workdir: "/workspace/project".to_string(),
+                mounts: vec![MountConfig {
+                    src: workspace_src.display().to_string(),
+                    dst: "/workspace/project".to_string(),
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                }],
+                ..Default::default()
+            },
+        );
+
+        let error = resolve_load_workspace(
+            &config,
+            &crate::selector::RoleSelector::new(None, "agent-smith"),
+            &std::env::temp_dir(),
+            LoadWorkspaceInput::Saved("my-ws".to_string()),
+            &[],
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("global mount destination conflicts")
         );
     }
 }

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -1397,12 +1397,12 @@ fn agent_picker_opens_when_multiple_agents_available() -> Result<()> {
         "multi-role dispatch must stay in the run-loop (Ok(None)); got {outcome:?}"
     );
     let ConsoleStage::Manager(ms) = &state.stage;
-    match &ms.list_modal {
-        Some(Modal::RolePicker { state: picker }) => {
+    match &ms.inline_role_picker {
+        Some(picker) => {
             assert_eq!(picker.roles.len(), 2);
             assert_eq!(picker.filtered.len(), 2);
         }
-        other => panic!("expected Modal::RolePicker on list_modal; got {other:?}"),
+        other => panic!("expected inline RolePicker; got {other:?}"),
     }
     Ok(())
 }
@@ -1427,7 +1427,7 @@ fn agent_picker_skipped_when_default_agent_set() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws) = outcome.expect("default_role must short-circuit to a direct launch");
+    let (role, _ws, _agent) = outcome.expect("default_role must short-circuit to a direct launch");
     assert_eq!(role.key(), "chainargos/agent-smith");
     let ConsoleStage::Manager(ms) = &state.stage;
     assert!(
@@ -1453,7 +1453,8 @@ fn agent_picker_skipped_when_single_eligible_agent() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws) = outcome.expect("single eligible role must short-circuit to a direct launch");
+    let (role, _ws, _agent) =
+        outcome.expect("single eligible role must short-circuit to a direct launch");
     assert_eq!(role.key(), "chainargos/agent-smith");
     let ConsoleStage::Manager(ms) = &state.stage;
     assert!(ms.list_modal.is_none());
@@ -1484,7 +1485,7 @@ fn agent_picker_enter_commits_launch() -> Result<()> {
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
     let ConsoleStage::Manager(ms) = &mut state.stage;
-    assert!(matches!(ms.list_modal, Some(Modal::RolePicker { .. })));
+    assert!(ms.inline_role_picker.is_some());
 
     // Enter on the picker — selection defaults to index 0
     // (BTreeMap ordering of role keys).
@@ -1500,8 +1501,8 @@ fn agent_picker_enter_commits_launch() -> Result<()> {
         other => panic!("expected LaunchWithAgent outcome; got {other:?}"),
     }
     assert!(
-        ms.list_modal.is_none(),
-        "picker commit must close the modal"
+        ms.inline_role_picker.is_none(),
+        "picker commit must close the inline picker"
     );
     Ok(())
 }
@@ -1529,7 +1530,7 @@ fn agent_picker_esc_closes_modal() -> Result<()> {
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
     let ConsoleStage::Manager(ms) = &mut state.stage;
-    assert!(matches!(ms.list_modal, Some(Modal::RolePicker { .. })));
+    assert!(ms.inline_role_picker.is_some());
 
     let outcome = handle_key(ms, &mut config, &paths, cwd, key(KeyCode::Esc))?;
     assert!(
@@ -1537,9 +1538,9 @@ fn agent_picker_esc_closes_modal() -> Result<()> {
         "Esc on the picker must produce Continue; got {outcome:?}"
     );
     assert!(
-        ms.list_modal.is_none(),
-        "Esc must close the picker modal; got {:?}",
-        ms.list_modal
+        ms.inline_role_picker.is_none(),
+        "Esc must close the inline picker; got {:?}",
+        ms.inline_role_picker
     );
     Ok(())
 }
@@ -2478,7 +2479,7 @@ fn launch_after_create_workspace_uses_fresh_data() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("freshly-created".into()),
     )?;
-    let (role, _ws) = outcome.expect(
+    let (role, _ws, _agent) = outcome.expect(
         "freshly-created workspace must resolve through the dispatcher; under the bug, \
          ConsoleState.workspaces was a startup snapshot and didn't include the new name",
     );
@@ -2520,7 +2521,7 @@ fn launch_after_rename_uses_new_name() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("renamed-ws".into()),
     )?;
-    let (role, _ws) = outcome.expect("renamed workspace must resolve under the new name");
+    let (role, _ws, _agent) = outcome.expect("renamed workspace must resolve under the new name");
     assert_eq!(role.key(), "chainargos/agent-smith");
 
     // OLD name must not resolve — under the snapshot bug it did.
@@ -2590,7 +2591,7 @@ fn launch_after_default_agent_change_uses_new_default() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws) = after.expect(
+    let (role, _ws, _agent) = after.expect(
         "after default_role is set, dispatch must short-circuit to a direct launch outcome; \
          under the bug, the snapshot's default_role: None forced the picker open",
     );
@@ -2664,7 +2665,7 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("survivor-ws".into()),
     )?;
-    let (role, _ws) = alive.expect("survivor-ws must still resolve");
+    let (role, _ws, _agent) = alive.expect("survivor-ws must still resolve");
     assert_eq!(role.key(), "chainargos/agent-smith");
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR ships Global Mount Visibility across the CLI and console. `jackin workspace show <name>` now separates saved workspace mounts from applicable global mounts, workspace list previews and workspace editor mount views keep workspace-owned mounts visually separate from global mounts, and the console adds a dedicated `Global config -> Global mounts` surface opened with `G` from the workspace list for adding, renaming, editing source/destination/scope, toggling readonly, removing, and explicitly saving global mounts. The same work hardens mount validation, moves mount tables to destination-first display with horizontal scrolling, makes TUI scroll handling resistant to touchpad/mouse event floods, makes editor tabs clickable, and keeps the full workspace -> role -> runtime agent selection flow inside the TUI.

## Host-side config boundary

This preserves the operator-only configuration boundary: workspace show, workspace overview, and workspace edit surfaces may read the global config so operators can see effective global mounts, but those workspace surfaces do not write global config. The only TUI write path for global mounts is `Global config -> Global mounts`, after explicit save confirmation, using the same config-editor persistence path as `jackin config mount`.

## What's deferred

- Broader Global Config TUI sections such as General, Environments, Authentication, and Trust are intentionally deferred. This PR finishes the global mounts slice only.
- Role-scoped global mounts are shown in workspace views only when the workspace role context is singular. Multi-role workspaces intentionally show an ambiguity note until launch or role selection resolves the effective global mount set.

## Verify locally

Checkout:

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/global-mount-visibility:refs/remotes/origin/feature/global-mount-visibility
git checkout -B feature/global-mount-visibility refs/remotes/origin/feature/global-mount-visibility
```

Static checks:

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --all-targets
```

Tests:

```sh
cargo nextest run --all-features
```

Result on 2026-05-11: all passed locally. `cargo nextest run --all-features` ran 1878 tests; 1878 passed.

User smoke:

```sh
cargo run --bin jackin -- console --debug
```

Smoke path:

1. Select a saved workspace and verify the overview shows workspace mounts and global mounts as separate panels.
2. Press `E`, open `Mounts`, and verify only workspace-owned rows expose workspace edit actions.
3. Return to the workspace list, press `G`, edit a test global mount, and confirm changes remain pending until `S` save confirmation.
4. Launch a workspace or Current directory whose role supports multiple runtime agents and verify the TUI advances from workspace selection to role selection to the inline runtime-agent picker before launch.
5. Use touchpad or horizontal wheel scrolling over the mounts/global mounts panels. Repeated scrolling at either edge should not drift, should not require compensating reverse scrolls, and should not leave raw mouse escape text in the shell after exit.
6. Verify global config changes only after saving from `Global config -> Global mounts`.

CLI smoke:

```sh
cargo run --bin jackin -- config mount list
cargo run --bin jackin -- workspace show <workspace> --debug
```

Verify workspace output has separate `Workspace mounts:` and `Global mounts` sections when role context is singular. For workspaces with multiple possible roles and role-scoped global mounts, verify it explains that selected role affects global mount visibility.

## Migration notes

None. This changes display, validation, and editing flows without changing versioned config, workspace, or role manifest schemas.

