### PR TITLE
docs: add container identity and session roadmaps

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -318,6 +318,7 @@ export default defineConfig({
                   items: [
                     { label: 'Bollard migration', slug: 'reference/roadmap/bollard-migration' },
                     { label: 'Construct user creation', slug: 'reference/roadmap/construct-user-creation' },
+                    { label: 'Unique container identity and restore', slug: 'reference/roadmap/unique-container-identity-restore' },
                   ],
                 },
                 {

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -172,6 +172,7 @@ export default defineConfig({
                       collapsed: true,
                       items: [
                         { label: 'Agent runtime status', slug: 'reference/roadmap/agent-runtime-status' },
+                        { label: 'Console agent session control', slug: 'reference/roadmap/console-agent-session-control' },
                         { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
                         { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
                         { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -76,6 +76,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 
 - **[Docker API migration](/reference/roadmap/bollard-migration/)** — incremental migration from CLI string-matching to the Bollard typed API client for more robust error handling (status: deferred — incremental migration is the pragmatic path)
 - **[Construct user creation optimization](/reference/roadmap/construct-user-creation/)** — move user creation to the derived layer to eliminate UID/GID remapping (status: deferred — needs design work)
+- **[Unique container identity and restore](/reference/roadmap/unique-container-identity-restore/)** — replace clone-derived Docker names with DNS-safe unique instance names, add per-instance restore metadata, and make deleted-Docker recovery explicit before fresh launches (status: open — design proposal)
 
 ### Operator surface and fleet operations
 

--- a/docs/src/content/docs/reference/roadmap/agent-orchestrator-research.mdx
+++ b/docs/src/content/docs/reference/roadmap/agent-orchestrator-research.mdx
@@ -297,6 +297,7 @@ same session contract and persistent storage decisions.
 | Item | Inspiration in multicode | Depends on |
 |---|---|---|
 | [Agent runtime status](/reference/roadmap/agent-runtime-status/) | Runtime-derived session status | Multi-runtime adapter seam |
+| [Console agent session control](/reference/roadmap/console-agent-session-control/) | TUI as the active workspace/session control plane | Unique container identity; agent runtime status |
 | [Console resource panel](/reference/roadmap/console-resource-panel/) | CPU/RAM/disk polling | Resource limits (Phase 1) |
 | [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) | `<multicode:*>` skill-driven tags | Agent runtime status |
 | [GitHub link tracking](/reference/roadmap/github-link-tracking/) | GitHub polling + SQLite cache | Tag protocol; persistent storage (Phase 3) |

--- a/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
+++ b/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
@@ -1,0 +1,189 @@
+---
+title: "Console Agent Session Control"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Phase 2, [Agent Orchestrator Research Program](/reference/roadmap/agent-orchestrator-research/))
+
+## Problem
+
+Jackin's current operator escape hatches still leak Docker details. When the operator wants a shell in a running environment, the practical path is a raw command such as:
+
+```sh
+docker exec -ti jackin-chainargos__agent-brown zsh
+```
+
+When the operator wants to reconnect to the original foreground agent, the path is `jackin hardline <container-name>`. That works for one primary process, but it does not give the console a first-class model of "this workspace has one isolated container with multiple active agent sessions inside it."
+
+The missing product model is a running container as an isolated collaboration environment, with one or more agent sessions inside it. The operator should be able to open a workspace in `jackin console`, see the running container, see each agent session inside that container, attach to one, start another, open a shell, or hardline the original agent without remembering Docker names.
+
+## Why It Matters
+
+The most useful review workflow often needs multiple agents against one branch and one filesystem state:
+
+- use Codex to implement a feature
+- ask Codex for a review prompt
+- start Claude Code in the same isolated container to review the same branch
+- keep both sessions reachable so the operator can switch between implementation, review, and follow-up prompts
+
+Jackin already builds containers with multiple agent runtimes available. The console should turn that into an intentional workflow rather than requiring manual `docker exec` commands. One isolated container can hold the feature branch, dependencies, DIND state, credentials, and tool caches while multiple agent processes collaborate over the same state.
+
+## Relationship To Unique Container Identity
+
+[Unique container identity and restore](/reference/roadmap/unique-container-identity-restore/) makes Docker names compact, DNS-safe, unique, and less meaningful as an operator API. This item is the operator-facing counterpart: once names are no longer stable human handles like `jackin-the-architect-clone-2`, `jackin console` and CLI commands must provide the actions people used raw Docker names for.
+
+The identity roadmap owns the container base name and restore metadata. This roadmap owns how the operator sees and controls active containers and agent sessions.
+
+## Recommended Shape
+
+Model three levels explicitly:
+
+1. **Workspace or ad-hoc directory** — the thing the operator chose.
+2. **Runtime instance** — one jackin-managed isolated container, with DIND/network/state attached.
+3. **Agent session** — one interactive process inside that container, such as Claude Code, Codex, Amp, or a plain shell.
+
+The console should render this as a nested view: workspace rows expand to runtime instances, and each instance expands to active sessions. A compact table is enough for V1:
+
+| Workspace | Runtime instance | Sessions | Actions |
+|---|---|---|---|
+| `chainargos` | `agentbrown · k7p9m2xq` | `Claude · running`, `Codex review · idle`, `shell · attached` | attach, new agent, shell, hardline, stop |
+
+The visible runtime row should use workspace, role, short unique ID, and status. The raw Docker container name can be shown in a details pane for debugging, but not as the primary handle.
+
+## Session Management
+
+Raw `docker exec -it <container> <agent>` processes are not reconnectable by themselves. If jackin wants reliable reconnect for secondary agents, it needs a reconnectable session substrate inside the container.
+
+Recommended V1: use `tmux` or an equivalent terminal multiplexer installed in the runtime image.
+
+- The primary launch agent runs in a named session such as `jackin-primary`.
+- A secondary Codex/Claude/Amp launch runs in a named session such as `jackin-codex-review-1`.
+- A shell entry runs in a named session such as `jackin-shell-1` when the operator wants reconnect, or as a one-shot exec when reconnect does not matter.
+- The host attaches by running `docker exec -it <container> tmux attach -t <session>`.
+- Session metadata is written into the instance manifest or future persistent store so the console can list sessions even after the operator's terminal disconnects.
+
+If `tmux` is not acceptable long term, replace it with a tiny in-container session supervisor. The important invariant is the same: jackin starts named, reconnectable sessions and records them. It should not pretend a raw exec process can be reattached after the terminal is gone.
+
+## CLI Surface
+
+Add CLI commands that operate by workspace/instance/session identity, not by raw Docker container names:
+
+```sh
+jackin instance list
+jackin instance shell <instance-id-or-selector>
+jackin instance hardline <instance-id-or-selector>
+jackin session list <instance-id-or-selector>
+jackin session start <instance-id-or-selector> --agent codex --name review
+jackin session attach <session-id-or-selector>
+jackin session stop <session-id-or-selector>
+```
+
+Names are illustrative. The implementation can choose shorter command names, but the command model should preserve the distinction between a container/runtime instance and an agent session inside it.
+
+Existing `jackin hardline` should remain as a compatibility surface while this lands, then move toward instance/session selectors. The long-term direction is that raw Docker container names are accepted only as an advanced/debug selector, not as the normal UX.
+
+## Console Actions
+
+The console should support these actions from the active-instance view:
+
+- **Attach** — reconnect to an existing agent session.
+- **Hardline** — reconnect to the original foreground agent/session when the container is still recoverable.
+- **New agent** — start another runtime inside the same container, sharing the same workspace state.
+- **Shell** — open a zsh shell inside the container without typing `docker exec`.
+- **Stop session** — stop a secondary agent process without stopping the whole container.
+- **Stop instance** — stop the whole isolated container after confirmation.
+- **Inspect** — show raw Docker names, labels, mount summary, DIND endpoint, and state paths for debugging.
+
+The UI should make it visually clear when several sessions share the same container. That is the point of the feature: one isolated feature environment can host multiple cooperating agents.
+
+## State Model
+
+Extend the instance manifest from [Unique container identity and restore](/reference/roadmap/unique-container-identity-restore/) with session records, or store them in the future persistent storage layer:
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "s1",
+      "name": "primary",
+      "agent_runtime": "claude",
+      "command": "claude",
+      "session_backend": "tmux",
+      "backend_name": "jackin-primary",
+      "created_at": "2026-05-11T00:00:00Z",
+      "status": "running",
+      "last_attached_at": "2026-05-11T00:00:00Z"
+    }
+  ]
+}
+```
+
+Session status should be reconciled from the backend. For `tmux`, list sessions inside the container and match known names. If the container is missing, sessions become `container_missing`. If the tmux session is gone but the manifest record remains, mark it `exited` or `unknown` and keep logs/history if available.
+
+## Corner Cases
+
+- **Secondary agent exits**: keep the session record with exit status/log pointer when possible. The console should offer "restart" and "discard" instead of silently removing it.
+- **Operator disconnects**: the tmux session keeps running. Reopening `jackin console` should list and reattach it.
+- **Container exits while sessions exist**: all sessions become stopped/unreachable, and restore follows the instance-level rules.
+- **DIND reset**: secondary sessions may still run, but Docker commands inside them may fail until the instance restore path rebuilds DIND/network/certs. Surface this at the instance row, not per session only.
+- **Two agents write the same files**: this feature intentionally allows it because the operator asked for one shared feature branch. The UI should label the sessions as sharing one filesystem and should not imply per-agent isolation inside the same container.
+- **Credential mode differs by agent runtime**: starting a secondary runtime must run the same auth provisioning rules used for primary launch. Do not leak a credential for an agent runtime whose current workspace/role mode says `ignore`.
+- **Role does not support requested runtime**: the new-agent action must block with the same support check as launch.
+- **TTY resize and terminal capabilities**: attach paths must preserve current terminal size and TERM behavior, matching the primary launch path as closely as possible.
+- **Session naming collisions**: if the operator asks for `review` twice, suffix the session display name or prompt. The backend session name should include the instance ID and a short session ID.
+- **Logs and transcript capture**: do not promise transcript persistence in V1 unless the runtime already writes it. Future persistent storage can track log pointers.
+- **Non-interactive usage**: CLI commands should support scripting, but starting or attaching interactive sessions still requires a terminal.
+
+## Implementation Plan
+
+### Phase 1 — Discovery and shell entry
+
+- Add instance discovery that lists running jackin-managed containers by manifest/labels instead of clone-family parsing.
+- Add `jackin instance shell` or equivalent to open zsh in a selected running container.
+- Add a console action that opens the same shell path.
+- Keep the first version one-shot if needed, but design the command name and UI around the future reconnectable session model.
+
+### Phase 2 — Reconnectable primary session
+
+- Start the primary agent inside a named session backend.
+- Teach `hardline` to attach to the named primary session instead of only `docker attach` when the backend is present.
+- Preserve current behavior for legacy containers.
+
+### Phase 3 — Secondary agent sessions
+
+- Add `session start/list/attach/stop` commands.
+- Add console actions for starting Claude/Codex/Amp sessions inside an existing instance.
+- Persist session records and reconcile them on console startup.
+
+### Phase 4 — Rich operator coordination
+
+- Combine session rows with [Agent runtime status](/reference/roadmap/agent-runtime-status/) so each session can show idle/busy/question.
+- Combine instance rows with [Console resource panel](/reference/roadmap/console-resource-panel/) so the operator can see shared container CPU/RAM pressure.
+- Add task/review labels so an operator can name a secondary session `review`, `tests`, `docs`, or similar.
+
+## Acceptance Criteria
+
+- Operators can open a shell in a running jackin container from CLI and console without typing `docker exec`.
+- Operators can see which workspaces/directories have running instances.
+- Operators can see which agent sessions are running inside each instance.
+- Operators can reconnect to the primary session through the console.
+- Operators can start and reconnect to a secondary agent session inside the same container.
+- The UI clearly communicates when multiple agents share one container, one branch, and one filesystem.
+- Raw Docker container names are no longer required for normal shell, hardline, or session attach flows.
+- Legacy `hardline <container-name>` remains usable until the replacement selectors ship.
+
+## Host-side effects
+
+This feature does not introduce new host repository mutations. It runs additional processes inside an already selected jackin-managed container and writes session metadata under jackin-managed state. Starting multiple agents in one container intentionally shares the same mounted workspace state, so the launch/session UI must make that sharing explicit before starting secondary agents.
+
+## Related Files
+
+- <RepoFile path="src/runtime/attach.rs" /> — current hardline attach/restart behavior.
+- <RepoFile path="src/runtime/launch.rs" /> — primary process launch and future session backend setup.
+- <RepoFile path="src/runtime/discovery.rs" /> — running container discovery.
+- <RepoFile path="src/console/manager/state.rs" /> — console state for expanded runtime/session rows.
+- <RepoFile path="src/console/manager/render/list.rs" /> — workspace list rendering that would grow active instance/session rows.
+- <RepoFile path="src/agent/mod.rs" /> — agent runtime identities for secondary sessions.
+- [Unique container identity and restore](/reference/roadmap/unique-container-identity-restore/) — instance IDs, manifests, and restore lookup.
+- [Agent runtime status](/reference/roadmap/agent-runtime-status/) — future per-session idle/busy/question status.
+- [Console resource panel](/reference/roadmap/console-resource-panel/) — future per-instance resource visibility.

--- a/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
+++ b/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
@@ -13,9 +13,9 @@ Jackin's current operator escape hatches still leak Docker details. When the ope
 docker exec -ti jackin-chainargos__agent-brown zsh
 ```
 
-When the operator wants to reconnect to the original foreground agent, the path is `jackin hardline <container-name>`. That works for one primary process, but it does not give the console a first-class model of "this workspace has one isolated container with multiple active agent sessions inside it."
+When the operator wants to reconnect to the original foreground agent, the path is `jackin hardline <container-name>`. That works for one primary process, but it does not give the console a first-class model of "this workspace or directory has one isolated container with multiple active agent sessions inside it."
 
-The missing product model is a running container as an isolated collaboration environment, with one or more agent sessions inside it. The operator should be able to open a workspace in `jackin console`, see the running container, see each agent session inside that container, attach to one, start another, open a shell, or hardline the original agent without remembering Docker names.
+The missing product model is a running container as an isolated collaboration environment, with one or more agent sessions inside it. The operator should be able to open `jackin console`, see all running instances for configured workspaces and ad-hoc directories, see each agent role and exact agent session inside those containers, attach to one, start another, open a shell, or hardline the original agent without remembering Docker names.
 
 ## Why It Matters
 
@@ -36,19 +36,21 @@ The identity roadmap owns the container base name and restore metadata. This roa
 
 ## Recommended Shape
 
-Model three levels explicitly:
+Model four levels explicitly:
 
-1. **Workspace or ad-hoc directory** — the thing the operator chose.
-2. **Runtime instance** — one jackin-managed isolated container, with DIND/network/state attached.
-3. **Agent session** — one interactive process inside that container, such as Claude Code, Codex, Amp, or a plain shell.
+1. **Workspace or ad-hoc directory** — the configured workspace name or the concrete directory path the operator launched from.
+2. **Agent role** — the role used to build/run the environment, such as `agentbrown` for display and `chainargos/agent-brown` in metadata.
+3. **Runtime instance** — one jackin-managed isolated container, with DIND/network/state attached.
+4. **Agent session** — one interactive process inside that container, such as Claude Code, Codex, Amp, or a plain shell.
 
-The console should render this as a nested view: workspace rows expand to runtime instances, and each instance expands to active sessions. A compact table is enough for V1:
+The console should render this as a nested view: workspace/directory rows expand to agent roles, roles expand to runtime instances, and each instance expands to active sessions. Configured workspaces and arbitrary directories belong in the same active-instances surface so the operator does not need two mental models for reconnecting.
 
-| Workspace | Runtime instance | Sessions | Actions |
+| Scope | Role | Runtime instance | Sessions | Actions |
 |---|---|---|---|
-| `chainargos` | `agentbrown · k7p9m2xq` | `Claude · running`, `Codex review · idle`, `shell · attached` | attach, new agent, shell, hardline, stop |
+| `workspace: chainargos` | `agentbrown` | `k7p9m2xq · running` | `Claude · running`, `Codex review · idle`, `shell · attached` | attach, new agent, shell, hardline, stop |
+| `dir: ~/Projects/tmp/spike` | `architect` | `m4d8q2xz · preserved` | `Claude · stopped` | attach, shell, purge |
 
-The visible runtime row should use workspace, role, short unique ID, and status. The raw Docker container name can be shown in a details pane for debugging, but not as the primary handle.
+The visible runtime row should use scope, role, short unique ID, and status. The raw Docker container name can be shown in a details pane for debugging, but not as the primary handle.
 
 ## Session Management
 
@@ -93,6 +95,7 @@ Legacy `jackin hardline <container-name>` should remain usable while this lands,
 
 The console should support these actions from the active-instance view:
 
+- **Filter by scope** — show active/preserved instances for all configured workspaces, for the current directory, or for a chosen arbitrary directory.
 - **Attach** — reconnect to an existing agent session.
 - **Hardline** — reconnect to the original foreground agent/session when the container is still recoverable.
 - **New agent** — start another runtime inside the same container, sharing the same workspace state.
@@ -101,7 +104,7 @@ The console should support these actions from the active-instance view:
 - **Stop instance** — stop the whole isolated container after confirmation.
 - **Inspect** — show raw Docker names, labels, mount summary, DIND endpoint, and state paths for debugging.
 
-The UI should make it visually clear when several sessions share the same container. That is the point of the feature: one isolated feature environment can host multiple cooperating agents.
+The UI should make it visually clear which scope owns the container, which agent role produced it, and which exact agent sessions are running inside it. When several sessions share the same container, the UI should say so plainly. That is the point of the feature: one isolated feature environment can host multiple cooperating agents.
 
 ## State Model
 
@@ -132,6 +135,7 @@ Session status should be reconciled from the backend. For `tmux`, list sessions 
 - **Secondary agent exits**: keep the session record with exit status/log pointer when possible. The console should offer "restart" and "discard" instead of silently removing it.
 - **Operator disconnects**: the tmux session keeps running. Reopening `jackin console` should list and reattach it.
 - **Container exits while sessions exist**: all sessions become stopped/unreachable, and restore follows the instance-level rules.
+- **Ad-hoc directory moves**: directory-backed instances should remain visible through stored metadata, but hardline from the old path should explain that the original directory no longer matches and offer inspect/purge rather than silently creating a wrong association.
 - **DIND reset**: secondary sessions may still run, but Docker commands inside them may fail until the instance restore path rebuilds DIND/network/certs. Surface this at the instance row, not per session only.
 - **Two agents write the same files**: this feature intentionally allows it because the operator asked for one shared feature branch. The UI should label the sessions as sharing one filesystem and should not imply per-agent isolation inside the same container.
 - **Credential mode differs by agent runtime**: starting a secondary runtime must run the same auth provisioning rules used for primary launch. Do not leak a credential for an agent runtime whose current workspace/role mode says `ignore`.
@@ -146,6 +150,7 @@ Session status should be reconciled from the backend. For `tmux`, list sessions 
 ### Phase 1 — Discovery and shell entry
 
 - Add instance discovery that lists running jackin-managed containers by manifest/labels instead of clone-family parsing.
+- Add a console active-instances view that includes configured workspaces and ad-hoc directory launches in one list.
 - Add `jackin hardline --shell` or equivalent to open zsh in a selected running container.
 - Add a console action that opens the same shell path.
 - Keep the first version one-shot if needed, but design the command name and UI around the future reconnectable session model.
@@ -171,8 +176,9 @@ Session status should be reconciled from the backend. For `tmux`, list sessions 
 ## Acceptance Criteria
 
 - Operators can open a shell in a running jackin container from CLI and console without typing `docker exec`.
-- Operators can see which workspaces/directories have running instances.
-- Operators can see which agent sessions are running inside each instance.
+- Operators can see which configured workspaces and ad-hoc directories have running or preserved instances.
+- Operators can see which agent roles are running under each workspace/directory scope.
+- Operators can see the exact agent sessions running inside each role/container.
 - Operators can reconnect to the primary session through the console.
 - Operators can start and reconnect to a secondary agent session inside the same container.
 - The UI clearly communicates when multiple agents share one container, one branch, and one filesystem.

--- a/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
+++ b/docs/src/content/docs/reference/roadmap/console-agent-session-control.mdx
@@ -64,23 +64,30 @@ Recommended V1: use `tmux` or an equivalent terminal multiplexer installed in th
 
 If `tmux` is not acceptable long term, replace it with a tiny in-container session supervisor. The important invariant is the same: jackin starts named, reconnectable sessions and records them. It should not pretend a raw exec process can be reattached after the terminal is gone.
 
-## CLI Surface
+## Hardline CLI Surface
 
-Add CLI commands that operate by workspace/instance/session identity, not by raw Docker container names:
+Do not add a separate `jackin restore`, `jackin instance`, or `jackin session` command family for the core flow. `hardline` is the operator verb for reconnecting to existing work and for entering an already-running isolated container.
+
+The command should work from the current directory, similar to `jackin load`:
+
+- If the current directory maps to one configured workspace or ad-hoc launch root with one running/preserved instance, `jackin hardline` selects it.
+- If multiple matching containers exist for that folder, `jackin hardline` prompts for the target runtime instance.
+- If the selected container has multiple agent sessions, `jackin hardline` prompts for the exact session to attach.
+- If the operator asks for another agent runtime, `jackin hardline --agent codex --new` or an equivalent flag starts a new Codex session inside the selected container instead of creating a fresh container.
+- If no matching instance exists, `jackin hardline` reports that there is nothing to reconnect to and points the operator at `jackin load`.
+
+Illustrative shape:
 
 ```sh
-jackin instance list
-jackin instance shell <instance-id-or-selector>
-jackin instance hardline <instance-id-or-selector>
-jackin session list <instance-id-or-selector>
-jackin session start <instance-id-or-selector> --agent codex --name review
-jackin session attach <session-id-or-selector>
-jackin session stop <session-id-or-selector>
+jackin hardline
+jackin hardline --agent claude
+jackin hardline --agent codex --new --name review
+jackin hardline --shell
 ```
 
-Names are illustrative. The implementation can choose shorter command names, but the command model should preserve the distinction between a container/runtime instance and an agent session inside it.
+The exact flags are design placeholders. The command model is the important part: `hardline` resolves workspace/directory context, then resolves runtime instance, then resolves or creates an agent session inside that instance.
 
-Existing `jackin hardline` should remain as a compatibility surface while this lands, then move toward instance/session selectors. The long-term direction is that raw Docker container names are accepted only as an advanced/debug selector, not as the normal UX.
+Legacy `jackin hardline <container-name>` should remain usable while this lands, but raw Docker names should become an advanced/debug selector rather than the normal path.
 
 ## Console Actions
 
@@ -139,7 +146,7 @@ Session status should be reconciled from the backend. For `tmux`, list sessions 
 ### Phase 1 — Discovery and shell entry
 
 - Add instance discovery that lists running jackin-managed containers by manifest/labels instead of clone-family parsing.
-- Add `jackin instance shell` or equivalent to open zsh in a selected running container.
+- Add `jackin hardline --shell` or equivalent to open zsh in a selected running container.
 - Add a console action that opens the same shell path.
 - Keep the first version one-shot if needed, but design the command name and UI around the future reconnectable session model.
 
@@ -151,7 +158,7 @@ Session status should be reconciled from the backend. For `tmux`, list sessions 
 
 ### Phase 3 — Secondary agent sessions
 
-- Add `session start/list/attach/stop` commands.
+- Expand `jackin hardline` flags/prompts so it can list, attach, start, and stop secondary sessions without a separate command family.
 - Add console actions for starting Claude/Codex/Amp sessions inside an existing instance.
 - Persist session records and reconcile them on console startup.
 

--- a/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
+++ b/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
@@ -117,32 +117,33 @@ Also add a lightweight global index under `~/.jackin/data/instances.json` or `~/
 
 Jackin's restore promise should be precise: if work was written to jackin-managed local storage, jackin can guide the operator back to it even when Docker containers are deleted. Jackin cannot recover writes that existed only in a deleted container's writable layer unless those paths were explicitly persisted or snapshotted.
 
-When launching a configured workspace or ad-hoc directory, jackin should:
+When launching or hardlining a configured workspace or ad-hoc directory, jackin should:
 
 1. Compute a lookup key from the configured workspace name, or from the canonical host directory path for ad-hoc mode. Include role key and agent runtime as filters, but allow the UI to show all unfinished instances for that workspace/directory.
 2. Scan the instance index for records whose status is `active`, `crashed`, `preserved_dirty`, `preserved_unpushed`, or `restore_available`.
 3. Inspect Docker state for each candidate. A candidate can have role/DIND containers running, stopped, missing, partially missing, or replaced by unrelated resources.
-4. If candidates exist, show a restore picker before creating a fresh instance. The picker should show workspace, role, agent, created/updated time, mount isolation summary, dirty/unpushed status, and Docker resource state.
-5. Provide explicit actions: `restore`, `start fresh`, `inspect path`, `purge`, and `cancel`.
+4. If candidates exist, show an instance picker before creating a fresh instance or attaching. The picker should show workspace, role, agent sessions, created/updated time, mount isolation summary, dirty/unpushed status, and Docker resource state.
+5. Provide explicit actions through existing surfaces: `hardline` to attach/restart/spawn inside an instance, `load` to start fresh, `purge` to discard, and console actions for inspection.
 
 Restore paths:
 
-- **Role container exists and DIND exists/running**: use `hardline` behavior and attach or restart in place.
+- **Role container exists and DIND exists/running**: `jackin hardline` attaches to an existing agent session, or prompts to start a new agent session inside the selected container when requested.
 - **Role container exists but DIND is missing/stopped**: rebuild the network, DIND sidecar, cert volume, and environment contract, then start or recreate the role container only if the role container's filesystem state is not required. If the role container has important writable-layer state, surface that it cannot be safely rehydrated without the original container.
 - **Docker containers are missing but state directory exists with worktree/clone records**: recreate a new role container using the same `container_base` and remount the stored worktree/clone paths. Do not regenerate a different base name for a restore, because isolation paths and scratch branches are keyed by the original container name.
 - **Docker containers are missing and only shared mounts existed**: there is no private worktree to restore, but jackin can restart a fresh container against the same workspace and mark the old instance as superseded.
 - **Docker containers are missing and the instance had unpersisted container-layer changes**: tell the operator those container-layer changes are gone. This is the boundary that motivates future snapshot work.
 - **State directory exists but host workdir moved**: resolve by workspace config first; if the original path fingerprint no longer matches, prompt the operator to locate the new directory or inspect the state path directly.
-- **State directory exists but role source changed**: default to the stored role source/ref for restore when available. Offer a fresh launch path if the operator wants the latest trusted role instead.
+- **State directory exists but role source changed**: default to the stored role source/ref for hardline/recovery when available. Offer a fresh launch path if the operator wants the latest trusted role instead.
 
-The restore picker belongs in `jackin console` first because it is a multi-instance decision. CLI should get scriptable equivalents:
+Do not introduce a separate `jackin restore` command. `hardline` is the CLI verb for reconnecting to existing work. It should become directory-aware in the same way `load` is: running `jackin hardline` from inside a configured workspace or ad-hoc project directory looks up matching unfinished/running instances, prompts when more than one exists, then prompts for the exact agent session when the selected container has multiple sessions. If no matching instance exists, it should fail with a clear "nothing to hardline" message or offer the operator the normal fresh `load` path.
 
 ```sh
-jackin restore list [--workspace <name>|--dir <path>]
-jackin restore show <instance-id-or-name>
-jackin restore attach <instance-id-or-name>
-jackin restore fresh <workspace-or-dir> <role>
+jackin hardline
+jackin hardline --agent claude
+jackin hardline --agent codex --new
 ```
+
+The exact flags are design placeholders. The invariant is that `hardline` owns reconnecting and spawning additional agent sessions inside an existing container, while `load` owns creating a fresh runtime instance.
 
 ## Required State Transitions
 
@@ -185,13 +186,13 @@ This avoids mutating live operator work while stopping new launches from creatin
 - **Manual Docker prune**: cert volumes may disappear while role containers remain stopped. Recreate DIND/certs/network when safe; otherwise explain why a full container-layer restore is impossible.
 - **Partial launch failure**: if state exists but mount materialization failed, mark the instance as `failed_setup` or keep `active` with an error field. The restore picker should show it as inspect/purge, not attachable.
 - **Clean exit with dirty shared mount**: shared mounts are already host state. Do not create a restore candidate solely because a shared host repo is dirty; jackin did not isolate that work.
-- **Clean exit with dirty isolated mount**: preserve and surface through restore/hardline/purge until the operator finalizes or discards it.
+- **Clean exit with dirty isolated mount**: preserve and surface through hardline/console/purge until the operator finalizes or discards it.
 - **Non-git mounts**: clone/worktree restore does not cover them. If they are writable and important, link this design to [Session snapshot and rollback](/reference/roadmap/session-snapshot-rollback/) for opt-in file snapshots.
 - **Secrets and auth state**: do not restore stale copied credentials silently across changed auth modes. Re-run the normal auth provisioning path on restore, then mount preserved state only where the current mode allows it.
 - **Role image drift**: the restored container should use the stored image tag/ref by default. If the image no longer exists locally, rebuild from the stored trusted source/ref or ask the operator whether to rebuild from the current source.
 - **Labels too long or invalid**: Docker labels can carry full metadata values that are not DNS-safe. Use labels for filtering and metadata for exact values; do not round-trip restore state by parsing DNS-safe slugs.
 - **Testcontainers reachability**: Java Testcontainers parses `DOCKER_HOST` strictly and may also need `TESTCONTAINERS_HOST_OVERRIDE`. A smoke test must run inside a jackin-launched role and start a trivial container through Testcontainers with TLS enabled.
-- **No Docker available**: restore listing should still work from local state; attach/recreate should fail with a Docker-specific error.
+- **No Docker available**: hardline/console listing should still work from local state; attach/recreate should fail with a Docker-specific error.
 
 ## Implementation Plan
 
@@ -208,11 +209,11 @@ This avoids mutating live operator work while stopping new launches from creatin
 - Write `.jackin/instance.json` before workspace materialization and update lifecycle fields throughout launch/finalize/error paths.
 - Add the rebuildable global index for lookup by workspace/directory/role.
 - Add reconciliation that compares manifest state with Docker state on launch.
-- Add restore prompts for interactive `jackin load` and `jackin console`; non-interactive CLI should fail with a clear message unless an explicit `--fresh` or restore target is supplied.
+- Add recovery prompts for interactive `jackin load`, `jackin hardline`, and `jackin console`; non-interactive CLI should fail with a clear message unless an explicit fresh-load or hardline target is supplied.
 
-### Phase 3 — Restore commands and UI
+### Phase 3 — Hardline and UI recovery
 
-- Add `jackin restore list/show/attach` or equivalent commands.
+- Expand `jackin hardline` so it resolves the current workspace/directory, prompts across matching instances, prompts across agent sessions, and can start a new agent session inside the selected running container.
 - Add a console restore picker and active-instance panel that separates human labels from Docker names.
 - Teach cleanup and purge to operate by instance ID/name and to distinguish Docker resource deletion from local state deletion.
 

--- a/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
+++ b/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
@@ -41,7 +41,7 @@ These names are technical identifiers, not the long-term operator API. The conso
 Container names that jackin uses as hostnames must obey hostname label rules, not only Docker's permissive container-name rules.
 
 - DNS labels are limited to 63 octets, and full domain names are limited to 255 octets including length bytes. See [RFC 1035 section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4).
-- Hostname labels use letters, digits, and hyphen, with labels beginning with a letter and ending with a letter or digit under the preferred hostname syntax. See [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1), which permits a leading digit.
+- Hostname labels use letters, digits, and hyphen, with labels beginning with a letter and ending with a letter or digit under the preferred hostname syntax. See [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123](https://www.rfc-editor.org/rfc/rfc1123), section 2.1, which permits a leading digit.
 - Underscores are not valid hostname label characters. Some Docker and libc paths resolve them, but Java URI parsing and many libraries reject them.
 
 Recommended invariant: every Docker network DNS name jackin emits must match lowercase RFC-1123 label syntax: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`, with length `1..=63`. Human-derived components should be stricter than the full label: `[a-z0-9]+` only. Hyphens are reserved for jackin's structural separators, which keeps `docker ps` visually scannable.
@@ -259,6 +259,6 @@ This feature writes only under jackin-managed state directories and creates/remo
 
 - Issue [#318](https://github.com/jackin-project/jackin/issues/318) — Testcontainers-compatible Docker host env failure caused by underscore-bearing DIND hostname.
 - [RFC 1035 section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4) — DNS label and name size limits.
-- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) — preferred hostname syntax and leading-digit relaxation.
+- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123](https://www.rfc-editor.org/rfc/rfc1123), section 2.1 — preferred hostname syntax and leading-digit relaxation.
 - [Testcontainers Docker environment discovery](https://java.testcontainers.org/supported_docker_environment/#docker-environment-discovery) — uses `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH`.
 - [Testcontainers DinD patterns](https://java.testcontainers.org/supported_docker_environment/continuous_integration/dind_patterns/) — documents `TESTCONTAINERS_HOST_OVERRIDE` for tests running inside containers.

--- a/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
+++ b/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
@@ -19,14 +19,22 @@ The target behavior is that every role launch gets a unique, DNS-safe instance i
 
 ## Naming Goal
 
-Use these operator-visible Docker base names:
+Use these Docker base names:
 
 ```text
 jackin-<workspace-name>-<agent-role>-<unique-id>
 jackin-<agent-role>-<unique-id>
 ```
 
-The first form is for configured workspaces. The second form is for ad-hoc launches from a random directory where there is no configured workspace name. These names are technical identifiers, not the main operator UX. The console and future UI should show a richer instance list with workspace, role, agent runtime, status, task/branch context, and restore state.
+The first form is for configured workspaces. The second form is for ad-hoc launches from a random directory where there is no configured workspace name. The workspace and role components are compact alphanumeric tokens, not slug phrases: `chainargos-project` becomes `chainargosproject`, `agent-brown` becomes `agentbrown`, and `chainargos/agent-brown` contributes the visible role component `agentbrown` while the full role key remains in metadata.
+
+Example:
+
+```text
+jackin-chainargosproject-agentbrown-k7p9m2xq
+```
+
+These names are technical identifiers, not the long-term operator API. The console and future CLI should show a richer instance list with workspace, role, agent runtime, status, task/branch context, restore state, and safe actions. Operators should not need to run `docker exec -ti jackin-chainargos__agent-brown zsh` or pass raw Docker container names to routine jackin commands. That operator surface is tracked separately in [Console agent session control](/reference/roadmap/console-agent-session-control/).
 
 ## DNS Limits
 
@@ -36,7 +44,7 @@ Container names that jackin uses as hostnames must obey hostname label rules, no
 - Hostname labels use letters, digits, and hyphen, with labels beginning with a letter and ending with a letter or digit under the preferred hostname syntax. See [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1), which permits a leading digit.
 - Underscores are not valid hostname label characters. Some Docker and libc paths resolve them, but Java URI parsing and many libraries reject them.
 
-Recommended invariant: every Docker network DNS name jackin emits must match lowercase RFC-1123 label syntax: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`, with length `1..=63`.
+Recommended invariant: every Docker network DNS name jackin emits must match lowercase RFC-1123 label syntax: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`, with length `1..=63`. Human-derived components should be stricter than the full label: `[a-z0-9]+` only. Hyphens are reserved for jackin's structural separators, which keeps `docker ps` visually scannable.
 
 Because jackin derives a DIND container name by appending `-dind`, the role-container base name must fit within 58 characters if the DIND container itself is used as a DNS label. If we also keep `-net` and `-dind-certs` derived from the same base, the DNS-critical limit is still the DIND label, but the same bounded-base discipline keeps all Docker resource names readable.
 
@@ -44,13 +52,15 @@ Because jackin derives a DIND container name by appending `-dind`, the role-cont
 
 Add a single instance-name builder that takes `{workspace_name?, workdir, role_key, agent_runtime}` and returns a DNS-safe base name plus structured metadata.
 
-1. Slug each human component to lowercase ASCII DNS labels: replace non `[a-z0-9-]` with `-`, collapse repeated hyphens, trim leading/trailing hyphens, and use a fallback such as `workspace` or `role` if the result is empty.
-2. Normalize role keys by using only the role name in the visible component when a namespace is present, then preserve the full role key in labels and metadata. Example: `chainargos/agent-brown` can display as `agent-brown`, while metadata still records `chainargos/agent-brown`.
+1. Compact each human component to lowercase ASCII alphanumerics: drop everything outside `[a-z0-9]`, including spaces, slashes, underscores, dots, and hyphens. Use a fallback such as `workspace` or `role` if the result is empty.
+2. Normalize role keys by using only the role name in the visible component when a namespace is present, then preserve the full role key in labels and metadata. Example: `chainargos/agent-brown` displays as `agentbrown`, while metadata still records `chainargos/agent-brown`.
 3. Generate a unique ID that is DNS-safe, short, and collision-resistant enough for local launches. Recommended: a Crockford-base32 or hex random ID of 8 to 12 chars. ULID is attractive for sorting, but the full 26-char value is expensive inside a 58-char DNS budget; use a shorter random suffix unless chronological sorting becomes load-bearing.
 4. Compose `jackin-{workspace_slug}-{role_slug}-{id}` for configured workspaces, or `jackin-{role_slug}-{id}` for ad-hoc directories.
 5. Enforce the DIND DNS budget before returning. With a 58-char base limit, reserve `7 + 1 + id_len` characters for `jackin-`, separator, and ID, then divide the remaining budget between workspace and role. Prefer preserving the right side of role slugs less aggressively than workspace slugs because the role is the more useful visual discriminator in `docker ps`.
-6. If truncation happens, add a small hash fragment to the truncated component when needed to avoid two long names becoming visually identical. Example shape: `jackin-very-long-workspace-a1b2-agent-brown-k7p9m2xq`.
+6. If truncation happens, add a small alphanumeric hash fragment to the truncated component when needed to avoid two long names becoming visually identical. Example shape: `jackin-verylongworkspacea1b2-agentbrown-k7p9m2xq`.
 7. Validate the final base name with a test helper. Validation failure is a programmer error in the builder, not something later launch code should paper over.
+
+Component collisions are acceptable. For example, `chainargos/agent-brown` and `chain-argos-a/gentb-rown` may both compact to visible components that look similar or identical. The unique ID makes the Docker identity distinct, and the instance manifest/console preserve the exact workspace and role identity for every operator action.
 
 Derived resource names:
 
@@ -75,7 +85,7 @@ Minimum fields:
 {
   "version": 1,
   "instance_id": "k7p9m2xq",
-  "container_base": "jackin-my-workspace-agent-brown-k7p9m2xq",
+  "container_base": "jackin-myworkspace-agentbrown-k7p9m2xq",
   "created_at": "2026-05-11T00:00:00Z",
   "updated_at": "2026-05-11T00:00:00Z",
   "workspace_name": "my-workspace",
@@ -91,10 +101,10 @@ Minimum fields:
   "status": "active",
   "last_attach_outcome": null,
   "docker": {
-    "role_container": "jackin-my-workspace-agent-brown-k7p9m2xq",
-    "dind_container": "jackin-my-workspace-agent-brown-k7p9m2xq-dind",
-    "network": "jackin-my-workspace-agent-brown-k7p9m2xq-net",
-    "certs_volume": "jackin-my-workspace-agent-brown-k7p9m2xq-dind-certs"
+    "role_container": "jackin-myworkspace-agentbrown-k7p9m2xq",
+    "dind_container": "jackin-myworkspace-agentbrown-k7p9m2xq-dind",
+    "network": "jackin-myworkspace-agentbrown-k7p9m2xq-net",
+    "certs_volume": "jackin-myworkspace-agentbrown-k7p9m2xq-dind-certs"
   }
 }
 ```
@@ -169,6 +179,7 @@ This avoids mutating live operator work while stopping new launches from creatin
 - **Ad-hoc directories with the same basename**: do not use only the basename for restore lookup. Store the canonical path and a fingerprint; use the short name only in the Docker base.
 - **Workspace rename**: restore should find by stored workspace ID/path when possible, not only by current workspace name. If workspaces do not yet have stable IDs, this design should add one or use canonical path fingerprint as a temporary key.
 - **Role namespace collisions**: `org-a/agent` and `org-b/agent` may share visible `agent` slug. The unique ID prevents Docker collisions; metadata and labels must preserve full role key.
+- **Compacted-name collisions**: `chainargos-project`, `chainargosproject`, and `chainargos.project` all compact to the same visible workspace component. This is expected. The visible name is for quick scanning only; the unique ID and instance manifest are authoritative.
 - **Concurrent launches**: the unique ID avoids most name-lock contention, but still create a per-base lock before writing state and before `docker run` to guard impossible random collisions.
 - **Docker daemon reset**: all containers, networks, and volumes may disappear while `~/.jackin/data` remains. Restore must treat Docker as reconstructible plumbing and local state as the source of truth.
 - **Manual Docker prune**: cert volumes may disappear while role containers remain stopped. Recreate DIND/certs/network when safe; otherwise explain why a full container-layer restore is impossible.
@@ -217,11 +228,13 @@ This avoids mutating live operator work while stopping new launches from creatin
 - DIND names used in `DOCKER_HOST` and `DOCKER_TLS_SAN` are RFC-1123-safe and at most 63 characters.
 - Configured workspaces use `jackin-<workspace-name>-<agent-role>-<unique-id>` within the DNS budget.
 - Ad-hoc directory launches use `jackin-<agent-role>-<unique-id>` within the DNS budget.
+- Workspace and role name components are compact lowercase alphanumeric strings with special characters removed, e.g. `chainargos-project` → `chainargosproject` and `agent-brown` → `agentbrown`.
 - No new launch emits `clone-N` naming.
 - Concurrent launches of the same workspace and role create separate unique instances without racing on deterministic slots.
 - `docker ps` remains readable, but console/restore UI becomes the source of truth for "which instance is which".
 - Deleting all Docker containers while leaving `~/.jackin/data` intact produces a restore prompt on the next matching launch.
 - Restore can reattach/recreate from preserved worktree/clone state without losing local changes.
+- Routine operator actions do not require copying raw Docker container names; shell entry, hardline, and future parallel-agent attach flows are exposed through jackin-owned CLI/TUI surfaces.
 - The system clearly reports unrecoverable container-writable-layer changes when Docker containers were deleted.
 - Java/Testcontainers smoke tests can parse `DOCKER_HOST`, connect through TLS, and start a simple child container from inside a jackin role.
 

--- a/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
+++ b/docs/src/content/docs/reference/roadmap/unique-container-identity-restore.mdx
@@ -1,0 +1,250 @@
+---
+title: "Unique Container Identity and Restore"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Infrastructure)
+
+## Problem
+
+Issue [#318](https://github.com/jackin-project/jackin/issues/318) exposed a narrow DIND hostname bug, but the underlying problem is broader: jackin currently treats the Docker container name as the role-class slot, the operator-facing instance identity, the state-directory key, the DIND hostname base, and the clone counter all at once.
+
+Today a namespaced role such as `chainargos/agent-brown` becomes a runtime slug with `__`, and concurrent sessions become `jackin-chainargos__agent-brown`, `jackin-chainargos__agent-brown-clone-1`, `jackin-chainargos__agent-brown-clone-2`, etc. That has three costs:
+
+- The `__` separator is valid enough for Docker names but not a safe DNS hostname label for Java URI parsing and Testcontainers. `DOCKER_HOST=tcp://jackin-chainargos__agent-brown-dind:2376` can parse with a null host in Java.
+- The `clone-N` language is misleading. A second session is not cloned from the first container. It is another instance of the same role, usually against the same workspace or directory.
+- Reusing deterministic names makes restore semantics ambiguous. A missing Docker container could mean "start a fresh primary slot" or "there was an unfinished state directory with work that should be recovered".
+
+The target behavior is that every role launch gets a unique, DNS-safe instance identity, while jackin keeps enough local metadata to restore unfinished work when Docker resources disappear.
+
+## Naming Goal
+
+Use these operator-visible Docker base names:
+
+```text
+jackin-<workspace-name>-<agent-role>-<unique-id>
+jackin-<agent-role>-<unique-id>
+```
+
+The first form is for configured workspaces. The second form is for ad-hoc launches from a random directory where there is no configured workspace name. These names are technical identifiers, not the main operator UX. The console and future UI should show a richer instance list with workspace, role, agent runtime, status, task/branch context, and restore state.
+
+## DNS Limits
+
+Container names that jackin uses as hostnames must obey hostname label rules, not only Docker's permissive container-name rules.
+
+- DNS labels are limited to 63 octets, and full domain names are limited to 255 octets including length bytes. See [RFC 1035 section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4).
+- Hostname labels use letters, digits, and hyphen, with labels beginning with a letter and ending with a letter or digit under the preferred hostname syntax. See [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1), which permits a leading digit.
+- Underscores are not valid hostname label characters. Some Docker and libc paths resolve them, but Java URI parsing and many libraries reject them.
+
+Recommended invariant: every Docker network DNS name jackin emits must match lowercase RFC-1123 label syntax: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`, with length `1..=63`.
+
+Because jackin derives a DIND container name by appending `-dind`, the role-container base name must fit within 58 characters if the DIND container itself is used as a DNS label. If we also keep `-net` and `-dind-certs` derived from the same base, the DNS-critical limit is still the DIND label, but the same bounded-base discipline keeps all Docker resource names readable.
+
+## Recommended Naming Algorithm
+
+Add a single instance-name builder that takes `{workspace_name?, workdir, role_key, agent_runtime}` and returns a DNS-safe base name plus structured metadata.
+
+1. Slug each human component to lowercase ASCII DNS labels: replace non `[a-z0-9-]` with `-`, collapse repeated hyphens, trim leading/trailing hyphens, and use a fallback such as `workspace` or `role` if the result is empty.
+2. Normalize role keys by using only the role name in the visible component when a namespace is present, then preserve the full role key in labels and metadata. Example: `chainargos/agent-brown` can display as `agent-brown`, while metadata still records `chainargos/agent-brown`.
+3. Generate a unique ID that is DNS-safe, short, and collision-resistant enough for local launches. Recommended: a Crockford-base32 or hex random ID of 8 to 12 chars. ULID is attractive for sorting, but the full 26-char value is expensive inside a 58-char DNS budget; use a shorter random suffix unless chronological sorting becomes load-bearing.
+4. Compose `jackin-{workspace_slug}-{role_slug}-{id}` for configured workspaces, or `jackin-{role_slug}-{id}` for ad-hoc directories.
+5. Enforce the DIND DNS budget before returning. With a 58-char base limit, reserve `7 + 1 + id_len` characters for `jackin-`, separator, and ID, then divide the remaining budget between workspace and role. Prefer preserving the right side of role slugs less aggressively than workspace slugs because the role is the more useful visual discriminator in `docker ps`.
+6. If truncation happens, add a small hash fragment to the truncated component when needed to avoid two long names becoming visually identical. Example shape: `jackin-very-long-workspace-a1b2-agent-brown-k7p9m2xq`.
+7. Validate the final base name with a test helper. Validation failure is a programmer error in the builder, not something later launch code should paper over.
+
+Derived resource names:
+
+```text
+role container:   <base>
+dind container:   <base>-dind
+network:          <base>-net
+cert volume:      <base>-dind-certs
+state directory:  ~/.jackin/data/<base>/
+lock file:        ~/.jackin/data/<base>.lock
+```
+
+The DIND `DOCKER_HOST`, `JACKIN_DIND_HOSTNAME`, `NO_PROXY`, `no_proxy`, and `DOCKER_TLS_SAN` values should all use the DNS-safe DIND name. `TESTCONTAINERS_HOST_OVERRIDE` should be set automatically when DIND is enabled. Prefer setting it to the same DNS-safe DIND hostname first; if smoke tests show Testcontainers-started sibling containers need an IP in specific Docker versions, resolve and store a companion `JACKIN_DIND_HOST_IP` and use that as the override.
+
+## Instance Metadata
+
+Container names should be unique, but restore should not depend on parsing those names. Add a small per-instance manifest under each state directory, for example `~/.jackin/data/<base>/.jackin/instance.json`.
+
+Minimum fields:
+
+```json
+{
+  "version": 1,
+  "instance_id": "k7p9m2xq",
+  "container_base": "jackin-my-workspace-agent-brown-k7p9m2xq",
+  "created_at": "2026-05-11T00:00:00Z",
+  "updated_at": "2026-05-11T00:00:00Z",
+  "workspace_name": "my-workspace",
+  "workspace_label": "my-workspace",
+  "workdir": "/workspace",
+  "host_workdir_fingerprint": "sha256:...",
+  "role_key": "chainargos/agent-brown",
+  "role_display_name": "Agent Brown",
+  "agent_runtime": "claude",
+  "role_source_git": "https://github.com/...",
+  "role_source_ref": "main",
+  "image_tag": "jackin-chainargos__agent-brown",
+  "status": "active",
+  "last_attach_outcome": null,
+  "docker": {
+    "role_container": "jackin-my-workspace-agent-brown-k7p9m2xq",
+    "dind_container": "jackin-my-workspace-agent-brown-k7p9m2xq-dind",
+    "network": "jackin-my-workspace-agent-brown-k7p9m2xq-net",
+    "certs_volume": "jackin-my-workspace-agent-brown-k7p9m2xq-dind-certs"
+  }
+}
+```
+
+The existing `isolation.json` should remain mount-specific. The new instance manifest owns instance-level identity, launch inputs, and restore state. Future SQLite persistence can consume the same identity rather than replacing it immediately.
+
+Also add a lightweight global index under `~/.jackin/data/instances.json` or `~/.jackin/data/instances/`. The index exists for quick lookup by workspace/directory/role without walking every state directory, but the per-instance manifest remains canonical. If the index is missing or corrupt, rebuild it by scanning manifests.
+
+## Restore Model
+
+Jackin's restore promise should be precise: if work was written to jackin-managed local storage, jackin can guide the operator back to it even when Docker containers are deleted. Jackin cannot recover writes that existed only in a deleted container's writable layer unless those paths were explicitly persisted or snapshotted.
+
+When launching a configured workspace or ad-hoc directory, jackin should:
+
+1. Compute a lookup key from the configured workspace name, or from the canonical host directory path for ad-hoc mode. Include role key and agent runtime as filters, but allow the UI to show all unfinished instances for that workspace/directory.
+2. Scan the instance index for records whose status is `active`, `crashed`, `preserved_dirty`, `preserved_unpushed`, or `restore_available`.
+3. Inspect Docker state for each candidate. A candidate can have role/DIND containers running, stopped, missing, partially missing, or replaced by unrelated resources.
+4. If candidates exist, show a restore picker before creating a fresh instance. The picker should show workspace, role, agent, created/updated time, mount isolation summary, dirty/unpushed status, and Docker resource state.
+5. Provide explicit actions: `restore`, `start fresh`, `inspect path`, `purge`, and `cancel`.
+
+Restore paths:
+
+- **Role container exists and DIND exists/running**: use `hardline` behavior and attach or restart in place.
+- **Role container exists but DIND is missing/stopped**: rebuild the network, DIND sidecar, cert volume, and environment contract, then start or recreate the role container only if the role container's filesystem state is not required. If the role container has important writable-layer state, surface that it cannot be safely rehydrated without the original container.
+- **Docker containers are missing but state directory exists with worktree/clone records**: recreate a new role container using the same `container_base` and remount the stored worktree/clone paths. Do not regenerate a different base name for a restore, because isolation paths and scratch branches are keyed by the original container name.
+- **Docker containers are missing and only shared mounts existed**: there is no private worktree to restore, but jackin can restart a fresh container against the same workspace and mark the old instance as superseded.
+- **Docker containers are missing and the instance had unpersisted container-layer changes**: tell the operator those container-layer changes are gone. This is the boundary that motivates future snapshot work.
+- **State directory exists but host workdir moved**: resolve by workspace config first; if the original path fingerprint no longer matches, prompt the operator to locate the new directory or inspect the state path directly.
+- **State directory exists but role source changed**: default to the stored role source/ref for restore when available. Offer a fresh launch path if the operator wants the latest trusted role instead.
+
+The restore picker belongs in `jackin console` first because it is a multi-instance decision. CLI should get scriptable equivalents:
+
+```sh
+jackin restore list [--workspace <name>|--dir <path>]
+jackin restore show <instance-id-or-name>
+jackin restore attach <instance-id-or-name>
+jackin restore fresh <workspace-or-dir> <role>
+```
+
+## Required State Transitions
+
+Use an explicit lifecycle enum in the instance manifest:
+
+- `active`: launch started and not finalized.
+- `running`: Docker role container observed running.
+- `clean_exited`: foreground session ended cleanly and no preserved isolated work remains.
+- `crashed`: role container exited non-zero or OOM-killed.
+- `preserved_dirty`: isolated worktree/clone has dirty changes after foreground finalization.
+- `preserved_unpushed`: isolated worktree/clone has commits not pushed or not merged back.
+- `restore_available`: Docker resources are gone, but local state remains recoverable.
+- `superseded`: operator chose fresh launch instead of restoring this instance.
+- `purged`: state intentionally removed.
+
+The launch path should write `active` before materializing mounts, update to `running` after the role container starts, and update the final state after `finalize_foreground_session`. Crash and OOM paths should be recorded before returning errors. If the process dies mid-launch, the stale `active` state becomes a restore candidate and the next launch reconciles it against Docker.
+
+## Migration From Clone Names
+
+No long compatibility shim is required for unreleased internal state, but operator data may already exist. The first implementation should include a one-time scanner:
+
+- Treat existing `jackin-*-clone-N` and namespaced `__` containers as legacy instances.
+- Keep legacy containers attachable by exact name through `hardline` and `eject`.
+- When launching a new instance, always use the new naming builder.
+- When a legacy state directory contains `isolation.json`, write an instance manifest next to it with `legacy_name = true` and a best-effort parsed role key. Do not rename live Docker containers or existing worktree directories during migration.
+- Once a legacy instance is cleanly exited and no preserved work remains, normal cleanup can remove it.
+
+This avoids mutating live operator work while stopping new launches from creating more clone-based names.
+
+## Corner Cases
+
+- **Long workspace and role names**: truncate inside the builder, not at call sites. Tests should cover max-length workspace, max-length role, both long together, empty-after-slugging Unicode names, and collision-prone truncation.
+- **Unicode workspace names**: transliteration is optional. A deterministic ASCII fallback plus hash is sufficient for Docker identity, while the UI can show the original Unicode name from metadata.
+- **Ad-hoc directories with the same basename**: do not use only the basename for restore lookup. Store the canonical path and a fingerprint; use the short name only in the Docker base.
+- **Workspace rename**: restore should find by stored workspace ID/path when possible, not only by current workspace name. If workspaces do not yet have stable IDs, this design should add one or use canonical path fingerprint as a temporary key.
+- **Role namespace collisions**: `org-a/agent` and `org-b/agent` may share visible `agent` slug. The unique ID prevents Docker collisions; metadata and labels must preserve full role key.
+- **Concurrent launches**: the unique ID avoids most name-lock contention, but still create a per-base lock before writing state and before `docker run` to guard impossible random collisions.
+- **Docker daemon reset**: all containers, networks, and volumes may disappear while `~/.jackin/data` remains. Restore must treat Docker as reconstructible plumbing and local state as the source of truth.
+- **Manual Docker prune**: cert volumes may disappear while role containers remain stopped. Recreate DIND/certs/network when safe; otherwise explain why a full container-layer restore is impossible.
+- **Partial launch failure**: if state exists but mount materialization failed, mark the instance as `failed_setup` or keep `active` with an error field. The restore picker should show it as inspect/purge, not attachable.
+- **Clean exit with dirty shared mount**: shared mounts are already host state. Do not create a restore candidate solely because a shared host repo is dirty; jackin did not isolate that work.
+- **Clean exit with dirty isolated mount**: preserve and surface through restore/hardline/purge until the operator finalizes or discards it.
+- **Non-git mounts**: clone/worktree restore does not cover them. If they are writable and important, link this design to [Session snapshot and rollback](/reference/roadmap/session-snapshot-rollback/) for opt-in file snapshots.
+- **Secrets and auth state**: do not restore stale copied credentials silently across changed auth modes. Re-run the normal auth provisioning path on restore, then mount preserved state only where the current mode allows it.
+- **Role image drift**: the restored container should use the stored image tag/ref by default. If the image no longer exists locally, rebuild from the stored trusted source/ref or ask the operator whether to rebuild from the current source.
+- **Labels too long or invalid**: Docker labels can carry full metadata values that are not DNS-safe. Use labels for filtering and metadata for exact values; do not round-trip restore state by parsing DNS-safe slugs.
+- **Testcontainers reachability**: Java Testcontainers parses `DOCKER_HOST` strictly and may also need `TESTCONTAINERS_HOST_OVERRIDE`. A smoke test must run inside a jackin-launched role and start a trivial container through Testcontainers with TLS enabled.
+- **No Docker available**: restore listing should still work from local state; attach/recreate should fail with a Docker-specific error.
+
+## Implementation Plan
+
+### Phase 1 — DNS-safe unique names
+
+- Add `src/runtime/instance_identity.rs` or equivalent for slugging, truncation, ID generation, and validation.
+- Replace `primary_container_name`, `next_container_name`, and clone-family matching in launch paths with generated instance names for new launches.
+- Keep exact-name operations for `hardline`, `eject`, and cleanup.
+- Update DIND, network, cert volume, `DOCKER_HOST`, `JACKIN_DIND_HOSTNAME`, `DOCKER_TLS_SAN`, `NO_PROXY`, and `TESTCONTAINERS_HOST_OVERRIDE` wiring.
+- Update tests that assert `__` and `clone-N` names. Add DNS-label and max-length tests.
+
+### Phase 2 — Instance manifest and restore detection
+
+- Write `.jackin/instance.json` before workspace materialization and update lifecycle fields throughout launch/finalize/error paths.
+- Add the rebuildable global index for lookup by workspace/directory/role.
+- Add reconciliation that compares manifest state with Docker state on launch.
+- Add restore prompts for interactive `jackin load` and `jackin console`; non-interactive CLI should fail with a clear message unless an explicit `--fresh` or restore target is supplied.
+
+### Phase 3 — Restore commands and UI
+
+- Add `jackin restore list/show/attach` or equivalent commands.
+- Add a console restore picker and active-instance panel that separates human labels from Docker names.
+- Teach cleanup and purge to operate by instance ID/name and to distinguish Docker resource deletion from local state deletion.
+
+### Phase 4 — Stronger recovery guarantees
+
+- Integrate with [Persistent storage layer](/reference/roadmap/persistent-storage-layer/) once available for lifecycle history and status transitions.
+- Integrate with [Session snapshot and rollback](/reference/roadmap/session-snapshot-rollback/) for non-git and container-layer recovery cases.
+- Add archive/export support for preserved instances.
+
+## Acceptance Criteria
+
+- New role launches never produce container, DIND, or network DNS names containing underscores.
+- DIND names used in `DOCKER_HOST` and `DOCKER_TLS_SAN` are RFC-1123-safe and at most 63 characters.
+- Configured workspaces use `jackin-<workspace-name>-<agent-role>-<unique-id>` within the DNS budget.
+- Ad-hoc directory launches use `jackin-<agent-role>-<unique-id>` within the DNS budget.
+- No new launch emits `clone-N` naming.
+- Concurrent launches of the same workspace and role create separate unique instances without racing on deterministic slots.
+- `docker ps` remains readable, but console/restore UI becomes the source of truth for "which instance is which".
+- Deleting all Docker containers while leaving `~/.jackin/data` intact produces a restore prompt on the next matching launch.
+- Restore can reattach/recreate from preserved worktree/clone state without losing local changes.
+- The system clearly reports unrecoverable container-writable-layer changes when Docker containers were deleted.
+- Java/Testcontainers smoke tests can parse `DOCKER_HOST`, connect through TLS, and start a simple child container from inside a jackin role.
+
+## Host-side effects
+
+This feature writes only under jackin-managed state directories and creates/removes jackin-managed Docker resources during normal launch, restore, and purge flows. It must not mutate host repositories except through the existing explicit per-mount isolation and finalization flows. Any future restore command that writes back into host project paths belongs to [Session snapshot and rollback](/reference/roadmap/session-snapshot-rollback/) and must require explicit operator confirmation.
+
+## Related Files
+
+- <RepoFile path="src/instance/naming.rs" /> — current deterministic `clone-N` naming.
+- <RepoFile path="src/runtime/naming.rs" /> — Docker labels, display formatting, and derived DIND cert volume naming.
+- <RepoFile path="src/runtime/launch.rs" /> — name claiming, DIND launch, env wiring, state preparation, and foreground finalization.
+- <RepoFile path="src/runtime/attach.rs" /> — current hardline restart behavior when containers exist.
+- <RepoFile path="src/runtime/cleanup.rs" /> — DIND/network/volume cleanup and orphan detection.
+- <RepoFile path="src/isolation/state.rs" /> — mount-level isolation records that restore should reference, not replace.
+- <RepoFile path="src/isolation/materialize.rs" /> — worktree/clone paths currently keyed by container name.
+- <RepoFile path="src/paths.rs" /> — data/cache/config directory roots.
+- <RepoFile path="tests/dind_e2e.rs" /> — DIND env and connectivity coverage that should grow a Testcontainers smoke case.
+
+## Source Materials
+
+- Issue [#318](https://github.com/jackin-project/jackin/issues/318) — Testcontainers-compatible Docker host env failure caused by underscore-bearing DIND hostname.
+- [RFC 1035 section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4) — DNS label and name size limits.
+- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) — preferred hostname syntax and leading-digit relaxation.
+- [Testcontainers Docker environment discovery](https://java.testcontainers.org/supported_docker_environment/#docker-environment-discovery) — uses `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH`.
+- [Testcontainers DinD patterns](https://java.testcontainers.org/supported_docker_environment/continuous_integration/dind_patterns/) — documents `TESTCONTAINERS_HOST_OVERRIDE` for tests running inside containers.


### PR DESCRIPTION
## Summary

Adds two linked roadmap items for the next naming and operator-control work. Unique Container Identity and Restore turns issue #318 into a concrete plan for compact DNS-safe container names, per-instance restore metadata, deleted-Docker recovery prompts, and moving routine workflows away from raw Docker container names. Console Agent Session Control captures the companion TUI/CLI work for a unified active-instances view covering configured workspaces and ad-hoc directories, showing roles and exact agent sessions, opening shells, using `hardline` as the reconnect/spawn surface, and coordinating multiple agent sessions inside one isolated container.

## What's deferred (follow-up PRs)

- Implement the compact alphanumeric instance-name builder and replace new `clone-N` launches.
- Add per-instance manifests, restore indexing, and launch-time/hardline recovery prompts.
- Expand `jackin hardline` so it resolves the current workspace/directory, prompts across matching containers and agent sessions, opens shells, and can spawn secondary agents inside an existing container.
- Add console active-instance/session control for configured workspaces and ad-hoc directories: scope filtering, role rows, exact agent-session rows, hardline attach, shell entry, secondary agent start/attach/stop, and reconnectable session backend support.
- Add Testcontainers smoke coverage for the DNS-safe DIND host contract.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/unique-container-identity-restore:refs/remotes/origin/docs/unique-container-identity-restore
git checkout -B docs/unique-container-identity-restore refs/remotes/origin/docs/unique-container-identity-restore
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/roadmap/unique-container-identity-restore/**  
NEW page. Confirm the Infrastructure roadmap item explains compact alphanumeric DNS-safe names, restore metadata, deleted-Docker recovery, Testcontainers handling, raw-Docker-name de-emphasis, `hardline` as the reconnect surface, and corner cases.

**http://localhost:4321/reference/roadmap/console-agent-session-control/**  
NEW page. Confirm the Agent Orchestrator Research live-operator item explains TUI/CLI shell entry, `hardline` directory-aware selection, configured workspace and ad-hoc directory scopes, role/session visibility, reconnectable named sessions, and multiple agents sharing one isolated container.

**http://localhost:4321/reference/roadmap/agent-orchestrator-research/**  
UPDATED program index. Confirm Console agent session control appears in Phase 2 — Live operator surface.

**http://localhost:4321/reference/roadmap/**  
UPDATED overview. Confirm Unique container identity and restore appears under Infrastructure improvements.

## Migration notes

None. This is a roadmap-only documentation PR.
