### PR TITLE
feat(console): Settings TUI, list view scrolling, and UX fixes (#324)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,12 @@ Rationale: Rust's ecosystem is one of the project's leverage points. The communi
 
 When you do hand-roll something this rule covers, leave a comment explaining why (crate unavailable, scope tiny, dependency cost specifically rejected) so a later maintainer can replace it without re-debating the decision.
 
+## Reuse shared TUI components for identical flows (agent-only)
+
+When two TUI surfaces implement the same flow, do not fork modal sizing, rendering, input handling, footer wording, row layout, or picker behavior into a second near-copy. Extract or extend a shared widget, renderer, input helper, or state adapter and have both surfaces call it.
+
+Settings screens that intentionally mirror workspace screens must reuse the workspace widgets and flow helpers wherever behavior is the same; keep separate code only for the different persistence target or config scope. Treat visual drift between duplicated TUI components as a bug. If reuse is blocked, call that out in the PR and keep the duplicate small and temporary.
+
 ## Changelog (agent-only)
 
 **Do not add entries to `CHANGELOG.md` until the first tagged release.**
@@ -210,6 +216,104 @@ This does not apply to:
 
 - Inspection commands the operator runs (`pgrep`, `pmset`, `cat`, `ls`) — those aren't jackin invocations.
 - Production recommendations or scripted automation (debug output is too noisy for those).
+
+## TUI navigation conventions (agent-only)
+
+> **Design decisions reference:** [`docs/src/content/docs/reference/tui-design-decisions.mdx`](docs/src/content/docs/reference/tui-design-decisions.mdx) is the canonical record of every binding TUI design decision — focusability rules, component reuse contracts, color palette, modal sizing, scroll semantics, and more. Read it before implementing any TUI change. When a new decision is made (operator explains what should change and why), add it there immediately.
+
+Jackin's TUI follows the **W3C ARIA Tabs interaction pattern** for all tabbed interfaces and the corresponding area-scoped arrow-key model everywhere else. These are non-negotiable design rules — violations are bugs and must be fixed before a PR lands.
+
+### Key roles
+
+**Tab / BackTab** are the designated cross-area navigation keys. They move focus between logical areas: from the field area to the button row, back from the button row to the field area, and between a tab list and its tab panel (content area). Tab always moves forward in the cycle; BackTab always moves backward.
+
+**Left / Right** are intra-area horizontal keys. They move focus within the current horizontal group (e.g. between buttons in a button row, or between tabs when the tab list has focus). They must never jump between distinct areas.
+
+**Up / Down (and j / k aliases)** are intra-area vertical keys. They move focus within the current vertical field group. They must never cross the boundary from a field area into the button area or vice versa.
+
+### W3C Tabs pattern (required for all tabbed interfaces)
+
+All tabbed surfaces (workspace editor, settings) must implement the W3C tablist/tabpanel pattern:
+
+1. **Tab list** (the row of tab labels) is its own focus area:
+   - `←` / `→` cycle between tabs.
+   - `Tab` or `↓` moves focus into the first block inside the tab panel (content area).
+   - The active tab is visually distinguished even without tab-list focus; when the tab list IS focused, an additional highlight (e.g. bold or underline) makes this clear.
+
+2. **Tab panel** (the content below the tabs) may contain one or more blocks:
+   - `↑` / `↓` navigate within the focused block.
+   - `Tab` advances to the next block within the panel; after the last block `Tab` cycles back to the tab list.
+   - `BackTab` / `Esc` returns focus to the tab list.
+
+3. Entry into a tabbed stage (opening Settings, opening the workspace editor) must start with **tab-list focus** — the operator sees the tab labels highlighted and uses `←` / `→` to pick a tab before `Tab` / `↓` drops them into the content.
+
+This rule applies to every tabbed surface that ships; add a `tab_bar_focused: bool` field to the relevant state struct and update input dispatch and rendering accordingly whenever a new tabbed surface is added.
+
+### Other area-boundary rules
+
+- Down from the last field in a form's field area is a no-op. Tab is the key that crosses into the button area.
+- Up from the first button in the button area is a no-op. BackTab is the key that crosses back into the field area.
+
+**Exception — tree header expand/collapse:** Right = expand and Left = collapse on tree-style header rows (Secrets AgentHeader, Auth RoleHeader, Environments RoleHeader) is a correct intra-area semantic action. This absorption pattern is intentional and must be preserved.
+
+**Exception — flat button-strip widgets:** Self-contained single-row button widgets (`confirm.rs`, `save_discard.rs`, `mount_dst_choice.rs`, `source_picker.rs`, `mount_isolation_choice.rs`, `scope_picker.rs`) may treat Left / Right as BackTab / Tab equivalents. The entire widget is a single flat area with no area boundary to cross, so there is no violation.
+
+### Navigation hints (exhaustive — no hidden keys)
+
+**Every keyboard shortcut that is active on the current screen must appear in the footer hint bar. No key may be silently available — users must never have to guess.** The hint bar updates whenever the focused area or row context changes.
+
+Rules:
+- `↑/↓ navigate` must appear whenever a list, table, or form with multiple rows is active. It is a global footer item, not a conditional one.
+- Every action key (`Enter`, `Space`, `D`, `A`, `R`, `N`, `1`, `2`, `3`, `O`, `P`, `M`, etc.) that is live on the current row must be shown alongside its one-word description.
+- When a key applies only under certain conditions (e.g. `O open in GitHub` only for GitHub-origin mounts), show it only when the condition holds — but never suppress a key that is unconditionally active.
+- `Tab switch tab`, `S save`, and `Esc back/discard` are always shown in the global footer.
+- Keep each hint concise: one symbol or key name, one word label. Use `·` separators between hints.
+
+This rule applies to every TUI surface: list view, workspace editor (all tabs), settings (all tabs), all modals and overlays.
+
+### Space vs Enter — W3C semantic distinction (strict rule)
+
+**`Space`** is the key for **toggle** semantics (on/off, checked/unchecked, trusted/untrusted, allowed/disallowed). It matches the W3C ARIA patterns for checkbox, switch, and radio group. Never bind Enter to the same action as Space on a toggle widget.
+
+**`Enter`** is the key for **action** semantics (activate a button, open a dialog, confirm a choice, navigate into detail, submit a form). It is also the key for shortcut-letter bindings (`Y` yes, `N` no, `S` save, `D` discard, etc.) on confirmation dialogs.
+
+Binding both `Space` and `Enter` to the same toggle action is a W3C violation — Space is sufficient and Enter would collide with its role as the action key. Binding both to a button widget is acceptable (W3C requires both on standard buttons), but jackin's button-strip widgets use letter shortcuts + Enter to avoid this; don't add Space to them.
+
+Summary:
+- Toggle row (keep_awake, git_pull, trusted, allowed role): `Space` only.
+- Action button (Save, Cancel, Discard, Yes, No): `Enter` only (plus letter shortcut if applicable).
+- Open/navigate (expand detail, open picker, rename): `Enter` only.
+- Cycle among options in a slot (auth mode): `Space` (radio-button pattern per W3C).
+- Re-open a picker for an already-set value (1Password op-ref, source): `Enter` (action). `P` is also supported as a shortcut where op_available is true, but `Enter` must always work.
+
+### Hints: footer only, never inside dialogs (strict rule)
+
+All keyboard hint text belongs in the footer bar at the bottom of the screen. Dialogs, modals, and overlays **must not** render their own internal hint line. When a modal is open, the main footer must show the modal's available keys instead of the keys for the content behind it.
+
+Enforcement:
+- Every widget in `src/console/widgets/` must expose a `footer_items` function (or equivalent) and remove its internal hint row.
+- `render_editor` checks `state.modal` first; if a modal is open it calls `modal_footer_items(modal)` and skips the normal contextual items.
+- `render_settings` checks the three settings modal chains (`auth.modal`, `env.modal`, `mounts.modal`) in priority order; if any is `Some`, calls the corresponding `*_modal_footer_items` function.
+- No `Constraint::Length` row for a hint line may remain inside any widget layout.
+
+### Scrollable blocks (strict rule)
+
+Every content block whose natural width can exceed the available terminal width **must** support horizontal scrolling. Add `scroll_x: u16` to the state struct, handle `H`/`L` keys, pass `.scroll((0, scroll_x))` to the `Paragraph`, and call `render_horizontal_scrollbar`. Always draw the scrollbar so the user can tell content exists off-screen.
+
+Mouse scroll events (`ScrollLeft`/`ScrollRight`/`ScrollUp`/`ScrollDown`) scroll whichever block the mouse cursor is currently over (hover-scroll), without requiring a click first. Extend `scroll_active_panel` in `input/mouse.rs` for every new scrollable block. Left-click inside a scrollable block also activates it (updates keyboard focus to that block).
+
+`ScrollUp`/`ScrollDown` are vertical-only events; `ScrollLeft`/`ScrollRight` are horizontal-only. A block that supports only one axis must silently ignore events on the other axis. A block that supports both axes routes each event to the correct axis.
+
+### Component reuse: single implementation per UX pattern (strict rule)
+
+Every visual pattern that appears in more than one place **must** use one shared implementation — a single widget, render function, or helper. Never create a second near-copy of an existing widget or render function. When the existing implementation cannot serve a new call site without modification, extend it (add parameters, generalize) rather than forking it.
+
+When a genuinely new component is needed (no existing implementation fits the UX pattern):
+1. The agent proposes the design with a sketch or description.
+2. The operator explicitly approves the design.
+3. Only then may the agent implement it.
+
+Violations — two functions that render the same kind of content with slightly different styling or behavior — must be fixed before a PR lands by consolidating them into one.
 
 ## Shared conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,6 @@ Rationale: Rust's ecosystem is one of the project's leverage points. The communi
 
 When you do hand-roll something this rule covers, leave a comment explaining why (crate unavailable, scope tiny, dependency cost specifically rejected) so a later maintainer can replace it without re-debating the decision.
 
-## Reuse shared TUI components for identical flows (agent-only)
-
-When two TUI surfaces implement the same flow, do not fork modal sizing, rendering, input handling, footer wording, row layout, or picker behavior into a second near-copy. Extract or extend a shared widget, renderer, input helper, or state adapter and have both surfaces call it.
-
-Settings screens that intentionally mirror workspace screens must reuse the workspace widgets and flow helpers wherever behavior is the same; keep separate code only for the different persistence target or config scope. Treat visual drift between duplicated TUI components as a bug. If reuse is blocked, call that out in the PR and keep the duplicate small and temporary.
-
 ## Changelog (agent-only)
 
 **Do not add entries to `CHANGELOG.md` until the first tagged release.**
@@ -217,103 +211,11 @@ This does not apply to:
 - Inspection commands the operator runs (`pgrep`, `pmset`, `cat`, `ls`) — those aren't jackin invocations.
 - Production recommendations or scripted automation (debug output is too noisy for those).
 
-## TUI navigation conventions (agent-only)
+## TUI design decisions (agent-only)
 
-> **Design decisions reference:** [`docs/src/content/docs/reference/tui-design-decisions.mdx`](docs/src/content/docs/reference/tui-design-decisions.mdx) is the canonical record of every binding TUI design decision — focusability rules, component reuse contracts, color palette, modal sizing, scroll semantics, and more. Read it before implementing any TUI change. When a new decision is made (operator explains what should change and why), add it there immediately.
+All TUI design rules — navigation conventions, W3C ARIA Tabs pattern, focusability, component reuse, color palette, modal sizing, scroll semantics, hint/footer rules, and more — live in [`docs/src/content/docs/reference/tui-design-decisions.mdx`](docs/src/content/docs/reference/tui-design-decisions.mdx).
 
-Jackin's TUI follows the **W3C ARIA Tabs interaction pattern** for all tabbed interfaces and the corresponding area-scoped arrow-key model everywhere else. These are non-negotiable design rules — violations are bugs and must be fixed before a PR lands.
-
-### Key roles
-
-**Tab / BackTab** are the designated cross-area navigation keys. They move focus between logical areas: from the field area to the button row, back from the button row to the field area, and between a tab list and its tab panel (content area). Tab always moves forward in the cycle; BackTab always moves backward.
-
-**Left / Right** are intra-area horizontal keys. They move focus within the current horizontal group (e.g. between buttons in a button row, or between tabs when the tab list has focus). They must never jump between distinct areas.
-
-**Up / Down (and j / k aliases)** are intra-area vertical keys. They move focus within the current vertical field group. They must never cross the boundary from a field area into the button area or vice versa.
-
-### W3C Tabs pattern (required for all tabbed interfaces)
-
-All tabbed surfaces (workspace editor, settings) must implement the W3C tablist/tabpanel pattern:
-
-1. **Tab list** (the row of tab labels) is its own focus area:
-   - `←` / `→` cycle between tabs.
-   - `Tab` or `↓` moves focus into the first block inside the tab panel (content area).
-   - The active tab is visually distinguished even without tab-list focus; when the tab list IS focused, an additional highlight (e.g. bold or underline) makes this clear.
-
-2. **Tab panel** (the content below the tabs) may contain one or more blocks:
-   - `↑` / `↓` navigate within the focused block.
-   - `Tab` advances to the next block within the panel; after the last block `Tab` cycles back to the tab list.
-   - `BackTab` / `Esc` returns focus to the tab list.
-
-3. Entry into a tabbed stage (opening Settings, opening the workspace editor) must start with **tab-list focus** — the operator sees the tab labels highlighted and uses `←` / `→` to pick a tab before `Tab` / `↓` drops them into the content.
-
-This rule applies to every tabbed surface that ships; add a `tab_bar_focused: bool` field to the relevant state struct and update input dispatch and rendering accordingly whenever a new tabbed surface is added.
-
-### Other area-boundary rules
-
-- Down from the last field in a form's field area is a no-op. Tab is the key that crosses into the button area.
-- Up from the first button in the button area is a no-op. BackTab is the key that crosses back into the field area.
-
-**Exception — tree header expand/collapse:** Right = expand and Left = collapse on tree-style header rows (Secrets AgentHeader, Auth RoleHeader, Environments RoleHeader) is a correct intra-area semantic action. This absorption pattern is intentional and must be preserved.
-
-**Exception — flat button-strip widgets:** Self-contained single-row button widgets (`confirm.rs`, `save_discard.rs`, `mount_dst_choice.rs`, `source_picker.rs`, `mount_isolation_choice.rs`, `scope_picker.rs`) may treat Left / Right as BackTab / Tab equivalents. The entire widget is a single flat area with no area boundary to cross, so there is no violation.
-
-### Navigation hints (exhaustive — no hidden keys)
-
-**Every keyboard shortcut that is active on the current screen must appear in the footer hint bar. No key may be silently available — users must never have to guess.** The hint bar updates whenever the focused area or row context changes.
-
-Rules:
-- `↑/↓ navigate` must appear whenever a list, table, or form with multiple rows is active. It is a global footer item, not a conditional one.
-- Every action key (`Enter`, `Space`, `D`, `A`, `R`, `N`, `1`, `2`, `3`, `O`, `P`, `M`, etc.) that is live on the current row must be shown alongside its one-word description.
-- When a key applies only under certain conditions (e.g. `O open in GitHub` only for GitHub-origin mounts), show it only when the condition holds — but never suppress a key that is unconditionally active.
-- `Tab switch tab`, `S save`, and `Esc back/discard` are always shown in the global footer.
-- Keep each hint concise: one symbol or key name, one word label. Use `·` separators between hints.
-
-This rule applies to every TUI surface: list view, workspace editor (all tabs), settings (all tabs), all modals and overlays.
-
-### Space vs Enter — W3C semantic distinction (strict rule)
-
-**`Space`** is the key for **toggle** semantics (on/off, checked/unchecked, trusted/untrusted, allowed/disallowed). It matches the W3C ARIA patterns for checkbox, switch, and radio group. Never bind Enter to the same action as Space on a toggle widget.
-
-**`Enter`** is the key for **action** semantics (activate a button, open a dialog, confirm a choice, navigate into detail, submit a form). It is also the key for shortcut-letter bindings (`Y` yes, `N` no, `S` save, `D` discard, etc.) on confirmation dialogs.
-
-Binding both `Space` and `Enter` to the same toggle action is a W3C violation — Space is sufficient and Enter would collide with its role as the action key. Binding both to a button widget is acceptable (W3C requires both on standard buttons), but jackin's button-strip widgets use letter shortcuts + Enter to avoid this; don't add Space to them.
-
-Summary:
-- Toggle row (keep_awake, git_pull, trusted, allowed role): `Space` only.
-- Action button (Save, Cancel, Discard, Yes, No): `Enter` only (plus letter shortcut if applicable).
-- Open/navigate (expand detail, open picker, rename): `Enter` only.
-- Cycle among options in a slot (auth mode): `Space` (radio-button pattern per W3C).
-- Re-open a picker for an already-set value (1Password op-ref, source): `Enter` (action). `P` is also supported as a shortcut where op_available is true, but `Enter` must always work.
-
-### Hints: footer only, never inside dialogs (strict rule)
-
-All keyboard hint text belongs in the footer bar at the bottom of the screen. Dialogs, modals, and overlays **must not** render their own internal hint line. When a modal is open, the main footer must show the modal's available keys instead of the keys for the content behind it.
-
-Enforcement:
-- Every widget in `src/console/widgets/` must expose a `footer_items` function (or equivalent) and remove its internal hint row.
-- `render_editor` checks `state.modal` first; if a modal is open it calls `modal_footer_items(modal)` and skips the normal contextual items.
-- `render_settings` checks the three settings modal chains (`auth.modal`, `env.modal`, `mounts.modal`) in priority order; if any is `Some`, calls the corresponding `*_modal_footer_items` function.
-- No `Constraint::Length` row for a hint line may remain inside any widget layout.
-
-### Scrollable blocks (strict rule)
-
-Every content block whose natural width can exceed the available terminal width **must** support horizontal scrolling. Add `scroll_x: u16` to the state struct, handle `H`/`L` keys, pass `.scroll((0, scroll_x))` to the `Paragraph`, and call `render_horizontal_scrollbar`. Always draw the scrollbar so the user can tell content exists off-screen.
-
-Mouse scroll events (`ScrollLeft`/`ScrollRight`/`ScrollUp`/`ScrollDown`) scroll whichever block the mouse cursor is currently over (hover-scroll), without requiring a click first. Extend `scroll_active_panel` in `input/mouse.rs` for every new scrollable block. Left-click inside a scrollable block also activates it (updates keyboard focus to that block).
-
-`ScrollUp`/`ScrollDown` are vertical-only events; `ScrollLeft`/`ScrollRight` are horizontal-only. A block that supports only one axis must silently ignore events on the other axis. A block that supports both axes routes each event to the correct axis.
-
-### Component reuse: single implementation per UX pattern (strict rule)
-
-Every visual pattern that appears in more than one place **must** use one shared implementation — a single widget, render function, or helper. Never create a second near-copy of an existing widget or render function. When the existing implementation cannot serve a new call site without modification, extend it (add parameters, generalize) rather than forking it.
-
-When a genuinely new component is needed (no existing implementation fits the UX pattern):
-1. The agent proposes the design with a sketch or description.
-2. The operator explicitly approves the design.
-3. Only then may the agent implement it.
-
-Violations — two functions that render the same kind of content with slightly different styling or behavior — must be fixed before a PR lands by consolidating them into one.
+**Read that document before implementing any TUI change.** When a new decision is made (operator explains what should change and why), add it there immediately, not here.
 
 ## Shared conventions
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -8,6 +8,28 @@ Never commit directly to `main`.
 - Keep branch names short, lowercase, and hyphen-separated
 - Merge back to `main` via pull request after review
 
+## Syncing with main: always rebase, never merge
+
+When a feature branch needs to incorporate new commits from `main`, always
+use rebase — never a merge commit:
+
+```bash
+git fetch origin
+git rebase origin/main
+git push --force-with-lease origin <branch>   # force-push requires operator approval
+```
+
+A merge commit (`git merge main`) creates a merge commit in the PR history that
+pulls in main's commits as branch commits. This causes DCO, review-history, and
+squash-merge problems: Renovate and other bot commits appear in the PR diff and
+must be signed off separately.
+
+Rebase replays only the branch's unique commits on top of the updated main,
+keeping the PR history clean and the DCO check scoped to work the branch author
+actually produced.
+
+Force-push after rebase still requires operator approval per the rule below.
+
 ## Force pushes
 
 Force pushes rewrite shared review history. Agents must never run

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -76,6 +76,17 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full DCO v1.1 text.
 
 Agent-specific attribution trailer requirements (e.g., for the Codex agent) are in [AGENTS.md](AGENTS.md).
 
+## Push after every commit (agent rule)
+
+After every `git commit`, immediately run `git push`. Never leave commits in local-only state. This applies to every commit on every branch — feature branches, fix branches, everything. There is no "push later" batching.
+
+```sh
+git commit -s -m "feat(scope): description"
+git push
+```
+
+The only exception is an explicit operator instruction to hold off.
+
 ## Merge-readiness Verification
 
 Do not run the full verification suite before every commit by default. Run it

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -57,7 +57,7 @@ Every pull request created by an agent must include a copy-pasteable "Verify loc
 
 Use the real PR number, repository URL, branch name, and verification commands for the change. Start from a separate test directory so the operator can inspect the PR without disturbing their normal working tree. The clone step must be idempotent: reuse the folder if it already exists, otherwise clone it. Prefer the actual head branch name over GitHub's synthetic `pull/<PR_NUMBER>/head` ref for same-repository PRs; use the synthetic PR ref only when the branch cannot be fetched directly, such as a fork PR without an added fork remote.
 
-Split verification into named blocks only when each block contains meaningful commands. Always include checkout instructions. Add Static Checks only when there is a local check worth running beyond CI and GitHub's diff UI. Add Tests only when there is a relevant automated test command. Add User Smoke only when the operator can exercise changed behavior locally, such as CLI, runtime, workspace, Docker, TUI, or operator-flow changes. Do not add placeholder sections that say no test applies, and do not add commands that only print files for review. For CLI/runtime smoke, run the local checkout's `jackin` binary and exercise the behavior touched by the PR. If the PR has no narrower manual path, use the console as the baseline smoke command: `cargo run --bin jackin -- console --debug`. For launch/runtime flows, prefer a command that hits the changed path, such as `cargo run --bin jackin -- load <role> <target> --debug`. For subcommands that do not support `--debug`, include the closest supported `jackin --debug` command in the same smoke block and explain the gap in one sentence.
+Split verification into named blocks only when each block contains meaningful commands. Always include checkout instructions. Add Static Checks only when there is a local check worth running beyond CI and GitHub's diff UI. Add Tests only when there is a relevant automated test command. Add User Smoke only when the operator can exercise changed behavior locally, such as CLI, runtime, workspace, Docker, TUI, or operator-flow changes. Do not add placeholder sections that say no test applies, and do not add commands that only print files for review. For CLI/runtime smoke, run the local checkout's `jackin` binary and exercise the behavior touched by the PR. If the PR changes a CLI command or TUI surface, the User Smoke block must include the exact command that opens that changed surface from the checkout, plus any setup commands needed to make the changed rows/options visible. Prose like "open the console and verify the tab" is incomplete unless it is preceded by the command the operator should paste and the state-seeding commands needed for the UI to show the changed behavior. If the PR has no narrower manual path, use the console as the baseline smoke command: `cargo run --bin jackin -- console --debug`. For launch/runtime flows, prefer a command that hits the changed path, such as `cargo run --bin jackin -- load <role> <target> --debug`. For subcommands that do not support `--debug`, include the closest supported `jackin --debug` command in the same smoke block and explain the gap in one sentence.
 
 ### Documentation-only PRs
 
@@ -135,10 +135,30 @@ For non-trivial code changes, structure the PR's "Verify locally" section by int
 
 Do not add generic commands that do not materially validate the PR. In particular, do not include `git diff --check` unless the PR is specifically about whitespace, patch hygiene, generated diffs, or another issue that command is meant to catch.
 
-For console/TUI changes that can be manually verified in jackin itself, prefer:
+For console/TUI changes that can be manually verified in jackin itself, include the command that opens the changed surface and then list the keys/clicks the operator should walk. Prefer:
 
 ```sh
 cargo run --bin jackin -- console --debug
+```
+
+When the TUI change depends on config or workspace state, seed that state in the PR body before the console command. Use a disposable `HOME` when the smoke test writes jackin-owned config, so the operator can verify save flows without mutating their real `~/.config/jackin`:
+
+```sh
+export JACKIN_VERIFY_HOME="$PWD/.verify-home/<feature>"
+rm -rf "$JACKIN_VERIFY_HOME"
+mkdir -p "$JACKIN_VERIFY_HOME/.config/jackin"
+cat > "$JACKIN_VERIFY_HOME/.config/jackin/config.toml" <<'TOML'
+version = "v1alpha2"
+# Add the smallest config that makes the changed UI visible.
+TOML
+
+HOME="$JACKIN_VERIFY_HOME" cargo run --bin jackin -- console --debug
+```
+
+For CLI subcommand changes, include the exact subcommand invocation and the expected output or persisted file change, for example:
+
+```sh
+cargo run --bin jackin -- config mount list --debug
 ```
 
 #### Isolation env vars
@@ -185,6 +205,7 @@ export JACKIN_CONSTRUCT_IMAGE="jackin-local/construct:trixie"
 `just construct-build-local` builds a single-platform image tagged `jackin-local/construct:trixie` and loads it into the local Docker daemon. `JACKIN_CONSTRUCT_IMAGE` then makes jackin use that image for Dockerfile validation and role container launch instead of the published one.
 
 Do not include `JACKIN_CONSTRUCT_IMAGE` in PRs that do not touch the construct image — the isolation pattern is about scoping test risk, not about exhaustively listing every available env var.
+
 
 ## Author the PR body so it renders correctly on GitHub
 

--- a/docs/src/content/docs/commands/console.mdx
+++ b/docs/src/content/docs/commands/console.mdx
@@ -7,7 +7,7 @@ import { Aside } from '@astrojs/starlight/components'
 <Aside type="tip">
 The operator console is the **simplest and most convenient way to use jackin'** day-to-day, and the surface most operators stay on. The CLI is for the **advanced and very specific cases**: scripted one-liners, niche flags, automation, and behaviours the console deliberately does not expose.
 
-Today the console covers launching agents (the `load` flow), managing workspaces (`workspace`), editing the per-workspace auth and env tables (`config` for those scopes), and common recovery actions for visible instances. The remaining CLI-only subcommands and surfaces — `eject`, `exile`, global mounts and global env, plus detail-level flags — live on the CLI for now; they will land in the console as the TUI grows feature by feature. There is no feature parity by design: niche flags continue to land on the CLI first.
+Today the console covers launching agents (the `load` flow), managing workspaces (`workspace`), editing per-workspace auth and env tables (`config` for those scopes), managing operator-level config through Settings, and common recovery actions for visible instances. The remaining CLI subcommands — `hardline`, `eject`, `exile`, multi-session preview — are **not in the console yet** and live on the CLI for now; they will land in the console as the TUI grows feature by feature. There is no feature parity by design: niche flags continue to land on the CLI first.
 
 The expectation is **most people use the TUI, and reach for the CLI only when they need it.**
 </Aside>
@@ -30,6 +30,7 @@ The console opens directly to a workspace manager list — no separate workspace
 - **Use your current directory as a workspace.** A synthetic row at the top of the manager list mounts your `cwd` at the same path inside the container. Useful for quick one-off launches without saving a workspace definition.
 - **Recover active and preserved instances.** Workspace and current-directory detail panes show an Instances panel when jackin-managed local state exists for that scope, with instance ID, status, agent runtime, and role. From that row, `r` reconnects or recovers, `s` starts another foreground agent session in a running instance, `i` prints a read-only state report, and `p` purges local recovery state when the guarded `purge` rules allow it.
 - **Open the workspace editor.** Edit the workspace's roles, environment variables, and authentication settings. Each editor surface lives on its own tab inside the editor.
+- **Open Settings.** Manage operator-level `jackin config` surfaces from the `Mounts`, `Environments`, `Auth`, and `Trust` tabs.
 
 For the per-axis details — what each tab manages, what defaults apply, where the launch summary surfaces what's effective — see the per-axis guide pages linked below.
 

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -40,6 +40,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 - [Per-mount isolation for parallel agents](/reference/roadmap/per-mount-isolation/) — `shared | worktree | clone` modes implemented in V1
 - [Split `config.toml` into per-workspace files](/reference/roadmap/split-workspace-config-files/) — `~/.config/jackin/workspaces/<name>.toml` layout shipped; per-file `version` stamps and migration land via the config-versioning item below
 - [Global mount visibility and editing](/reference/roadmap/global-mount-visibility/) — workspace views show applicable global mounts separately, and the console has a dedicated global mounts editor for `~/.config/jackin/config.toml`
+- [Settings TUI](/reference/roadmap/settings-tui/) — the console has a tabbed `Settings` shell covering existing `jackin config` surfaces: global mounts, global/per-role env vars, global auth forwarding modes, and role source trust
 - [Unique container identity and restore](/reference/roadmap/unique-container-identity-restore/) — DNS-safe unique container identities, per-instance manifests and rebuildable index, hardline/load/console recovery flows, durable per-instance agent home restore, related-instance recovery/rebuild, moved ad-hoc path recovery, guarded purge, and Java Testcontainers DinD smoke coverage have shipped; reconnectable named sessions and persistent lifecycle history are tracked separately
 
 ## Partially implemented
@@ -90,10 +91,6 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 - **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
 - **[Cargo workspace split](/reference/roadmap/cargo-workspace-split/)** — deferred multi-crate Cargo workspace plan for when LOC, compile time, or external-consumer triggers make crate boundaries worth the overhead (status: deferred to Phase 3 — trigger not yet met, but architecture is ready)
 - **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see <RepoFile path="AGENTS.md" /> → "Code review & automated scanning").
-
-### Configuration ergonomics
-
-- **[Settings TUI](/reference/roadmap/settings-tui/)** — visualize and control existing operator config inside the console as a tabbed Settings surface. Global mounts ship first as a single stage delivered by the global mount visibility goal; an eager tab-shell refactor renames the stage to `Settings`, then per-tab work for Environments, Auth, and Trust follows. Strictly visualization of existing config — no new fields, no behavior changes (status: open — design proposal)
 
 ### Documentation infrastructure
 

--- a/docs/src/content/docs/reference/roadmap/settings-tui.mdx
+++ b/docs/src/content/docs/reference/roadmap/settings-tui.mdx
@@ -3,13 +3,13 @@ title: "Settings TUI"
 ---
 import RepoFile from '../../../../components/RepoFile.astro'
 
-**Status**: Open — design proposal (Configuration ergonomics)
+**Status**: Implemented — Settings now covers the existing `jackin config` operator surfaces in a tabbed console UI.
 
 ## Problem
 
 `~/.config/jackin/config.toml` is becoming the operator-level control plane for things that apply across workspaces: global mounts, authentication defaults, role source trust, runtime defaults, and future environment defaults. Today those features are split across CLI commands and manual TOML editing. That works for automation, but it is not the right primary experience for an operator already inside the console.
 
-The console should grow a dedicated **Settings** area that feels like the workspace editor: a first-class TUI entered from the workspace list, with tabs for each configuration axis. The first delivered surface is **Mounts**, because global mount visibility and editing were the active implementation goal. The other tabs should be designed deliberately and shipped one at a time, not folded into a single PR.
+The console now has a dedicated **Settings** area that feels like the workspace editor: a first-class TUI entered from the workspace list, with tabs for each existing `jackin config` axis.
 
 ## Scope discipline (load-bearing)
 
@@ -37,17 +37,17 @@ Phase 1 lands as part of the [Global Mount Visibility](/reference/roadmap/global
 - Persistence goes through `ConfigEditor::open(paths)` + `editor.save()`, the same path `jackin config mount` uses. Validation via `AppConfig::validate_global_mount_rows`.
 - Workspace views read global mount config for display; only this surface and the `jackin config mount` CLI write it.
 
-This roadmap item starts after Phase 1.
+Phase 1 is complete.
 
-### Phase 2 — Eager rename to Settings + tab-shell refactor
+### Phase 2 — Settings shell + `jackin config` tab parity
 
-Phase 2 is its **own PR**, landed right after Phase 1, even before any second tab exists. The motivation is consistency: the Phase 1 chrome already says `global config · mounts` and the doc describes a tab shell. Carrying a single-stage shape labeled like a tab shell is misleading; the rename plus the empty shell removes the ambiguity. Subsequent per-tab PRs then fill the shell rather than restructure it.
+Phase 2 is complete. It turned the global mounts editor into the Settings editor and filled it with the existing `jackin config` surfaces.
 
-The same Phase 2 PR does:
+Phase 2 delivered:
 
 1. **Rename**:
-   - <RepoFile path="src/console/manager/state.rs" />: `ManagerStage::GlobalMounts(GlobalMountsState)` → `ManagerStage::Settings(SettingsState)` where `SettingsState` owns `active_tab: SettingsTab`, `mounts: GlobalMountsState`, and the per-tab dirty/save plumbing.
-   - Add `enum SettingsTab { Mounts }`. New variants land with their own per-tab PRs.
+   - <RepoFile path="src/console/manager/state.rs" />: `ManagerStage::GlobalMounts(GlobalMountsState)` → `ManagerStage::Settings(SettingsState)` where `SettingsState` owns `active_tab: SettingsTab`, per-tab state for Mounts / Environments / Auth / Trust, and the shared dirty/save plumbing.
+   - Add `enum SettingsTab { Mounts, Environments, Auth, Trust }`.
    - Workspace list footer: `G global config` → `S settings`.
    - Stage chrome header: `global config · mounts` → `settings · mounts`.
    - Save confirmation copy: `Save global mounts to ~/.config/jackin/config.toml?` → `Save settings to ~/.config/jackin/config.toml?` (or equivalent that names the file once).
@@ -57,13 +57,11 @@ The same Phase 2 PR does:
 4. **Mounts tab — scope-first Add flow cleanup** (see "Mounts tab" below). Phase 1 ships name → source → destination → scope; Phase 2 re-orders to scope → name → source → destination → review.
 5. **Workspace editor Mounts tab — isolation-first Add flow cleanup** (see "Workspace mounts parity" below). Workspace mounts already support `shared` / `worktree` / `clone` isolation as a post-add `I` hotkey; Phase 2 moves that choice to the front of the Add flow so workspace mounts get the same "differentiator first" UX as global mounts.
 
-Phase 2 ships even though `SettingsTab` only contains `Mounts`. That is intentional: the empty-shell refactor is the contract that future per-tab PRs slot into.
+6. **Environments tab** surfaces global and role-scoped env vars from the same config layers as `jackin config env`.
+7. **Auth tab** surfaces global auth-forwarding modes for Claude Code, Codex, and Amp, matching `jackin config auth`.
+8. **Trust tab** surfaces registered role sources and lets the operator toggle trust state, matching the persisted trust state used by `jackin config trust`.
 
-### Phase 3+ — Additional tabs (one per design pass)
-
-Each per-tab section below is a separate work item. They land one at a time, in any order the operator picks, and each gets its own design pass before implementation. None are gated on each other except where noted.
-
-## Target shape (post Phase 2)
+## Current shape
 
 The workspace list remains the entry point:
 
@@ -92,11 +90,9 @@ The TUI behaves like the workspace editor:
 - `Esc` backs out, with save/discard confirmation when dirty.
 - Footer hints stay contextual to the active row and active tab.
 
-After Phase 2 the only tab present is `Mounts`. The tab strip still renders so the structural contract is visible to the operator and to subsequent PR authors.
-
 ## Mounts tab
 
-The Mounts tab is the baseline shipped in Phase 1. The Phase 2 cleanup is the only behavior change planned for it, and it does not introduce new fields — the scope choice already exists as the post-`E` edit on a global mount row.
+The Mounts tab is the baseline shipped in Phase 1. The Phase 2 cleanup is complete and did not introduce new fields — the scope choice already existed as the post-`E` edit on a global mount row.
 
 ### Phase 2 cleanup — scope-first Add flow
 
@@ -109,7 +105,7 @@ Re-order the Add flow to ask scope first, matching the mental model used for wor
 5. Enter destination.
 6. Review/save.
 
-The Phase 1 ordering (name → source → destination → scope) keeps shipping until this cleanup lands.
+The earlier Phase 1 ordering (name → source → destination → scope) no longer ships.
 
 ### Continuing parity (no behavior change)
 
@@ -142,46 +138,35 @@ Read-only stays a post-add `R` hotkey on the row, because it is a per-mount prop
 
 This change is **purely UX re-ordering**. It does not add new fields, new isolation modes, or new mount capabilities — `shared` / `worktree` / `clone` already exist as the supported choices and the `I` hotkey already cycles them. Implementation lives in the workspace editor input handler in <RepoFile path="src/console/manager/input/editor.rs" />.
 
-The change ships in the same Phase 2 PR as the global mounts scope-first Add flow so both Mounts surfaces converge on the same "pick the differentiator first" UX.
-
-## Future tabs (Phase 3+)
-
-Each tab below lands as its own PR after its own design pass. Every tab obeys the visualization-only scope discipline at the top of this page: surface what the underlying config already supports, and omit the tab if there is nothing to surface.
+This change shipped with the global mounts scope-first Add flow so both Mounts surfaces use the same "pick the differentiator first" UX.
 
 ### Environments
 
-Surface what `config.toml`'s environment-related sections already express:
+The Environments tab surfaces what `config.toml`'s environment-related sections already express:
 
 - Global env vars applied to all launches.
 - Role-scoped global env vars.
-- Conflict behavior when workspace and global env vars share a key (display only — the resolution rule already exists in the runtime).
-- 1Password-backed env values, using the same picker patterns as workspace envs.
-
-Coordinate the visualization with [`${env.VAR}` interpolation](/reference/roadmap/env-var-interpolation/) and [1Password integration](/reference/roadmap/onepassword-integration/) so the Settings tab shows interpolation and secret semantics consistently with how the runtime resolves them. Do not introduce new env precedence rules in this tab.
+- Add, edit, and remove env rows with the same reserved-name validation as the CLI.
+- Literal, host-ref, interpolation, and `op://` values continue to use the existing operator-env semantics; this tab does not introduce new precedence rules.
 
 ### Auth
 
-Surface what jackin's auth forwarding config already supports:
+The Auth tab surfaces what `jackin config auth` supports:
 
-- Global auth forwarding defaults for Claude, Codex, Amp, and GitHub.
-- Per-role overrides for those auth defaults.
-- Credential source selection: sync, literal env var, 1Password reference, or ignore, depending on the runtime.
-- Status badges indicating whether the selected credential source is currently available on the host.
+- Global auth forwarding defaults for Claude Code, Codex, and Amp.
+- Mode cycling constrained by each runtime's supported modes.
+- Credential env-var hints for env-backed modes.
 
-Do not implement this by copying the workspace Auth tab blindly. The global Auth tab edits defaults; workspace Auth edits overrides. The UI must make that layering obvious.
-
-This tab is gated on the auth-strategy work resolved or partially resolved by [Reliable Claude authentication strategy](/reference/roadmap/claude-auth-strategy/), [Live bidirectional auth sync](/reference/roadmap/live-auth-sync/), [GitHub CLI authentication strategy](/reference/roadmap/github-cli-auth-strategy/), and [Workspace Claude token setup](/reference/roadmap/workspace-claude-token-setup/). Shipping the Auth tab before those clarify the defaults-vs-overrides layering would bake the wrong shape into the UI.
+Workspace Auth remains the place to edit workspace and per-role overrides. GitHub CLI auth is intentionally not part of `jackin config auth` today, so this Settings tab does not invent a GitHub global-auth control.
 
 ### Trust
 
-Surface what `~/.config/jackin/config.toml` and the role trust state already record:
+The Trust tab surfaces what `~/.config/jackin/config.toml` and the role trust state already record:
 
-- Trusted and untrusted role sources.
-- Source URL, branch, and trust state per source.
-- Trust, untrust, or refresh a role source — using the same operations the CLI exposes today.
-- Validation failures from role manifest checks.
-
-Coordinates with [Agent source trust](/reference/roadmap/agent-source-trust/) and any future role update / version pinning work.
+- Registered role sources.
+- Source URL and trust state per source.
+- Trust and untrust toggles for non-built-in registered sources.
+- Built-in roles remain always trusted.
 
 ## Tabs intentionally not planned
 
@@ -191,9 +176,10 @@ There is no **General** tab. If the operator-facing config surfaces a setting th
 
 The Settings TUI does not replace the CLI, and it does not replace direct TOML editing. CLI remains the automation surface, direct TOML editing remains the escape hatch, TUI becomes the interactive operator surface.
 
-The TUI eventually covers the same user-facing operations as:
+The TUI covers the same persisted operator config surfaces as:
 
 - `jackin config mount add` / `list` / `remove`
+- `jackin config env set` / `list` / `unset`
 - `jackin config auth …`
 - `jackin config trust …`
 
@@ -210,7 +196,7 @@ For every Settings tab, command handlers and TUI save paths converge on the same
 
 ## Implementation notes
 
-- Phase 2 renames `ManagerStage::GlobalMounts` → `ManagerStage::Settings`, footer `G global config` → `S settings`, header `global config · mounts` → `settings · mounts`. Plumb the rename through dispatcher, footer hints, mouse focus tracking, save-confirmation copy, and snapshot tests in the same PR.
+- Phase 2 renames `ManagerStage::GlobalMounts` → `ManagerStage::Settings`, footer `G global config` → `S settings`, header `global config · mounts` → `settings · mounts`, and adds tabs matching `jackin config mount` / `env` / `auth` / `trust`. Plumb the rename through dispatcher, footer hints, mouse focus tracking, save-confirmation copy, and snapshot tests in the same PR.
 - The `S` mnemonic for the workspace list is free today (existing keys are `E` / `N` / `D` / `G` / `Q`). Confirm at PR time that `S` does not collide with another binding the workspace list grew between now and Phase 2.
 - Per-tab dirty state lives on `SettingsState` so the parent stage can render an unambiguous save/discard prompt; do not put the dirty bit only on individual tab states.
 - Reuse <RepoFile path="src/console/manager/render/editor.rs" /> tab-strip rendering and click hit-testing rather than rewriting them.

--- a/docs/src/content/docs/reference/tui-design-decisions.mdx
+++ b/docs/src/content/docs/reference/tui-design-decisions.mdx
@@ -5,9 +5,88 @@ description: Canonical design rules for the jackin' terminal UI — authoritativ
 
 import RepoFile from '../../../components/RepoFile.astro';
 
-This document records every binding design decision for the jackin' TUI. It is the authoritative reference when implementing or reviewing any TUI change. If a proposed implementation conflicts with a rule here, fix the implementation, not the rule (or open a discussion to amend the rule first).
+This document is the **canonical record of every binding TUI design decision** — navigation conventions, focusability rules, component reuse contracts, color palette, modal sizing, scroll semantics, and more. Read it before implementing any TUI change. When a new decision is made, add it here immediately.
 
-Source of truth for navigation rules lives in `AGENTS.md` → **TUI navigation conventions**. This document extends those rules with visual, interaction, and component-reuse decisions.
+If a proposed implementation conflicts with a rule here, fix the implementation, not the rule (or open a discussion to amend the rule first). Violations are bugs and must be fixed before a PR lands.
+
+---
+
+## Navigation conventions
+
+Jackin's TUI follows the **W3C ARIA Tabs interaction pattern** for all tabbed interfaces and the corresponding area-scoped arrow-key model everywhere else.
+
+### Key roles
+
+**Tab / BackTab** are the designated cross-area navigation keys. They move focus between logical areas: from the field area to the button row, back from the button row to the field area, and between a tab list and its tab panel (content area). Tab always moves forward in the cycle; BackTab always moves backward.
+
+**Left / Right** are intra-area horizontal keys. They move focus within the current horizontal group (e.g. between buttons in a button row, or between tabs when the tab list has focus). They must never jump between distinct areas.
+
+**Up / Down (and j / k aliases)** are intra-area vertical keys. They move focus within the current vertical field group. They must never cross the boundary from a field area into the button area or vice versa.
+
+### W3C Tabs pattern (required for all tabbed interfaces)
+
+All tabbed surfaces (workspace editor, settings) must implement the W3C tablist/tabpanel pattern:
+
+1. **Tab list** (the row of tab labels) is its own focus area:
+   - `←` / `→` cycle between tabs.
+   - `Tab` or `↓` moves focus into the first block inside the tab panel (content area).
+   - The active tab is visually distinguished even without tab-list focus; when the tab list IS focused, an additional highlight (e.g. bold or underline) makes this clear.
+
+2. **Tab panel** (the content below the tabs) may contain one or more blocks:
+   - `↑` / `↓` navigate within the focused block.
+   - `Tab` advances to the next block within the panel; after the last block `Tab` cycles back to the tab list.
+   - `BackTab` / `Esc` returns focus to the tab list.
+
+3. Entry into a tabbed stage (opening Settings, opening the workspace editor) must start with **tab-list focus** — the operator sees the tab labels highlighted and uses `←` / `→` to pick a tab before `Tab` / `↓` drops them into the content.
+
+This rule applies to every tabbed surface that ships; add a `tab_bar_focused: bool` field to the relevant state struct and update input dispatch and rendering accordingly whenever a new tabbed surface is added.
+
+### Other area-boundary rules
+
+- Down from the last field in a form's field area is a no-op. Tab is the key that crosses into the button area.
+- Up from the first button in the button area is a no-op. BackTab is the key that crosses back into the field area.
+
+**Exception — tree header expand/collapse:** Right = expand and Left = collapse on tree-style header rows (Secrets AgentHeader, Auth RoleHeader, Environments RoleHeader) is a correct intra-area semantic action. This absorption pattern is intentional and must be preserved.
+
+**Exception — flat button-strip widgets:** Self-contained single-row button widgets (`confirm.rs`, `save_discard.rs`, `mount_dst_choice.rs`, `source_picker.rs`, `mount_isolation_choice.rs`, `scope_picker.rs`) may treat Left / Right as BackTab / Tab equivalents. The entire widget is a single flat area with no area boundary to cross, so there is no violation.
+
+### Navigation hints (exhaustive — no hidden keys)
+
+**Every keyboard shortcut that is active on the current screen must appear in the footer hint bar. No key may be silently available — users must never have to guess.** The hint bar updates whenever the focused area or row context changes.
+
+Rules:
+- `↑/↓ navigate` must appear whenever a list, table, or form with multiple rows is active. It is a global footer item, not a conditional one.
+- Every action key (`Enter`, `Space`, `D`, `A`, `R`, `N`, `1`, `2`, `3`, `O`, `P`, `M`, etc.) that is live on the current row must be shown alongside its one-word description.
+- When a key applies only under certain conditions (e.g. `O open in GitHub` only for GitHub-origin mounts), show it only when the condition holds — but never suppress a key that is unconditionally active.
+- `Tab switch tab`, `S save`, and `Esc back/discard` are always shown in the global footer.
+- Keep each hint concise: one symbol or key name, one word label. Use `·` separators between hints.
+
+This rule applies to every TUI surface: list view, workspace editor (all tabs), settings (all tabs), all modals and overlays.
+
+### Space vs Enter — W3C semantic distinction
+
+**`Space`** is the key for **toggle** semantics (on/off, checked/unchecked, trusted/untrusted, allowed/disallowed). It matches the W3C ARIA patterns for checkbox, switch, and radio group. Never bind Enter to the same action as Space on a toggle widget.
+
+**`Enter`** is the key for **action** semantics (activate a button, open a dialog, confirm a choice, navigate into detail, submit a form). It is also the key for shortcut-letter bindings (`Y` yes, `N` no, `S` save, `D` discard, etc.) on confirmation dialogs.
+
+Binding both `Space` and `Enter` to the same toggle action is a W3C violation — Space is sufficient and Enter would collide with its role as the action key. Binding both to a button widget is acceptable (W3C requires both on standard buttons), but jackin's button-strip widgets use letter shortcuts + Enter to avoid this; don't add Space to them.
+
+Summary:
+- Toggle row (keep_awake, git_pull, trusted, allowed role): `Space` only.
+- Action button (Save, Cancel, Discard, Yes, No): `Enter` only (plus letter shortcut if applicable).
+- Open/navigate (expand detail, open picker, rename): `Enter` only.
+- Cycle among options in a slot (auth mode): `Space` (radio-button pattern per W3C).
+- Re-open a picker for an already-set value (1Password op-ref, source): `Enter` (action). `P` is also supported as a shortcut where op_available is true, but `Enter` must always work.
+
+### Hints: footer only, never inside dialogs
+
+All keyboard hint text belongs in the footer bar at the bottom of the screen. Dialogs, modals, and overlays **must not** render their own internal hint line. When a modal is open, the main footer must show the modal's available keys instead of the keys for the content behind it.
+
+Enforcement:
+- Every widget in `src/console/widgets/` must expose a `footer_items` function (or equivalent) and remove its internal hint row.
+- `render_editor` checks `state.modal` first; if a modal is open it calls `modal_footer_items(modal)` and skips the normal contextual items.
+- `render_settings` checks the three settings modal chains (`auth.modal`, `env.modal`, `mounts.modal`) in priority order; if any is `Some`, calls the corresponding `*_modal_footer_items` function.
+- No `Constraint::Length` row for a hint line may remain inside any widget layout.
 
 ---
 
@@ -179,4 +258,15 @@ Role-level sentinels (`RoleAddSentinel`) and role section headers keep their `" 
 
 ## Component Reuse — Strict Rule
 
-See `AGENTS.md` → **Component reuse: single implementation per UX pattern** for the binding rule. Short form: if a pattern appears in two places, extract it. Never fork.
+When two TUI surfaces implement the same flow, do not fork modal sizing, rendering, input handling, footer wording, row layout, or picker behavior into a second near-copy. Extract or extend a shared widget, renderer, input helper, or state adapter and have both surfaces call it.
+
+Settings screens that intentionally mirror workspace screens must reuse the workspace widgets and flow helpers wherever behavior is the same; keep separate code only for the different persistence target or config scope. Treat visual drift between duplicated TUI components as a bug. If reuse is blocked, call that out in the PR and keep the duplicate small and temporary.
+
+Every visual pattern that appears in more than one place **must** use one shared implementation — a single widget, render function, or helper. Never create a second near-copy of an existing widget or render function. When the existing implementation cannot serve a new call site without modification, extend it (add parameters, generalize) rather than forking it.
+
+When a genuinely new component is needed (no existing implementation fits the UX pattern):
+1. The agent proposes the design with a sketch or description.
+2. The operator explicitly approves the design.
+3. Only then may the agent implement it.
+
+Violations — two functions that render the same kind of content with slightly different styling or behavior — must be fixed before a PR lands by consolidating them into one.

--- a/docs/src/content/docs/reference/tui-design-decisions.mdx
+++ b/docs/src/content/docs/reference/tui-design-decisions.mdx
@@ -1,0 +1,182 @@
+---
+title: TUI Design Decisions
+description: Canonical design rules for the jackin' terminal UI — authoritative reference for all TUI development
+---
+
+import RepoFile from '../../../components/RepoFile.astro';
+
+This document records every binding design decision for the jackin' TUI. It is the authoritative reference when implementing or reviewing any TUI change. If a proposed implementation conflicts with a rule here, fix the implementation, not the rule (or open a discussion to amend the rule first).
+
+Source of truth for navigation rules lives in `AGENTS.md` → **TUI navigation conventions**. This document extends those rules with visual, interaction, and component-reuse decisions.
+
+---
+
+## Focusability
+
+**A block is focusable only when its content overflows the visible area in at least one axis (horizontal or vertical).**
+
+When a block's content fits entirely within its viewport, clicking it must not activate it (green border must not appear) and keyboard scroll keys must not change its scroll offset.
+
+This rule exists because a focused non-scrollable block gives the user false affordance — the green border implies "you can scroll here" but nothing moves. Operators are confused when they click a block, see it highlight, and then H/L/scroll wheel does nothing.
+
+### Implementation
+
+The scrollability check runs in two places and must agree:
+
+1. **`update_scroll_focus` (mouse click)** — `is_scrollable(area, content_width) || is_scrollable_v(area, content_height)` must be `true` before setting focus. If false, click in that block clears focus (sets `list_scroll_focus = None`).
+
+2. **`focused_block_still_scrollable` (resize guard, every render frame)** — returns `false` when content fits after a terminal resize, which clears `list_scroll_focus = None` so the green border disappears.
+
+Both checks must use the **same content height and width values** as `render_scrollable_block` uses for the actual rendered lines. Any mismatch causes the bug where the block looks scrollable (green border, scrollbar visible) but scrolling does nothing, or looks non-scrollable but is still focused.
+
+### Content height formula for each block type
+
+These are the exact formulas that match what each render function passes to `render_scrollable_block`:
+
+| Block | `content_height` |
+|---|---|
+| Workspace mounts | `1 + max(data_rows, 1)` where `data_rows = sum of 1-or-2 per mount (1 if src==dst, 2 otherwise)` |
+| Global mounts / Role global mounts | `1 + n*2 + 1` where n = mount count (assumes src≠dst; +1 for header) |
+| Roles | `2 + agent_count` (1 "Default …" row + 1 blank row + agent rows) |
+| Left sidebar (workspace names) | no vertical scroll — use `clamp_list_scroll_for_area` horizontal-only path |
+
+The workspace mounts formula uses `.max(1)` because an empty mount list renders a "(none)" placeholder row, so even zero mounts produce 1 data row.
+
+---
+
+## Scrollable Blocks — Shared Component
+
+**All bordered scrollable content blocks must use `render_scrollable_block` from `render/mod.rs`.** Never hand-roll block creation, Paragraph scroll, or scrollbar rendering inline.
+
+`render_scrollable_block` guarantees:
+- Border color `PHOSPHOR_GREEN` when focused, `PHOSPHOR_DARK` otherwise.
+- Horizontal scrollbar rendered only when content overflows horizontally.
+- Vertical scrollbar rendered only when content overflows vertically.
+- `*scroll_x` and `*scroll_y` clamped to valid range in-place every frame (eliminates stale overshoot).
+
+Signature:
+```rust
+pub(super) fn render_scrollable_block(
+    frame: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'_>>,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
+    focused: bool,
+    title: Option<&str>,
+)
+```
+
+Pass `None` for `title` to suppress the block title. Pass `Some(" Title ")` (with surrounding spaces) to match the standard label style.
+
+---
+
+## Focus Persistence
+
+**`list_names_focused` (left sidebar) is cleared only when:**
+1. The user clicks in the right pane — `update_scroll_focus` sets it to `false`.
+2. The terminal resizes so the content fits — `clamp_list_scroll_for_area` sets it to `false`.
+
+It must **not** be cleared by `reset_list_scroll`. Workspace selection changes keep the user in the left pane; the focus state should persist.
+
+**`list_scroll_focus` (right-pane blocks) is cleared when:**
+1. Content no longer overflows after resize — `focused_block_still_scrollable` returns `false`.
+2. User clicks left pane — `update_scroll_focus` clears it.
+3. Workspace changes — `reset_list_scroll` sets it to `None`.
+
+---
+
+## Mouse Scroll (Hover-Scroll)
+
+Mouse `ScrollLeft`/`ScrollRight` scroll whichever block the cursor is currently over **without requiring a prior click**. This is hover-scroll semantics, not click-then-scroll.
+
+In `scroll_active_panel`, dispatch order for the list stage:
+1. If `list_names_focused` → scroll `list_names_scroll_x` (left pane).
+2. Otherwise → compute `list_scroll_areas`, route to the block under the pointer.
+
+The left pane scroll uses `apply_horizontal_scroll_unbounded` (no clamping to content width) because `render_scrollable_block` clamps on every frame anyway.
+
+---
+
+## PHOSPHOR Color Palette
+
+Canonical definitions live in <RepoFile path="src/console/widgets/mod.rs" />. All other files use `pub(super) use` re-exports from `render/mod.rs`. Never define local constants.
+
+| Constant | Value | Usage |
+|---|---|---|
+| `PHOSPHOR_GREEN` | `Rgb(0, 255, 65)` | Active/focused elements, selected text |
+| `PHOSPHOR_DIM` | `Rgb(0, 140, 30)` | Inactive text, scrollbar thumbs |
+| `PHOSPHOR_DARK` | `Rgb(0, 80, 18)` | Borders (unfocused), separators |
+| `WHITE` | `Rgb(255, 255, 255)` | Labels, keys, headings |
+
+---
+
+## Block Border Colors
+
+- **Focused block**: `PHOSPHOR_GREEN` border.
+- **Unfocused block**: `PHOSPHOR_DARK` border (or no border where layout dictates).
+- Border color is controlled exclusively through the `focused` parameter to `render_scrollable_block`. Never set border style separately.
+
+---
+
+## Left Sidebar (Workspace Name List)
+
+- Horizontal scroll only — no vertical scroll.
+- Uses `render_scrollable_block` with `scroll_y = 0u16` (a throwaway variable; vertical scrollbar never appears because line count always fits the list height).
+- H/L keys and `ScrollLeft`/`ScrollRight` both update `state.list_names_scroll_x`.
+- Focus set on click via `update_scroll_focus`; persists until user clicks the right pane.
+- Focus cleared by `clamp_list_scroll_for_area` when content width ≤ viewport (content fits horizontally).
+
+---
+
+## Tab Bar
+
+**W3C ARIA Tabs pattern** (see `AGENTS.md` → TUI navigation conventions for full spec). Summary:
+
+- Tab bar has its own focus area (`tab_bar_focused: bool` in state).
+- **Tab bar focused**: active tab shows `fg(WHITE) + BOLD`; underline bar (`━━━━`) beneath the active tab label.
+- **Content focused** (tab bar not focused): active tab shows `bg(PHOSPHOR_GREEN) + fg(Black) + BOLD`; no underline bar.
+- `←`/`→` cycle tabs when tab bar is focused.
+- `Tab`/`↓` moves focus from tab bar into the first content block.
+- `BackTab`/`Esc` returns focus to the tab bar from content.
+
+---
+
+## Modal Sizing Rules
+
+Modals use `centered_rect_fixed(outer, pct_w, rows)`. `rows` is the **total outer height** including both borders. Inner rows = `rows - 2`.
+
+| Modal | `pct_w` | `rows` | Reasoning |
+|---|---|---|---|
+| Scope picker | 50 | 4 | 1 button row + 2 borders + 1 spacer |
+| Text input | 60 | 5 | 1 input row + 2 borders + 2 label/padding |
+| Role picker | auto | `filtered.len() + 6` | filter row + spacer + roles + border overhead |
+
+Never add excess padding rows to modals. The outer rect must be exactly tight enough to render the widget's layout constraints without blank overflow rows.
+
+---
+
+## Hints / Footer Bar
+
+Every keyboard shortcut active on the current screen must appear in the footer. No hidden keys. See `AGENTS.md` → **Navigation hints** for the complete rule.
+
+When a scrollable block is focused, the footer must show scroll direction hints:
+- Horizontal-only block: `←/→ scroll block`
+- Vertical-only block: `↑/↓ scroll block`  
+- Both axes: `↑/↓/←/→ scroll block`
+
+The hints update dynamically based on which block is focused and which axes overflow.
+
+---
+
+## Env / Secrets Sentinel Indentation
+
+`+ Add environment variable` sentinel at workspace level must align with workspace-level content (2-char `cursor_col` indent only). It must **not** pick up the 5-space `marker_col` that role-level rows use.
+
+Role-level sentinels (`RoleAddSentinel`) and role section headers keep their `"     "` (5-space) indentation to visually group them under the role section.
+
+---
+
+## Component Reuse — Strict Rule
+
+See `AGENTS.md` → **Component reuse: single implementation per UX pattern** for the binding rule. Short form: if a pattern appears in two places, extract it. Never fork.

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -17,6 +17,7 @@ use crate::paths::JackinPaths;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvScope {
     Global,
+    GlobalGithub,
     Role(String),
     Workspace(String),
     WorkspaceRole {
@@ -269,6 +270,24 @@ impl ConfigEditor {
     ) {
         let table = table_path_mut(&mut self.doc, &[agent.slug().to_string()]);
         table.insert("auth_forward", toml_edit::value(auth_forward_str(mode)));
+    }
+
+    /// Write `[github].auth_forward = <mode>` at the global layer.
+    pub fn set_global_github_auth_forward(&mut self, mode: crate::config::GithubAuthMode) {
+        let table = table_path_mut(&mut self.doc, &["github".to_string()]);
+        table.insert("auth_forward", toml_edit::value(github_mode_str(mode)));
+    }
+
+    pub fn set_global_github_env_var(
+        &mut self,
+        key: &str,
+        value: crate::operator_env::EnvValue,
+    ) -> anyhow::Result<()> {
+        self.set_env_var(&EnvScope::GlobalGithub, key, value)
+    }
+
+    pub fn remove_global_github_env_var(&mut self, key: &str) -> bool {
+        self.remove_env_var(&EnvScope::GlobalGithub, key)
     }
 
     /// Write or clear `[<agent>].auth_forward` inside the workspace file.
@@ -552,7 +571,9 @@ impl ConfigEditor {
 
     fn doc_and_path_for_env_scope(&mut self, scope: &EnvScope) -> (&mut DocumentMut, Vec<String>) {
         match scope {
-            EnvScope::Global | EnvScope::Role(_) => (&mut self.doc, env_scope_path(scope)),
+            EnvScope::Global | EnvScope::GlobalGithub | EnvScope::Role(_) => {
+                (&mut self.doc, env_scope_path(scope))
+            }
             EnvScope::Workspace(w) => {
                 let doc = self.workspace_doc_mut(w);
                 (doc, vec!["env".to_string()])
@@ -606,6 +627,7 @@ const fn github_mode_str(mode: crate::config::GithubAuthMode) -> &'static str {
 fn env_scope_path(scope: &EnvScope) -> Vec<String> {
     match scope {
         EnvScope::Global => vec!["env".to_string()],
+        EnvScope::GlobalGithub => vec!["github".to_string(), "env".to_string()],
         EnvScope::Role(a) => vec!["roles".to_string(), a.clone(), "env".to_string()],
         EnvScope::Workspace(w) => vec!["workspaces".to_string(), w.clone(), "env".to_string()],
         EnvScope::WorkspaceRole { workspace, role } => vec![

--- a/src/config/mounts.rs
+++ b/src/config/mounts.rs
@@ -271,6 +271,16 @@ impl AppConfig {
                 let scope = row.scope.as_deref().unwrap_or("global");
                 anyhow::bail!("duplicate global mount entry: {} [{}]", row.name, scope);
             }
+            if !matches!(
+                row.mount.isolation,
+                crate::isolation::MountIsolation::Shared
+            ) {
+                anyhow::bail!(
+                    "global mount {} cannot use isolation {}; global mounts are always shared",
+                    row.name,
+                    row.mount.isolation.as_str()
+                );
+            }
             let expanded = MountConfig {
                 src: expand_tilde(&row.mount.src),
                 dst: row.mount.dst.clone(),
@@ -742,6 +752,26 @@ gradle-cache = { src = "/tmp/x", dst = "/workspace/x", isolation = "worktree" }
         assert!(
             msg.contains("did not match any variant of untagged enum MountEntry"),
             "expected untagged-enum mismatch error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_global_mount_rows_rejects_non_shared_isolation() {
+        let rows = vec![GlobalMountRow {
+            scope: None,
+            name: "repo".into(),
+            mount: MountConfig {
+                src: "/tmp/repo".into(),
+                dst: "/workspace/repo".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Worktree,
+            },
+        }];
+
+        let err = AppConfig::validate_global_mount_rows(&rows).unwrap_err();
+        assert!(
+            err.to_string().contains("global mounts are always shared"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/src/console/manager/input/auth.rs
+++ b/src/console/manager/input/auth.rs
@@ -340,8 +340,9 @@ pub(super) fn handle_auth_form_key(
 /// Keystroke router for the `CredentialSource` row.
 ///
 /// - `Enter` → open the shared source picker (literal vs. 1Password).
-/// - `Down/j`/`Tab` → focus `Save` (forward through the cycle).
-/// - `Up/k`/`BackTab` → focus `Mode` (backward through the cycle).
+/// - `Down/j` → no-op (bottom of the field area; Tab crosses to the button area).
+/// - `Tab` → focus `Save` (cross-area jump to the button row).
+/// - `Up/k`/`BackTab` → focus `Mode` (intra-area up / reverse cross-area).
 fn handle_credential_source_key(
     editor: &mut EditorState<'_>,
     key: KeyEvent,
@@ -353,7 +354,7 @@ fn handle_credential_source_key(
 
     match key.code {
         KeyCode::Enter => open_auth_source_picker_from_form(editor, op_available),
-        KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
+        KeyCode::Tab => {
             *focus = AuthFormFocus::Save;
             false
         }
@@ -609,10 +610,14 @@ fn apply_op_picker_to_auth_form_with_runner<R: crate::operator_env::OpRunner + ?
 fn handle_mode_key(focus: &mut AuthFormFocus, form: &mut AuthForm, key: KeyEvent) {
     match key.code {
         KeyCode::Char(' ') => cycle_mode(form),
-        KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => *focus = next_focus_after_mode(form),
+        // Down/j moves within the field area; Tab crosses into the button area.
+        // No credential row: Down is a no-op at the bottom of the field area.
+        KeyCode::Down | KeyCode::Char('j') if form.shows_credential_block() => {
+            *focus = AuthFormFocus::CredentialSource;
+        }
+        KeyCode::Tab => *focus = next_focus_after_mode(form),
         // BackTab wraps backward through the cycle to Reset (the last
-        // focusable control). Forward Tab from Reset wraps to Mode in
-        // `handle_reset_key`.
+        // focusable control). Tab from Reset wraps forward to Mode.
         KeyCode::BackTab => *focus = AuthFormFocus::Reset,
         _ => {}
     }
@@ -633,9 +638,8 @@ fn handle_save_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
             *focus = AuthFormFocus::Cancel;
             false
         }
-        // BackTab walks backward through the cycle to the credential
-        // row (when shown) or Mode (otherwise); Up mirrors that.
-        KeyCode::Up | KeyCode::BackTab => {
+        // Up is a no-op at the top of the button area; BackTab crosses back into the field area.
+        KeyCode::BackTab => {
             *focus = if state.shows_credential_block() {
                 AuthFormFocus::CredentialSource
             } else {
@@ -688,8 +692,8 @@ fn handle_reset_key(editor: &mut EditorState<'_>, key: KeyEvent) -> bool {
             *focus = AuthFormFocus::Cancel;
             false
         }
-        // Tab from the last focusable control wraps to Mode (first).
-        KeyCode::Right | KeyCode::Tab => {
+        // Tab wraps the cycle back to the first field; Right stays on the button row.
+        KeyCode::Tab => {
             *focus = AuthFormFocus::Mode;
             false
         }
@@ -1032,9 +1036,9 @@ mod tests {
         });
         open_auth_form_modal(editor, &cfg);
         // Tab through to Reset and Enter.
-        // From Mode → Down → Cred → Down → Save → Tab → Cancel → Tab → Reset.
-        drive_key(editor, key(KeyCode::Down)); // Mode → CredentialSource
-        drive_key(editor, key(KeyCode::Down)); // → Save
+        // From Mode → Down → Cred → Tab → Save → Tab → Cancel → Tab → Reset.
+        drive_key(editor, key(KeyCode::Down)); // Mode → CredentialSource (intra-area)
+        drive_key(editor, key(KeyCode::Tab)); // Cred → Save (Tab crosses to button area)
         drive_key(editor, key(KeyCode::Tab)); // → Cancel
         drive_key(editor, key(KeyCode::Tab)); // → Reset
         let closed = drive_key(editor, key(KeyCode::Enter));
@@ -1134,6 +1138,30 @@ mod tests {
             *focus,
             AuthFormFocus::Reset,
             "BackTab on Mode must wrap to Reset"
+        );
+    }
+
+    #[test]
+    fn auth_form_right_on_reset_stays_on_reset() {
+        let (cfg, mut state) = build_state();
+        let ManagerStage::Editor(editor) = &mut state.stage else {
+            panic!()
+        };
+        open_auth_form_modal(editor, &cfg);
+        // Walk to Reset: Mode → Tab → Save → Tab → Cancel → Tab → Reset.
+        drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Tab));
+        drive_key(editor, key(KeyCode::Tab));
+
+        // Right must not leave the button row.
+        drive_key(editor, key(KeyCode::Right));
+        let Some(Modal::AuthForm { focus, .. }) = &editor.modal else {
+            panic!("auth form must still be open")
+        };
+        assert_eq!(
+            *focus,
+            AuthFormFocus::Reset,
+            "Right on Reset must not move focus off the button row"
         );
     }
 

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -54,6 +54,7 @@ pub(super) fn handle_editor_key(
                     if let ManagerStage::Editor(editor) = &mut state.stage {
                         editor.auth_selected_kind = None;
                         editor.active_field = FieldFocus::Row(0);
+                        editor.tab_scroll_y = 0;
                     }
                     return Ok(InputOutcome::Continue);
                 }
@@ -99,13 +100,75 @@ pub(super) fn handle_editor_key(
             editor.workspace_mounts_scroll_focused = true;
             editor.workspace_mounts_scroll_x = editor.workspace_mounts_scroll_x.saturating_add(8);
         }
-        KeyCode::Tab | KeyCode::Right => {
-            // Secrets tab `AgentHeader` absorbs `→` in both states
-            // (expand or no-op) — falling through to tab-cycle on an
-            // expanded header would surprise the operator. See
-            // RULES.md "TUI Keybindings → Contextual key absorption".
-            // `Tab` never absorbs.
-            if key.code == KeyCode::Right && editor.active_tab == EditorTab::Secrets {
+        // W3C ARIA Tabs: Left/BackTab cycle backward, Right cycles forward when
+        // the tab bar has focus. Tab and Down enter the content area.
+        KeyCode::Left | KeyCode::BackTab if editor.tab_bar_focused => {
+            let was_secrets = editor.active_tab == EditorTab::Secrets;
+            editor.active_tab = match editor.active_tab {
+                EditorTab::General => EditorTab::Auth,
+                EditorTab::Mounts => EditorTab::General,
+                EditorTab::Roles => EditorTab::Mounts,
+                EditorTab::Secrets => EditorTab::Roles,
+                EditorTab::Auth => EditorTab::Secrets,
+            };
+            editor.active_field = FieldFocus::Row(0);
+            editor.tab_scroll_y = 0;
+            if editor.active_tab != EditorTab::Auth {
+                editor.auth_selected_kind = None;
+            }
+            if was_secrets {
+                reset_secrets_view(editor);
+            }
+        }
+        KeyCode::Right if editor.tab_bar_focused => {
+            let was_secrets = editor.active_tab == EditorTab::Secrets;
+            editor.active_tab = match editor.active_tab {
+                EditorTab::General => EditorTab::Mounts,
+                EditorTab::Mounts => EditorTab::Roles,
+                EditorTab::Roles => EditorTab::Secrets,
+                EditorTab::Secrets => EditorTab::Auth,
+                EditorTab::Auth => EditorTab::General,
+            };
+            editor.active_field = FieldFocus::Row(0);
+            editor.tab_scroll_y = 0;
+            if editor.active_tab != EditorTab::Auth {
+                editor.auth_selected_kind = None;
+            }
+            if was_secrets {
+                reset_secrets_view(editor);
+            }
+        }
+        KeyCode::Tab | KeyCode::Down | KeyCode::Char('j' | 'J') if editor.tab_bar_focused => {
+            editor.tab_bar_focused = false;
+        }
+        // Tab from content returns focus to tab bar and advances to next tab.
+        KeyCode::Tab => {
+            let was_secrets = editor.active_tab == EditorTab::Secrets;
+            editor.active_tab = match editor.active_tab {
+                EditorTab::General => EditorTab::Mounts,
+                EditorTab::Mounts => EditorTab::Roles,
+                EditorTab::Roles => EditorTab::Secrets,
+                EditorTab::Secrets => EditorTab::Auth,
+                EditorTab::Auth => EditorTab::General,
+            };
+            editor.tab_bar_focused = true;
+            editor.active_field = FieldFocus::Row(0);
+            editor.tab_scroll_y = 0;
+            if editor.active_tab != EditorTab::Auth {
+                editor.auth_selected_kind = None;
+            }
+            if was_secrets {
+                reset_secrets_view(editor);
+            }
+        }
+        // BackTab from content returns focus to tab bar without changing tab.
+        KeyCode::BackTab => {
+            editor.tab_bar_focused = true;
+        }
+        // Right expands role headers in Secrets/Auth tabs; no-op everywhere else.
+        // Left/Right are intra-area horizontal keys and must not cycle tabs.
+        KeyCode::Right => {
+            if editor.active_tab == EditorTab::Secrets {
                 let FieldFocus::Row(n) = editor.active_field;
                 let rows = secrets_flat_rows(editor);
                 if let Some(SecretsRow::RoleHeader { role, expanded }) = rows.get(n).cloned() {
@@ -115,7 +178,7 @@ pub(super) fn handle_editor_key(
                     return Ok(InputOutcome::Continue);
                 }
             }
-            if key.code == KeyCode::Right && editor.active_tab == EditorTab::Auth {
+            if editor.active_tab == EditorTab::Auth {
                 let FieldFocus::Row(n) = editor.active_field;
                 let rows = super::super::render::editor::auth_flat_rows(editor, config);
                 if let Some(super::super::render::editor::AuthRow::RoleHeader { role, expanded }) =
@@ -127,25 +190,9 @@ pub(super) fn handle_editor_key(
                     return Ok(InputOutcome::Continue);
                 }
             }
-            let was_secrets = editor.active_tab == EditorTab::Secrets;
-            editor.active_tab = match editor.active_tab {
-                EditorTab::General => EditorTab::Mounts,
-                EditorTab::Mounts => EditorTab::Roles,
-                EditorTab::Roles => EditorTab::Secrets,
-                EditorTab::Secrets => EditorTab::Auth,
-                EditorTab::Auth => EditorTab::General,
-            };
-            editor.active_field = FieldFocus::Row(0);
-            if editor.active_tab != EditorTab::Auth {
-                editor.auth_selected_kind = None;
-            }
-            if was_secrets {
-                reset_secrets_view(editor);
-            }
         }
+        // Left collapses role headers in Secrets/Auth tabs; no-op everywhere else.
         KeyCode::Left => {
-            // Mirror of Tab/Right above — `AgentHeader` absorbs `←`
-            // in both states (collapse or no-op).
             if editor.active_tab == EditorTab::Secrets {
                 let FieldFocus::Row(n) = editor.active_field;
                 let rows = secrets_flat_rows(editor);
@@ -168,21 +215,6 @@ pub(super) fn handle_editor_key(
                     return Ok(InputOutcome::Continue);
                 }
             }
-            let was_secrets = editor.active_tab == EditorTab::Secrets;
-            editor.active_tab = match editor.active_tab {
-                EditorTab::General => EditorTab::Auth,
-                EditorTab::Mounts => EditorTab::General,
-                EditorTab::Roles => EditorTab::Mounts,
-                EditorTab::Secrets => EditorTab::Roles,
-                EditorTab::Auth => EditorTab::Secrets,
-            };
-            editor.active_field = FieldFocus::Row(0);
-            if editor.active_tab != EditorTab::Auth {
-                editor.auth_selected_kind = None;
-            }
-            if was_secrets {
-                reset_secrets_view(editor);
-            }
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             let FieldFocus::Row(n) = editor.active_field;
@@ -199,6 +231,11 @@ pub(super) fn handle_editor_key(
                 candidate
             };
             editor.active_field = FieldFocus::Row(next);
+            editor.tab_scroll_y = super::super::render::cursor_scroll_for_panel(
+                next,
+                editor.tab_scroll_y,
+                state.cached_term_size,
+            );
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
             let FieldFocus::Row(n) = editor.active_field;
@@ -219,20 +256,44 @@ pub(super) fn handle_editor_key(
                     editor.active_field = FieldFocus::Row(candidate);
                 }
             }
+            let FieldFocus::Row(new_cursor) = editor.active_field;
+            editor.tab_scroll_y = super::super::render::cursor_scroll_for_panel(
+                new_cursor,
+                editor.tab_scroll_y,
+                state.cached_term_size,
+            );
         }
         KeyCode::Enter => match editor.active_tab {
             EditorTab::General => open_editor_field_modal(editor),
             EditorTab::Mounts => {
                 let FieldFocus::Row(n) = editor.active_field;
                 if n == editor.pending.mounts.len() {
-                    editor.modal = Some(Modal::FileBrowser {
-                        target: FileBrowserTarget::EditAddMountSrc,
-                        state: FileBrowserState::new_from_home()?,
-                    });
+                    open_add_mount_file_browser(editor);
                 }
             }
             EditorTab::Secrets => {
-                open_secrets_enter_modal(editor);
+                // For op-ref rows Enter re-opens the 1Password picker (same as P).
+                let FieldFocus::Row(n) = editor.active_field;
+                let rows = secrets_flat_rows(editor);
+                let is_op_ref = match rows.get(n) {
+                    Some(SecretsRow::WorkspaceKeyRow(key)) => editor
+                        .pending
+                        .env
+                        .get(key)
+                        .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_))),
+                    Some(SecretsRow::RoleKeyRow { role, key }) => editor
+                        .pending
+                        .roles
+                        .get(role)
+                        .and_then(|o| o.env.get(key))
+                        .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_))),
+                    _ => false,
+                };
+                if is_op_ref && op_available {
+                    open_secrets_picker_modal(editor, op_cache);
+                } else {
+                    open_secrets_enter_modal(editor);
+                }
             }
             EditorTab::Roles => {
                 let FieldFocus::Row(n) = editor.active_field;
@@ -247,6 +308,7 @@ pub(super) fn handle_editor_key(
                     Some(super::super::render::editor::AuthRow::AuthKindRow { kind }) => {
                         editor.auth_selected_kind = Some(*kind);
                         editor.active_field = FieldFocus::Row(0);
+                        editor.tab_scroll_y = 0;
                     }
                     Some(super::super::render::editor::AuthRow::AddSentinel { .. }) => {
                         super::auth::open_auth_role_picker(editor, config);
@@ -291,10 +353,7 @@ pub(super) fn handle_editor_key(
             toggle_default_agent_at_cursor(editor, config);
         }
         KeyCode::Char('a' | 'A') if editor.active_tab == EditorTab::Mounts => {
-            editor.modal = Some(Modal::FileBrowser {
-                target: FileBrowserTarget::EditAddMountSrc,
-                state: FileBrowserState::new_from_home()?,
-            });
+            open_add_mount_file_browser(editor);
         }
         KeyCode::Char('d' | 'D') if editor.active_tab == EditorTab::Mounts => {
             remove_mount_at_cursor(editor);
@@ -1610,6 +1669,20 @@ fn add_role_to_workspace_editor(editor: &mut EditorState<'_>, config: &AppConfig
     }
 }
 
+fn open_add_mount_file_browser(editor: &mut EditorState<'_>) {
+    match FileBrowserState::new_from_home() {
+        Ok(state) => {
+            editor.modal = Some(Modal::FileBrowser {
+                target: FileBrowserTarget::EditAddMountSrc,
+                state,
+            });
+        }
+        Err(e) => {
+            open_editor_action_error(editor, &e);
+        }
+    }
+}
+
 fn persist_trusted_role_add(
     editor: &mut EditorState<'_>,
     config: &mut AppConfig,
@@ -1867,6 +1940,7 @@ plugins = []
         let mut state = ManagerState::from_config(&AppConfig::default(), std::path::Path::new("/"));
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Roles;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(row);
         state.stage = ManagerStage::Editor(editor);
         state
@@ -1876,6 +1950,7 @@ plugins = []
         let mut state = ManagerState::from_config(&AppConfig::default(), std::path::Path::new("/"));
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Mounts;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(row);
         state.stage = ManagerStage::Editor(editor);
         state
@@ -1919,6 +1994,7 @@ plugins = []
     fn editor_with_browser_committed(src: &str) -> EditorState<'static> {
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         editor.active_tab = EditorTab::Mounts;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         apply_file_browser_to_editor(
             FileBrowserTarget::EditAddMountSrc,
@@ -1941,6 +2017,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         editor.active_tab = start_tab;
+        editor.tab_bar_focused = false;
         state.stage = ManagerStage::Editor(editor);
         (state, config, paths, tmp)
     }
@@ -1967,6 +2044,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, cwd);
         let mut editor = EditorState::new_create();
         editor.pending_name = Some("typo-name".into());
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
 
@@ -2022,6 +2100,7 @@ plugins = []
         let cwd = tmp.path();
         let mut state = ManagerState::from_config(&config, cwd);
         let mut editor = EditorState::new_edit("keep-me".into(), ws);
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
 
@@ -2056,6 +2135,43 @@ plugins = []
             editor.pending.mounts.len(),
             0,
             "no mount must be pushed until the operator commits in the choice modal"
+        );
+    }
+
+    #[test]
+    fn mounts_add_opens_file_browser_directly() {
+        let ws = WorkspaceConfig::default();
+        let mut state = editor_on_mounts_tab(ws, 0);
+        let mut config = AppConfig::default();
+
+        press(&mut state, &mut config, KeyCode::Char('a')).unwrap();
+
+        let ManagerStage::Editor(editor) = &state.stage else {
+            panic!("expected editor stage");
+        };
+        assert!(
+            matches!(editor.modal, Some(Modal::FileBrowser { .. })),
+            "expected FileBrowser modal; got {:?}",
+            editor.modal
+        );
+    }
+
+    #[test]
+    fn added_mount_defaults_to_shared_isolation() {
+        let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        editor.active_tab = EditorTab::Mounts;
+
+        apply_file_browser_to_editor(
+            FileBrowserTarget::EditAddMountSrc,
+            &mut editor,
+            std::path::PathBuf::from("/host/path"),
+        );
+        handle_modal(&mut editor, key(KeyCode::Char('m')));
+
+        assert_eq!(editor.pending.mounts.len(), 1);
+        assert_eq!(
+            editor.pending.mounts[0].isolation,
+            crate::isolation::MountIsolation::Shared
         );
     }
 
@@ -2121,11 +2237,11 @@ plugins = []
         assert_eq!(editor.pending.mounts.len(), 0, "`c` must not push a mount");
     }
 
-    // ── Editor Left/Right = prev/next tab ──────────────────────────────
+    // ── Editor tab navigation: Tab = forward, Left/Right = no-op on non-header rows ─────
 
     #[test]
-    fn editor_right_arrow_advances_tab() {
-        // Right should match Tab's forward cycle: General → Mounts.
+    fn editor_right_arrow_is_noop_on_non_header_row() {
+        // Right must not cycle tabs — it is an intra-area horizontal key.
         let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::General);
         handle_key(
             &mut state,
@@ -2138,12 +2254,16 @@ plugins = []
         let ManagerStage::Editor(e) = &state.stage else {
             panic!("editor stage expected");
         };
-        assert_eq!(e.active_tab, EditorTab::Mounts);
+        assert_eq!(
+            e.active_tab,
+            EditorTab::General,
+            "Right must not advance tab"
+        );
     }
 
     #[test]
-    fn editor_left_arrow_rewinds_tab() {
-        // Left implements the reverse tab cycle: Mounts → General.
+    fn editor_left_arrow_is_noop_on_non_header_row() {
+        // Left must not cycle tabs — it is an intra-area horizontal key.
         let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::Mounts);
         handle_key(
             &mut state,
@@ -2156,43 +2276,7 @@ plugins = []
         let ManagerStage::Editor(e) = &state.stage else {
             panic!("editor stage expected");
         };
-        assert_eq!(e.active_tab, EditorTab::General);
-    }
-
-    #[test]
-    fn editor_left_wraps_to_last_tab_from_first() {
-        // Match Tab's wrap contract: Left from General → Auth (last tab).
-        let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::General);
-        handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Left),
-        )
-        .unwrap();
-        let ManagerStage::Editor(e) = &state.stage else {
-            panic!("editor stage expected");
-        };
-        assert_eq!(e.active_tab, EditorTab::Auth);
-    }
-
-    #[test]
-    fn editor_right_wraps_to_first_tab_from_last() {
-        // Match Tab's wrap contract: Right from Auth (last tab) → General.
-        let (mut state, mut config, paths, tmp) = editor_state_on_tab(EditorTab::Auth);
-        handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Right),
-        )
-        .unwrap();
-        let ManagerStage::Editor(e) = &state.stage else {
-            panic!("editor stage expected");
-        };
-        assert_eq!(e.active_tab, EditorTab::General);
+        assert_eq!(e.active_tab, EditorTab::Mounts, "Left must not rewind tab");
     }
 
     // ── Roles tab: `*` default-toggle binding ───────────────────────
@@ -3108,7 +3192,7 @@ plugins = []
 
         press(&mut state, &mut config, KeyCode::Char('R')).unwrap();
 
-        let ManagerStage::Editor(editor) = &state.stage else {
+        let ManagerStage::Editor(editor) = &mut state.stage else {
             panic!("editor stage expected");
         };
         let backend = TestBackend::new(80, 10);
@@ -3160,6 +3244,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0); // the only key row
         state.stage = ManagerStage::Editor(editor);
 
@@ -3213,6 +3298,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.secrets_expanded.insert("smith".into());
         // Rows: WorkspaceAddSentinel(0), SectionSpacer(1), AgentHeader(2),
         //       AgentKeyRow(3), AgentAddSentinel(4). Focus the key row.
@@ -3255,6 +3341,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0); // the only key row
         state.stage = ManagerStage::Editor(editor);
 
@@ -3293,6 +3380,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         // Rows are alphabetically ordered: ALPHA(0), BETA(1), Sentinel(2).
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
@@ -3334,6 +3422,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
 
@@ -3384,6 +3473,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
 
@@ -3419,6 +3509,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.active_field = FieldFocus::Row(0);
         state.stage = ManagerStage::Editor(editor);
 
@@ -3431,7 +3522,7 @@ plugins = []
             key(KeyCode::Char('m')),
         )
         .unwrap();
-        // Tab to Auth → leaves Secrets.
+        // Tab from content → tab bar + advances tab to Auth (leaves Secrets).
         handle_key(
             &mut state,
             &mut config,
@@ -3440,15 +3531,14 @@ plugins = []
             key(KeyCode::Tab),
         )
         .unwrap();
-        // Tab around the wheel back to Secrets (Auth → General → Mounts →
-        // Roles → Secrets is 4 more presses).
+        // Now on tab bar (Auth). Right × 4: General → Mounts → Roles → Secrets.
         for _ in 0..4 {
             handle_key(
                 &mut state,
                 &mut config,
                 &paths,
                 tmp.path(),
-                key(KeyCode::Tab),
+                key(KeyCode::Right),
             )
             .unwrap();
         }
@@ -3491,6 +3581,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         editor.secrets_expanded.insert("smith".into());
         let role_key_row = super::super::super::render::editor::secrets_flat_rows(&editor)
             .iter()
@@ -3559,6 +3650,7 @@ plugins = []
         let mut state = ManagerState::from_config(&config, tmp.path());
         let mut editor = EditorState::new_edit("ws".into(), ws);
         editor.active_tab = EditorTab::Secrets;
+        editor.tab_bar_focused = false;
         // Rows with no workspace env keys + one collapsed role section:
         //   0 WorkspaceAddSentinel
         //   1 SectionSpacer

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -1,70 +1,187 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use super::super::render::global_mounts::{SettingsEnvRow, settings_env_flat_rows};
 use super::super::state::{
-    GlobalMountConfirm, GlobalMountDraft, GlobalMountModal, GlobalMountTextTarget, ManagerStage,
-    ManagerState, Toast, ToastKind,
+    AuthFormFocus, AuthFormReturnPath, AuthFormTarget, GlobalMountConfirm, GlobalMountDraft,
+    GlobalMountModal, GlobalMountTextTarget, ManagerStage, ManagerState, SettingsAuthModal,
+    SettingsEnvConfirm, SettingsEnvModal, SettingsEnvScope, SettingsEnvTextTarget, SettingsTab,
+    Toast, ToastKind,
 };
+use crate::config::AppConfig;
+use crate::console::widgets::ModalOutcome;
+use crate::console::widgets::auth_panel::{AuthForm, CredentialInput};
+use crate::console::widgets::confirm::ConfirmState;
+use crate::console::widgets::file_browser::FileBrowserState;
+use crate::console::widgets::role_picker::RolePickerState;
+use crate::console::widgets::text_input::TextInputState;
+use crate::paths::JackinPaths;
+use crate::selector::RoleSelector;
+use crate::workspace::{MountConfig, resolve_path};
 
 const NO_MOUNT_SELECTED: &str = "No mount selected.";
 const MOUNT_NAME_EMPTY: &str = "Mount name cannot be empty.";
 const MOUNT_GONE: &str = "Mount no longer exists; selection was cleared.";
 const ADD_DRAFT_LOST: &str = "Add-mount draft was lost; press 'a' to start over.";
-use crate::config::AppConfig;
-use crate::console::widgets::ModalOutcome;
-use crate::console::widgets::confirm::ConfirmState;
-use crate::console::widgets::text_input::TextInputState;
-use crate::paths::JackinPaths;
-use crate::workspace::{MountConfig, resolve_path};
 
-pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEvent) {
-    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+pub(super) fn handle_settings_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
         return;
     };
+
+    // W3C ARIA Tabs: when tab_bar_focused, Left/Right cycle tabs and Tab/↓
+    // enters the content area.
+    if settings.tab_bar_focused {
+        match key.code {
+            KeyCode::Left | KeyCode::BackTab => {
+                settings.active_tab = settings.active_tab.previous();
+                return;
+            }
+            KeyCode::Right => {
+                settings.active_tab = settings.active_tab.next();
+                return;
+            }
+            KeyCode::Tab | KeyCode::Down | KeyCode::Char('j') => {
+                settings.tab_bar_focused = false;
+                return;
+            }
+            _ => {}
+        }
+        // All other keys (S, Esc, etc.) fall through to content handling.
+    }
+
+    match key.code {
+        // Right on an Environments role header expands it; Right elsewhere is
+        // intra-area and must not cycle tabs.
+        KeyCode::Right if settings.active_tab == SettingsTab::Environments => {
+            let rows = settings_env_flat_rows(settings);
+            if let Some(SettingsEnvRow::RoleHeader { role, expanded }) =
+                rows.get(settings.env.selected).cloned()
+                && !expanded
+            {
+                settings.env.expanded.insert(role);
+            }
+            return;
+        }
+        // Left on an Environments role header collapses it.
+        KeyCode::Left if settings.active_tab == SettingsTab::Environments => {
+            let rows = settings_env_flat_rows(settings);
+            if let Some(SettingsEnvRow::RoleHeader { role, expanded }) =
+                rows.get(settings.env.selected).cloned()
+                && expanded
+            {
+                settings.env.expanded.remove(&role);
+            }
+            return;
+        }
+        // Tab from content returns to tab bar and advances to next tab.
+        KeyCode::Tab => {
+            settings.tab_bar_focused = true;
+            settings.active_tab = settings.active_tab.next();
+            return;
+        }
+        // BackTab from content returns focus to tab bar without changing tab.
+        KeyCode::BackTab => {
+            settings.tab_bar_focused = true;
+            return;
+        }
+        _ => {}
+    }
+    match settings.active_tab {
+        SettingsTab::Mounts => handle_global_mounts_key(state, key),
+        SettingsTab::Environments => handle_env_key(state, key),
+        SettingsTab::Auth => handle_auth_key(state, key),
+        SettingsTab::Trust => handle_trust_key(state, key),
+    }
+}
+
+fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    // S is handled here, before `global` borrows `settings.mounts`, so
+    // `open_settings_save_preview` can receive all of `settings`.
+    if matches!(key.code, KeyCode::Char('s' | 'S')) {
+        let ManagerStage::Settings(settings) = &mut state.stage else {
+            return;
+        };
+        if has_sensitive_mount(&settings.mounts.pending) {
+            settings.mounts.modal = Some(confirm_modal(GlobalMountConfirm::Sensitive));
+        } else {
+            open_settings_save_preview(settings);
+        }
+        return;
+    }
+
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    let is_dirty = settings.is_dirty();
+    let global = &mut settings.mounts;
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
-            if global.is_dirty() {
+            if is_dirty {
                 global.modal = Some(confirm_modal(GlobalMountConfirm::Discard));
             } else {
                 state.stage = ManagerStage::List;
             }
         }
-        KeyCode::Left | KeyCode::Char('h' | 'H') => {
+        KeyCode::Char('h' | 'H') => {
             global.scroll_x = global.scroll_x.saturating_sub(8);
         }
-        KeyCode::Right | KeyCode::Char('l' | 'L') => {
+        KeyCode::Char('l' | 'L') => {
             global.scroll_x = global.scroll_x.saturating_add(8);
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
             global.selected = global.selected.saturating_sub(1);
+            global.scroll_y = super::super::render::cursor_scroll_for_panel(
+                global.selected,
+                global.scroll_y,
+                state.cached_term_size,
+            );
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
-            let max = global.pending.len().saturating_sub(1);
+            let max = global.pending.len();
             global.selected = (global.selected + 1).min(max);
+            global.scroll_y = super::super::render::cursor_scroll_for_panel(
+                global.selected,
+                global.scroll_y,
+                state.cached_term_size,
+            );
+        }
+        KeyCode::Enter if global.selected == global.pending.len() => {
+            open_global_mount_scope_picker(global);
         }
         KeyCode::Char('a' | 'A') => {
-            global.add_draft = Some(GlobalMountDraft::default());
-            global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
+            open_global_mount_scope_picker(global);
         }
-        KeyCode::Char('s' | 'S') => {
-            let action = if has_sensitive_mount(&global.pending) {
-                GlobalMountConfirm::Sensitive
-            } else {
-                GlobalMountConfirm::Save
-            };
-            global.modal = Some(confirm_modal(action));
-        }
+        // S is handled before the match (early-return above) so `open_settings_save_preview`
+        // can receive all of `settings` without conflicting with the `global` borrow.
         KeyCode::Char('d' | 'D') => {
             if global.pending.is_empty() {
                 set_toast(state, "Nothing to remove.", ToastKind::Error);
-            } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
+            } else {
                 global.modal = Some(confirm_modal(GlobalMountConfirm::Remove));
             }
         }
         KeyCode::Char('r' | 'R') => {
             if let Some(row) = global.pending.get_mut(global.selected) {
                 row.mount.readonly = !row.mount.readonly;
-            } else {
-                set_toast(state, NO_MOUNT_SELECTED, ToastKind::Error);
+            }
+        }
+        KeyCode::Char('o' | 'O') => {
+            if let Some(row) = global.pending.get(global.selected) {
+                match super::super::mount_info::inspect(&row.mount.src) {
+                    super::super::mount_info::MountKind::Git {
+                        origin: Some(super::super::mount_info::GitOrigin::Github { web_url, .. }),
+                        ..
+                    } => {
+                        if let Err(err) = open::that_detached(&web_url) {
+                            global.error = Some(format!("failed to open URL: {err}"));
+                        }
+                    }
+                    super::super::mount_info::MountKind::Git { .. }
+                    | super::super::mount_info::MountKind::Folder
+                    | super::super::mount_info::MountKind::Missing => {
+                        global.error = Some("no GitHub URL for this mount".into());
+                    }
+                }
             }
         }
         KeyCode::Char('n' | 'N') => open_edit_text(state, GlobalMountTextTarget::Rename),
@@ -75,66 +192,797 @@ pub(super) fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEve
     }
 }
 
-pub(super) fn handle_global_mounts_modal(
-    global: &mut super::super::state::GlobalMountsState<'_>,
-    config: &mut AppConfig,
-    paths: &JackinPaths,
-    key: KeyEvent,
+fn handle_env_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    let op_cache = state.op_cache.clone();
+    let op_available = state.op_available;
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
+            if settings.is_dirty() {
+                settings.mounts.modal = Some(confirm_modal(GlobalMountConfirm::Discard));
+            } else {
+                state.stage = ManagerStage::List;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k' | 'K') => {
+            let rows = settings_env_flat_rows(settings);
+            settings.env.selected =
+                step_settings_env_cursor_up(&rows, settings.env.selected.saturating_sub(1));
+            settings.env.scroll_y = super::super::render::cursor_scroll_for_panel(
+                settings.env.selected,
+                settings.env.scroll_y,
+                state.cached_term_size,
+            );
+        }
+        KeyCode::Down | KeyCode::Char('j' | 'J') => {
+            let rows = settings_env_flat_rows(settings);
+            let max = rows.len().saturating_sub(1);
+            let candidate = (settings.env.selected + 1).min(max);
+            settings.env.selected = step_settings_env_cursor_down(&rows, candidate, max);
+            settings.env.scroll_y = super::super::render::cursor_scroll_for_panel(
+                settings.env.selected,
+                settings.env.scroll_y,
+                state.cached_term_size,
+            );
+        }
+        KeyCode::Char('a' | 'A') => {
+            open_settings_env_add_modal(settings);
+        }
+        KeyCode::Char('s' | 'S') => {
+            open_settings_save_preview(settings);
+        }
+        KeyCode::Char('d' | 'D') if (key.modifiers - KeyModifiers::SHIFT).is_empty() => {
+            open_settings_env_delete_confirm(settings);
+        }
+        KeyCode::Char('m' | 'M') if (key.modifiers - KeyModifiers::SHIFT).is_empty() => {
+            toggle_settings_env_mask(settings);
+        }
+        KeyCode::Char('p' | 'P')
+            if (key.modifiers - KeyModifiers::SHIFT).is_empty() && op_available =>
+        {
+            open_settings_env_picker_modal(settings, op_cache);
+        }
+        KeyCode::Enter => {
+            // For op-ref rows Enter re-opens the 1Password picker (same as P).
+            // W3C rule: Enter = action/activate; op-ref rows open the picker.
+            let rows = settings_env_flat_rows(settings);
+            let is_op_ref = matches!(
+                rows.get(settings.env.selected),
+                Some(SettingsEnvRow::Key { scope, key })
+                    if settings_env_value(&settings.env, scope, key)
+                        .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            );
+            if is_op_ref && op_available {
+                open_settings_env_picker_modal(settings, op_cache);
+            } else {
+                open_settings_env_enter_modal(settings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn step_settings_env_cursor_down(rows: &[SettingsEnvRow], candidate: usize, max: usize) -> usize {
+    let mut idx = candidate;
+    while idx <= max {
+        match rows.get(idx) {
+            Some(SettingsEnvRow::SectionSpacer) => idx += 1,
+            _ => return idx,
+        }
+    }
+    candidate
+}
+
+fn step_settings_env_cursor_up(rows: &[SettingsEnvRow], candidate: usize) -> usize {
+    let mut idx = candidate;
+    loop {
+        match rows.get(idx) {
+            Some(SettingsEnvRow::SectionSpacer) => {
+                if idx == 0 {
+                    return 0;
+                }
+                idx -= 1;
+            }
+            _ => return idx,
+        }
+    }
+}
+
+fn handle_auth_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
+            if settings.auth.selected_kind.is_some() {
+                settings.auth.selected_kind = None;
+                settings.auth.selected = 0;
+            } else if settings.is_dirty() {
+                settings.mounts.modal = Some(confirm_modal(GlobalMountConfirm::Discard));
+            } else {
+                state.stage = ManagerStage::List;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k' | 'K') => {
+            settings.auth.selected = settings.auth.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j' | 'J') => {
+            let max = settings_auth_row_count(&settings.auth).saturating_sub(1);
+            settings.auth.selected = (settings.auth.selected + 1).min(max);
+        }
+        KeyCode::Enter => {
+            if settings.auth.selected_kind.is_none() {
+                if let Some(row) = settings.auth.pending.get(settings.auth.selected) {
+                    settings.auth.selected_kind = Some(row.kind);
+                    settings.auth.selected = 0;
+                }
+            } else {
+                open_settings_auth_form(&mut settings.auth, &settings.env);
+            }
+        }
+        KeyCode::Char('s' | 'S') => {
+            open_settings_save_preview(settings);
+        }
+        _ => {}
+    }
+}
+
+fn settings_auth_row_count(auth: &super::super::state::SettingsAuthState) -> usize {
+    let Some(kind) = auth.selected_kind else {
+        return auth.pending.len();
+    };
+    let Some(row) = auth.pending.iter().find(|row| row.kind == kind) else {
+        return 0;
+    };
+    if kind.required_env_var(row.mode).is_some() {
+        2
+    } else {
+        1
+    }
+}
+
+fn open_settings_auth_form(
+    auth: &mut super::super::state::SettingsAuthState,
+    env: &super::super::state::SettingsEnvState<'_>,
 ) {
-    let Some(mut modal) = global.modal.take() else {
+    let Some(kind) = auth.selected_kind else {
+        return;
+    };
+    let Some(row) = auth.pending.iter().find(|row| row.kind == kind) else {
+        return;
+    };
+    let existing_credential = kind
+        .required_env_var(row.mode)
+        .and_then(|name| match kind {
+            crate::console::manager::auth_kind::AuthKind::Github => auth.github_env.get(name),
+            crate::console::manager::auth_kind::AuthKind::Claude
+            | crate::console::manager::auth_kind::AuthKind::Codex
+            | crate::console::manager::auth_kind::AuthKind::Amp => env.pending.env.get(name),
+        })
+        .cloned();
+    let form = AuthForm::from_existing(kind, row.mode, existing_credential);
+    let literal_buffer = if let CredentialInput::Literal(s) = &form.credential {
+        s.clone()
+    } else {
+        String::new()
+    };
+    auth.modal = Some(SettingsAuthModal::AuthForm {
+        target: AuthFormTarget::Workspace { kind },
+        state: Box::new(form),
+        focus: AuthFormFocus::Mode,
+        literal_buffer,
+    });
+}
+
+#[allow(clippy::too_many_lines)]
+pub(super) fn handle_settings_auth_modal(
+    auth: &mut super::super::state::SettingsAuthState,
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    key: KeyEvent,
+    op_available: bool,
+    op_cache: std::rc::Rc<std::cell::RefCell<crate::console::op_cache::OpCache>>,
+) {
+    let Some(mut modal) = auth.modal.take() else {
         return;
     };
     match &mut modal {
-        GlobalMountModal::Text { target, state } => match state.handle_key(key) {
-            ModalOutcome::Commit(value) => commit_text(global, target, &value),
-            ModalOutcome::Cancel => {
-                if global.add_draft.take().is_some() {
-                    global.error = Some("Add mount cancelled.".to_string());
+        SettingsAuthModal::AuthForm {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        } => {
+            if key.code == KeyCode::Esc {
+                auth.pending_auth_form_return = None;
+                return;
+            }
+            match *focus {
+                AuthFormFocus::Mode => match key.code {
+                    KeyCode::Char(' ') => cycle_auth_form_mode(state),
+                    // Down/j moves within the field area; Tab crosses into the button area.
+                    // No credential row: Down is a no-op at the bottom of the field area.
+                    KeyCode::Down | KeyCode::Char('j') if state.shows_credential_block() => {
+                        *focus = AuthFormFocus::CredentialSource;
+                    }
+                    KeyCode::Tab => {
+                        *focus = if state.shows_credential_block() {
+                            AuthFormFocus::CredentialSource
+                        } else {
+                            AuthFormFocus::Save
+                        };
+                    }
+                    KeyCode::BackTab => *focus = AuthFormFocus::Reset,
+                    _ => {}
+                },
+                AuthFormFocus::CredentialSource => match key.code {
+                    KeyCode::Enter => {
+                        let Some(env_var) = state.mode.and_then(|m| state.kind.required_env_var(m))
+                        else {
+                            auth.modal = Some(modal);
+                            return;
+                        };
+                        auth.pending_auth_form_return = Some(AuthFormReturnPath {
+                            target: target.clone(),
+                            state: std::mem::replace(state, Box::new(AuthForm::new(state.kind))),
+                            focus: *focus,
+                            literal_buffer: literal_buffer.clone(),
+                        });
+                        auth.modal = Some(SettingsAuthModal::SourcePicker {
+                            state: crate::console::widgets::source_picker::SourcePickerState::new(
+                                env_var.to_string(),
+                                op_available,
+                            ),
+                        });
+                        return;
+                    }
+                    // Down/j is a no-op at the bottom of the field area; Tab crosses to button area.
+                    KeyCode::Tab => {
+                        *focus = AuthFormFocus::Save;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
+                        *focus = AuthFormFocus::Mode;
+                    }
+                    _ => {}
+                },
+                AuthFormFocus::Save => match key.code {
+                    KeyCode::Right | KeyCode::Tab => *focus = AuthFormFocus::Cancel,
+                    // Up is a no-op at the top of the button area; BackTab crosses back to field area.
+                    KeyCode::BackTab => {
+                        *focus = if state.shows_credential_block() {
+                            AuthFormFocus::CredentialSource
+                        } else {
+                            AuthFormFocus::Mode
+                        };
+                    }
+                    KeyCode::Enter if state.can_save() => {
+                        persist_settings_auth_form(auth, env, state);
+                        return;
+                    }
+                    _ => {}
+                },
+                AuthFormFocus::Cancel => match key.code {
+                    KeyCode::Left | KeyCode::BackTab => *focus = AuthFormFocus::Save,
+                    KeyCode::Right | KeyCode::Tab => *focus = AuthFormFocus::Reset,
+                    KeyCode::Enter => return,
+                    _ => {}
+                },
+                AuthFormFocus::Reset => match key.code {
+                    KeyCode::Left | KeyCode::BackTab => *focus = AuthFormFocus::Cancel,
+                    // Tab wraps the cycle back to the first field; Right stays on the button row.
+                    KeyCode::Tab => *focus = AuthFormFocus::Mode,
+                    KeyCode::Enter => {
+                        clear_settings_auth_kind(auth, env, target);
+                        return;
+                    }
+                    _ => {}
+                },
+            }
+            auth.modal = Some(modal);
+        }
+        SettingsAuthModal::SourcePicker { state } => {
+            use crate::console::widgets::source_picker::SourceChoice;
+            match state.handle_key(key) {
+                ModalOutcome::Commit(SourceChoice::Plain) => {
+                    let literal = auth
+                        .pending_auth_form_return
+                        .as_ref()
+                        .map(|return_path| return_path.literal_buffer.clone())
+                        .unwrap_or_default();
+                    auth.modal = Some(SettingsAuthModal::TextInput {
+                        state: Box::new(TextInputState::new("Credential", literal)),
+                    });
+                }
+                ModalOutcome::Commit(SourceChoice::Op) => {
+                    auth.modal = Some(SettingsAuthModal::OpPicker {
+                        state: Box::new(
+                            crate::console::widgets::op_picker::OpPickerState::new_with_cache(
+                                op_cache,
+                            ),
+                        ),
+                    });
+                }
+                ModalOutcome::Cancel => restore_settings_auth_form(auth),
+                ModalOutcome::Continue => auth.modal = Some(modal),
+            }
+        }
+        SettingsAuthModal::TextInput { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(value) => {
+                if let Some(AuthFormReturnPath {
+                    target, mut state, ..
+                }) = auth.pending_auth_form_return.take()
+                {
+                    state.set_literal(value.clone());
+                    auth.modal = Some(SettingsAuthModal::AuthForm {
+                        target,
+                        state,
+                        focus: AuthFormFocus::Save,
+                        literal_buffer: value,
+                    });
                 }
             }
-            ModalOutcome::Continue => global.modal = Some(modal),
+            ModalOutcome::Cancel => restore_settings_auth_form(auth),
+            ModalOutcome::Continue => auth.modal = Some(modal),
         },
-        GlobalMountModal::Confirm { action, state } => match state.handle_key(key) {
-            ModalOutcome::Commit(true) => commit_confirm(global, *action, config, paths),
-            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {
-                if matches!(action, GlobalMountConfirm::Sensitive) {
-                    global.error = Some("Save aborted: sensitive paths not confirmed.".into());
+        SettingsAuthModal::OpPicker { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(op_ref) => {
+                if let Some(AuthFormReturnPath {
+                    target,
+                    mut state,
+                    literal_buffer,
+                    ..
+                }) = auth.pending_auth_form_return.take()
+                {
+                    match state.try_commit_op_ref(&crate::operator_env::OpCli::new(), op_ref) {
+                        Ok(()) => {
+                            auth.modal = Some(SettingsAuthModal::AuthForm {
+                                target,
+                                state,
+                                focus: AuthFormFocus::Save,
+                                literal_buffer,
+                            });
+                        }
+                        Err(err) => {
+                            auth.error = Some(format!("1Password read failed: {err}"));
+                        }
+                    }
                 }
             }
-            ModalOutcome::Continue => global.modal = Some(modal),
+            ModalOutcome::Cancel => restore_settings_auth_form(auth),
+            ModalOutcome::Continue => auth.modal = Some(modal),
         },
     }
 }
 
-fn commit_confirm(
-    global: &mut super::super::state::GlobalMountsState<'_>,
+fn cycle_auth_form_mode(form: &mut AuthForm) {
+    let modes = form.available_modes();
+    if modes.is_empty() {
+        return;
+    }
+    let next = form.mode.map_or(modes[0], |current| {
+        let idx = modes.iter().position(|mode| *mode == current).unwrap_or(0);
+        modes[(idx + 1) % modes.len()]
+    });
+    form.set_mode(next);
+}
+
+fn restore_settings_auth_form(auth: &mut super::super::state::SettingsAuthState) {
+    if let Some(AuthFormReturnPath {
+        target,
+        state,
+        focus,
+        literal_buffer,
+    }) = auth.pending_auth_form_return.take()
+    {
+        auth.modal = Some(SettingsAuthModal::AuthForm {
+            target,
+            state,
+            focus,
+            literal_buffer,
+        });
+    }
+}
+
+fn persist_settings_auth_form(
+    auth: &mut super::super::state::SettingsAuthState,
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    form: &AuthForm,
+) {
+    let Some(outcome) = form.commit() else {
+        return;
+    };
+    if let Some(row) = auth.pending.iter_mut().find(|row| row.kind == form.kind) {
+        row.mode = outcome.mode;
+    }
+    if let (Some(name), Some(value)) = (outcome.env_var_name, outcome.env_value) {
+        match form.kind {
+            crate::console::manager::auth_kind::AuthKind::Github => {
+                auth.github_env.insert(name.to_string(), value);
+            }
+            crate::console::manager::auth_kind::AuthKind::Claude
+            | crate::console::manager::auth_kind::AuthKind::Codex
+            | crate::console::manager::auth_kind::AuthKind::Amp => {
+                env.pending.env.insert(name.to_string(), value);
+            }
+        }
+    }
+    auth.selected = auth
+        .selected
+        .min(settings_auth_row_count(auth).saturating_sub(1));
+}
+
+fn clear_settings_auth_kind(
+    auth: &mut super::super::state::SettingsAuthState,
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    target: &AuthFormTarget,
+) {
+    let AuthFormTarget::Workspace { kind } = target else {
+        return;
+    };
+    if let Some(row) = auth.pending.iter_mut().find(|row| row.kind == *kind) {
+        row.mode = crate::console::manager::auth_kind::AuthMode::Sync;
+    }
+    for mode in kind.supported_modes() {
+        if let Some(env_var) = kind.required_env_var(*mode) {
+            match kind {
+                crate::console::manager::auth_kind::AuthKind::Github => {
+                    auth.github_env.remove(env_var);
+                }
+                crate::console::manager::auth_kind::AuthKind::Claude
+                | crate::console::manager::auth_kind::AuthKind::Codex
+                | crate::console::manager::auth_kind::AuthKind::Amp => {
+                    env.pending.env.remove(env_var);
+                }
+            }
+        }
+    }
+}
+
+fn handle_trust_key(state: &mut ManagerState<'_>, key: KeyEvent) {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    let trust = &mut settings.trust;
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
+            if settings.is_dirty() {
+                settings.mounts.modal = Some(confirm_modal(GlobalMountConfirm::Discard));
+            } else {
+                state.stage = ManagerStage::List;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k' | 'K') => {
+            trust.selected = trust.selected.saturating_sub(1);
+            trust.scroll_y = super::super::render::cursor_scroll_for_panel(
+                trust.selected,
+                trust.scroll_y,
+                state.cached_term_size,
+            );
+        }
+        KeyCode::Down | KeyCode::Char('j' | 'J') => {
+            trust.selected = (trust.selected + 1).min(trust.pending.len().saturating_sub(1));
+            trust.scroll_y = super::super::render::cursor_scroll_for_panel(
+                trust.selected,
+                trust.scroll_y,
+                state.cached_term_size,
+            );
+        }
+        KeyCode::Char('h' | 'H') => {
+            trust.scroll_x = trust.scroll_x.saturating_sub(8);
+        }
+        KeyCode::Char('l' | 'L') => {
+            trust.scroll_x = trust.scroll_x.saturating_add(8);
+        }
+        // Space is the W3C toggle key (checkbox/switch pattern). Enter is for actions.
+        KeyCode::Char(' ') => {
+            if let Some(row) = trust.pending.get_mut(trust.selected) {
+                row.trusted = !row.trusted;
+            }
+        }
+        KeyCode::Char('s' | 'S') => {
+            open_settings_save_preview(settings);
+        }
+        _ => {}
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub(super) fn handle_settings_confirm_modal(
+    settings: &mut super::super::state::SettingsState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+    key: KeyEvent,
+) {
+    let Some(mut modal) = settings.mounts.modal.take() else {
+        return;
+    };
+    match &mut modal {
+        GlobalMountModal::Text { target, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(value) => commit_text(&mut settings.mounts, target, &value),
+            ModalOutcome::Cancel => {
+                if settings.mounts.add_draft.take().is_some() {
+                    settings.mounts.error = Some("Add mount cancelled.".to_string());
+                }
+            }
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+        GlobalMountModal::FileBrowser { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(path) => {
+                let src = path.display().to_string();
+                if let Some(draft) = settings.mounts.add_draft.as_mut() {
+                    draft.src.clone_from(&src);
+                }
+                settings.mounts.modal = Some(GlobalMountModal::MountDstChoice {
+                    state: crate::console::widgets::mount_dst_choice::MountDstChoiceState::new(src),
+                });
+            }
+            ModalOutcome::Cancel => {
+                settings.mounts.add_draft = None;
+            }
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+        GlobalMountModal::MountDstChoice { state } => {
+            use crate::console::widgets::mount_dst_choice::MountDstChoice;
+            let src = state.src.clone();
+            match state.handle_key(key) {
+                ModalOutcome::Commit(MountDstChoice::SamePath) => {
+                    if let Some(draft) = settings.mounts.add_draft.as_mut() {
+                        draft.dst = src;
+                    }
+                    finalize_global_mount_add(&mut settings.mounts);
+                }
+                ModalOutcome::Commit(MountDstChoice::Edit) => {
+                    if let Some(draft) = settings.mounts.add_draft.as_mut() {
+                        draft.dst.clone_from(&src);
+                    }
+                    settings.mounts.modal = Some(text_modal(
+                        GlobalMountTextTarget::AddDestination,
+                        "Destination",
+                        &src,
+                    ));
+                }
+                ModalOutcome::Cancel => {
+                    settings.mounts.add_draft = None;
+                }
+                ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+            }
+        }
+        GlobalMountModal::ScopePicker { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(choice) => commit_add_scope_choice(settings, choice),
+            ModalOutcome::Cancel => {
+                if settings.mounts.add_draft.take().is_some() {
+                    settings.mounts.error = Some("Add mount cancelled.".to_string());
+                }
+            }
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+        GlobalMountModal::RolePicker { state: picker } => match picker.handle_key(key) {
+            ModalOutcome::Commit(role) => {
+                if let Some(draft) = settings.mounts.add_draft.as_mut() {
+                    draft.scope = Some(role.key());
+                    open_global_mount_file_browser(&mut settings.mounts);
+                } else {
+                    settings.mounts.error = Some(ADD_DRAFT_LOST.into());
+                }
+            }
+            ModalOutcome::Cancel => {
+                if settings.mounts.add_draft.take().is_some() {
+                    settings.mounts.error = Some("Add mount cancelled.".to_string());
+                }
+            }
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+        GlobalMountModal::Confirm { action, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => commit_settings_confirm(settings, *action, config, paths),
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {
+                if matches!(action, GlobalMountConfirm::Sensitive) {
+                    settings.mounts.error =
+                        Some("Save aborted: sensitive paths not confirmed.".into());
+                }
+            }
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+        GlobalMountModal::PreviewSave { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(_) => commit_settings_save(settings, config, paths),
+            ModalOutcome::Cancel => {} // modal already taken; don't put back
+            ModalOutcome::Continue => settings.mounts.modal = Some(modal),
+        },
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+pub(super) fn handle_settings_env_modal(
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    key: KeyEvent,
+    op_cache: std::rc::Rc<std::cell::RefCell<crate::console::op_cache::OpCache>>,
+) {
+    let Some(mut modal) = env.modal.take() else {
+        return;
+    };
+    match &mut modal {
+        SettingsEnvModal::Text { target, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(value) => commit_env_text(env, target, &value),
+            ModalOutcome::Cancel => {
+                env.pending_env_key = None;
+                env.pending_picker_value = None;
+                env.error = Some("Env edit cancelled.".to_string());
+            }
+            ModalOutcome::Continue => env.modal = Some(modal),
+        },
+        SettingsEnvModal::SourcePicker { state: source } => {
+            use crate::console::widgets::source_picker::SourceChoice;
+            match source.handle_key(key) {
+                ModalOutcome::Commit(SourceChoice::Plain) => {
+                    let Some((scope, key)) = env.pending_env_key.clone() else {
+                        env.modal = None;
+                        return;
+                    };
+                    env.modal = Some(env_text_modal(
+                        SettingsEnvTextTarget::EnvValue {
+                            scope,
+                            key: key.clone(),
+                        },
+                        &format!("Value for {key}"),
+                        "",
+                    ));
+                }
+                ModalOutcome::Commit(SourceChoice::Op) => {
+                    let Some((scope, key)) = env.pending_env_key.clone() else {
+                        env.modal = None;
+                        return;
+                    };
+                    env.pending_picker_target = Some((scope, Some(key)));
+                    env.pending_env_key = None;
+                    env.modal = Some(SettingsEnvModal::OpPicker {
+                        state: Box::new(
+                            crate::console::widgets::op_picker::OpPickerState::new_with_cache(
+                                op_cache,
+                            ),
+                        ),
+                    });
+                }
+                ModalOutcome::Cancel => {
+                    env.modal = None;
+                    env.pending_env_key = None;
+                    env.pending_picker_value = None;
+                }
+                ModalOutcome::Continue => env.modal = Some(modal),
+            }
+        }
+        SettingsEnvModal::OpPicker { state: picker } => match picker.handle_key(key) {
+            ModalOutcome::Commit(op_ref) => {
+                let target = env.pending_picker_target.take();
+                match target {
+                    Some((scope, Some(key))) => {
+                        set_settings_env_value_typed(
+                            env,
+                            &scope,
+                            &key,
+                            crate::operator_env::EnvValue::OpRef(op_ref),
+                        );
+                        env.modal = None;
+                    }
+                    Some((scope, None)) => {
+                        env.pending_picker_value =
+                            Some(crate::operator_env::EnvValue::OpRef(op_ref));
+                        let label = format!(
+                            "New environment key for {}",
+                            settings_env_scope_label(&scope)
+                        );
+                        let state = settings_env_key_input_state(env, &scope, label, "");
+                        env.modal = Some(SettingsEnvModal::Text {
+                            target: SettingsEnvTextTarget::EnvKey { scope },
+                            state: Box::new(state),
+                        });
+                    }
+                    None => env.modal = None,
+                }
+            }
+            ModalOutcome::Cancel => {
+                env.modal = None;
+                env.pending_picker_target = None;
+                env.pending_picker_value = None;
+            }
+            ModalOutcome::Continue => env.modal = Some(modal),
+        },
+        SettingsEnvModal::RolePicker { state: picker } => match picker.handle_key(key) {
+            ModalOutcome::Commit(role) => {
+                let role_key = role.key();
+                let scope = SettingsEnvScope::Role(role_key.clone());
+                let state = settings_env_key_input_state(
+                    env,
+                    &scope,
+                    format!("New {role_key} environment key"),
+                    "",
+                );
+                env.modal = Some(SettingsEnvModal::Text {
+                    target: SettingsEnvTextTarget::EnvKey { scope },
+                    state: Box::new(state),
+                });
+            }
+            ModalOutcome::Cancel => {
+                env.error = Some("Add env cancelled.".to_string());
+            }
+            ModalOutcome::Continue => env.modal = Some(modal),
+        },
+        SettingsEnvModal::ScopePicker { state } => match state.handle_key(key) {
+            ModalOutcome::Commit(choice) => match choice {
+                crate::console::widgets::scope_picker::ScopeChoice::AllAgents => {
+                    let scope = SettingsEnvScope::Global;
+                    let state =
+                        settings_env_key_input_state(env, &scope, "New global environment key", "");
+                    env.modal = Some(SettingsEnvModal::Text {
+                        target: SettingsEnvTextTarget::EnvKey { scope },
+                        state: Box::new(state),
+                    });
+                }
+                crate::console::widgets::scope_picker::ScopeChoice::SpecificAgent => {
+                    open_settings_env_role_picker(env);
+                }
+            },
+            ModalOutcome::Cancel => {
+                env.error = Some("Add env cancelled.".to_string());
+            }
+            ModalOutcome::Continue => env.modal = Some(modal),
+        },
+        SettingsEnvModal::Confirm { action, state } => match state.handle_key(key) {
+            ModalOutcome::Commit(true) => match action {
+                SettingsEnvConfirm::Delete => {
+                    delete_selected_settings_env(env);
+                }
+            },
+            ModalOutcome::Commit(false) | ModalOutcome::Cancel => {}
+            ModalOutcome::Continue => env.modal = Some(modal),
+        },
+    }
+}
+
+fn commit_settings_confirm(
+    settings: &mut super::super::state::SettingsState<'_>,
     action: GlobalMountConfirm,
     config: &mut AppConfig,
     paths: &JackinPaths,
 ) {
     match action {
         GlobalMountConfirm::Remove => {
+            let global = &mut settings.mounts;
             if global.selected < global.pending.len() {
                 global.pending.remove(global.selected);
-                global.selected = global.selected.min(global.pending.len().saturating_sub(1));
+                global.selected = global.selected.min(global.pending.len());
             }
         }
-        GlobalMountConfirm::Save => match global.save_to_config(paths) {
-            Ok(saved) => {
-                *config = saved;
-                global.success = Some("Global mounts saved.".into());
-                global.exit_requested = true;
-            }
-            Err(err) => global.error = Some(err.to_string()),
-        },
+        GlobalMountConfirm::Save => commit_settings_save(settings, config, paths),
         GlobalMountConfirm::Sensitive => {
-            global.modal = Some(confirm_modal(GlobalMountConfirm::Save));
+            open_settings_save_preview(settings);
         }
         GlobalMountConfirm::Discard => {
-            global.discard();
-            global.exit_requested = true;
+            settings.discard();
+            settings.mounts.exit_requested = true;
         }
     }
+}
+
+fn commit_settings_save(
+    settings: &mut super::super::state::SettingsState<'_>,
+    config: &mut AppConfig,
+    paths: &JackinPaths,
+) {
+    match settings.save_to_config(paths) {
+        Ok(saved) => {
+            *config = saved;
+            settings.mounts.success = Some("Settings saved.".into());
+            settings.mounts.exit_requested = true;
+        }
+        Err(err) => settings.mounts.error = Some(err.to_string()),
+    }
+}
+
+fn open_settings_save_preview(settings: &mut super::super::state::SettingsState<'_>) {
+    let lines = super::save::build_settings_save_lines(settings);
+    settings.mounts.modal = Some(super::super::state::GlobalMountModal::PreviewSave {
+        state: crate::console::widgets::confirm_save::ConfirmSaveState::new(lines),
+    });
 }
 
 fn commit_text(
@@ -144,59 +992,17 @@ fn commit_text(
 ) {
     let trimmed = value.trim();
     match target {
+        GlobalMountTextTarget::AddScope => {
+            commit_add_scope_text(global, trimmed);
+        }
         GlobalMountTextTarget::AddName => {
-            if trimmed.is_empty() {
-                global.error = Some(MOUNT_NAME_EMPTY.into());
-                global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
-                return;
-            }
-            let Some(draft) = global.add_draft.as_mut() else {
-                global.error = Some(ADD_DRAFT_LOST.into());
-                return;
-            };
-            draft.name = trimmed.to_string();
-            global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
+            commit_add_name_text(global, trimmed);
         }
         GlobalMountTextTarget::AddSource => {
-            let Some(draft) = global.add_draft.as_mut() else {
-                global.error = Some(ADD_DRAFT_LOST.into());
-                return;
-            };
-            draft.src = resolve_path(trimmed);
-            global.modal = Some(text_modal(
-                GlobalMountTextTarget::AddDestination,
-                "Destination",
-                "",
-            ));
+            commit_add_source_text(global, trimmed);
         }
         GlobalMountTextTarget::AddDestination => {
-            let Some(draft) = global.add_draft.as_mut() else {
-                global.error = Some(ADD_DRAFT_LOST.into());
-                return;
-            };
-            draft.dst = trimmed.to_string();
-            global.modal = Some(text_modal(
-                GlobalMountTextTarget::AddScope,
-                "Scope (empty = global)",
-                "",
-            ));
-        }
-        GlobalMountTextTarget::AddScope => {
-            let Some(draft) = global.add_draft.take() else {
-                global.error = Some(ADD_DRAFT_LOST.into());
-                return;
-            };
-            global.pending.push(crate::config::GlobalMountRow {
-                scope: scope_value(trimmed),
-                name: draft.name,
-                mount: MountConfig {
-                    src: draft.src,
-                    dst: draft.dst,
-                    readonly: false,
-                    isolation: crate::isolation::MountIsolation::Shared,
-                },
-            });
-            global.selected = global.pending.len().saturating_sub(1);
+            commit_add_destination_text(global, trimmed);
         }
         GlobalMountTextTarget::Source => {
             let Some(row) = global.pending.get_mut(global.selected) else {
@@ -233,10 +1039,202 @@ fn commit_text(
     }
 }
 
-fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget) {
-    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+fn commit_env_text(
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    target: &SettingsEnvTextTarget,
+    value: &str,
+) {
+    let trimmed = value.trim();
+    match target {
+        SettingsEnvTextTarget::EnvKey { scope } => {
+            if trimmed.is_empty() {
+                env.error = Some("Env key cannot be empty.".into());
+                let state = settings_env_key_input_state(env, scope, "Key cannot be empty", "");
+                env.modal = Some(SettingsEnvModal::Text {
+                    target: SettingsEnvTextTarget::EnvKey {
+                        scope: scope.clone(),
+                    },
+                    state: Box::new(state),
+                });
+                return;
+            }
+            let key = trimmed.to_string();
+            if let Some(stashed) = env.pending_picker_value.take() {
+                set_settings_env_value_typed(env, scope, &key, stashed);
+                env.pending_env_key = None;
+                return;
+            }
+            env.pending_env_key = Some((scope.clone(), key.clone()));
+            env.modal = Some(SettingsEnvModal::SourcePicker {
+                state: crate::console::widgets::source_picker::SourcePickerState::new(key, true),
+            });
+        }
+        SettingsEnvTextTarget::EnvValue { scope, key } => {
+            set_settings_env_value_typed(
+                env,
+                scope,
+                key,
+                crate::operator_env::EnvValue::Plain(value.to_string()),
+            );
+            env.pending_env_key = None;
+        }
+    }
+}
+
+fn open_settings_env_role_picker(env: &mut super::super::state::SettingsEnvState<'_>) {
+    use crate::console::widgets::role_picker::RolePickerState;
+    use crate::selector::RoleSelector;
+
+    let roles = env
+        .pending
+        .roles
+        .keys()
+        .filter_map(|role| RoleSelector::parse(role).ok())
+        .collect::<Vec<_>>();
+    if roles.is_empty() {
+        env.error = Some("No registered roles available.".into());
+        return;
+    }
+    env.modal = Some(SettingsEnvModal::RolePicker {
+        state: RolePickerState::with_confirm_label(roles, "select"),
+    });
+}
+
+fn commit_add_scope_text(global: &mut super::super::state::GlobalMountsState<'_>, value: &str) {
+    let Some(draft) = global.add_draft.as_mut() else {
+        global.error = Some(ADD_DRAFT_LOST.into());
         return;
     };
+    draft.scope = scope_value(value);
+    open_global_mount_file_browser(global);
+}
+
+fn commit_add_name_text(global: &mut super::super::state::GlobalMountsState<'_>, value: &str) {
+    if value.is_empty() {
+        global.error = Some(MOUNT_NAME_EMPTY.into());
+        global.modal = Some(text_modal(GlobalMountTextTarget::AddName, "Mount name", ""));
+        return;
+    }
+    let Some(draft) = global.add_draft.as_mut() else {
+        global.error = Some(ADD_DRAFT_LOST.into());
+        return;
+    };
+    draft.name = value.to_string();
+    global.modal = Some(text_modal(GlobalMountTextTarget::AddSource, "Source", ""));
+}
+
+fn commit_add_source_text(global: &mut super::super::state::GlobalMountsState<'_>, value: &str) {
+    let Some(draft) = global.add_draft.as_mut() else {
+        global.error = Some(ADD_DRAFT_LOST.into());
+        return;
+    };
+    draft.src = resolve_path(value);
+    global.modal = Some(text_modal(
+        GlobalMountTextTarget::AddDestination,
+        "Destination",
+        "",
+    ));
+}
+
+fn commit_add_destination_text(
+    global: &mut super::super::state::GlobalMountsState<'_>,
+    value: &str,
+) {
+    let Some(draft) = global.add_draft.as_mut() else {
+        global.error = Some(ADD_DRAFT_LOST.into());
+        return;
+    };
+    draft.dst = value.to_string();
+    finalize_global_mount_add(global);
+}
+
+fn open_global_mount_scope_picker(global: &mut super::super::state::GlobalMountsState<'_>) {
+    global.add_draft = Some(GlobalMountDraft::default());
+    global.modal = Some(scope_picker_modal());
+}
+
+fn open_global_mount_file_browser(global: &mut super::super::state::GlobalMountsState<'_>) {
+    match FileBrowserState::new_from_home() {
+        Ok(state) => {
+            global.modal = Some(GlobalMountModal::FileBrowser {
+                state: Box::new(state),
+            });
+        }
+        Err(err) => {
+            global.add_draft = None;
+            global.error = Some(err.to_string());
+        }
+    }
+}
+
+fn finalize_global_mount_add(global: &mut super::super::state::GlobalMountsState<'_>) {
+    let Some(mut draft) = global.add_draft.take() else {
+        global.error = Some(ADD_DRAFT_LOST.into());
+        return;
+    };
+    if draft.dst.trim().is_empty() {
+        global.error = Some("Mount destination cannot be empty.".into());
+        global.add_draft = Some(draft);
+        return;
+    }
+    draft.name = unique_global_mount_name(global, &draft);
+    global.pending.push(crate::config::GlobalMountRow {
+        scope: draft.scope,
+        name: draft.name,
+        mount: MountConfig {
+            src: draft.src,
+            dst: draft.dst,
+            readonly: false,
+            isolation: crate::isolation::MountIsolation::Shared,
+        },
+    });
+    global.selected = global.pending.len().saturating_sub(1);
+}
+
+fn unique_global_mount_name(
+    global: &super::super::state::GlobalMountsState<'_>,
+    draft: &GlobalMountDraft,
+) -> String {
+    let basename = std::path::Path::new(&draft.dst)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("mount");
+    let base = basename
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    let base = if base.is_empty() {
+        "mount".to_string()
+    } else {
+        base
+    };
+    let mut candidate = base.clone();
+    let mut suffix = 2;
+    while global
+        .pending
+        .iter()
+        .any(|row| row.scope == draft.scope && row.name == candidate)
+    {
+        candidate = format!("{base}-{suffix}");
+        suffix += 1;
+    }
+    candidate
+}
+
+fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget) {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    let global = &mut settings.mounts;
     let Some(row) = global.pending.get(global.selected) else {
         set_toast(state, NO_MOUNT_SELECTED, ToastKind::Error);
         return;
@@ -250,20 +1248,289 @@ fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget) {
             row.scope.clone().unwrap_or_default(),
         ),
         // Add-flow targets are driven by the four-step text wizard, not this entry point.
-        GlobalMountTextTarget::AddName
+        GlobalMountTextTarget::AddScope
+        | GlobalMountTextTarget::AddName
         | GlobalMountTextTarget::AddSource
-        | GlobalMountTextTarget::AddDestination
-        | GlobalMountTextTarget::AddScope => return,
+        | GlobalMountTextTarget::AddDestination => return,
     };
     global.modal = Some(text_modal(target, label, &initial));
+}
+
+fn open_settings_env_enter_modal(settings: &mut super::super::state::SettingsState<'_>) {
+    let rows = settings_env_flat_rows(settings);
+    let Some(row) = rows.get(settings.env.selected).cloned() else {
+        return;
+    };
+    match row {
+        SettingsEnvRow::Key { scope, key } => {
+            if settings_env_value(&settings.env, &scope, &key)
+                .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+            {
+                return;
+            }
+            let current = settings_env_value(&settings.env, &scope, &key)
+                .map(|v| v.as_persisted_str().to_string())
+                .unwrap_or_default();
+            settings.env.modal = Some(SettingsEnvModal::Text {
+                target: SettingsEnvTextTarget::EnvValue {
+                    scope,
+                    key: key.clone(),
+                },
+                state: Box::new(TextInputState::new_allow_empty(
+                    format!("Edit {key}"),
+                    current,
+                )),
+            });
+        }
+        SettingsEnvRow::GlobalAddSentinel => {
+            settings.env.modal = Some(SettingsEnvModal::ScopePicker {
+                state: crate::console::widgets::scope_picker::ScopePickerState::new(),
+            });
+        }
+        SettingsEnvRow::RoleHeader { role, expanded } => {
+            if !expanded {
+                settings.env.expanded.insert(role);
+            }
+        }
+        SettingsEnvRow::RoleAddSentinel(role) => {
+            let scope = SettingsEnvScope::Role(role.clone());
+            let label = format!("New {role} environment key");
+            let state = settings_env_key_input_state(&settings.env, &scope, label, "");
+            settings.env.modal = Some(SettingsEnvModal::Text {
+                target: SettingsEnvTextTarget::EnvKey { scope },
+                state: Box::new(state),
+            });
+        }
+        SettingsEnvRow::SectionSpacer => {}
+    }
+}
+
+fn open_settings_env_add_modal(settings: &mut super::super::state::SettingsState<'_>) {
+    let rows = settings_env_flat_rows(settings);
+    let Some(row) = rows.get(settings.env.selected).cloned() else {
+        return;
+    };
+    let (scope, label) = match row {
+        SettingsEnvRow::Key {
+            scope: SettingsEnvScope::Global,
+            ..
+        }
+        | SettingsEnvRow::GlobalAddSentinel => (
+            SettingsEnvScope::Global,
+            "New global environment key".to_string(),
+        ),
+        SettingsEnvRow::RoleHeader { role, .. }
+        | SettingsEnvRow::Key {
+            scope: SettingsEnvScope::Role(role),
+            ..
+        }
+        | SettingsEnvRow::RoleAddSentinel(role) => (
+            SettingsEnvScope::Role(role.clone()),
+            format!("New {role} environment key"),
+        ),
+        SettingsEnvRow::SectionSpacer => return,
+    };
+    let state = settings_env_key_input_state(&settings.env, &scope, label, "");
+    settings.env.modal = Some(SettingsEnvModal::Text {
+        target: SettingsEnvTextTarget::EnvKey { scope },
+        state: Box::new(state),
+    });
+}
+
+fn open_settings_env_delete_confirm(settings: &mut super::super::state::SettingsState<'_>) {
+    let rows = settings_env_flat_rows(settings);
+    let Some(SettingsEnvRow::Key { key, .. }) = rows.get(settings.env.selected).cloned() else {
+        return;
+    };
+    settings.env.modal = Some(SettingsEnvModal::Confirm {
+        action: SettingsEnvConfirm::Delete,
+        state: ConfirmState::new(format!("Delete environment variable {key}?")),
+    });
+}
+
+fn toggle_settings_env_mask(settings: &mut super::super::state::SettingsState<'_>) {
+    let rows = settings_env_flat_rows(settings);
+    let Some(SettingsEnvRow::Key { scope, key }) = rows.get(settings.env.selected).cloned() else {
+        return;
+    };
+    if settings_env_value(&settings.env, &scope, &key)
+        .is_some_and(|v| matches!(v, crate::operator_env::EnvValue::OpRef(_)))
+    {
+        return;
+    }
+    let tag = (scope, key);
+    if !settings.env.unmasked_rows.remove(&tag) {
+        settings.env.unmasked_rows.insert(tag);
+    }
+}
+
+fn open_settings_env_picker_modal(
+    settings: &mut super::super::state::SettingsState<'_>,
+    op_cache: std::rc::Rc<std::cell::RefCell<crate::console::op_cache::OpCache>>,
+) {
+    let rows = settings_env_flat_rows(settings);
+    let Some(row) = rows.get(settings.env.selected).cloned() else {
+        return;
+    };
+    let target = match row {
+        SettingsEnvRow::Key { scope, key } => Some((scope, Some(key))),
+        SettingsEnvRow::GlobalAddSentinel => Some((SettingsEnvScope::Global, None)),
+        SettingsEnvRow::RoleAddSentinel(role) => Some((SettingsEnvScope::Role(role), None)),
+        SettingsEnvRow::RoleHeader { .. } | SettingsEnvRow::SectionSpacer => None,
+    };
+    let Some(target) = target else {
+        return;
+    };
+    settings.env.pending_picker_target = Some(target);
+    settings.env.modal = Some(SettingsEnvModal::OpPicker {
+        state: Box::new(
+            crate::console::widgets::op_picker::OpPickerState::new_with_cache(op_cache),
+        ),
+    });
+}
+
+fn delete_selected_settings_env(env: &mut super::super::state::SettingsEnvState<'_>) {
+    let rows = settings_env_rows_from_env(env);
+    if let Some(SettingsEnvRow::Key { scope, key }) = rows.get(env.selected).cloned() {
+        match scope {
+            SettingsEnvScope::Global => {
+                env.pending.env.remove(&key);
+            }
+            SettingsEnvScope::Role(role) => {
+                if let Some(role_env) = env.pending.roles.get_mut(&role) {
+                    role_env.remove(&key);
+                }
+            }
+        }
+        let row_count = settings_env_rows_from_env(env).len();
+        env.selected = env.selected.min(row_count.saturating_sub(1));
+    }
+}
+
+fn settings_env_rows_from_env(
+    env: &super::super::state::SettingsEnvState<'_>,
+) -> Vec<SettingsEnvRow> {
+    let mut rows = Vec::new();
+    for key in env.pending.env.keys() {
+        rows.push(SettingsEnvRow::Key {
+            scope: SettingsEnvScope::Global,
+            key: key.clone(),
+        });
+    }
+    if !env.pending.env.is_empty() {
+        rows.push(SettingsEnvRow::SectionSpacer);
+    }
+    rows.push(SettingsEnvRow::GlobalAddSentinel);
+    for (role, role_env) in &env.pending.roles {
+        if role_env.is_empty() {
+            continue;
+        }
+        rows.push(SettingsEnvRow::SectionSpacer);
+        let expanded = env.expanded.contains(role);
+        rows.push(SettingsEnvRow::RoleHeader {
+            role: role.clone(),
+            expanded,
+        });
+        if expanded {
+            if let Some(role_env) = env.pending.roles.get(role) {
+                for key in role_env.keys() {
+                    rows.push(SettingsEnvRow::Key {
+                        scope: SettingsEnvScope::Role(role.clone()),
+                        key: key.clone(),
+                    });
+                }
+            }
+            rows.push(SettingsEnvRow::SectionSpacer);
+            rows.push(SettingsEnvRow::RoleAddSentinel(role.clone()));
+        }
+    }
+    rows
+}
+
+fn settings_env_value<'a>(
+    env: &'a super::super::state::SettingsEnvState<'_>,
+    scope: &SettingsEnvScope,
+    key: &str,
+) -> Option<&'a crate::operator_env::EnvValue> {
+    match scope {
+        SettingsEnvScope::Global => env.pending.env.get(key),
+        SettingsEnvScope::Role(role) => env
+            .pending
+            .roles
+            .get(role)
+            .and_then(|role_env| role_env.get(key)),
+    }
+}
+
+const fn settings_env_scope_label(scope: &SettingsEnvScope) -> &str {
+    match scope {
+        SettingsEnvScope::Global => "global",
+        SettingsEnvScope::Role(role) => role.as_str(),
+    }
+}
+
+fn forbidden_settings_env_keys(
+    env: &super::super::state::SettingsEnvState<'_>,
+    scope: &SettingsEnvScope,
+) -> Vec<String> {
+    match scope {
+        SettingsEnvScope::Global => env.pending.env.keys().cloned().collect(),
+        SettingsEnvScope::Role(role) => env
+            .pending
+            .roles
+            .get(role)
+            .map(|role_env| role_env.keys().cloned().collect())
+            .unwrap_or_default(),
+    }
+}
+
+fn forbidden_settings_env_label(scope: &SettingsEnvScope) -> String {
+    match scope {
+        SettingsEnvScope::Global => "global env".to_string(),
+        SettingsEnvScope::Role(role) => format!("role {role}"),
+    }
+}
+
+fn settings_env_key_input_state<'a>(
+    env: &super::super::state::SettingsEnvState<'_>,
+    scope: &SettingsEnvScope,
+    label: impl Into<String>,
+    initial: impl Into<String>,
+) -> TextInputState<'a> {
+    let mut state =
+        TextInputState::new_with_forbidden(label, initial, forbidden_settings_env_keys(env, scope));
+    state.forbidden_label = forbidden_settings_env_label(scope);
+    state
+}
+
+fn set_settings_env_value_typed(
+    env: &mut super::super::state::SettingsEnvState<'_>,
+    scope: &SettingsEnvScope,
+    key: &str,
+    value: crate::operator_env::EnvValue,
+) {
+    match scope {
+        SettingsEnvScope::Global => {
+            env.pending.env.insert(key.to_string(), value);
+        }
+        SettingsEnvScope::Role(role) => {
+            env.pending
+                .roles
+                .entry(role.clone())
+                .or_default()
+                .insert(key.to_string(), value);
+            env.expanded.insert(role.clone());
+        }
+    }
 }
 
 /// Promote pending error/success messages to toasts; pop back to the
 /// workspace list when the handler set `exit_requested`.
 pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
-    let ManagerStage::GlobalMounts(global) = &mut state.stage else {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
         return;
     };
+    let global = &mut settings.mounts;
     let error = global.error.take();
     let success = global.success.take();
     let exit = std::mem::take(&mut global.exit_requested);
@@ -277,6 +1544,19 @@ pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
     }
 }
 
+pub(super) fn after_settings_event(state: &mut ManagerState<'_>) {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return;
+    };
+    let env_error = settings.env.error.take();
+    let auth_error = settings.auth.error.take();
+    let trust_error = settings.trust.error.take();
+    if let Some(err) = env_error.or(auth_error).or(trust_error) {
+        set_toast(state, &err, ToastKind::Error);
+    }
+    after_global_mounts_event(state);
+}
+
 fn set_toast(state: &mut ManagerState<'_>, msg: &str, kind: ToastKind) {
     state.toast = Some(Toast {
         message: msg.to_string(),
@@ -287,7 +1567,7 @@ fn set_toast(state: &mut ManagerState<'_>, msg: &str, kind: ToastKind) {
 
 fn confirm_modal(action: GlobalMountConfirm) -> GlobalMountModal<'static> {
     let prompt = match action {
-        GlobalMountConfirm::Save => "Save global mounts to ~/.config/jackin/config.toml?",
+        GlobalMountConfirm::Save => "Save settings to ~/.config/jackin/config.toml?",
         GlobalMountConfirm::Sensitive => "Sensitive global mount path detected. Save anyway?",
         GlobalMountConfirm::Remove => "Remove selected global mount?",
         GlobalMountConfirm::Discard => "Discard unsaved global mount changes?",
@@ -298,6 +1578,44 @@ fn confirm_modal(action: GlobalMountConfirm) -> GlobalMountModal<'static> {
     }
 }
 
+const fn scope_picker_modal() -> GlobalMountModal<'static> {
+    GlobalMountModal::ScopePicker {
+        state: crate::console::widgets::scope_picker::ScopePickerState::with_title(
+            " Which agent role do you want to add? ",
+        ),
+    }
+}
+
+fn commit_add_scope_choice(
+    settings: &mut super::super::state::SettingsState<'_>,
+    choice: crate::console::widgets::scope_picker::ScopeChoice,
+) {
+    match choice {
+        crate::console::widgets::scope_picker::ScopeChoice::AllAgents => {
+            commit_text(&mut settings.mounts, &GlobalMountTextTarget::AddScope, "");
+        }
+        crate::console::widgets::scope_picker::ScopeChoice::SpecificAgent => {
+            open_global_mount_role_picker(settings);
+        }
+    }
+}
+
+fn open_global_mount_role_picker(settings: &mut super::super::state::SettingsState<'_>) {
+    let roles = settings
+        .trust
+        .pending
+        .iter()
+        .filter_map(|row| RoleSelector::parse(&row.role).ok())
+        .collect::<Vec<_>>();
+    if roles.is_empty() {
+        settings.mounts.error = Some("No registered roles available.".into());
+        return;
+    }
+    settings.mounts.modal = Some(GlobalMountModal::RolePicker {
+        state: RolePickerState::with_confirm_label(roles, "select"),
+    });
+}
+
 fn text_modal(
     target: GlobalMountTextTarget,
     label: &str,
@@ -306,6 +1624,22 @@ fn text_modal(
     GlobalMountModal::Text {
         target,
         state: Box::new(TextInputState::new(label, initial)),
+    }
+}
+
+fn env_text_modal(
+    target: SettingsEnvTextTarget,
+    label: &str,
+    initial: &str,
+) -> SettingsEnvModal<'static> {
+    let state = if matches!(target, SettingsEnvTextTarget::EnvValue { .. }) {
+        TextInputState::new_allow_empty(label, initial)
+    } else {
+        TextInputState::new(label, initial)
+    };
+    SettingsEnvModal::Text {
+        target,
+        state: Box::new(state),
     }
 }
 
@@ -324,7 +1658,14 @@ fn has_sensitive_mount(rows: &[crate::config::GlobalMountRow]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::state::{
+        ManagerStage, ManagerState, SettingsEnvModal, SettingsEnvTextTarget, SettingsState,
+        SettingsTab,
+    };
+    use super::super::test_support::key;
     use super::*;
+    use crate::config::RoleSource;
+    use std::collections::BTreeMap;
 
     #[test]
     fn global_mount_save_detects_sensitive_sources() {
@@ -340,5 +1681,304 @@ mod tests {
         }];
 
         assert!(has_sensitive_mount(&rows));
+    }
+
+    #[test]
+    fn add_flow_asks_scope_before_workspace_mount_flow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        state.stage = ManagerStage::Settings(SettingsState::from_config(&config));
+
+        handle_settings_key(&mut state, key(KeyCode::Char('a')));
+        let ManagerStage::Settings(settings) = &mut state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(matches!(
+            settings.mounts.modal,
+            Some(GlobalMountModal::ScopePicker { .. })
+        ));
+
+        handle_settings_confirm_modal(settings, &mut config, &paths, key(KeyCode::Enter));
+        assert!(matches!(
+            settings.mounts.modal,
+            Some(GlobalMountModal::FileBrowser { .. })
+        ));
+    }
+
+    #[test]
+    fn add_flow_specific_scope_uses_shared_role_picker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        config.roles.insert(
+            "agent-smith".into(),
+            RoleSource {
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".into(),
+                trusted: true,
+                env: BTreeMap::new(),
+            },
+        );
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        state.stage = ManagerStage::Settings(SettingsState::from_config(&config));
+
+        handle_settings_key(&mut state, key(KeyCode::Char('a')));
+        let ManagerStage::Settings(settings) = &mut state.stage else {
+            panic!("expected settings stage");
+        };
+        let Some(GlobalMountModal::ScopePicker { state: picker }) = settings.mounts.modal.as_mut()
+        else {
+            panic!("expected scope picker");
+        };
+        picker.focused = crate::console::widgets::scope_picker::ScopeChoice::SpecificAgent;
+        handle_settings_confirm_modal(settings, &mut config, &paths, key(KeyCode::Enter));
+        assert!(matches!(
+            settings.mounts.modal,
+            Some(GlobalMountModal::RolePicker { .. })
+        ));
+
+        handle_settings_confirm_modal(settings, &mut config, &paths, key(KeyCode::Enter));
+        assert!(matches!(
+            settings.mounts.modal,
+            Some(GlobalMountModal::FileBrowser { .. })
+        ));
+        assert_eq!(
+            settings
+                .mounts
+                .add_draft
+                .as_ref()
+                .and_then(|draft| draft.scope.as_deref()),
+            Some("agent-smith")
+        );
+    }
+
+    #[test]
+    fn settings_tab_navigation_reaches_all_config_tabs() {
+        // W3C ARIA Tabs: Right cycles tabs when the tab bar has focus.
+        let tmp = tempfile::tempdir().unwrap();
+        let config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        state.stage = ManagerStage::Settings(SettingsState::from_config(&config));
+        // Settings opens with tab_bar_focused = true; Right cycles forward.
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(s) if s.tab_bar_focused),
+            "must start on tab bar"
+        );
+
+        handle_settings_key(&mut state, key(KeyCode::Right));
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(settings) if settings.active_tab == SettingsTab::Environments)
+        );
+        handle_settings_key(&mut state, key(KeyCode::Right));
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(settings) if settings.active_tab == SettingsTab::Auth)
+        );
+        handle_settings_key(&mut state, key(KeyCode::Right));
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(settings) if settings.active_tab == SettingsTab::Trust)
+        );
+        handle_settings_key(&mut state, key(KeyCode::Right));
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(settings) if settings.active_tab == SettingsTab::Mounts)
+        );
+    }
+
+    #[test]
+    fn trust_tab_space_toggles_trusted_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = AppConfig::default();
+        config.roles.insert(
+            "agent-smith".into(),
+            RoleSource {
+                git: "https://github.com/jackin-project/jackin-agent-smith.git".into(),
+                trusted: true,
+                env: BTreeMap::new(),
+            },
+        );
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.active_tab = SettingsTab::Trust;
+        settings.tab_bar_focused = false;
+        state.stage = ManagerStage::Settings(settings);
+
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(settings.trust.pending[0].trusted);
+
+        handle_settings_key(&mut state, key(KeyCode::Char(' ')));
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(!settings.trust.pending[0].trusted);
+
+        handle_settings_key(&mut state, key(KeyCode::Char(' ')));
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(settings.trust.pending[0].trusted);
+    }
+
+    #[test]
+    fn auth_tab_mode_row_ignores_space_and_enter_opens_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.active_tab = SettingsTab::Auth;
+        settings.tab_bar_focused = false;
+        state.stage = ManagerStage::Settings(settings);
+
+        handle_settings_key(&mut state, key(KeyCode::Enter));
+        handle_settings_key(&mut state, key(KeyCode::Char(' ')));
+
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("expected settings stage");
+        };
+        assert_eq!(
+            settings.auth.pending[0].mode,
+            crate::console::manager::auth_kind::AuthMode::Sync
+        );
+        assert!(!settings.auth.is_dirty());
+        assert!(settings.auth.modal.is_none());
+
+        handle_settings_key(&mut state, key(KeyCode::Enter));
+
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(matches!(
+            settings.auth.modal,
+            Some(SettingsAuthModal::AuthForm { .. })
+        ));
+    }
+
+    #[test]
+    fn env_tab_add_flow_asks_scope_before_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.active_tab = SettingsTab::Environments;
+        settings.tab_bar_focused = false;
+        state.stage = ManagerStage::Settings(settings);
+
+        handle_settings_key(&mut state, key(KeyCode::Enter));
+        let ManagerStage::Settings(settings) = &mut state.stage else {
+            panic!("expected settings stage");
+        };
+        assert!(matches!(
+            settings.env.modal,
+            Some(SettingsEnvModal::ScopePicker { .. })
+        ));
+
+        handle_settings_env_modal(
+            &mut settings.env,
+            key(KeyCode::Enter),
+            state.op_cache.clone(),
+        );
+        assert!(matches!(
+            settings.env.modal,
+            Some(SettingsEnvModal::Text {
+                target: SettingsEnvTextTarget::EnvKey {
+                    scope: super::super::super::state::SettingsEnvScope::Global
+                },
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn env_tab_specific_scope_uses_workspace_role_picker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = AppConfig::default();
+        config.roles.insert(
+            "chainargos/agent-brown".into(),
+            RoleSource {
+                git: "https://example.invalid/brown.git".into(),
+                trusted: false,
+                env: BTreeMap::new(),
+            },
+        );
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.active_tab = SettingsTab::Environments;
+        settings.tab_bar_focused = false;
+        state.stage = ManagerStage::Settings(settings);
+
+        handle_settings_key(&mut state, key(KeyCode::Enter));
+        let ManagerStage::Settings(settings) = &mut state.stage else {
+            panic!("expected settings stage");
+        };
+        let Some(SettingsEnvModal::ScopePicker { state: picker }) = settings.env.modal.as_mut()
+        else {
+            panic!("expected scope picker");
+        };
+        picker.focused = crate::console::widgets::scope_picker::ScopeChoice::SpecificAgent;
+        handle_settings_env_modal(
+            &mut settings.env,
+            key(KeyCode::Enter),
+            state.op_cache.clone(),
+        );
+        assert!(matches!(
+            settings.env.modal,
+            Some(SettingsEnvModal::RolePicker { .. })
+        ));
+
+        handle_settings_env_modal(
+            &mut settings.env,
+            key(KeyCode::Enter),
+            state.op_cache.clone(),
+        );
+        assert!(matches!(
+            &settings.env.modal,
+            Some(SettingsEnvModal::Text {
+                target: SettingsEnvTextTarget::EnvKey {
+                    scope: super::super::super::state::SettingsEnvScope::Role(role)
+                },
+                ..
+            }) if role == "chainargos/agent-brown"
+        ));
+    }
+
+    #[test]
+    fn settings_env_rows_hide_roles_without_env_entries() {
+        let mut config = AppConfig::default();
+        config.roles.insert(
+            "agent-empty".into(),
+            RoleSource {
+                git: "https://example.invalid/empty.git".into(),
+                trusted: false,
+                env: BTreeMap::new(),
+            },
+        );
+        config.roles.insert(
+            "agent-with-env".into(),
+            RoleSource {
+                git: "https://example.invalid/with-env.git".into(),
+                trusted: false,
+                env: BTreeMap::from([(
+                    "ROLE_ALPHA".into(),
+                    crate::operator_env::EnvValue::Plain("one".into()),
+                )]),
+            },
+        );
+        let settings = SettingsState::from_config(&config);
+        let rows = settings_env_flat_rows(&settings);
+
+        assert!(
+            !rows
+                .iter()
+                .any(|row| matches!(row, SettingsEnvRow::RoleHeader { role, .. } if role == "agent-empty")),
+            "empty role env sections should stay hidden: {rows:?}"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| matches!(row, SettingsEnvRow::RoleHeader { role, .. } if role == "agent-with-env")),
+            "roles with env entries should remain visible: {rows:?}"
+        );
     }
 }

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -7,8 +7,8 @@ use super::super::super::widgets::{
     ModalOutcome, confirm::ConfirmState, file_browser::FileBrowserState,
 };
 use super::super::state::{
-    EditorState, FileBrowserTarget, GlobalMountsState, ManagerListRow, ManagerStage, ManagerState,
-    Modal, Toast, ToastKind,
+    EditorState, FileBrowserTarget, ManagerListRow, ManagerStage, ManagerState, Modal,
+    SettingsState, Toast, ToastKind,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -27,30 +27,38 @@ pub(super) fn handle_list_key(
     match key.code {
         KeyCode::Esc | KeyCode::Char('q' | 'Q') => Ok(InputOutcome::ExitJackin),
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            scroll_focused_mount_block(state, -8);
+            scroll_list_horizontal(state, -8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            scroll_focused_mount_block(state, 8);
+            scroll_list_horizontal(state, 8);
             Ok(InputOutcome::Continue)
         }
         KeyCode::Up | KeyCode::Char('k' | 'K') => {
-            state.inline_role_picker = None;
-            state.inline_agent_picker = None;
-            let selected = state.selected.saturating_sub(1);
-            if selected != state.selected {
-                state.reset_list_scroll();
-                state.selected = selected;
+            if state.list_scroll_focus.is_some() {
+                scroll_focused_mount_block_vertical(state, -3);
+            } else {
+                state.inline_role_picker = None;
+                state.inline_agent_picker = None;
+                let selected = state.selected.saturating_sub(1);
+                if selected != state.selected {
+                    state.reset_list_scroll();
+                    state.selected = selected;
+                }
             }
             Ok(InputOutcome::Continue)
         }
         KeyCode::Down | KeyCode::Char('j' | 'J') => {
-            state.inline_role_picker = None;
-            state.inline_agent_picker = None;
-            let selected = (state.selected + 1).min(state.row_count() - 1);
-            if selected != state.selected {
-                state.reset_list_scroll();
-                state.selected = selected;
+            if state.list_scroll_focus.is_some() {
+                scroll_focused_mount_block_vertical(state, 3);
+            } else {
+                state.inline_role_picker = None;
+                state.inline_agent_picker = None;
+                let selected = (state.selected + 1).min(state.row_count() - 1);
+                if selected != state.selected {
+                    state.reset_list_scroll();
+                    state.selected = selected;
+                }
             }
             Ok(InputOutcome::Continue)
         }
@@ -79,15 +87,9 @@ pub(super) fn handle_list_key(
         },
         KeyCode::Char('e' | 'E') => {
             match state.selected_row() {
-                ManagerListRow::CurrentDirectory => {
-                    state.toast = Some(Toast {
-                        message: "Current directory cannot be edited".into(),
-                        kind: ToastKind::Error,
-                        shown_at: std::time::Instant::now(),
-                    });
-                }
-                ManagerListRow::NewWorkspace => {
-                    // Silent no-op on the sentinel.
+                ManagerListRow::CurrentDirectory | ManagerListRow::NewWorkspace => {
+                    // Silent no-op — current directory has no config to edit,
+                    // and NewWorkspace is a sentinel.
                 }
                 ManagerListRow::SavedWorkspace(i) => {
                     if let Some(summary) = state.workspaces.get(i) {
@@ -112,14 +114,7 @@ pub(super) fn handle_list_key(
         }
         KeyCode::Char('d' | 'D') => {
             match state.selected_row() {
-                ManagerListRow::CurrentDirectory => {
-                    state.toast = Some(Toast {
-                        message: "Current directory cannot be deleted".into(),
-                        kind: ToastKind::Error,
-                        shown_at: std::time::Instant::now(),
-                    });
-                }
-                ManagerListRow::NewWorkspace => {
+                ManagerListRow::CurrentDirectory | ManagerListRow::NewWorkspace => {
                     // Silent no-op on the sentinel.
                 }
                 ManagerListRow::SavedWorkspace(i) => {
@@ -143,11 +138,6 @@ pub(super) fn handle_list_key(
             ConsoleInstanceAction::Reconnect,
             "No recoverable instance for this row",
         )),
-        KeyCode::Char('s' | 'S') => Ok(instance_action_outcome(
-            state,
-            ConsoleInstanceAction::NewSession,
-            "No running instance for this row",
-        )),
         KeyCode::Char('i' | 'I') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::Inspect,
@@ -158,8 +148,8 @@ pub(super) fn handle_list_key(
             ConsoleInstanceAction::Purge,
             "No purgeable instance state for this row",
         )),
-        KeyCode::Char('g' | 'G') => {
-            state.stage = ManagerStage::GlobalMounts(GlobalMountsState::from_config(config));
+        KeyCode::Char('s' | 'S') => {
+            state.stage = ManagerStage::Settings(SettingsState::from_config(config));
             Ok(InputOutcome::Continue)
         }
         _ => Ok(InputOutcome::Continue),
@@ -244,16 +234,11 @@ const fn instance_action_accepts_status(
     }
 }
 
-/// Dispatch the `o` key on the workspace list view. Keeps `handle_list_key`
-/// below clippy's `too_many_lines` threshold and isolates the
-/// toast/open/picker decision tree.
+/// Dispatch the `o` key on the workspace list view.
 fn handle_list_open_in_github(state: &mut ManagerState<'_>, config: &AppConfig) {
+    // Silent no-op when there is no workspace or no GitHub URLs — the hint is
+    // already suppressed in those cases so the operator never sees the key.
     let Some(summary) = state.selected_workspace_summary() else {
-        state.toast = Some(Toast {
-            message: "no workspace selected".into(),
-            kind: ToastKind::Error,
-            shown_at: std::time::Instant::now(),
-        });
         return;
     };
     let Some(ws) = config.workspaces.get(&summary.name) else {
@@ -261,19 +246,14 @@ fn handle_list_open_in_github(state: &mut ManagerState<'_>, config: &AppConfig) 
     };
     let choices = super::super::github_mounts::resolve_for_workspace(ws);
     match choices.len() {
-        0 => {
-            state.toast = Some(Toast {
-                message: "no GitHub URLs for this workspace".into(),
-                kind: ToastKind::Error,
-                shown_at: std::time::Instant::now(),
-            });
-        }
+        0 => {}
         1 => {
             if let Err(e) = open::that_detached(&choices[0].url) {
-                state.toast = Some(Toast {
-                    message: format!("failed to open URL: {e}"),
-                    kind: ToastKind::Error,
-                    shown_at: std::time::Instant::now(),
+                state.list_modal = Some(Modal::ErrorPopup {
+                    state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                        "Failed to open URL",
+                        format!("{e}"),
+                    ),
                 });
             }
         }
@@ -286,13 +266,6 @@ fn handle_list_open_in_github(state: &mut ManagerState<'_>, config: &AppConfig) 
 }
 
 /// Dispatch a key into whatever modal currently sits on `state.list_modal`.
-/// Today the slot can hold either `Modal::GithubPicker` (opened by `o` on
-/// a workspace row) or `Modal::RolePicker` (opened by Enter when the
-/// highlighted workspace has multiple eligible roles). Any other variant
-/// that sneaks in is treated as cancel so the operator isn't stuck.
-///
-/// Returns the resulting `InputOutcome` so the `AgentPicker` commit path
-/// can surface the chosen role up to `run_console` for launch.
 pub(super) fn handle_list_modal(state: &mut ManagerState<'_>, key: KeyEvent) -> InputOutcome {
     let Some(modal) = state.list_modal.as_mut() else {
         return InputOutcome::Continue;
@@ -302,10 +275,11 @@ pub(super) fn handle_list_modal(state: &mut ManagerState<'_>, key: KeyEvent) -> 
             ModalOutcome::Commit(url) => {
                 state.list_modal = None;
                 if let Err(e) = open::that_detached(&url) {
-                    state.toast = Some(Toast {
-                        message: format!("failed to open URL: {e}"),
-                        kind: ToastKind::Error,
-                        shown_at: std::time::Instant::now(),
+                    state.list_modal = Some(Modal::ErrorPopup {
+                        state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                            "Failed to open URL",
+                            format!("{e}"),
+                        ),
                     });
                 }
                 InputOutcome::Continue
@@ -327,8 +301,13 @@ pub(super) fn handle_list_modal(state: &mut ManagerState<'_>, key: KeyEvent) -> 
             }
             ModalOutcome::Continue => InputOutcome::Continue,
         },
-        // Defensive catch-all — no other Modal variants are placed on the
-        // list_modal slot today.
+        Modal::ErrorPopup { state: popup } => match popup.handle_key(key) {
+            ModalOutcome::Commit(()) | ModalOutcome::Cancel => {
+                state.list_modal = None;
+                InputOutcome::Continue
+            }
+            ModalOutcome::Continue => InputOutcome::Continue,
+        },
         _ => {
             state.list_modal = None;
             InputOutcome::Continue
@@ -345,11 +324,11 @@ pub(super) fn handle_inline_role_picker(
     };
     match key.code {
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            scroll_focused_mount_block(state, -8);
+            scroll_list_horizontal(state, -8);
             InputOutcome::Continue
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            scroll_focused_mount_block(state, 8);
+            scroll_list_horizontal(state, 8);
             InputOutcome::Continue
         }
         _ => match picker.handle_key(key) {
@@ -375,11 +354,11 @@ pub(super) fn handle_inline_agent_picker(
     };
     match key.code {
         KeyCode::Left | KeyCode::Char('h' | 'H') => {
-            scroll_focused_mount_block(state, -8);
+            scroll_list_horizontal(state, -8);
             InputOutcome::Continue
         }
         KeyCode::Right | KeyCode::Char('l' | 'L') => {
-            scroll_focused_mount_block(state, 8);
+            scroll_list_horizontal(state, 8);
             InputOutcome::Continue
         }
         _ => match picker.handle_key(key) {
@@ -396,6 +375,20 @@ pub(super) fn handle_inline_agent_picker(
     }
 }
 
+const fn scroll_list_horizontal(state: &mut ManagerState<'_>, delta: i16) {
+    if state.list_names_focused {
+        state.list_names_scroll_x = if delta.is_negative() {
+            state
+                .list_names_scroll_x
+                .saturating_sub(delta.unsigned_abs())
+        } else {
+            state.list_names_scroll_x.saturating_add(delta as u16)
+        };
+    } else {
+        scroll_focused_mount_block(state, delta);
+    }
+}
+
 const fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
     let Some(focus) = state.list_scroll_focus else {
         return;
@@ -408,13 +401,23 @@ const fn scroll_focused_mount_block(state: &mut ManagerState<'_>, delta: i16) {
     }
 }
 
+const fn scroll_focused_mount_block_vertical(state: &mut ManagerState<'_>, delta: i16) {
+    let Some(focus) = state.list_scroll_focus else {
+        return;
+    };
+    let value = state.list_scroll_y_mut(focus);
+    if delta.is_negative() {
+        *value = value.saturating_sub(delta.unsigned_abs());
+    } else {
+        *value = value.saturating_add(delta as u16);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! List-stage tests: row-0 (current dir) gating, Enter routing,
     //! `o`-key resolver to GitHub URLs, and the `GithubPicker` modal.
-    use super::super::super::state::{
-        ManagerStage, ManagerState, Modal, MountScrollFocus, ToastKind,
-    };
+    use super::super::super::state::{ManagerStage, ManagerState, Modal, MountScrollFocus};
     use super::super::test_support::{key, mount};
     use super::InputOutcome;
     use crate::config::AppConfig;
@@ -473,19 +476,15 @@ mod tests {
         }
     }
 
-    /// Current-directory row (index 0) must reject the `e` edit shortcut and
-    /// the `d` delete shortcut with a toast, without entering the Editor or
-    /// `ConfirmDelete` stages. Paired with the render-side assertion that row 0
-    /// is labelled "Current directory".
+    /// `e` and `d` on the current-directory row must be silent no-ops —
+    /// no toast, no stage transition.
     #[test]
-    fn current_directory_row_rejects_edit_and_delete() {
+    fn current_directory_row_silently_ignores_edit_and_delete() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();
         let cwd = tmp.path();
 
-        // Minimal config with one saved workspace so the list has a non-
-        // trivial shape (current-dir + one saved + sentinel).
         let mut config = AppConfig::default();
         config.workspaces.insert(
             "some-ws".into(),
@@ -496,10 +495,8 @@ mod tests {
             },
         );
         let mut state = ManagerState::from_config(&config, cwd);
-        // cwd is unrelated to /unrelated, so preselect falls back to row 0.
         assert_eq!(state.selected, 0);
 
-        // Press `e` — must produce a toast and remain in the List stage.
         handle_key(
             &mut state,
             &mut config,
@@ -513,20 +510,8 @@ mod tests {
             "e on row 0 must not open the Editor; got {:?}",
             state.stage
         );
-        let toast = state.toast.as_ref().expect("edit rejection must toast");
-        assert!(
-            matches!(toast.kind, ToastKind::Error),
-            "edit rejection must be an error toast"
-        );
-        assert!(
-            toast.message.contains("edit"),
-            "toast should mention edit: {}",
-            toast.message
-        );
-        state.toast = None;
+        assert!(state.toast.is_none(), "e on row 0 must not show a toast");
 
-        // Press `d` — must produce a toast and remain in the List stage
-        // (no ConfirmDelete transition).
         handle_key(
             &mut state,
             &mut config,
@@ -540,16 +525,7 @@ mod tests {
             "d on row 0 must not open ConfirmDelete; got {:?}",
             state.stage
         );
-        let toast = state.toast.as_ref().expect("delete rejection must toast");
-        assert!(
-            matches!(toast.kind, ToastKind::Error),
-            "delete rejection must be an error toast"
-        );
-        assert!(
-            toast.message.contains("delete"),
-            "toast should mention delete: {}",
-            toast.message
-        );
+        assert!(state.toast.is_none(), "d on row 0 must not show a toast");
     }
 
     /// Enter on row 0 returns `LaunchCurrentDir`; Enter on row 1 returns
@@ -587,6 +563,30 @@ mod tests {
             InputOutcome::LaunchNamed(name) => assert_eq!(name, "alpha"),
             other => panic!("row 1 Enter must produce LaunchNamed(\"alpha\"); got {other:?}"),
         }
+    }
+
+    #[test]
+    fn s_opens_settings_stage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let cwd = tmp.path();
+        let mut config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, cwd);
+
+        let outcome = handle_key(
+            &mut state,
+            &mut config,
+            &paths,
+            cwd,
+            key(KeyCode::Char('s')),
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, InputOutcome::Continue));
+        assert!(
+            matches!(&state.stage, ManagerStage::Settings(settings) if settings.mounts.pending.is_empty())
+        );
     }
 
     #[test]
@@ -654,58 +654,6 @@ mod tests {
     }
 
     #[test]
-    fn new_session_shortcut_requires_running_instance() {
-        let workdir = "/workspace/demo";
-        let ws = WorkspaceConfig {
-            workdir: workdir.into(),
-            mounts: vec![],
-            ..Default::default()
-        };
-        let (mut state, mut config, paths, tmp) = list_state_selecting_ws(ws);
-        state.instances = vec![instance_entry(
-            "jackin-demo-architect-123456",
-            InstanceStatus::RestoreAvailable,
-            workdir,
-        )];
-
-        let outcome = handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Char('s')),
-        )
-        .unwrap();
-        assert!(matches!(outcome, InputOutcome::Continue));
-        assert!(
-            state
-                .toast
-                .as_ref()
-                .is_some_and(|toast| toast.message.contains("No running instance")),
-            "non-running `s` shortcut should toast; got {:?}",
-            state.toast
-        );
-
-        state.toast = None;
-        state.instances[0].status = InstanceStatus::Running;
-        let outcome = handle_key(
-            &mut state,
-            &mut config,
-            &paths,
-            tmp.path(),
-            key(KeyCode::Char('s')),
-        )
-        .unwrap();
-        match outcome {
-            InputOutcome::InstanceAction { container, action } => {
-                assert_eq!(container, "jackin-demo-architect-123456");
-                assert_eq!(action, crate::console::ConsoleInstanceAction::NewSession);
-            }
-            other => panic!("expected new-session instance action; got {other:?}"),
-        }
-    }
-
-    #[test]
     fn moving_selection_resets_mount_scroll_state() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
@@ -721,12 +669,13 @@ mod tests {
                 ..Default::default()
             },
         );
+        // When no block is focused, Down navigates the workspace list and resets scroll.
         let mut state = ManagerState::from_config(&config, cwd);
         state.selected = 0;
         state.list_mounts_scroll_x = 24;
         state.list_global_mounts_scroll_x = 16;
         state.list_role_global_mounts_scroll_x = 8;
-        state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+        state.list_scroll_focus = None;
 
         handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Down)).unwrap();
 
@@ -735,6 +684,39 @@ mod tests {
         assert_eq!(state.list_global_mounts_scroll_x, 0);
         assert_eq!(state.list_role_global_mounts_scroll_x, 0);
         assert_eq!(state.list_scroll_focus, None);
+    }
+
+    #[test]
+    fn down_key_with_focused_block_scrolls_vertically_not_selection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let cwd = tmp.path();
+
+        let mut config = AppConfig::default();
+        config.workspaces.insert(
+            "alpha".into(),
+            WorkspaceConfig {
+                workdir: "/alpha".into(),
+                mounts: vec![],
+                ..Default::default()
+            },
+        );
+        // When a block is focused, Down scrolls that block vertically, not the list.
+        let mut state = ManagerState::from_config(&config, cwd);
+        state.selected = 0;
+        state.list_scroll_focus = Some(MountScrollFocus::Workspace);
+
+        handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Down)).unwrap();
+
+        assert_eq!(
+            state.selected, 0,
+            "selection must not change while block focused"
+        );
+        assert!(
+            state.list_mounts_scroll_y > 0,
+            "block must have scrolled vertically"
+        );
     }
 
     // ── List-view `o` key → GitHub resolver + picker ──────────────────
@@ -848,22 +830,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(
-            state.list_modal.is_none(),
-            "no modal should open when there are no github mounts"
-        );
-        let toast = state.toast.as_ref().expect("expected a toast");
-        assert!(
-            toast.message.contains("no GitHub URL"),
-            "toast should explain the no-mounts state: {}",
-            toast.message
-        );
+        // Silent no-op: no modal, no toast.
+        assert!(state.list_modal.is_none(), "no modal when no GitHub URLs");
+        assert!(state.toast.is_none(), "no toast when no GitHub URLs");
     }
 
     #[test]
-    fn list_o_on_row_zero_toasts_no_workspace_selected() {
-        // Row 0 is the synthetic "Current directory" — no saved workspace
-        // to read mounts from; hint should nudge the operator, not crash.
+    fn list_o_on_row_zero_is_silent_noop() {
+        // Row 0 is "Current directory" — O must be silent (no toast, no modal).
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();
@@ -883,9 +857,11 @@ mod tests {
         )
         .unwrap();
 
-        let toast = state.toast.as_ref().expect("expected a toast");
-        assert!(toast.message.contains("no workspace selected"));
-        assert!(state.list_modal.is_none());
+        assert!(state.toast.is_none(), "O on row 0 must not toast");
+        assert!(
+            state.list_modal.is_none(),
+            "O on row 0 must not open a modal"
+        );
     }
 
     #[test]
@@ -920,9 +896,11 @@ mod tests {
         )
         .unwrap();
 
+        // Modal is either closed (open succeeded) or shows ErrorPopup (open failed).
+        // Either way, GithubPicker is gone.
         assert!(
-            state.list_modal.is_none(),
-            "picker Enter must close the modal"
+            !matches!(state.list_modal, Some(Modal::GithubPicker { .. })),
+            "GithubPicker must be gone after Enter"
         );
     }
 

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -145,11 +145,31 @@ pub fn handle_key(
         }
         return Ok(InputOutcome::Continue);
     }
-    if let ManagerStage::GlobalMounts(global) = &mut state.stage
-        && global.modal.is_some()
+    if let ManagerStage::Settings(settings) = &mut state.stage
+        && settings.mounts.modal.is_some()
     {
-        global_mounts::handle_global_mounts_modal(global, config, paths, key);
-        global_mounts::after_global_mounts_event(state);
+        global_mounts::handle_settings_confirm_modal(settings, config, paths, key);
+        global_mounts::after_settings_event(state);
+        return Ok(InputOutcome::Continue);
+    }
+    if let ManagerStage::Settings(settings) = &mut state.stage
+        && settings.env.modal.is_some()
+    {
+        global_mounts::handle_settings_env_modal(&mut settings.env, key, op_cache);
+        global_mounts::after_settings_event(state);
+        return Ok(InputOutcome::Continue);
+    }
+    if let ManagerStage::Settings(settings) = &mut state.stage
+        && settings.auth.modal.is_some()
+    {
+        global_mounts::handle_settings_auth_modal(
+            &mut settings.auth,
+            &mut settings.env,
+            key,
+            op_available,
+            op_cache,
+        );
+        global_mounts::after_settings_event(state);
         return Ok(InputOutcome::Continue);
     }
     if matches!(state.stage, ManagerStage::CreatePrelude(_)) {
@@ -224,14 +244,14 @@ pub fn handle_key(
     enum StageDis {
         List,
         Editor,
-        GlobalMounts,
+        Settings,
         CreatePrelude,
         ConfirmDelete,
     }
     let dis = match &state.stage {
         ManagerStage::List => StageDis::List,
         ManagerStage::Editor(_) => StageDis::Editor,
-        ManagerStage::GlobalMounts(_) => StageDis::GlobalMounts,
+        ManagerStage::Settings(_) => StageDis::Settings,
         ManagerStage::CreatePrelude(_) => StageDis::CreatePrelude,
         ManagerStage::ConfirmDelete { .. } => StageDis::ConfirmDelete,
     };
@@ -239,9 +259,9 @@ pub fn handle_key(
     match dis {
         StageDis::List => list::handle_list_key(state, config, paths, cwd, key),
         StageDis::Editor => editor::handle_editor_key(state, config, paths, cwd, key),
-        StageDis::GlobalMounts => {
-            global_mounts::handle_global_mounts_key(state, key);
-            global_mounts::after_global_mounts_event(state);
+        StageDis::Settings => {
+            global_mounts::handle_settings_key(state, key);
+            global_mounts::after_settings_event(state);
             Ok(InputOutcome::Continue)
         }
         StageDis::CreatePrelude => Ok(prelude::handle_prelude_key(state, config, paths, cwd, key)),

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -2,15 +2,16 @@
 //! click-to-select in the list pane, and `FileBrowser` URL-click fallthrough.
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 use super::super::super::widgets::file_browser::FileBrowserState;
+use super::super::render::global_mounts::trust_content_width;
 use super::super::render::list::{
     global_mounts_content_width, mount_block_height, workspace_mounts_content_width,
 };
 use super::super::state::{
     DragState, EditorTab, FieldFocus, ManagerListRow, ManagerStage, ManagerState, Modal,
-    MountScrollFocus, clamp_split,
+    MountScrollFocus, SettingsTab, clamp_split,
 };
 
 /// Minimum terminal width (in columns) at which the list/details seam is
@@ -33,6 +34,7 @@ const LIST_FOOTER_HEIGHT: u16 = 2;
 const EDITOR_HEADER_HEIGHT: u16 = 3;
 const EDITOR_TAB_STRIP_HEIGHT: u16 = 2;
 const MOUSE_HORIZONTAL_SCROLL_STEP: u16 = 1;
+const MOUSE_VERTICAL_SCROLL_STEP: i16 = 1;
 
 /// Dispatch a mouse event into the workspace manager's list view. Drives
 /// the mouse-draggable seam between the list pane and the details pane.
@@ -54,6 +56,7 @@ pub fn handle_mouse(state: &mut ManagerState<'_>, mouse: MouseEvent, term_size: 
     handle_mouse_with_config(state, mouse, term_size, None);
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn handle_mouse_with_config(
     state: &mut ManagerState<'_>,
     mouse: MouseEvent,
@@ -69,6 +72,11 @@ pub fn handle_mouse_with_config(
     {
         return;
     }
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+        && try_select_settings_tab(state, mouse)
+    {
+        return;
+    }
 
     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
         update_scroll_focus(state, mouse, term_size, config);
@@ -80,7 +88,7 @@ pub fn handle_mouse_with_config(
         {
             return;
         }
-        MouseEventKind::ScrollLeft | MouseEventKind::ScrollUp => {
+        MouseEventKind::ScrollLeft => {
             scroll_active_panel(
                 state,
                 mouse,
@@ -90,7 +98,7 @@ pub fn handle_mouse_with_config(
             );
             return;
         }
-        MouseEventKind::ScrollRight | MouseEventKind::ScrollDown => {
+        MouseEventKind::ScrollRight => {
             scroll_active_panel(
                 state,
                 mouse,
@@ -100,11 +108,25 @@ pub fn handle_mouse_with_config(
             );
             return;
         }
+        MouseEventKind::ScrollUp => {
+            scroll_active_panel_vertical(state, mouse, term_size, -MOUSE_VERTICAL_SCROLL_STEP);
+            return;
+        }
+        MouseEventKind::ScrollDown => {
+            scroll_active_panel_vertical(state, mouse, term_size, MOUSE_VERTICAL_SCROLL_STEP);
+            return;
+        }
         _ => {}
     }
 
     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
         && try_select_editor_mount_row(state, mouse, term_size)
+    {
+        return;
+    }
+
+    if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+        && try_select_settings_trust_row(state, mouse, term_size)
     {
         return;
     }
@@ -209,6 +231,63 @@ fn editor_tab_at(mouse: MouseEvent) -> Option<EditorTab> {
     None
 }
 
+fn try_select_settings_tab(state: &mut ManagerState<'_>, mouse: MouseEvent) -> bool {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return false;
+    };
+    if settings.mounts.modal.is_some() || settings.env.modal.is_some() {
+        return false;
+    }
+
+    let Some(tab) = settings_tab_at(mouse) else {
+        return false;
+    };
+    settings.active_tab = tab;
+    true
+}
+
+fn settings_tab_at(mouse: MouseEvent) -> Option<SettingsTab> {
+    if mouse.row < EDITOR_HEADER_HEIGHT
+        || mouse.row >= EDITOR_HEADER_HEIGHT.saturating_add(EDITOR_TAB_STRIP_HEIGHT)
+    {
+        return None;
+    }
+    let mut x = 0u16;
+    for tab in SettingsTab::ALL {
+        let width = tab.label().len() as u16 + 2;
+        if mouse.column >= x && mouse.column < x.saturating_add(width) {
+            return Some(tab);
+        }
+        x = x.saturating_add(width + 1);
+    }
+    None
+}
+
+/// Click inside the Trust block selects the row and activates the block for scrolling.
+fn try_select_settings_trust_row(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+) -> bool {
+    let ManagerStage::Settings(settings) = &mut state.stage else {
+        return false;
+    };
+    if settings.active_tab != SettingsTab::Trust || settings.mounts.modal.is_some() {
+        return false;
+    }
+    let area = settings_content_area(term_size);
+    if !point_in(mouse, area) {
+        return false;
+    }
+    // Row 0 is the header; rows 1.. are trust entries.
+    let clicked_row = usize::from(mouse.row.saturating_sub(area.y + 1));
+    if clicked_row < settings.trust.pending.len() {
+        settings.trust.selected = clicked_row;
+    }
+    settings.trust.scroll_focused = true;
+    true
+}
+
 fn try_select_editor_mount_row(
     state: &mut ManagerState<'_>,
     mouse: MouseEvent,
@@ -221,7 +300,8 @@ fn try_select_editor_mount_row(
         return false;
     }
 
-    let area = editor_scroll_area(editor, term_size).area;
+    let area_info = editor_scroll_area(editor, term_size);
+    let area = area_info.area;
     if mouse.column <= area.x
         || mouse.column >= area.x.saturating_add(area.width).saturating_sub(1)
         || mouse.row <= area.y
@@ -235,7 +315,7 @@ fn try_select_editor_mount_row(
         return false;
     };
     editor.active_field = FieldFocus::Row(index);
-    editor.workspace_mounts_scroll_focused = true;
+    editor.workspace_mounts_scroll_focused = is_scrollable(area, area_info.content_width);
     true
 }
 
@@ -326,19 +406,24 @@ fn try_drag_horizontal_scrollbar(
             }
             dragged
         }
-        ManagerStage::GlobalMounts(global) => drag_scrollbar(
-            &mut global.scroll_x,
-            mouse,
-            Rect {
-                x: 0,
-                y: LIST_HEADER_HEIGHT,
-                width: term_size.width,
-                height: term_size
-                    .height
-                    .saturating_sub(LIST_HEADER_HEIGHT + LIST_FOOTER_HEIGHT),
-            },
-            global_mount_rows_content_width(&global.pending),
-        ),
+        ManagerStage::Settings(settings) => {
+            if settings.active_tab != SettingsTab::Mounts {
+                return false;
+            }
+            drag_scrollbar(
+                &mut settings.mounts.scroll_x,
+                mouse,
+                Rect {
+                    x: 0,
+                    y: EDITOR_HEADER_HEIGHT + EDITOR_TAB_STRIP_HEIGHT,
+                    width: term_size.width,
+                    height: term_size.height.saturating_sub(
+                        EDITOR_HEADER_HEIGHT + EDITOR_TAB_STRIP_HEIGHT + LIST_FOOTER_HEIGHT,
+                    ),
+                },
+                global_mount_rows_content_width(&settings.mounts.pending),
+            )
+        }
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => false,
     }
 }
@@ -351,40 +436,98 @@ fn update_scroll_focus(
 ) {
     match &mut state.stage {
         ManagerStage::List => {
+            // Determine whether the click is in the left pane.
+            let seam_x = seam_column(state.list_split_pct, term_size.width);
+            let left_pane_area = Rect {
+                x: 0,
+                y: LIST_HEADER_HEIGHT,
+                width: seam_x,
+                height: term_size
+                    .height
+                    .saturating_sub(LIST_HEADER_HEIGHT + LIST_FOOTER_HEIGHT),
+            };
+            if point_in(mouse, left_pane_area) {
+                // Click in left pane: activate left pane, clear right focus.
+                state.list_names_focused = true;
+                state.list_scroll_focus = None;
+                return;
+            }
+            state.list_names_focused = false;
+
             let Some(areas) = list_scroll_areas(state, term_size, config) else {
                 state.list_scroll_focus = None;
                 return;
             };
             state.list_scroll_focus = if point_in(mouse, areas.workspace.area)
-                && is_scrollable(areas.workspace.area, areas.workspace.content_width)
+                && (is_scrollable(areas.workspace.area, areas.workspace.content_width)
+                    || is_scrollable_v(areas.workspace.area, areas.workspace.content_height))
             {
                 Some(MountScrollFocus::Workspace)
             } else if point_in(mouse, areas.global.area)
-                && is_scrollable(areas.global.area, areas.global.content_width)
+                && areas.global.area.height > 0
+                && (is_scrollable(areas.global.area, areas.global.content_width)
+                    || is_scrollable_v(areas.global.area, areas.global.content_height))
             {
                 Some(MountScrollFocus::Global)
-            } else if let Some(role) = areas.role_global {
-                if point_in(mouse, role.area) && is_scrollable(role.area, role.content_width) {
-                    Some(MountScrollFocus::RoleGlobal)
-                } else {
-                    None
-                }
+            } else if areas.role_global.is_some_and(|r| {
+                point_in(mouse, r.area)
+                    && (is_scrollable(r.area, r.content_width)
+                        || is_scrollable_v(r.area, r.content_height))
+            }) {
+                Some(MountScrollFocus::RoleGlobal)
+            } else if areas.roles.is_some_and(|r| {
+                point_in(mouse, r.area)
+                    && (is_scrollable(r.area, r.content_width)
+                        || is_scrollable_v(r.area, r.content_height))
+            }) {
+                Some(MountScrollFocus::Roles)
             } else {
                 None
             };
         }
         ManagerStage::Editor(editor) => {
-            if editor.active_tab != EditorTab::Mounts {
+            if editor.active_tab == EditorTab::Mounts {
+                if editor.modal.is_some() {
+                    editor.workspace_mounts_scroll_focused = false;
+                } else {
+                    let area = editor_scroll_area(editor, term_size);
+                    editor.workspace_mounts_scroll_focused =
+                        point_in(mouse, area.area) && is_scrollable(area.area, area.content_width);
+                }
+                editor.tab_content_scroll_focused = false;
+            } else {
                 editor.workspace_mounts_scroll_focused = false;
-                return;
+                if editor.modal.is_some() {
+                    editor.tab_content_scroll_focused = false;
+                } else {
+                    let content_area = settings_content_area(term_size);
+                    let in_content = point_in(mouse, content_area);
+                    let viewport_h = content_area.height.saturating_sub(2) as usize;
+                    editor.tab_content_scroll_focused =
+                        in_content && editor.tab_content_height > viewport_h;
+                }
             }
-            let area = editor_scroll_area(editor, term_size);
-            editor.workspace_mounts_scroll_focused =
-                point_in(mouse, area.area) && is_scrollable(area.area, area.content_width);
         }
-        ManagerStage::GlobalMounts(_)
-        | ManagerStage::CreatePrelude(_)
-        | ManagerStage::ConfirmDelete { .. } => {}
+        ManagerStage::Settings(settings) => {
+            let content_area = settings_content_area(term_size);
+            let in_content = point_in(mouse, content_area);
+            settings.mounts.scroll_focused =
+                settings.active_tab == SettingsTab::Mounts && in_content;
+            settings.trust.scroll_focused = settings.active_tab == SettingsTab::Trust && in_content;
+        }
+        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
+    }
+}
+
+/// The content area below the header + tab strip in Settings/Editor stages.
+const fn settings_content_area(term_size: Rect) -> Rect {
+    Rect {
+        x: 0,
+        y: EDITOR_HEADER_HEIGHT + EDITOR_TAB_STRIP_HEIGHT,
+        width: term_size.width,
+        height: term_size
+            .height
+            .saturating_sub(EDITOR_HEADER_HEIGHT + EDITOR_TAB_STRIP_HEIGHT),
     }
 }
 
@@ -400,10 +543,16 @@ const fn is_scrollable(area: Rect, content_width: usize) -> bool {
     viewport > 0 && content_width > viewport
 }
 
+const fn is_scrollable_v(area: Rect, content_height: usize) -> bool {
+    let viewport = area.height.saturating_sub(2) as usize;
+    viewport > 0 && content_height > viewport
+}
+
 #[derive(Clone, Copy)]
 struct ScrollArea {
     area: Rect,
     content_width: usize,
+    content_height: usize,
 }
 
 fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width: usize) -> bool {
@@ -434,6 +583,10 @@ fn scroll_active_panel(
     match &mut state.stage {
         ManagerStage::List => {
             update_scroll_focus(state, mouse, term_size, config);
+            if state.list_names_focused {
+                apply_horizontal_scroll_unbounded(&mut state.list_names_scroll_x, delta);
+                return;
+            }
             let Some(areas) = list_scroll_areas(state, term_size, config) else {
                 state.list_scroll_focus = None;
                 return;
@@ -445,6 +598,7 @@ fn scroll_active_panel(
                 MountScrollFocus::Workspace => Some(areas.workspace),
                 MountScrollFocus::Global => Some(areas.global),
                 MountScrollFocus::RoleGlobal => areas.role_global,
+                MountScrollFocus::Roles => areas.roles,
             };
             let Some(area_info) = area_info else {
                 return;
@@ -474,21 +628,111 @@ fn scroll_active_panel(
                 editor.workspace_mounts_scroll_focused = false;
             }
         }
-        ManagerStage::GlobalMounts(global) => apply_horizontal_scroll(
-            &mut global.scroll_x,
-            delta,
-            Rect {
-                x: 0,
-                y: LIST_HEADER_HEIGHT,
-                width: term_size.width,
-                height: term_size
-                    .height
-                    .saturating_sub(LIST_HEADER_HEIGHT + LIST_FOOTER_HEIGHT),
-            },
-            global_mount_rows_content_width(&global.pending),
-        ),
+        ManagerStage::Settings(settings) => {
+            // Hover-scroll: fire on whichever block the cursor is over.
+            let content_area = settings_content_area(term_size);
+            if !point_in(mouse, content_area) {
+                return;
+            }
+            match settings.active_tab {
+                SettingsTab::Mounts => {
+                    apply_horizontal_scroll(
+                        &mut settings.mounts.scroll_x,
+                        delta,
+                        content_area,
+                        global_mount_rows_content_width(&settings.mounts.pending),
+                    );
+                }
+                SettingsTab::Trust => {
+                    let cw = trust_content_width(settings);
+                    apply_horizontal_scroll(&mut settings.trust.scroll_x, delta, content_area, cw);
+                }
+                _ => {}
+            }
+        }
         ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
     }
+}
+
+/// Dispatch a vertical scroll event to whichever content block the mouse is over.
+/// Horizontal-only blocks (List view mounts) are silently ignored here —
+/// their scroll is only driven by left/right events via `scroll_active_panel`.
+fn scroll_active_panel_vertical(
+    state: &mut ManagerState<'_>,
+    mouse: MouseEvent,
+    term_size: Rect,
+    delta: i16,
+) {
+    match &mut state.stage {
+        ManagerStage::Settings(settings) => {
+            let content_area = settings_content_area(term_size);
+            if !point_in(mouse, content_area) {
+                return;
+            }
+            match settings.active_tab {
+                SettingsTab::Mounts => {
+                    apply_vertical_scroll(&mut settings.mounts.scroll_y, delta);
+                }
+                SettingsTab::Environments => {
+                    apply_vertical_scroll(&mut settings.env.scroll_y, delta);
+                }
+                SettingsTab::Trust => {
+                    apply_vertical_scroll(&mut settings.trust.scroll_y, delta);
+                }
+                // Auth has too few rows to overflow — ignore vertical scroll.
+                SettingsTab::Auth => {}
+            }
+        }
+        ManagerStage::Editor(editor) => {
+            match editor.active_tab {
+                // General has 4 fixed rows — no vertical scroll needed.
+                EditorTab::General => {}
+                // Mounts, Roles, Secrets, Auth all use tab_scroll_y.
+                EditorTab::Mounts | EditorTab::Roles | EditorTab::Secrets | EditorTab::Auth => {
+                    apply_vertical_scroll(&mut editor.tab_scroll_y, delta);
+                }
+            }
+        }
+        ManagerStage::List => {
+            // Scroll the focused block vertically.
+            match state.list_scroll_focus {
+                Some(MountScrollFocus::Workspace) => {
+                    apply_vertical_scroll(&mut state.list_mounts_scroll_y, delta);
+                }
+                Some(MountScrollFocus::Global) => {
+                    apply_vertical_scroll(&mut state.list_global_mounts_scroll_y, delta);
+                }
+                Some(MountScrollFocus::RoleGlobal) => {
+                    apply_vertical_scroll(&mut state.list_role_global_mounts_scroll_y, delta);
+                }
+                Some(MountScrollFocus::Roles) => {
+                    apply_vertical_scroll(&mut state.list_roles_scroll_y, delta);
+                }
+                None => {}
+            }
+        }
+        ManagerStage::CreatePrelude(_) | ManagerStage::ConfirmDelete { .. } => {}
+    }
+}
+
+#[allow(clippy::missing_const_for_fn)]
+fn apply_vertical_scroll(value: &mut u16, delta: i16) {
+    *value = if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    };
+}
+
+/// Apply a horizontal scroll delta without clamping to content width.
+/// The render frame (`render_scrollable_block`) clamps the stored value each
+/// time it draws, so no separate max is needed here.
+const fn apply_horizontal_scroll_unbounded(value: &mut u16, delta: i16) {
+    *value = if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    };
 }
 
 fn apply_horizontal_scroll(value: &mut u16, delta: i16, area: Rect, content_width: usize) {
@@ -517,6 +761,7 @@ struct ListScrollAreas {
     workspace: ScrollArea,
     global: ScrollArea,
     role_global: Option<ScrollArea>,
+    roles: Option<ScrollArea>,
 }
 
 fn list_scroll_areas(
@@ -525,12 +770,12 @@ fn list_scroll_areas(
     config: Option<&crate::config::AppConfig>,
 ) -> Option<ListScrollAreas> {
     let config = config?;
-    let seam_x = seam_column(state.list_split_pct, term_size.width);
-    let right_x = seam_x;
-    let right_w = term_size.width.saturating_sub(seam_x);
+    let (right_x, right_w) = right_pane_dims(state.list_split_pct, term_size.width);
     let body_y = LIST_HEADER_HEIGHT;
     if state.is_current_dir_selected() {
-        return Some(current_dir_scroll_areas(state, right_x, right_w, body_y));
+        return Some(current_dir_scroll_areas(
+            state, config, right_x, right_w, body_y,
+        ));
     }
     let summary = state.selected_workspace_summary()?;
     let workspace = config.workspaces.get(&summary.name)?;
@@ -563,6 +808,20 @@ fn list_scroll_areas(
     } else {
         mount_block_height(role_global_mounts.as_slice())
     };
+    let agent_count = super::super::render::list::agents_block_agent_count(Some(workspace), config);
+    let roles_h = super::super::render::list::agents_block_height(agent_count);
+    let roles_y = body_y + 3 + mounts_h + global_h + role_global_h;
+    let roles_content_w =
+        super::super::render::list::agents_block_content_width(Some(workspace), config);
+    let workspace_mounts_content_h = 1 + workspace
+        .mounts
+        .iter()
+        .map(|m| if m.src == m.dst { 1 } else { 2 })
+        .sum::<usize>()
+        .max(1);
+    let global_content_h = global_mounts.len() * 2 + 1;
+    let role_global_content_h = role_global_mounts.len() * 2 + 1;
+    let roles_content_h = 2 + agent_count;
     Some(ListScrollAreas {
         workspace: ScrollArea {
             area: Rect {
@@ -572,6 +831,7 @@ fn list_scroll_areas(
                 height: mounts_h,
             },
             content_width: workspace_mounts_content_width(workspace.mounts.as_slice()),
+            content_height: workspace_mounts_content_h,
         },
         global: ScrollArea {
             area: Rect {
@@ -581,6 +841,7 @@ fn list_scroll_areas(
                 height: global_h,
             },
             content_width: global_mounts_content_width(global_mounts.as_slice()),
+            content_height: global_content_h,
         },
         role_global: (role_global_h > 0).then(|| ScrollArea {
             area: Rect {
@@ -590,18 +851,40 @@ fn list_scroll_areas(
                 height: role_global_h,
             },
             content_width: global_mounts_content_width(role_global_mounts.as_slice()),
+            content_height: role_global_content_h,
+        }),
+        roles: (roles_h > 0).then_some(ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: roles_y,
+                width: right_w,
+                height: roles_h,
+            },
+            content_width: roles_content_w,
+            content_height: roles_content_h,
         }),
     })
 }
 
 fn current_dir_scroll_areas(
     state: &ManagerState<'_>,
+    config: &crate::config::AppConfig,
     right_x: u16,
     right_w: u16,
     body_y: u16,
 ) -> ListScrollAreas {
     let mounts = [current_dir_mount(state)];
     let mounts_h = mount_block_height(&mounts);
+    let agent_count = super::super::render::list::agents_block_agent_count(None, config);
+    let roles_h = super::super::render::list::agents_block_height(agent_count);
+    let roles_y = body_y + 3 + mounts_h;
+    let roles_content_w = super::super::render::list::agents_block_content_width(None, config);
+    let workspace_content_h = 1 + mounts
+        .iter()
+        .map(|m| if m.src == m.dst { 1 } else { 2 })
+        .sum::<usize>()
+        .max(1);
+    let roles_content_h = 2 + agent_count;
     ListScrollAreas {
         workspace: ScrollArea {
             area: Rect {
@@ -611,17 +894,29 @@ fn current_dir_scroll_areas(
                 height: mounts_h,
             },
             content_width: workspace_mounts_content_width(&mounts),
+            content_height: workspace_content_h,
         },
         global: ScrollArea {
             area: Rect {
                 x: right_x,
-                y: body_y + 3 + mounts_h,
+                y: roles_y,
                 width: right_w,
                 height: 0,
             },
             content_width: 0,
+            content_height: 0,
         },
         role_global: None,
+        roles: (roles_h > 0).then_some(ScrollArea {
+            area: Rect {
+                x: right_x,
+                y: roles_y,
+                width: right_w,
+                height: roles_h,
+            },
+            content_width: roles_content_w,
+            content_height: roles_content_h,
+        }),
     }
 }
 
@@ -651,6 +946,7 @@ fn editor_scroll_area(
             height: (rows as u16 + 2).min(body_h.max(4)),
         },
         content_width: workspace_mounts_content_width(editor.pending.mounts.as_slice()),
+        content_height: rows,
     }
 }
 
@@ -742,6 +1038,28 @@ const fn seam_column(pct: u16, width: u16) -> u16 {
     // panic. Under MIN_DRAGGABLE_WIDTH this arithmetic is already gated off
     // by the caller, but keep the helper safe for direct unit-testing.
     width.saturating_mul(pct) / 100
+}
+
+/// Return `(right_x, right_w)` using ratatui's own `Layout::split` arithmetic
+/// so that scroll-offset clamping in mouse handlers uses the same viewport
+/// width as `render_scrollable_block`. Integer division in `seam_column`
+/// disagrees with ratatui's percentage rounding for some terminal widths,
+/// causing touchpad scroll to stop 1 column short of the keyboard-reachable max.
+fn right_pane_dims(pct: u16, total_width: u16) -> (u16, u16) {
+    let right_pct = 100u16.saturating_sub(pct);
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(pct),
+            Constraint::Percentage(right_pct),
+        ])
+        .split(Rect {
+            x: 0,
+            y: 0,
+            width: total_width,
+            height: 1,
+        });
+    (cols[1].x, cols[1].width)
 }
 
 /// `true` when `column` is within ±`SEAM_HIT_SLACK` of `seam_x`.
@@ -1198,20 +1516,6 @@ mod mouse_drag_tests {
         }
     }
 
-    const fn mouse_kind_with_modifiers_at(
-        kind: MouseEventKind,
-        modifiers: KeyModifiers,
-        col: u16,
-        row: u16,
-    ) -> MouseEvent {
-        MouseEvent {
-            kind,
-            column: col,
-            row,
-            modifiers,
-        }
-    }
-
     /// Build a list state with `n` saved workspaces (row 0 + n + spacer + sentinel).
     fn list_state_with_saved(n: usize) -> ManagerState<'static> {
         let mut config = crate::config::AppConfig::default();
@@ -1413,7 +1717,7 @@ mod mouse_drag_tests {
 
         handle_mouse_with_config(
             &mut state,
-            mouse_kind_at(MouseEventKind::ScrollDown, 31, 7),
+            mouse_kind_at(MouseEventKind::ScrollRight, 31, 7),
             term(100),
             Some(&config),
         );
@@ -1458,35 +1762,9 @@ mod mouse_drag_tests {
     }
 
     #[test]
-    fn shift_vertical_mouse_wheel_scrolls_horizontally() {
-        let config = config_with_scrollable_workspace_and_global_mounts();
-        let mut state = selected_demo_state(&config);
-
-        handle_mouse_with_config(
-            &mut state,
-            mouse_kind_with_modifiers_at(MouseEventKind::ScrollDown, KeyModifiers::SHIFT, 31, 12),
-            term(100),
-            Some(&config),
-        );
-
-        assert_eq!(
-            state.list_global_mounts_scroll_x,
-            MOUSE_HORIZONTAL_SCROLL_STEP
-        );
-        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
-
-        handle_mouse_with_config(
-            &mut state,
-            mouse_kind_with_modifiers_at(MouseEventKind::ScrollUp, KeyModifiers::SHIFT, 31, 12),
-            term(100),
-            Some(&config),
-        );
-
-        assert_eq!(state.list_global_mounts_scroll_x, 0);
-    }
-
-    #[test]
-    fn plain_vertical_mouse_wheel_scrolls_horizontally_over_mount_block() {
+    fn vertical_mouse_wheel_does_not_scroll_horizontal_only_list_block() {
+        // W3C rule: ScrollUp/Down are vertical events; horizontal-only blocks
+        // (List view mounts) must ignore them. Only ScrollLeft/Right scroll them.
         let config = config_with_scrollable_workspace_and_global_mounts();
         let mut state = selected_demo_state(&config);
 
@@ -1498,10 +1776,9 @@ mod mouse_drag_tests {
         );
 
         assert_eq!(
-            state.list_global_mounts_scroll_x,
-            MOUSE_HORIZONTAL_SCROLL_STEP
+            state.list_global_mounts_scroll_x, 0,
+            "ScrollDown must not change horizontal scroll on a horizontal-only block"
         );
-        assert_eq!(state.list_scroll_focus, Some(MountScrollFocus::Global));
 
         handle_mouse_with_config(
             &mut state,
@@ -1575,7 +1852,7 @@ mod mouse_drag_tests {
         for _ in 0..100 {
             handle_mouse_with_config(
                 &mut state,
-                mouse_kind_at(MouseEventKind::ScrollDown, 31, 7),
+                mouse_kind_at(MouseEventKind::ScrollRight, 31, 7),
                 term(100),
                 Some(&config),
             );
@@ -1687,7 +1964,8 @@ mod mouse_drag_tests {
     }
 
     #[test]
-    fn editor_mounts_tab_click_full_row_width_selects_mount() {
+    fn editor_mounts_tab_click_full_row_width_selects_mount_without_scroll_focus_when_unscrollable()
+    {
         let mut state = list_state();
         let ws = WorkspaceConfig {
             workdir: "/w".into(),
@@ -1721,11 +1999,12 @@ mod mouse_drag_tests {
             panic!("editor stage expected");
         };
         assert!(matches!(editor.active_field, FieldFocus::Row(1)));
-        assert!(editor.workspace_mounts_scroll_focused);
+        assert!(!editor.workspace_mounts_scroll_focused);
     }
 
     #[test]
-    fn editor_mounts_tab_click_host_source_continuation_selects_parent_mount() {
+    fn editor_mounts_tab_click_host_source_continuation_selects_parent_without_scroll_focus_when_unscrollable()
+     {
         let mut state = list_state();
         let ws = WorkspaceConfig {
             workdir: "/w".into(),
@@ -1749,6 +2028,6 @@ mod mouse_drag_tests {
             panic!("editor stage expected");
         };
         assert!(matches!(editor.active_field, FieldFocus::Row(0)));
-        assert!(editor.workspace_mounts_scroll_focused);
+        assert!(!editor.workspace_mounts_scroll_focused);
     }
 }

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1,5 +1,6 @@
 //! Editor save flow: two-phase commit with planner validation, a
 //! `ConfirmSave` preview modal, and `ConfigEditor`-driven writes.
+#![allow(clippy::items_after_test_module)]
 
 use super::super::state::{
     EditorMode, EditorSaveFlow, EditorState, ManagerListRow, ManagerStage, ManagerState, Modal,
@@ -2298,4 +2299,436 @@ mod tests {
             "UUID URI must NOT appear in pre-save diff; got: {joined}"
         );
     }
+}
+
+// ── Settings save preview ─────────────────────────────────────────────────────
+
+/// Build the diff preview lines for the settings save confirmation dialog.
+/// Mirrors the format of `build_confirm_save_lines` for the workspace editor.
+/// Shows a summary section (counts per category) followed by per-category diffs.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub(super) fn build_settings_save_lines(
+    settings: &super::super::state::SettingsState<'_>,
+) -> Vec<ratatui::text::Line<'static>> {
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+
+    let green = Color::Rgb(0, 255, 65);
+    let dim = Color::Rgb(0, 140, 30);
+    let white = Color::Rgb(255, 255, 255);
+    let heading = Style::default().fg(white).add_modifier(Modifier::BOLD);
+    let add_style = Style::default().fg(green);
+    let remove_style = Style::default().fg(dim);
+    let sep_style = Style::default().fg(Color::Rgb(0, 50, 12));
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+
+    // ── Summary ───────────────────────────────────────────────────────
+    out.push(Line::from(Span::styled("Save settings", heading)));
+    out.push(Line::raw(""));
+
+    let mount_stats = settings_mount_stats(&settings.mounts.original, &settings.mounts.pending);
+    let env_stats = settings_env_stats(&settings.env.original, &settings.env.pending);
+    let auth_stats = settings_auth_stats(
+        &settings.auth.original,
+        &settings.auth.pending,
+        &settings.auth.original_github_env,
+        &settings.auth.github_env,
+    );
+    let trust_stats = settings_trust_stats(&settings.trust.original, &settings.trust.pending);
+
+    if let Some(s) = mount_stats.as_deref() {
+        out.push(Line::from(vec![
+            Span::styled("  Mounts:       ", heading),
+            Span::styled(s.to_owned(), add_style),
+        ]));
+    }
+    if let Some(s) = env_stats.as_deref() {
+        out.push(Line::from(vec![
+            Span::styled("  Environments: ", heading),
+            Span::styled(s.to_owned(), add_style),
+        ]));
+    }
+    if let Some(s) = auth_stats.as_deref() {
+        out.push(Line::from(vec![
+            Span::styled("  Auth:         ", heading),
+            Span::styled(s.to_owned(), add_style),
+        ]));
+    }
+    if let Some(s) = trust_stats.as_deref() {
+        out.push(Line::from(vec![
+            Span::styled("  Trust:        ", heading),
+            Span::styled(s.to_owned(), add_style),
+        ]));
+    }
+
+    // Separator before details
+    out.push(Line::raw(""));
+    out.push(Line::from(Span::styled("  \u{2500}".repeat(30), sep_style)));
+    out.push(Line::raw(""));
+
+    // ── Mount details ─────────────────────────────────────────────────
+    let mount_lines = settings_mount_diff_lines(
+        &settings.mounts.original,
+        &settings.mounts.pending,
+        add_style,
+        remove_style,
+    );
+    if !mount_lines.is_empty() {
+        out.push(Line::from(Span::styled("Mounts:", heading)));
+        out.extend(mount_lines);
+        out.push(Line::raw(""));
+    }
+
+    // ── Environment details ───────────────────────────────────────────
+    let env_lines = settings_env_diff_lines(
+        &settings.env.original,
+        &settings.env.pending,
+        add_style,
+        remove_style,
+    );
+    if !env_lines.is_empty() {
+        out.push(Line::from(Span::styled("Environments:", heading)));
+        out.extend(env_lines);
+        out.push(Line::raw(""));
+    }
+
+    // ── Auth details ──────────────────────────────────────────────────
+    let auth_lines = settings_auth_diff_lines(
+        &settings.auth.original,
+        &settings.auth.pending,
+        &settings.auth.original_github_env,
+        &settings.auth.github_env,
+        add_style,
+        remove_style,
+    );
+    if !auth_lines.is_empty() {
+        out.push(Line::from(Span::styled("Auth:", heading)));
+        out.extend(auth_lines);
+        out.push(Line::raw(""));
+    }
+
+    // ── Trust details ─────────────────────────────────────────────────
+    let trust_lines = settings_trust_diff_lines(
+        &settings.trust.original,
+        &settings.trust.pending,
+        add_style,
+        remove_style,
+    );
+    if !trust_lines.is_empty() {
+        out.push(Line::from(Span::styled("Trust:", heading)));
+        out.extend(trust_lines);
+        out.push(Line::raw(""));
+    }
+
+    // Strip trailing blank lines.
+    while out.last().is_some_and(|l: &Line| {
+        l.spans.is_empty() || l.spans.iter().all(|s| s.content.trim().is_empty())
+    }) {
+        out.pop();
+    }
+
+    out
+}
+
+// ── Summary stats helpers ─────────────────────────────────────────────────────
+
+fn settings_mount_stats(
+    original: &[crate::config::GlobalMountRow],
+    pending: &[crate::config::GlobalMountRow],
+) -> Option<String> {
+    let (added, removed, modified) = mount_diff_counts(original, pending);
+    if added + removed + modified == 0 {
+        return None;
+    }
+    let mut parts: Vec<String> = Vec::new();
+    if added > 0 {
+        parts.push(format!("{added} added"));
+    }
+    if removed > 0 {
+        parts.push(format!("{removed} removed"));
+    }
+    if modified > 0 {
+        parts.push(format!("{modified} modified"));
+    }
+    Some(parts.join(", "))
+}
+
+fn settings_env_stats(
+    original: &super::super::state::SettingsEnvConfig,
+    pending: &super::super::state::SettingsEnvConfig,
+) -> Option<String> {
+    let (added, removed, modified) = env_config_diff_counts(original, pending);
+    if added + removed + modified == 0 {
+        return None;
+    }
+    let mut parts: Vec<String> = Vec::new();
+    if added > 0 {
+        parts.push(format!("{added} added"));
+    }
+    if removed > 0 {
+        parts.push(format!("{removed} removed"));
+    }
+    if modified > 0 {
+        parts.push(format!("{modified} modified"));
+    }
+    Some(parts.join(", "))
+}
+
+fn settings_auth_stats(
+    original: &[super::super::state::SettingsAuthRow],
+    pending: &[super::super::state::SettingsAuthRow],
+    orig_github_env: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pend_github_env: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+) -> Option<String> {
+    let row_changes = original
+        .iter()
+        .zip(pending.iter())
+        .filter(|(a, b)| a.mode != b.mode)
+        .count();
+    let (env_added, env_removed, env_modified) =
+        env_map_diff_counts(orig_github_env, pend_github_env);
+    let total = row_changes + env_added + env_removed + env_modified;
+    if total == 0 {
+        return None;
+    }
+    Some(format!("{total} changed"))
+}
+
+fn settings_trust_stats(
+    original: &[super::super::state::SettingsTrustRow],
+    pending: &[super::super::state::SettingsTrustRow],
+) -> Option<String> {
+    let changed = original
+        .iter()
+        .zip(pending.iter())
+        .filter(|(a, b)| a.trusted != b.trusted)
+        .count();
+    if changed == 0 {
+        return None;
+    }
+    Some(format!("{changed} changed"))
+}
+
+// ── Count helpers ─────────────────────────────────────────────────────────────
+
+fn mount_diff_counts(
+    original: &[crate::config::GlobalMountRow],
+    pending: &[crate::config::GlobalMountRow],
+) -> (usize, usize, usize) {
+    use std::collections::BTreeMap;
+    let orig_map: BTreeMap<(Option<String>, String), &crate::config::GlobalMountRow> = original
+        .iter()
+        .map(|r| ((r.scope.clone(), r.name.clone()), r))
+        .collect();
+    let pend_map: BTreeMap<(Option<String>, String), &crate::config::GlobalMountRow> = pending
+        .iter()
+        .map(|r| ((r.scope.clone(), r.name.clone()), r))
+        .collect();
+    let added = pend_map
+        .keys()
+        .filter(|k| !orig_map.contains_key(k))
+        .count();
+    let removed = orig_map
+        .keys()
+        .filter(|k| !pend_map.contains_key(k))
+        .count();
+    let modified = pend_map
+        .iter()
+        .filter(|(k, prow)| orig_map.get(k).is_some_and(|orow| orow.mount != prow.mount))
+        .count();
+    (added, removed, modified)
+}
+
+fn env_config_diff_counts(
+    original: &super::super::state::SettingsEnvConfig,
+    pending: &super::super::state::SettingsEnvConfig,
+) -> (usize, usize, usize) {
+    let (ga, gr, gm) = env_map_diff_counts(&original.env, &pending.env);
+    let all_roles: std::collections::BTreeSet<&String> =
+        original.roles.keys().chain(pending.roles.keys()).collect();
+    let empty = std::collections::BTreeMap::default();
+    let (ra, rr, rm) = all_roles.into_iter().fold((0, 0, 0), |(a, r, m), role| {
+        let oe = original.roles.get(role).unwrap_or(&empty);
+        let pe = pending.roles.get(role).unwrap_or(&empty);
+        let (da, dr, dm) = env_map_diff_counts(oe, pe);
+        (a + da, r + dr, m + dm)
+    });
+    (ga + ra, gr + rr, gm + rm)
+}
+
+fn env_map_diff_counts(
+    original: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pending: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+) -> (usize, usize, usize) {
+    let added = pending
+        .keys()
+        .filter(|k| !original.contains_key(*k))
+        .count();
+    let removed = original
+        .keys()
+        .filter(|k| !pending.contains_key(*k))
+        .count();
+    let modified = pending
+        .iter()
+        .filter(|(k, v)| original.get(*k).is_some_and(|ov| ov != *v))
+        .count();
+    (added, removed, modified)
+}
+
+// ── Detail diff-line helpers ──────────────────────────────────────────────────
+
+fn settings_mount_diff_lines(
+    original: &[crate::config::GlobalMountRow],
+    pending: &[crate::config::GlobalMountRow],
+    add_style: ratatui::style::Style,
+    remove_style: ratatui::style::Style,
+) -> Vec<ratatui::text::Line<'static>> {
+    use ratatui::text::{Line, Span};
+    use std::collections::BTreeMap;
+
+    let orig_map: BTreeMap<(Option<String>, String), &crate::config::GlobalMountRow> = original
+        .iter()
+        .map(|r| ((r.scope.clone(), r.name.clone()), r))
+        .collect();
+    let pend_map: BTreeMap<(Option<String>, String), &crate::config::GlobalMountRow> = pending
+        .iter()
+        .map(|r| ((r.scope.clone(), r.name.clone()), r))
+        .collect();
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for (key, row) in &pend_map {
+        if !orig_map.contains_key(key) {
+            out.push(Line::from(Span::styled(
+                format!("  + {}", mount_row_summary(row)),
+                add_style,
+            )));
+        }
+    }
+    for (key, row) in &orig_map {
+        if !pend_map.contains_key(key) {
+            out.push(Line::from(Span::styled(
+                format!("  - {}", mount_row_summary(row)),
+                remove_style,
+            )));
+        }
+    }
+    for (key, prow) in &pend_map {
+        if let Some(orow) = orig_map.get(key)
+            && orow.mount != prow.mount
+        {
+            out.push(Line::from(Span::styled(
+                format!("  ~ {}", mount_row_summary(prow)),
+                add_style,
+            )));
+            out.push(Line::from(Span::styled(
+                format!("      was: {}", mount_row_summary(orow)),
+                remove_style,
+            )));
+        }
+    }
+    out
+}
+
+fn mount_row_summary(row: &crate::config::GlobalMountRow) -> String {
+    let scope = row
+        .scope
+        .as_deref()
+        .map(|s| format!("[{s}] "))
+        .unwrap_or_default();
+    let src = crate::tui::shorten_home(&row.mount.src);
+    let dst = crate::tui::shorten_home(&row.mount.dst);
+    let ro = if row.mount.readonly { " (ro)" } else { "" };
+    format!("{scope}{src} → {dst}{ro}")
+}
+
+fn settings_env_diff_lines(
+    original: &super::super::state::SettingsEnvConfig,
+    pending: &super::super::state::SettingsEnvConfig,
+    add_style: ratatui::style::Style,
+    remove_style: ratatui::style::Style,
+) -> Vec<ratatui::text::Line<'static>> {
+    use ratatui::text::{Line, Span};
+    let mut out: Vec<Line<'static>> = Vec::new();
+    append_env_map_diff_lines(
+        &mut out,
+        None,
+        &original.env,
+        &pending.env,
+        add_style,
+        remove_style,
+    );
+    let all_roles: std::collections::BTreeSet<&String> =
+        original.roles.keys().chain(pending.roles.keys()).collect();
+    let empty = std::collections::BTreeMap::default();
+    for role in all_roles {
+        let oe = original.roles.get(role).unwrap_or(&empty);
+        let pe = pending.roles.get(role).unwrap_or(&empty);
+        let mut probe: Vec<Line<'static>> = Vec::new();
+        append_env_map_diff_lines(&mut probe, None, oe, pe, add_style, remove_style);
+        if !probe.is_empty() {
+            out.push(Line::from(Span::styled(
+                format!("  role {role}:"),
+                add_style,
+            )));
+            append_env_map_diff_lines(&mut out, Some("  "), oe, pe, add_style, remove_style);
+        }
+    }
+    out
+}
+
+fn settings_auth_diff_lines(
+    original: &[super::super::state::SettingsAuthRow],
+    pending: &[super::super::state::SettingsAuthRow],
+    orig_github_env: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    pend_github_env: &std::collections::BTreeMap<String, crate::operator_env::EnvValue>,
+    add_style: ratatui::style::Style,
+    remove_style: ratatui::style::Style,
+) -> Vec<ratatui::text::Line<'static>> {
+    use ratatui::text::{Line, Span};
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for (orig_row, pend_row) in original.iter().zip(pending.iter()) {
+        if orig_row.mode != pend_row.mode {
+            out.push(Line::from(Span::styled(
+                format!(
+                    "  ~ {}  {} \u{2192} {}",
+                    pend_row.kind.label(),
+                    orig_row.mode.as_str(),
+                    pend_row.mode.as_str(),
+                ),
+                add_style,
+            )));
+        }
+    }
+    append_env_map_diff_lines(
+        &mut out,
+        None,
+        orig_github_env,
+        pend_github_env,
+        add_style,
+        remove_style,
+    );
+    out
+}
+
+fn settings_trust_diff_lines(
+    original: &[super::super::state::SettingsTrustRow],
+    pending: &[super::super::state::SettingsTrustRow],
+    add_style: ratatui::style::Style,
+    remove_style: ratatui::style::Style,
+) -> Vec<ratatui::text::Line<'static>> {
+    use ratatui::text::{Line, Span};
+    let mut out: Vec<Line<'static>> = Vec::new();
+    for (orig_row, pend_row) in original.iter().zip(pending.iter()) {
+        if orig_row.trusted != pend_row.trusted {
+            let (label, style) = if pend_row.trusted {
+                (format!("  + {}  trusted", pend_row.role), add_style)
+            } else {
+                (format!("  - {}  untrusted", pend_row.role), remove_style)
+            };
+            out.push(Line::from(Span::styled(label, style)));
+        }
+    }
+    out
 }

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -19,7 +19,8 @@ use super::list::{
     render_mount_header,
 };
 use super::{
-    FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
+    FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, footer_height, render_footer,
+    render_header,
 };
 use crate::config::AppConfig;
 use crate::operator_env::EnvValue;
@@ -29,7 +30,7 @@ use crate::operator_env::EnvValue;
 const ACTION_ACCENT: Color = Color::Rgb(180, 255, 180);
 const DISCLOSURE_ACCENT: Color = Color::Rgb(255, 208, 102);
 
-fn action_row_style(selected: bool) -> Style {
+pub(in crate::console::manager) fn action_row_style(selected: bool) -> Style {
     let style = Style::default().fg(ACTION_ACCENT);
     if selected {
         style.add_modifier(Modifier::BOLD)
@@ -38,26 +39,99 @@ fn action_row_style(selected: bool) -> Style {
     }
 }
 
-fn disclosure_style() -> Style {
+pub(in crate::console::manager) fn disclosure_style() -> Style {
     Style::default()
         .fg(DISCLOSURE_ACCENT)
         .add_modifier(Modifier::BOLD)
 }
 
+fn editor_footer_items(
+    state: &EditorState<'_>,
+    config: &AppConfig,
+    op_available: bool,
+) -> Vec<FooterItem> {
+    if let Some(modal) = &state.modal {
+        return super::modal::modal_footer_items(modal);
+    }
+    if state.tab_bar_focused {
+        let mut items = vec![
+            FooterItem::Key("\u{2190}\u{2192}"),
+            FooterItem::Text("switch tab"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Tab/\u{2193}"),
+            FooterItem::Text("enter content"),
+            FooterItem::GroupSep,
+            FooterItem::Key("S"),
+            FooterItem::Text("save workspace"),
+        ];
+        if state.is_dirty() {
+            items.push(FooterItem::Dyn(format!(
+                "({} changes)",
+                state.change_count()
+            )));
+        }
+        items.extend([
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            if state.is_dirty() {
+                FooterItem::Text("discard")
+            } else {
+                FooterItem::Text("back")
+            },
+        ]);
+        return items;
+    }
+    let mut items: Vec<FooterItem> = vec![
+        FooterItem::Key("\u{2191}\u{2193}"),
+        FooterItem::Text("navigate"),
+    ];
+    let row_items = contextual_row_items(state, config, op_available);
+    if !row_items.is_empty() {
+        items.push(FooterItem::GroupSep);
+        items.extend(row_items);
+    }
+    items.extend([
+        FooterItem::GroupSep,
+        FooterItem::Key("BackTab"),
+        FooterItem::Text("tab bar"),
+        FooterItem::GroupSep,
+        FooterItem::Key("S"),
+        FooterItem::Text("save workspace"),
+    ]);
+    if state.is_dirty() {
+        items.push(FooterItem::Dyn(format!(
+            "({} changes)",
+            state.change_count()
+        )));
+    }
+    items.extend([
+        FooterItem::GroupSep,
+        FooterItem::Key("Esc"),
+        if state.is_dirty() {
+            FooterItem::Text("discard")
+        } else {
+            FooterItem::Text("back")
+        },
+    ]);
+    items
+}
+
 pub fn render_editor(
     frame: &mut Frame,
-    state: &EditorState<'_>,
+    state: &mut EditorState<'_>,
     config: &AppConfig,
     op_available: bool,
 ) {
     let area = frame.area();
+    let items = editor_footer_items(state, config, op_available);
+    let footer_h = footer_height(&items, area.width).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
             Constraint::Length(2),
-            Constraint::Min(8),
-            Constraint::Length(2),
+            Constraint::Min(5),
+            Constraint::Length(footer_h),
         ])
         .split(area);
 
@@ -66,8 +140,7 @@ pub fn render_editor(
         EditorMode::Create => "create workspace".to_string(),
     };
     render_header(frame, chunks[0], &title);
-
-    render_tab_strip(frame, chunks[1], state.active_tab);
+    render_editor_tab_strip(frame, chunks[1], state.active_tab, state.tab_bar_focused);
 
     match state.active_tab {
         EditorTab::General => render_general_tab(frame, chunks[2], state),
@@ -75,31 +148,6 @@ pub fn render_editor(
         EditorTab::Roles => render_roles_tab(frame, chunks[2], state, config),
         EditorTab::Secrets => render_secrets_tab(frame, chunks[2], state, config),
         EditorTab::Auth => render_auth_tab(frame, chunks[2], state, config),
-    }
-
-    let mut items: Vec<FooterItem> = Vec::new();
-
-    let row_items = contextual_row_items(state, config, op_available);
-    if !row_items.is_empty() {
-        items.extend(row_items);
-        items.push(FooterItem::GroupSep);
-    }
-
-    items.push(FooterItem::Key("S"));
-    items.push(FooterItem::Text("save workspace"));
-    if state.is_dirty() {
-        items.push(FooterItem::Dyn(format!(
-            "({} changes)",
-            state.change_count()
-        )));
-    }
-
-    items.push(FooterItem::GroupSep);
-    items.push(FooterItem::Key("Esc"));
-    if state.is_dirty() {
-        items.push(FooterItem::Text("discard"));
-    } else {
-        items.push(FooterItem::Text("back"));
     }
 
     render_footer(frame, chunks[3], &items);
@@ -232,20 +280,25 @@ fn contextual_row_items(
                 Some(SecretsRow::WorkspaceKeyRow(_) | SecretsRow::RoleKeyRow { .. })
                     if focused_value_is_op_ref =>
                 {
-                    // Op:// rows: only D delete · A add · Q exit.
-                    // Per operator preference, mask/unmask and Enter edit
-                    // are suppressed because the breadcrumb isn't a
-                    // credential and isn't text-editable.
-                    vec![
+                    let mut items = if op_available {
+                        vec![
+                            FooterItem::Key("Enter"),
+                            FooterItem::Sep,
+                            FooterItem::Key("P"),
+                            FooterItem::Text("re-pick from 1Password"),
+                            FooterItem::Sep,
+                        ]
+                    } else {
+                        Vec::new()
+                    };
+                    items.extend([
                         FooterItem::Key("D"),
                         FooterItem::Text("delete"),
                         FooterItem::Sep,
                         FooterItem::Key("A"),
                         FooterItem::Text("add"),
-                        FooterItem::Sep,
-                        FooterItem::Key("Q"),
-                        FooterItem::Text("exit"),
-                    ]
+                    ]);
+                    items
                 }
                 Some(SecretsRow::WorkspaceKeyRow(_) | SecretsRow::RoleKeyRow { .. }) => {
                     let mut items = vec![
@@ -349,10 +402,35 @@ pub(in crate::console::manager) const EDITOR_TAB_LABELS: &[(EditorTab, &str)] = 
     (EditorTab::Auth, "Auth"),
 ];
 
-fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
-    let mut spans = Vec::new();
-    for &(tab, label) in EDITOR_TAB_LABELS {
-        let style = if tab == active {
+fn render_editor_tab_strip(
+    frame: &mut Frame,
+    area: Rect,
+    active: EditorTab,
+    tab_bar_focused: bool,
+) {
+    let labels: Vec<(&str, bool)> = EDITOR_TAB_LABELS
+        .iter()
+        .map(|(tab, label)| (*label, *tab == active))
+        .collect();
+    render_tab_strip(frame, area, &labels, tab_bar_focused);
+}
+
+pub(in crate::console::manager) fn render_tab_strip(
+    frame: &mut Frame,
+    area: Rect,
+    labels: &[(&str, bool)],
+    tab_bar_focused: bool,
+) {
+    let mut label_spans: Vec<Span> = Vec::new();
+    // Row 1: underline bar shown only when the tab bar has keyboard focus
+    // so the operator can see which area is active.
+    let mut bar_spans: Vec<Span> = Vec::new();
+
+    for &(label, active) in labels {
+        let cell_width = label.len() + 2; // " label " padding
+        let label_style = if active {
+            // Active tab always shows green background — underline bar is the
+            // additional indicator when the tab bar itself has keyboard focus.
             Style::default()
                 .bg(PHOSPHOR_GREEN)
                 .fg(Color::Black)
@@ -360,10 +438,34 @@ fn render_tab_strip(frame: &mut Frame, area: Rect, active: EditorTab) {
         } else {
             Style::default().fg(PHOSPHOR_DIM)
         };
-        spans.push(Span::styled(format!(" {label} "), style));
-        spans.push(Span::raw(" "));
+        label_spans.push(Span::styled(format!(" {label} "), label_style));
+        label_spans.push(Span::raw(" "));
+
+        // Underline bar only meaningful when tab bar is focused.
+        if tab_bar_focused {
+            let bar_text = if active {
+                "━".repeat(cell_width)
+            } else {
+                " ".repeat(cell_width)
+            };
+            bar_spans.push(Span::styled(
+                bar_text,
+                if active {
+                    Style::default().fg(WHITE)
+                } else {
+                    Style::default()
+                },
+            ));
+        } else {
+            bar_spans.push(Span::raw(" ".repeat(cell_width)));
+        }
+        bar_spans.push(Span::raw(" "));
     }
-    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+
+    frame.render_widget(
+        Paragraph::new(vec![Line::from(label_spans), Line::from(bar_spans)]),
+        area,
+    );
 }
 
 fn render_general_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
@@ -451,7 +553,7 @@ fn render_editor_row(row: usize, cursor: usize, label: &str, value: &str) -> Lin
     Line::from(spans)
 }
 
-fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
+fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &mut EditorState<'_>) {
     let FieldFocus::Row(cursor) = state.active_field;
 
     // Build aligned table rows for all mounts.
@@ -514,39 +616,24 @@ fn render_mounts_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>) {
         action_row_style(sentinel_selected),
     )));
 
-    let workspace_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(
-            Style::default().fg(if state.workspace_mounts_scroll_focused {
-                PHOSPHOR_GREEN
-            } else {
-                PHOSPHOR_DARK
-            }),
-        )
-        .title(Span::styled(
-            " Workspace mounts ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-
-    let workspace_content_width = super::max_line_width(&lines);
-    let scroll_x = super::effective_scroll_x(
-        workspace_content_width,
-        area.width.saturating_sub(2) as usize,
-        state.workspace_mounts_scroll_x,
-    );
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(workspace_block)
-            .scroll((0, scroll_x)),
+    state.tab_content_height = lines.len();
+    super::render_scrollable_block(
+        frame,
         area,
+        lines,
+        &mut state.workspace_mounts_scroll_x,
+        &mut state.tab_scroll_y,
+        state.workspace_mounts_scroll_focused,
+        None,
     );
-    super::render_horizontal_scrollbar(frame, area, workspace_content_width, scroll_x);
 }
 
-fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK));
+fn render_roles_tab(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut EditorState<'_>,
+    config: &AppConfig,
+) {
     let FieldFocus::Row(cursor) = state.active_field;
 
     // Status line: "Allowed roles:  [ all ]" or "[ custom ]   (3 of 5 allowed)"
@@ -619,7 +706,17 @@ fn render_roles_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, conf
         format!("{sentinel_prefix}+ Add role"),
         action_row_style(sentinel_selected),
     )));
-    frame.render_widget(Paragraph::new(lines).block(block), area);
+    state.tab_content_height = lines.len();
+    let mut no_scroll_x = 0u16;
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut no_scroll_x,
+        &mut state.tab_scroll_y,
+        state.tab_content_scroll_focused,
+        None,
+    );
 }
 
 /// Flat row model for the Secrets tab; cursor is a single index.
@@ -853,10 +950,12 @@ pub(in crate::console::manager) fn eligible_agents_for_override(
 
 // Linear match per row kind reads better than scattered helpers.
 #[allow(clippy::too_many_lines)]
-fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK));
+fn render_secrets_tab(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut EditorState<'_>,
+    config: &AppConfig,
+) {
     let FieldFocus::Row(cursor) = state.active_field;
 
     let rows = secrets_flat_rows(state);
@@ -888,13 +987,8 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
                 ));
             }
             SecretsRow::WorkspaceAddSentinel => {
-                let marker_col = if state.pending.env.is_empty() {
-                    ""
-                } else {
-                    "     "
-                };
                 lines.push(Line::from(Span::styled(
-                    format!("{cursor_col}{marker_col}+ Add environment variable"),
+                    format!("{cursor_col}+ Add environment variable"),
                     action_row_style(selected),
                 )));
             }
@@ -948,7 +1042,17 @@ fn render_secrets_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, co
         }
     }
 
-    frame.render_widget(Paragraph::new(lines).block(block), area);
+    state.tab_content_height = lines.len();
+    let mut no_scroll_x = 0u16;
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut no_scroll_x,
+        &mut state.tab_scroll_y,
+        state.tab_content_scroll_focused,
+        None,
+    );
 }
 
 /// Display-side breadcrumb parser for `OpRef.path`.
@@ -1020,7 +1124,7 @@ fn split_bracket_subtitle(s: &str) -> (String, Option<String>) {
 /// optional `?attribute=...` query suffix renders in `PHOSPHOR_DIM` after
 /// the field. `Plain` rows render as a literal / masked value with no
 /// `[op]` marker.
-fn render_secrets_key_line(
+pub(in crate::console::manager) fn render_secrets_key_line(
     selected: bool,
     cursor_col: &str,
     key: &str,
@@ -1138,12 +1242,7 @@ fn render_secrets_key_line(
 /// Materializes a synthetic [`AppConfig`] from the editor's pending workspace
 /// merged with the (mostly read-only) global layer of the live config so
 /// in-flight edits are reflected immediately.
-fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, config: &AppConfig) {
-    use crate::console::widgets::auth_panel::{PHOSPHOR_DARK, WHITE};
-    use ratatui::style::Modifier;
-    use ratatui::text::Span;
-    use ratatui::widgets::{List, ListItem, ListState};
-
+fn render_auth_tab(frame: &mut Frame, area: Rect, state: &mut EditorState<'_>, config: &AppConfig) {
     let synthesized = synthesize_appconfig_for_auth(state, config);
     let workspace_name = workspace_name_for_panel(state);
     let rows = auth_flat_rows(state, config);
@@ -1152,32 +1251,24 @@ fn render_auth_tab(frame: &mut Frame, area: Rect, state: &EditorState<'_>, confi
     let max_idx = rows.len().saturating_sub(1);
     let selected = cursor.min(max_idx);
 
-    let items: Vec<ListItem> = rows
+    let lines: Vec<ratatui::text::Line> = rows
         .iter()
         .enumerate()
-        .map(|(i, r)| {
-            ListItem::new(render_auth_row(
-                i == selected,
-                r,
-                &synthesized,
-                &workspace_name,
-            ))
-        })
+        .map(|(i, r)| render_auth_row(i == selected, r, &synthesized, &workspace_name))
         .collect();
-    let mut block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK));
-    if let Some(kind) = state.auth_selected_kind {
-        let title_span = Span::styled(
-            format!(" {} ", kind.label()),
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        );
-        block = block.title(title_span);
-    }
-    let list = List::new(items).block(block).highlight_symbol("▸ ");
-    let mut list_state = ListState::default();
-    list_state.select(Some(selected));
-    frame.render_stateful_widget(list, area, &mut list_state);
+
+    state.tab_content_height = lines.len();
+    let title = state.auth_selected_kind.map(|k| format!(" {} ", k.label()));
+    let mut no_scroll_x = 0u16;
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut no_scroll_x,
+        &mut state.tab_scroll_y,
+        state.tab_content_scroll_focused,
+        title.as_deref(),
+    );
 }
 
 fn render_auth_row(
@@ -1194,7 +1285,11 @@ fn render_auth_row(
 
     match row {
         AuthRow::AuthKindRow { kind } => {
-            ratatui::text::Line::from(Span::styled(kind.label().to_string(), bold_white))
+            let cursor_col = if selected { "▸ " } else { "  " };
+            ratatui::text::Line::from(vec![
+                Span::raw(cursor_col),
+                Span::styled(kind.label().to_string(), bold_white),
+            ])
         }
         AuthRow::WorkspaceMode { kind } => {
             let ws = synthesized.workspaces.get(workspace_name);
@@ -1206,8 +1301,10 @@ fn render_auth_row(
             } else {
                 " (inherited)"
             };
+            let cursor_col = if selected { "▸ " } else { "  " };
             ratatui::text::Line::from(vec![
-                Span::styled(format!("{:<14}", "Mode"), bold_white),
+                Span::raw(cursor_col),
+                Span::styled(format!("{:<12}", "Mode"), bold_white),
                 Span::styled(mode_str(mode).to_string(), phosphor),
                 Span::styled(suffix.to_string(), dim_green),
             ])
@@ -1244,7 +1341,9 @@ fn render_auth_row(
             } else {
                 String::new()
             };
+            let cursor_col = if selected { "▸ " } else { "  " };
             ratatui::text::Line::from(vec![
+                Span::raw(cursor_col),
                 Span::styled("+ Override for a role", label_style),
                 Span::styled(suffix, dim_green),
             ])
@@ -1746,7 +1845,7 @@ mod agents_tab_render_tests {
         let backend = TestBackend::new(60, 10);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            render_roles_tab(f, Rect::new(0, 0, 60, 10), &editor, config);
+            render_roles_tab(f, Rect::new(0, 0, 60, 10), &mut editor, config);
         })
         .unwrap();
         let buf = term.backend().buffer();
@@ -1900,7 +1999,7 @@ mod secrets_tab_render_tests {
 
     /// Render the Secrets tab to a 80x15 `TestBackend`, return the raw
     /// buffer as newline-delimited rows so tests can search for glyphs.
-    fn render_to_dump(editor: &EditorState<'_>) -> String {
+    fn render_to_dump(editor: &mut EditorState<'_>) -> String {
         let config = AppConfig::default();
         let backend = TestBackend::new(80, 15);
         let mut term = Terminal::new(backend).unwrap();
@@ -1923,12 +2022,12 @@ mod secrets_tab_render_tests {
     fn secrets_tab_defaults_to_masked() {
         // `new_edit` leaves `unmasked_rows` empty, so every plain-text
         // value renders masked by default.
-        let editor = editor_with_workspace_env();
+        let mut editor = editor_with_workspace_env();
         assert!(
             editor.unmasked_rows.is_empty(),
             "new_edit must leave unmasked_rows empty (default = all masked)"
         );
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("●●●●●●●●●●●"),
             "masked-default render must show the mask glyph; got:\n{dump}"
@@ -1945,7 +2044,7 @@ mod secrets_tab_render_tests {
         editor
             .unmasked_rows
             .insert((SecretsScopeTag::Workspace, "DB_URL".into()));
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("postgres://localhost/db"),
             "unmasked render must show literal value; got:\n{dump}"
@@ -1961,9 +2060,9 @@ mod secrets_tab_render_tests {
         // `secrets_expanded` is empty by default (set by `new_edit`), so
         // the role section header renders but its `LOG_LEVEL` key row
         // does not.
-        let editor = editor_with_agent_override();
+        let mut editor = editor_with_agent_override();
         assert!(editor.secrets_expanded.is_empty());
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("agent-smith"),
             "role header must render; got:\n{dump}"
@@ -1978,7 +2077,7 @@ mod secrets_tab_render_tests {
     fn secrets_tab_expanded_agent_shows_key_rows() {
         let mut editor = editor_with_agent_override();
         editor.secrets_expanded.insert("agent-smith".into());
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("agent-smith"),
             "role header must still render when expanded; got:\n{dump}"
@@ -2089,8 +2188,8 @@ mod secrets_tab_render_tests {
 
     #[test]
     fn secrets_tab_empty_renders_only_sentinel() {
-        let editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
-        let dump = render_to_dump(&editor);
+        let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
+        let dump = render_to_dump(&mut editor);
 
         assert!(
             dump.contains("+ Add environment variable"),
@@ -2128,7 +2227,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("Work"),
             "breadcrumb must render vault segment; dump:\n{dump}"
@@ -2181,7 +2280,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         // All four components must appear, in order, with the arrow
         // glyph between the section and the field.
         assert!(
@@ -2229,7 +2328,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("[op]"),
             "OpRef row must render the `[op]` text marker; dump:\n{dump}"
@@ -2252,7 +2351,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             !dump.contains("[op]"),
             "plain-text row must not render the `[op]` marker; dump:\n{dump}"
@@ -2277,7 +2376,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         assert!(
             dump.contains("[op] "),
             "OpRef row must render the marker as exactly `[op] ` (5 chars \
@@ -2303,7 +2402,7 @@ mod secrets_tab_render_tests {
         let mut term = Terminal::new(backend).unwrap();
         let config = AppConfig::default();
         term.draw(|f| {
-            render_secrets_tab(f, Rect::new(0, 0, 80, 15), &editor, &config);
+            render_secrets_tab(f, Rect::new(0, 0, 80, 15), &mut editor, &config);
         })
         .unwrap();
         let buf = term.backend().buffer();
@@ -2332,7 +2431,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         let alpha = dump.find("ALPHA").expect("ALPHA must appear");
         let mike = dump.find("MIKE").expect("MIKE must appear");
         let zulu = dump.find("ZULU").expect("ZULU must appear");
@@ -2429,7 +2528,7 @@ mod secrets_tab_render_tests {
 
     /// Helper that renders the Secrets tab to a wider (120-column) terminal
     /// so long breadcrumbs (subtitle + section + field) are not truncated.
-    fn render_to_dump_wide(editor: &EditorState<'_>) -> String {
+    fn render_to_dump_wide(editor: &mut EditorState<'_>) -> String {
         let config = AppConfig::default();
         let backend = TestBackend::new(120, 15);
         let mut term = Terminal::new(backend).unwrap();
@@ -2470,7 +2569,7 @@ mod secrets_tab_render_tests {
         editor.active_field = FieldFocus::Row(0);
 
         // Use the wide terminal so the subtitle and field are not truncated.
-        let dump = render_to_dump_wide(&editor);
+        let dump = render_to_dump_wide(&mut editor);
         // The row must carry the [op] marker (OpRef variant).
         assert!(
             dump.contains("[op]"),
@@ -2518,7 +2617,7 @@ mod secrets_tab_render_tests {
         editor.active_field = FieldFocus::Row(0);
 
         // Use the wide terminal so `?attribute=otp` is not truncated.
-        let dump = render_to_dump_wide(&editor);
+        let dump = render_to_dump_wide(&mut editor);
         // The row must carry the [op] marker.
         assert!(
             dump.contains("[op]"),
@@ -2559,7 +2658,7 @@ mod secrets_tab_render_tests {
         editor.active_field = FieldFocus::Row(0);
 
         // Use the wide terminal so no piece is truncated.
-        let dump = render_to_dump_wide(&editor);
+        let dump = render_to_dump_wide(&mut editor);
 
         // All visible pieces must appear in order:
         // vault → item → subtitle → section → field → query.
@@ -2591,7 +2690,7 @@ mod secrets_tab_render_tests {
         editor.active_tab = EditorTab::Secrets;
         editor.active_field = FieldFocus::Row(0);
 
-        let dump = render_to_dump(&editor);
+        let dump = render_to_dump(&mut editor);
         // Plain rows carrying a legacy op:// string must NOT render the
         // [op] marker — the visual distinction signals the need to re-pick.
         assert!(
@@ -2633,7 +2732,7 @@ mod secrets_tab_render_tests {
         editor.active_field = FieldFocus::Row(0);
 
         // Use the wide terminal so the breadcrumb is not truncated.
-        let dump = render_to_dump_wide(&editor);
+        let dump = render_to_dump_wide(&mut editor);
         assert!(
             dump.contains("CLAUDE_CODE_OAUTH_TOKEN  Private"),
             "expected at least 2 spaces between key and breadcrumb; dump:\n{dump}"
@@ -2669,7 +2768,7 @@ mod secrets_tab_render_tests {
             .unmasked_rows
             .insert((SecretsScopeTag::Workspace, "TOKEN".into()));
 
-        let dump = render_to_dump_wide(&editor);
+        let dump = render_to_dump_wide(&mut editor);
         // Malformed path → parse_path_breadcrumb returns None → no [op] marker.
         assert!(!dump.contains("[op]"), "no [op] marker; dump:\n{dump}");
         // Re-pick placeholder must be shown instead of the UUID URI.

--- a/src/console/manager/render/global_mounts.rs
+++ b/src/console/manager/render/global_mounts.rs
@@ -3,153 +3,786 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
 };
+use std::collections::BTreeMap;
 
 use super::{
-    FooterItem, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, render_footer, render_header,
+    FooterItem, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE, footer_height, render_footer, render_header,
 };
-use crate::console::manager::render::list::mount_display_paths;
-use crate::console::manager::state::{GlobalMountModal, GlobalMountsState};
+use crate::console::manager::auth_kind::AuthKind;
+use crate::console::manager::render::list::{
+    MOUNT_MODE_COL_WIDTH, format_mount_rows, mount_path_width,
+};
+use crate::console::manager::state::{
+    GlobalMountModal, SettingsAuthModal, SettingsEnvModal, SettingsEnvScope, SettingsState,
+    SettingsTab,
+};
+use crate::operator_env::EnvValue;
 
 pub(super) fn global_mounts_content_width(rows: &[crate::config::GlobalMountRow]) -> usize {
-    let lines = global_mount_lines(rows, None);
+    let lines = global_mount_lines(rows, None, false);
     super::max_line_width(&lines)
 }
 
-pub(super) fn render_global_mounts(frame: &mut Frame, state: &GlobalMountsState<'_>) {
+pub(super) fn render_settings(
+    frame: &mut Frame,
+    state: &mut SettingsState<'_>,
+    op_available: bool,
+) {
+    use super::modal::{
+        settings_auth_modal_footer_items, settings_env_modal_footer_items,
+        settings_mounts_modal_footer_items,
+    };
     let area = frame.area();
+    // When a modal is open, show its keys in the footer (the "behind" keys are unreachable).
+    // Check in priority order: auth modal > env modal > mounts modal > no modal.
+    let footer = if let Some(modal) = &state.auth.modal {
+        settings_auth_modal_footer_items(modal)
+    } else if let Some(modal) = &state.env.modal {
+        settings_env_modal_footer_items(modal)
+    } else if let Some(modal) = &state.mounts.modal {
+        settings_mounts_modal_footer_items(modal)
+    } else {
+        footer_items(state, op_available)
+    };
+    let footer_h = footer_height(&footer, area.width).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
-            Constraint::Min(10),
             Constraint::Length(2),
+            Constraint::Min(5),
+            Constraint::Length(footer_h),
         ])
         .split(area);
-    render_header(frame, chunks[0], "global config · mounts");
+    render_header(frame, chunks[0], "settings");
+    let labels = SettingsTab::ALL
+        .iter()
+        .map(|tab| (tab.label(), *tab == state.active_tab))
+        .collect::<Vec<_>>();
+    super::editor::render_tab_strip(frame, chunks[1], &labels, state.tab_bar_focused);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(Span::styled(
-            " Global mounts ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-    let mut lines = global_mount_lines(&state.pending, Some(state.selected));
-    if let Some(err) = &state.error {
+    match state.active_tab {
+        SettingsTab::Mounts => render_mounts_tab(frame, state, chunks[2]),
+        SettingsTab::Environments => render_env_tab(frame, state, chunks[2]),
+        SettingsTab::Auth => render_auth_tab(frame, state, chunks[2]),
+        SettingsTab::Trust => render_trust_tab(frame, state, chunks[2]),
+    }
+
+    render_footer(frame, chunks[3], &footer);
+}
+
+fn render_mounts_tab(
+    frame: &mut Frame,
+    state: &mut SettingsState<'_>,
+    area: ratatui::layout::Rect,
+) {
+    let mut lines = global_mount_lines(&state.mounts.pending, Some(state.mounts.selected), true);
+    if let Some(err) = &state.mounts.error {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             format!("  {err}"),
             Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
         )));
     }
-    let content_width = super::max_line_width(&lines);
-    let scroll_x = super::effective_scroll_x(
-        content_width,
-        chunks[1].width.saturating_sub(2) as usize,
-        state.scroll_x,
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut state.mounts.scroll_x,
+        &mut state.mounts.scroll_y,
+        state.mounts.scroll_focused,
+        None,
     );
-    frame.render_widget(
-        Paragraph::new(lines).block(block).scroll((0, scroll_x)),
-        chunks[1],
-    );
-    super::render_horizontal_scrollbar(frame, chunks[1], content_width, scroll_x);
+}
 
+fn render_env_tab(frame: &mut Frame, state: &mut SettingsState<'_>, area: ratatui::layout::Rect) {
+    let mut lines = env_lines(state, area.width);
+    if let Some(err) = &state.env.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {err}"),
+            Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
+        )));
+    }
+    let mut no_scroll_x = 0u16;
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut no_scroll_x,
+        &mut state.env.scroll_y,
+        false,
+        None,
+    );
+}
+
+fn render_auth_tab(frame: &mut Frame, state: &SettingsState<'_>, area: ratatui::layout::Rect) {
+    let title = state.auth.selected_kind.map(|k| format!(" {} ", k.label()));
+    let mut lines = auth_lines(state);
+    if let Some(err) = &state.auth.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {err}"),
+            Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
+        )));
+    }
+    let mut no_scroll_x = 0u16;
+    let mut no_scroll_y = 0u16;
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut no_scroll_x,
+        &mut no_scroll_y,
+        false,
+        title.as_deref(),
+    );
+}
+
+fn render_trust_tab(frame: &mut Frame, state: &mut SettingsState<'_>, area: ratatui::layout::Rect) {
+    let mut lines = trust_lines(state);
+    if let Some(err) = &state.trust.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("  {err}"),
+            Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
+        )));
+    }
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        &mut state.trust.scroll_x,
+        &mut state.trust.scroll_y,
+        state.trust.scroll_focused,
+        None,
+    );
+}
+
+/// Natural content width of the Trust tab (used by mouse scroll).
+pub(in crate::console::manager) fn trust_content_width(state: &SettingsState<'_>) -> usize {
+    super::max_line_width(&trust_lines(state))
+}
+
+fn footer_items(state: &SettingsState<'_>, op_available: bool) -> Vec<FooterItem> {
+    if state.tab_bar_focused {
+        // Tab bar has focus: show tab-navigation keys, then global actions.
+        let mut items = vec![
+            FooterItem::Key("\u{2190}\u{2192}"),
+            FooterItem::Text("switch tab"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Tab/\u{2193}"),
+            FooterItem::Text("enter content"),
+        ];
+        items.extend([
+            FooterItem::GroupSep,
+            FooterItem::Key("S"),
+            FooterItem::Text("save settings"),
+        ]);
+        if state.is_dirty() {
+            items.push(FooterItem::Dyn(format!(
+                "({} changes)",
+                state.change_count()
+            )));
+        }
+        items.extend([
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text(if state.is_dirty() { "discard" } else { "back" }),
+        ]);
+        return items;
+    }
+
+    // Content area has focus.
     let mut items = vec![
-        FooterItem::Key("A"),
-        FooterItem::Text("add"),
-        FooterItem::Sep,
-        FooterItem::Key("N"),
-        FooterItem::Text("rename"),
-        FooterItem::Sep,
-        FooterItem::Key("1"),
-        FooterItem::Text("source"),
-        FooterItem::Sep,
-        FooterItem::Key("2"),
-        FooterItem::Text("destination"),
-        FooterItem::Sep,
-        FooterItem::Key("3"),
-        FooterItem::Text("scope"),
-        FooterItem::Sep,
-        FooterItem::Key("R"),
-        FooterItem::Text("ro/rw"),
-        FooterItem::Sep,
-        FooterItem::Key("D"),
-        FooterItem::Text("remove"),
-        FooterItem::GroupSep,
-        FooterItem::Key("S"),
-        FooterItem::Text("save global config"),
-        FooterItem::GroupSep,
-        FooterItem::Key("←/→"),
-        FooterItem::Text("scroll"),
+        FooterItem::Key("\u{2191}\u{2193}"),
+        FooterItem::Text("navigate"),
     ];
+
+    let row_items = contextual_row_items(state, op_available);
+    if !row_items.is_empty() {
+        items.push(FooterItem::GroupSep);
+        items.extend(row_items);
+    }
+
+    items.extend([
+        FooterItem::GroupSep,
+        FooterItem::Key("BackTab"),
+        FooterItem::Text("tab bar"),
+        FooterItem::GroupSep,
+    ]);
+    items.extend([FooterItem::Key("S"), FooterItem::Text("save settings")]);
     if state.is_dirty() {
-        items.push(FooterItem::Dyn("(unsaved)".to_string()));
+        items.push(FooterItem::Dyn(format!(
+            "({} changes)",
+            state.change_count()
+        )));
     }
     items.extend([
         FooterItem::GroupSep,
         FooterItem::Key("Esc"),
-        FooterItem::Text("back"),
+        FooterItem::Text(if state.is_dirty() { "discard" } else { "back" }),
     ]);
-    render_footer(frame, chunks[2], &items);
+    items
+}
+
+#[allow(clippy::too_many_lines)]
+fn contextual_row_items(state: &SettingsState<'_>, op_available: bool) -> Vec<FooterItem> {
+    match state.active_tab {
+        SettingsTab::Mounts => {
+            let cursor = state.mounts.selected;
+            let mount_count = state.mounts.pending.len();
+            if cursor == mount_count {
+                vec![FooterItem::Key("Enter/A"), FooterItem::Text("add")]
+            } else {
+                let mut items = vec![
+                    FooterItem::Key("D"),
+                    FooterItem::Text("remove"),
+                    FooterItem::Sep,
+                    FooterItem::Key("A"),
+                    FooterItem::Text("add"),
+                ];
+                if let Some(row) = state.mounts.pending.get(cursor)
+                    && matches!(
+                        super::super::mount_info::inspect(&row.mount.src),
+                        super::super::mount_info::MountKind::Git {
+                            origin: Some(super::super::mount_info::GitOrigin::Github { .. }),
+                            ..
+                        }
+                    )
+                {
+                    items.push(FooterItem::Sep);
+                    items.push(FooterItem::Key("O"));
+                    items.push(FooterItem::Text("open in GitHub"));
+                }
+                items.extend([
+                    FooterItem::Sep,
+                    FooterItem::Key("R"),
+                    FooterItem::Text("toggle ro/rw"),
+                    FooterItem::Sep,
+                    FooterItem::Key("N"),
+                    FooterItem::Text("rename"),
+                    FooterItem::Sep,
+                    FooterItem::Key("1"),
+                    FooterItem::Text("edit source"),
+                    FooterItem::Sep,
+                    FooterItem::Key("2"),
+                    FooterItem::Text("edit dst"),
+                    FooterItem::Sep,
+                    FooterItem::Key("3"),
+                    FooterItem::Text("edit scope"),
+                    FooterItem::Sep,
+                    FooterItem::Key("H/L"),
+                    FooterItem::Text("scroll"),
+                ]);
+                items
+            }
+        }
+        SettingsTab::Environments => {
+            let rows = settings_env_flat_rows(state);
+            match rows.get(state.env.selected) {
+                Some(SettingsEnvRow::Key { scope, key })
+                    if settings_env_value_is_op_ref(state, scope, key) =>
+                {
+                    let mut items = vec![
+                        FooterItem::Key("Enter"),
+                        FooterItem::Sep,
+                        FooterItem::Key("P"),
+                        FooterItem::Text("re-pick from 1Password"),
+                        FooterItem::Sep,
+                        FooterItem::Key("D"),
+                        FooterItem::Text("delete"),
+                        FooterItem::Sep,
+                        FooterItem::Key("A"),
+                        FooterItem::Text("add"),
+                    ];
+                    if op_available {
+                        // Enter/P both work; if 1Password is unavailable, hint is less useful.
+                    } else {
+                        // 1Password not available; remove the Enter/P hint.
+                        items.drain(..4);
+                    }
+                    items
+                }
+                Some(SettingsEnvRow::Key { .. }) => {
+                    let mut items = vec![
+                        FooterItem::Key("Enter"),
+                        FooterItem::Text("edit"),
+                        FooterItem::Sep,
+                        FooterItem::Key("D"),
+                        FooterItem::Text("delete"),
+                        FooterItem::Sep,
+                        FooterItem::Key("A"),
+                        FooterItem::Text("add"),
+                        FooterItem::Sep,
+                        FooterItem::Key("M"),
+                        FooterItem::Text("mask/unmask"),
+                    ];
+                    if op_available {
+                        items.push(FooterItem::Sep);
+                        items.push(FooterItem::Key("P"));
+                        items.push(FooterItem::Text("1Password"));
+                    }
+                    items
+                }
+                Some(SettingsEnvRow::RoleHeader { .. }) => vec![
+                    FooterItem::Key("Enter"),
+                    FooterItem::Text("expand"),
+                    FooterItem::Sep,
+                    FooterItem::Key("←/→"),
+                    FooterItem::Text("collapse/expand"),
+                    FooterItem::Sep,
+                    FooterItem::Key("A"),
+                    FooterItem::Text("add"),
+                ],
+                Some(SettingsEnvRow::GlobalAddSentinel | SettingsEnvRow::RoleAddSentinel(_)) => {
+                    let mut items = vec![FooterItem::Key("Enter"), FooterItem::Text("add")];
+                    if op_available {
+                        items.extend([
+                            FooterItem::Sep,
+                            FooterItem::Key("P"),
+                            FooterItem::Text("1Password"),
+                        ]);
+                    }
+                    items
+                }
+                Some(SettingsEnvRow::SectionSpacer) | None => Vec::new(),
+            }
+        }
+        SettingsTab::Auth => {
+            if state.auth.selected_kind.is_none() {
+                vec![FooterItem::Key("Enter"), FooterItem::Text("manage auth")]
+            } else if state.auth.selected == 0 {
+                // Esc here pops back to the auth list; the global footer already
+                // shows Esc for the settings-level exit — omit it here to avoid duplication.
+                vec![FooterItem::Key("Enter"), FooterItem::Text("edit mode")]
+            } else {
+                vec![FooterItem::Key("Enter"), FooterItem::Text("edit source")]
+            }
+        }
+        SettingsTab::Trust => {
+            if state.trust.pending.is_empty() {
+                Vec::new()
+            } else {
+                vec![
+                    FooterItem::Key("Space"),
+                    FooterItem::Text("trust/untrust"),
+                    FooterItem::Sep,
+                    FooterItem::Key("H/L"),
+                    FooterItem::Text("scroll"),
+                ]
+            }
+        }
+    }
 }
 
 fn global_mount_lines(
     rows: &[crate::config::GlobalMountRow],
     selected: Option<usize>,
+    include_sentinel: bool,
 ) -> Vec<Line<'static>> {
+    let mounts = rows.iter().map(|row| row.mount.clone()).collect::<Vec<_>>();
+    let display_rows = format_mount_rows(&mounts);
+    let path_w = mount_path_width(&display_rows);
     let mut lines = vec![Line::from(Span::styled(
-        "  Name                 Destination                    Mode Scope",
+        format!(
+            "  {path:<path_w$}  {mode:<MOUNT_MODE_COL_WIDTH$}  Type",
+            path = "Destination",
+            mode = "Mode"
+        ),
         Style::default().fg(WHITE),
     ))];
-    if rows.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  (none)",
-            Style::default().fg(PHOSPHOR_DIM),
-        )));
-    }
-    for (i, row) in rows.iter().enumerate() {
+    for (i, row) in display_rows.iter().enumerate() {
         let is_selected = selected == Some(i);
         let prefix = if is_selected { "▸ " } else { "  " };
-        let style = if is_selected {
+        let base_style = if is_selected {
             Style::default()
                 .fg(PHOSPHOR_GREEN)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(PHOSPHOR_GREEN)
         };
-        let mode = if row.mount.readonly { "ro" } else { "rw" };
-        let scope = row.scope.as_deref().unwrap_or("global");
-        let (destination, host_source) = mount_display_paths(&row.mount);
-        lines.push(Line::from(Span::styled(
-            format!(
-                "{prefix}{:<20} {:<30} {:<4} {:<16}",
-                truncate(&row.name, 20),
-                truncate(&destination, 30),
-                mode,
-                truncate(scope, 16)
+        let dim_style = Style::default()
+            .fg(PHOSPHOR_DIM)
+            .add_modifier(Modifier::ITALIC);
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{prefix}{:<path_w$}  ", row.destination),
+                base_style,
             ),
-            style,
-        )));
-        if let Some(host_source) = host_source {
+            Span::styled(
+                format!("{:<MOUNT_MODE_COL_WIDTH$}", row.mode),
+                Style::default().fg(PHOSPHOR_DIM),
+            ),
+            Span::raw("  "),
+            Span::styled(row.kind.clone(), dim_style),
+        ]));
+        if let Some(host_source) = &row.host_source {
             lines.push(Line::from(Span::styled(
-                format!("  {:<20} {}", "", truncate(&host_source, 64)),
+                format!("  {host_source:<path_w$}"),
                 Style::default().fg(PHOSPHOR_DIM),
             )));
+        }
+    }
+    if include_sentinel {
+        let sentinel_selected = selected == Some(rows.len());
+        let sentinel_prefix = if sentinel_selected { "▸ " } else { "  " };
+        if !rows.is_empty() {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(Span::styled(
+            format!("{sentinel_prefix}+ Add mount"),
+            super::editor::action_row_style(sentinel_selected),
+        )));
+    }
+    lines
+}
+
+fn env_lines(state: &SettingsState<'_>, area_width: u16) -> Vec<Line<'static>> {
+    let rows = settings_env_flat_rows(state);
+    let mut lines = Vec::with_capacity(rows.len());
+    let label_width = 22;
+    for (i, row) in rows.iter().enumerate() {
+        let selected = state.env.selected == i;
+        let cursor_col = if selected { "▸ " } else { "  " };
+        match row {
+            SettingsEnvRow::Key { scope, key } => {
+                let Some(value) = settings_env_value(state, scope, key) else {
+                    continue;
+                };
+                let masked = !state
+                    .env
+                    .unmasked_rows
+                    .contains(&(scope.clone(), key.clone()));
+                lines.push(super::editor::render_secrets_key_line(
+                    selected,
+                    cursor_col,
+                    key,
+                    value,
+                    masked,
+                    area_width,
+                    label_width,
+                ));
+            }
+            SettingsEnvRow::GlobalAddSentinel => {
+                lines.push(Line::from(Span::styled(
+                    format!("{cursor_col}+ Add environment variable"),
+                    super::editor::action_row_style(selected),
+                )));
+            }
+            SettingsEnvRow::RoleHeader { role, expanded } => {
+                let arrow = if *expanded { "▼" } else { "▶" };
+                let count = state.env.pending.roles.get(role).map_or(0, BTreeMap::len);
+                lines.push(Line::from(vec![
+                    Span::raw(cursor_col.to_string()),
+                    Span::styled(arrow.to_string(), super::editor::disclosure_style()),
+                    Span::styled(
+                        format!(" Role: {role}  ({count} vars)"),
+                        super::editor::disclosure_style(),
+                    ),
+                ]));
+            }
+            SettingsEnvRow::RoleAddSentinel(role) => {
+                lines.push(Line::from(Span::styled(
+                    format!("{cursor_col}+ Add {role} environment variable"),
+                    super::editor::action_row_style(selected),
+                )));
+            }
+            SettingsEnvRow::SectionSpacer => lines.push(Line::from("")),
         }
     }
     lines
 }
 
+#[derive(Debug, Clone)]
+pub(in crate::console::manager) enum SettingsEnvRow {
+    Key {
+        scope: SettingsEnvScope,
+        key: String,
+    },
+    GlobalAddSentinel,
+    RoleHeader {
+        role: String,
+        expanded: bool,
+    },
+    RoleAddSentinel(String),
+    SectionSpacer,
+}
+
+pub(in crate::console::manager) fn settings_env_flat_rows(
+    state: &SettingsState<'_>,
+) -> Vec<SettingsEnvRow> {
+    let mut rows = Vec::new();
+    for key in state.env.pending.env.keys() {
+        rows.push(SettingsEnvRow::Key {
+            scope: SettingsEnvScope::Global,
+            key: key.clone(),
+        });
+    }
+    if !state.env.pending.env.is_empty() {
+        rows.push(SettingsEnvRow::SectionSpacer);
+    }
+    rows.push(SettingsEnvRow::GlobalAddSentinel);
+    for (role, role_env) in &state.env.pending.roles {
+        if role_env.is_empty() {
+            continue;
+        }
+        rows.push(SettingsEnvRow::SectionSpacer);
+        let expanded = state.env.expanded.contains(role);
+        rows.push(SettingsEnvRow::RoleHeader {
+            role: role.clone(),
+            expanded,
+        });
+        if expanded {
+            if let Some(env) = state.env.pending.roles.get(role) {
+                for key in env.keys() {
+                    rows.push(SettingsEnvRow::Key {
+                        scope: SettingsEnvScope::Role(role.clone()),
+                        key: key.clone(),
+                    });
+                }
+            }
+            rows.push(SettingsEnvRow::SectionSpacer);
+            rows.push(SettingsEnvRow::RoleAddSentinel(role.clone()));
+        }
+    }
+    rows
+}
+
+fn settings_env_value<'a>(
+    state: &'a SettingsState<'_>,
+    scope: &SettingsEnvScope,
+    key: &str,
+) -> Option<&'a crate::operator_env::EnvValue> {
+    match scope {
+        SettingsEnvScope::Global => state.env.pending.env.get(key),
+        SettingsEnvScope::Role(role) => state
+            .env
+            .pending
+            .roles
+            .get(role)
+            .and_then(|env| env.get(key)),
+    }
+}
+
+fn settings_env_value_is_op_ref(
+    state: &SettingsState<'_>,
+    scope: &SettingsEnvScope,
+    key: &str,
+) -> bool {
+    settings_env_value(state, scope, key)
+        .is_some_and(|value| matches!(value, crate::operator_env::EnvValue::OpRef(_)))
+}
+
+fn auth_lines(state: &SettingsState<'_>) -> Vec<Line<'static>> {
+    use crate::console::widgets::auth_panel::mode_str;
+
+    let bold_white = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
+    let phosphor = Style::default().fg(PHOSPHOR_GREEN);
+    let dim = Style::default().fg(PHOSPHOR_DIM);
+    let Some(kind) = state.auth.selected_kind else {
+        return state
+            .auth
+            .pending
+            .iter()
+            .enumerate()
+            .map(|(i, row)| {
+                let selected = state.auth.selected == i;
+                let cursor_col = if selected { "▸ " } else { "  " };
+                Line::from(Span::styled(
+                    format!("{cursor_col}{}", row.kind.label()),
+                    bold_white,
+                ))
+            })
+            .collect();
+    };
+    let Some(row) = state.auth.pending.iter().find(|row| row.kind == kind) else {
+        return Vec::new();
+    };
+    let mut lines = Vec::new();
+    let mode_style = if state.auth.selected == 0 {
+        phosphor.add_modifier(Modifier::BOLD)
+    } else {
+        phosphor
+    };
+    let cursor_col = if state.auth.selected == 0 {
+        "▸ "
+    } else {
+        "  "
+    };
+    lines.push(Line::from(vec![
+        Span::styled(cursor_col, mode_style),
+        Span::styled(format!("{:<14}", "Mode"), bold_white),
+        Span::styled(mode_str(row.mode).to_string(), mode_style),
+    ]));
+    if let Some(env_name) = kind.required_env_var(row.mode) {
+        let source_style = if state.auth.selected == 1 {
+            dim.add_modifier(Modifier::BOLD)
+        } else {
+            dim
+        };
+        let cursor_col = if state.auth.selected == 1 {
+            "▸ "
+        } else {
+            "  "
+        };
+        let mut spans = vec![
+            Span::styled(cursor_col, source_style),
+            Span::styled(format!("{:<14}", "Source"), bold_white),
+        ];
+        match settings_auth_source_value(state, kind, env_name) {
+            Some(EnvValue::Plain(value)) if !value.is_empty() => {
+                spans.push(Span::styled(
+                    "●".repeat(value.chars().count().clamp(1, 12)),
+                    source_style,
+                ));
+            }
+            Some(EnvValue::OpRef(op_ref)) => {
+                spans.push(Span::styled("[op] ", source_style));
+                super::editor::push_op_breadcrumb_spans(&mut spans, &op_ref.path);
+            }
+            _ => {
+                spans.push(Span::styled(
+                    format!("unset  ({env_name} for {})", mode_str(row.mode)),
+                    Style::default().fg(crate::console::widgets::auth_panel::DANGER_RED),
+                ));
+            }
+        }
+        lines.push(Line::from(spans));
+    }
+    lines.push(Line::from(""));
+    lines
+}
+
+fn settings_auth_source_value<'a>(
+    state: &'a SettingsState<'_>,
+    kind: AuthKind,
+    env_name: &str,
+) -> Option<&'a EnvValue> {
+    if kind == AuthKind::Github {
+        state.auth.github_env.get(env_name)
+    } else {
+        state.env.pending.env.get(env_name)
+    }
+}
+
+fn trust_lines(state: &SettingsState<'_>) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "  Role                         Trust      Git",
+        Style::default().fg(WHITE),
+    ))];
+    if state.trust.pending.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (none)",
+            Style::default().fg(PHOSPHOR_DIM),
+        )));
+    }
+    for (i, row) in state.trust.pending.iter().enumerate() {
+        let selected = state.trust.selected == i;
+        let style = if selected {
+            Style::default()
+                .fg(PHOSPHOR_GREEN)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(PHOSPHOR_GREEN)
+        };
+        let prefix = if selected { "▸ " } else { "  " };
+        let trust = if row.trusted { "trusted" } else { "untrusted" };
+        lines.push(Line::from(Span::styled(
+            format!(
+                "{prefix}{:<28} {:<10} {}",
+                truncate(&row.role, 28),
+                trust,
+                row.git // full URL — horizontal scroll handles overflow
+            ),
+            style,
+        )));
+    }
+    lines
+}
+
 pub(super) fn render_global_mount_modal(frame: &mut Frame, modal: &mut GlobalMountModal<'_>) {
-    let area = super::centered_rect_fixed(frame.area(), 70, 7);
     match modal {
         GlobalMountModal::Text { state, .. } => {
+            let area = super::modal::text_input_rect(frame.area());
             crate::console::widgets::text_input::render(frame, area, state);
         }
+        GlobalMountModal::FileBrowser { state } => {
+            let area = super::centered_rect_fixed(frame.area(), 70, 22);
+            crate::console::widgets::file_browser::render(frame, area, state);
+        }
+        GlobalMountModal::MountDstChoice { state } => {
+            let area = super::modal::mount_choice_rect(frame.area());
+            crate::console::widgets::mount_dst_choice::render(frame, area, state);
+        }
+        GlobalMountModal::ScopePicker { state } => {
+            let area = super::modal::scope_picker_rect(frame.area());
+            crate::console::widgets::scope_picker::render(frame, area, state);
+        }
+        GlobalMountModal::RolePicker { state } => {
+            let area = super::modal::role_picker_rect(frame.area(), state);
+            crate::console::widgets::role_picker::render(frame, area, state);
+        }
         GlobalMountModal::Confirm { state, .. } => {
+            let area = super::modal::confirm_rect(frame.area(), state);
             crate::console::widgets::confirm::render(frame, area, state);
+        }
+        GlobalMountModal::PreviewSave { state } => {
+            use crate::console::widgets::confirm_save;
+            let height = confirm_save::required_height(state).min(frame.area().height);
+            let area = super::centered_rect_fixed(frame.area(), 80, height);
+            confirm_save::render(frame, area, state);
+        }
+    }
+}
+
+pub(super) fn render_settings_env_modal(frame: &mut Frame, modal: &mut SettingsEnvModal<'_>) {
+    match modal {
+        SettingsEnvModal::Text { state, .. } => {
+            let area = super::modal::text_input_rect(frame.area());
+            crate::console::widgets::text_input::render(frame, area, state);
+        }
+        SettingsEnvModal::SourcePicker { state } => {
+            let area = super::modal::source_picker_rect(frame.area());
+            crate::console::widgets::source_picker::render(frame, area, state);
+        }
+        SettingsEnvModal::OpPicker { state } => {
+            let area = super::modal::op_picker_rect(frame.area());
+            crate::console::widgets::op_picker::render::render(frame, area, state);
+        }
+        SettingsEnvModal::RolePicker { state } => {
+            let area = super::modal::role_picker_rect(frame.area(), state);
+            crate::console::widgets::role_picker::render(frame, area, state);
+        }
+        SettingsEnvModal::ScopePicker { state } => {
+            let area = super::modal::scope_picker_rect(frame.area());
+            crate::console::widgets::scope_picker::render(frame, area, state);
+        }
+        SettingsEnvModal::Confirm { state, .. } => {
+            let area = super::modal::confirm_rect(frame.area(), state);
+            crate::console::widgets::confirm::render(frame, area, state);
+        }
+    }
+}
+
+pub(super) fn render_settings_auth_modal(frame: &mut Frame, modal: &mut SettingsAuthModal<'_>) {
+    match modal {
+        SettingsAuthModal::AuthForm { state, focus, .. } => {
+            let area = super::modal::auth_form_rect(frame.area(), state);
+            crate::console::widgets::auth_panel::render::render_form(frame, area, state, *focus);
+        }
+        SettingsAuthModal::SourcePicker { state } => {
+            let area = super::modal::source_picker_rect(frame.area());
+            crate::console::widgets::source_picker::render(frame, area, state);
+        }
+        SettingsAuthModal::TextInput { state } => {
+            let area = super::modal::text_input_rect(frame.area());
+            crate::console::widgets::text_input::render(frame, area, state);
+        }
+        SettingsAuthModal::OpPicker { state } => {
+            let area = super::modal::op_picker_rect(frame.area());
+            crate::console::widgets::op_picker::render::render(frame, area, state);
         }
     }
 }
@@ -161,4 +794,46 @@ fn truncate(value: &str, width: usize) -> String {
         out.push('…');
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AppConfig;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn render_settings_to_dump(state: &mut SettingsState<'_>) -> String {
+        let backend = TestBackend::new(90, 18);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|frame| render_settings(frame, state, false))
+            .unwrap();
+        let buf = term.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn settings_header_does_not_duplicate_active_tab_label() {
+        let config = AppConfig::default();
+        for tab in SettingsTab::ALL {
+            let mut state = SettingsState::from_config(&config);
+            state.active_tab = tab;
+            let dump = render_settings_to_dump(&mut state);
+            let header = dump.lines().next().unwrap_or_default();
+            assert!(
+                header.contains("settings"),
+                "settings header missing for {tab:?}: {header:?}"
+            );
+            assert!(
+                !header.contains("settings ·"),
+                "settings header must not duplicate active tab for {tab:?}: {header:?}"
+            );
+        }
+    }
 }

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -14,10 +14,11 @@ use super::super::state::{ManagerListRow, ManagerState, MountScrollFocus, Worksp
 use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 use crate::config::AppConfig;
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn render_list_body(
     frame: &mut Frame,
     area: Rect,
-    state: &ManagerState<'_>,
+    state: &mut ManagerState<'_>,
     config: &AppConfig,
     cwd: &std::path::Path,
 ) {
@@ -49,8 +50,8 @@ pub(super) fn render_list_body(
             render_sentinel_description_pane(frame, columns[1]);
         }
         ManagerListRow::SavedWorkspace(i) => {
-            if let Some(ws) = state.workspaces.get(i) {
-                render_details_pane(frame, columns[1], ws, config, state);
+            if let Some(ws) = state.workspaces.get(i).cloned() {
+                render_details_pane(frame, columns[1], &ws, config, state);
             }
         }
     }
@@ -64,44 +65,98 @@ pub(super) fn render_list_body(
         render_role_picker_sidebar(frame, list_area, title, picker);
     } else {
         // Left: [Current directory] + saved workspaces + blank spacer +
-        // [+ New workspace]. The spacer is visual-only; state keeps logical row
-        // indices without it.
-        // The cwd path itself is shown on the right-pane `workdir` line; keep the
-        // list row label short to avoid duplicate visual load.
+        // [+ New workspace]. Rendered as a Paragraph so horizontal scroll
+        // works for long workspace names.
+        let visual_selected = state.visual_selected();
         let has_saved_workspaces = saved_count > 0;
-        let mut items: Vec<ListItem> =
+        // Initialise max_w at the inner viewport width so the selected-row
+        // background always fills the full block width, even when all names
+        // are shorter than the visible area.
+        let inner_w = list_area.width.saturating_sub(2) as usize;
+        let mut max_w: usize = inner_w;
+
+        let mut list_lines: Vec<Line> =
             Vec::with_capacity(saved_count + 2 + usize::from(has_saved_workspaces));
-        items.push(ListItem::new(Line::from(Span::styled(
-            "Current directory",
-            Style::default().fg(WHITE),
-        ))));
-        items.extend(
-            state
-                .workspaces
-                .iter()
-                .map(|w| ListItem::new(Line::from(w.name.as_str()))),
-        );
-        if has_saved_workspaces {
-            items.push(ListItem::new(Line::from("")));
+
+        // Row 0 — "Current directory"
+        {
+            let selected = visual_selected == 0;
+            let prefix = if selected { "▸ " } else { "  " };
+            let style = if selected {
+                Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black)
+            } else {
+                Style::default().fg(WHITE)
+            };
+            max_w = max_w.max(2 + "Current directory".len());
+            list_lines.push(Line::from(Span::styled(
+                format!("{prefix}Current directory"),
+                style,
+            )));
         }
-        items.push(ListItem::new(Line::from(Span::styled(
-            "+ New workspace",
-            Style::default().fg(WHITE),
-        ))));
+        // Saved workspace rows
+        for (i, ws) in state.workspaces.iter().enumerate() {
+            let visual_idx = i + 1;
+            let selected = visual_selected == visual_idx;
+            let prefix = if selected { "▸ " } else { "  " };
+            let style = if selected {
+                Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black)
+            } else {
+                Style::default().fg(PHOSPHOR_GREEN)
+            };
+            max_w = max_w.max(2 + ws.name.chars().count());
+            list_lines.push(Line::from(Span::styled(
+                format!("{prefix}{}", ws.name),
+                style,
+            )));
+        }
+        // Blank spacer before sentinel when there are saved workspaces
+        if has_saved_workspaces {
+            list_lines.push(Line::from(""));
+        }
+        // Sentinel — WHITE when unselected to signal it's an action, not a workspace.
+        {
+            let selected = visual_selected
+                == if has_saved_workspaces {
+                    saved_count + 2
+                } else {
+                    1
+                };
+            let prefix = if selected { "▸ " } else { "  " };
+            let style = if selected {
+                Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black)
+            } else {
+                Style::default().fg(WHITE)
+            };
+            max_w = max_w.max(2 + "+ New workspace".len());
+            list_lines.push(Line::from(Span::styled(
+                format!("{prefix}+ New workspace"),
+                style,
+            )));
+        }
 
-        let list = List::new(items)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(PHOSPHOR_DARK)),
-            )
-            .style(Style::default().fg(PHOSPHOR_GREEN))
-            .highlight_style(Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black))
-            .highlight_symbol("▸ ");
+        // visual_selected maps 1-to-1 to list_lines indices: cwd=0,
+        // workspaces=1..=saved_count, sentinel=last. Pad the selected line
+        // with a bg-colored trailing span so the highlight fills max_w.
+        if let Some(line) = list_lines.get_mut(visual_selected) {
+            let current_w = super::line_width(line);
+            if current_w < max_w {
+                line.spans.push(Span::styled(
+                    " ".repeat(max_w - current_w),
+                    Style::default().bg(PHOSPHOR_GREEN).fg(Color::Black),
+                ));
+            }
+        }
 
-        let mut ls = ListState::default();
-        ls.select(Some(state.visual_selected()));
-        frame.render_stateful_widget(list, list_area, &mut ls);
+        let mut scroll_y = 0u16;
+        super::render_scrollable_block(
+            frame,
+            list_area,
+            list_lines,
+            &mut state.list_names_scroll_x,
+            &mut scroll_y,
+            state.list_names_focused,
+            None,
+        );
     }
 
     // Toast overlay — rendered last so it appears on top.
@@ -361,12 +416,13 @@ pub(in crate::console::manager) fn global_mounts_content_width(
     super::max_line_width(&lines)
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_details_pane(
     frame: &mut Frame,
     area: Rect,
     ws: &WorkspaceSummary,
     config: &AppConfig,
-    state: &ManagerState<'_>,
+    state: &mut ManagerState<'_>,
 ) {
     let ws_config = config.workspaces.get(&ws.name);
     let mounts = ws_config.map_or(&[][..], |w| w.mounts.as_slice());
@@ -428,26 +484,31 @@ fn render_details_pane(
     let mut idx = 0;
     render_general_subpanel(frame, rows[idx], ws);
     idx += 1;
+    let ws_focused = state.list_scroll_focus == Some(MountScrollFocus::Workspace);
     render_mounts_subpanel(
         frame,
         rows[idx],
         mounts,
-        state.list_mounts_scroll_x,
-        state.list_scroll_focus == Some(MountScrollFocus::Workspace),
+        &mut state.list_mounts_scroll_x,
+        &mut state.list_mounts_scroll_y,
+        ws_focused,
     );
     idx += 1;
     if has_global {
         let role_label = picker_role
             .as_ref()
             .map_or_else(String::new, crate::selector::RoleSelector::key);
+        let global_focused = state.list_scroll_focus;
         render_global_mounts_subpanel(
             frame,
             rows[idx],
             &role_label,
             &global_rows,
-            state.list_global_mounts_scroll_x,
-            state.list_role_global_mounts_scroll_x,
-            state.list_scroll_focus,
+            &mut state.list_global_mounts_scroll_x,
+            &mut state.list_global_mounts_scroll_y,
+            &mut state.list_role_global_mounts_scroll_x,
+            &mut state.list_role_global_mounts_scroll_y,
+            global_focused,
         );
         idx += 1;
     }
@@ -460,7 +521,16 @@ fn render_details_pane(
         idx += 1;
     }
     if !inline_picker_active {
-        render_agents_subpanel(frame, rows[idx], ws_config, config);
+        let roles_focused = state.list_scroll_focus == Some(MountScrollFocus::Roles);
+        render_agents_subpanel_scrollable(
+            frame,
+            rows[idx],
+            ws_config,
+            config,
+            &mut state.list_roles_scroll_x,
+            &mut state.list_roles_scroll_y,
+            roles_focused,
+        );
     }
 }
 
@@ -530,7 +600,7 @@ fn env_block_height(ws_config: Option<&crate::workspace::WorkspaceConfig>) -> u1
     (total_rows + 2).min(20) as u16
 }
 
-fn agents_block_agent_count(
+pub(in crate::console::manager) fn agents_block_agent_count(
     ws_config: Option<&crate::workspace::WorkspaceConfig>,
     config: &AppConfig,
 ) -> usize {
@@ -542,11 +612,20 @@ fn agents_block_agent_count(
     }
 }
 
-fn agents_block_height(agent_count: usize) -> u16 {
+pub(in crate::console::manager) fn agents_block_height(agent_count: usize) -> u16 {
     // Reserve at least one row even when empty so the block doesn't
     // read as broken.
     let agent_rows = agent_count.max(1);
     (2 + 1 + 1 + agent_rows).min(14) as u16
+}
+
+pub(in crate::console::manager) fn agents_block_content_width(
+    _ws_config: Option<&crate::workspace::WorkspaceConfig>,
+    config: &AppConfig,
+) -> usize {
+    // 4 chars prefix + longest role name gives a good enough estimate for
+    // scroll range — avoids duplicating the full line-building logic here.
+    config.roles.keys().map(|k| k.len() + 4).max().unwrap_or(0)
 }
 
 fn instance_block_height(instance_count: usize) -> u16 {
@@ -560,7 +639,7 @@ fn render_current_dir_details_pane(
     area: Rect,
     cwd: &std::path::Path,
     config: &AppConfig,
-    state: &ManagerState<'_>,
+    state: &mut ManagerState<'_>,
 ) {
     let cwd_str = cwd.display().to_string();
     let workdir_short = crate::tui::shorten_home(&cwd_str);
@@ -620,12 +699,14 @@ fn render_current_dir_details_pane(
         rows[0],
     );
 
+    let ws_focused = state.list_scroll_focus == Some(MountScrollFocus::Workspace);
     render_mounts_subpanel(
         frame,
         rows[1],
         &mounts,
-        state.list_mounts_scroll_x,
-        state.list_scroll_focus == Some(MountScrollFocus::Workspace),
+        &mut state.list_mounts_scroll_x,
+        &mut state.list_mounts_scroll_y,
+        ws_focused,
     );
 
     let agents_row = if instance_rows.is_empty() {
@@ -638,7 +719,16 @@ fn render_current_dir_details_pane(
     // Roles block — reuse the no-`ws_config` branch of the shared renderer,
     // which lists every globally-configured role (without per-role
     // overrides since the cwd workspace has none).
-    render_agents_subpanel(frame, rows[agents_row], None, config);
+    let roles_focused = state.list_scroll_focus == Some(MountScrollFocus::Roles);
+    render_agents_subpanel_scrollable(
+        frame,
+        rows[agents_row],
+        None,
+        config,
+        &mut state.list_roles_scroll_x,
+        &mut state.list_roles_scroll_y,
+        roles_focused,
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -726,7 +816,7 @@ fn render_instances_subpanel(frame: &mut Frame, area: Rect, rows: &[InstanceDisp
         ])
     }));
     lines.push(Line::from(Span::styled(
-        "  r recover  s session  i inspect  p purge",
+        "  r recover  i inspect  p purge",
         Style::default().fg(PHOSPHOR_DIM),
     )));
 
@@ -847,103 +937,89 @@ fn render_mounts_subpanel(
     frame: &mut Frame,
     area: Rect,
     mounts: &[crate::workspace::MountConfig],
-    scroll_x: u16,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
     focused: bool,
 ) {
-    let border = if focused {
-        PHOSPHOR_GREEN
-    } else {
-        PHOSPHOR_DARK
-    };
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(border))
-        .title(Span::styled(
-            " Mounts ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-
     let mut lines: Vec<Line> = Vec::new();
-
     if mounts.is_empty() {
-        // No data rows — fall back to the minimum column width so the header
-        // still shows sensible column boundaries.
         lines.push(render_mount_header(mount_path_width(&[])));
         lines.push(Line::from(Span::styled(
             "  (none)",
             Style::default().fg(PHOSPHOR_DIM),
         )));
     } else {
-        // Plain-text labels — the operator uses the `o` key on a selected
-        // mount row to open the GitHub URL in a real browser instead.
         let rows = format_mount_rows(mounts);
         let path_w = mount_path_width(&rows);
         lines.push(render_mount_header(path_w));
         lines.extend(render_mount_lines(&rows, path_w));
     }
-
-    let content_width = super::max_line_width(&lines);
-    let scroll_x = super::effective_scroll_x(
-        content_width,
-        area.width.saturating_sub(2) as usize,
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
         scroll_x,
+        scroll_y,
+        focused,
+        Some(" Mounts "),
     );
-    let p = Paragraph::new(lines)
-        .block(block)
-        .scroll((0, scroll_x))
-        .style(Style::default().fg(PHOSPHOR_GREEN));
-    frame.render_widget(p, area);
-    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_global_mounts_subpanel(
     frame: &mut Frame,
     area: Rect,
     role: &str,
     rows: &[crate::config::GlobalMountRow],
-    global_scroll_x: u16,
-    role_scroll_x: u16,
+    global_scroll_x: &mut u16,
+    global_scroll_y: &mut u16,
+    role_scroll_x: &mut u16,
+    role_scroll_y: &mut u16,
     focused: Option<MountScrollFocus>,
 ) {
     let (global, scoped) = split_global_mount_rows(rows);
-    let mut sections: Vec<(
-        String,
-        Vec<&crate::config::GlobalMountRow>,
-        MountScrollFocus,
-        u16,
-    )> = Vec::new();
-    if !global.is_empty() || scoped.is_empty() {
-        sections.push((
-            " Global mounts ".to_string(),
-            global,
-            MountScrollFocus::Global,
+    let chunks = {
+        let constraints: Vec<Constraint> = {
+            let mut c = Vec::new();
+            if !global.is_empty() || scoped.is_empty() {
+                c.push(Constraint::Length(global_mount_rows_height(global.len())));
+            }
+            if !scoped.is_empty() {
+                c.push(Constraint::Length(global_mount_rows_height(scoped.len())));
+            }
+            c
+        };
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(area)
+    };
+    let mut chunk_iter = chunks.iter();
+    if (!global.is_empty() || scoped.is_empty())
+        && let Some(chunk) = chunk_iter.next()
+    {
+        render_global_mount_rows_section(
+            frame,
+            *chunk,
+            " Global mounts ",
+            &global,
             global_scroll_x,
-        ));
+            global_scroll_y,
+            focused == Some(MountScrollFocus::Global),
+        );
     }
-    if !scoped.is_empty() {
-        sections.push((
-            format!(" Role global mounts · {role} "),
-            scoped,
-            MountScrollFocus::RoleGlobal,
-            role_scroll_x,
-        ));
-    }
-    let constraints: Vec<Constraint> = sections
-        .iter()
-        .map(|(_, rows, _, _)| Constraint::Length(global_mount_rows_height(rows.len())))
-        .collect();
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(constraints)
-        .split(area);
-    for ((title, rows, section_focus, scroll_x), chunk) in sections.into_iter().zip(chunks.iter()) {
+    if !scoped.is_empty()
+        && let Some(chunk) = chunk_iter.next()
+    {
+        let title = format!(" Role global mounts · {role} ");
         render_global_mount_rows_section(
             frame,
             *chunk,
             &title,
-            &rows,
-            scroll_x,
-            focused == Some(section_focus),
+            &scoped,
+            role_scroll_x,
+            role_scroll_y,
+            focused == Some(MountScrollFocus::RoleGlobal),
         );
     }
 }
@@ -953,20 +1029,10 @@ fn render_global_mount_rows_section(
     area: Rect,
     title: &str,
     rows: &[&crate::config::GlobalMountRow],
-    scroll_x: u16,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
     focused: bool,
 ) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(if focused {
-            PHOSPHOR_GREEN
-        } else {
-            PHOSPHOR_DARK
-        }))
-        .title(Span::styled(
-            title.to_string(),
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
     let mut lines = Vec::new();
     if rows.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -981,18 +1047,7 @@ fn render_global_mount_rows_section(
         lines.push(render_global_mount_header(path_w));
         lines.extend(render_global_mount_lines(&display_rows, path_w));
     }
-    let content_width = super::max_line_width(&lines);
-    let scroll_x = super::effective_scroll_x(
-        content_width,
-        area.width.saturating_sub(2) as usize,
-        scroll_x,
-    );
-    let p = Paragraph::new(lines)
-        .block(block)
-        .scroll((0, scroll_x))
-        .style(Style::default().fg(PHOSPHOR_GREEN));
-    frame.render_widget(p, area);
-    super::render_horizontal_scrollbar(frame, area, content_width, scroll_x);
+    super::render_scrollable_block(frame, area, lines, scroll_x, scroll_y, focused, Some(title));
 }
 
 /// One row in the flat Environments preview list.
@@ -1136,26 +1191,30 @@ fn env_row_line(row: &EnvRow, inner_width: usize) -> Line<'static> {
     Line::from(spans)
 }
 
+#[cfg(test)]
 fn render_agents_subpanel(
     frame: &mut Frame,
     area: Rect,
     ws_config: Option<&crate::workspace::WorkspaceConfig>,
     config: &AppConfig,
 ) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
-        .title(Span::styled(
-            " Roles ",
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
+    render_agents_subpanel_scrollable(frame, area, ws_config, config, &mut 0, &mut 0, false);
+}
 
+fn render_agents_subpanel_scrollable(
+    frame: &mut Frame,
+    area: Rect,
+    ws_config: Option<&crate::workspace::WorkspaceConfig>,
+    config: &AppConfig,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
+    focused: bool,
+) {
     let allowed = ws_config.map_or(&[][..], |w| w.allowed_roles.as_slice());
     let all_allowed = ws_config.is_none_or(super::super::agent_allow::allows_all_agents);
+    let default = ws_config.and_then(|w| w.default_role.as_deref());
 
     let mut lines: Vec<Line> = Vec::new();
-
-    let default = ws_config.and_then(|w| w.default_role.as_deref());
     let (value_text, value_style): (String, Style) = default.map_or_else(
         || ("(none)".to_string(), Style::default().fg(PHOSPHOR_DIM)),
         |name| (name.to_string(), Style::default().fg(PHOSPHOR_GREEN)),
@@ -1172,7 +1231,6 @@ fn render_agents_subpanel(
     } else {
         allowed.iter().map(String::as_str).collect()
     };
-
     let name_style = |role: &str| {
         if config.roles.contains_key(role) {
             Style::default().fg(PHOSPHOR_GREEN)
@@ -1180,13 +1238,11 @@ fn render_agents_subpanel(
             Style::default().fg(PHOSPHOR_DIM)
         }
     };
-    let star_style = Style::default().fg(PHOSPHOR_DIM);
-
     for role in &agent_names {
         let is_default = Some(*role) == default;
         let mut spans = vec![Span::styled(format!("  {role}"), name_style(role))];
         if is_default {
-            spans.push(Span::styled(" \u{2605}", star_style));
+            spans.push(Span::styled(" \u{2605}", Style::default().fg(PHOSPHOR_DIM)));
         }
         if let Ok(selector) = crate::selector::RoleSelector::parse(role) {
             let scoped_count = config
@@ -1203,11 +1259,15 @@ fn render_agents_subpanel(
         }
         lines.push(Line::from(spans));
     }
-
-    let p = Paragraph::new(lines)
-        .block(block)
-        .style(Style::default().fg(PHOSPHOR_GREEN));
-    frame.render_widget(p, area);
+    super::render_scrollable_block(
+        frame,
+        area,
+        lines,
+        scroll_x,
+        scroll_y,
+        focused,
+        Some(" Roles "),
+    );
 }
 
 #[cfg(test)]
@@ -1572,7 +1632,7 @@ mod subpanel_padding_tests {
         let backend = TestBackend::new(40, 4);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[], 0, false);
+            render_mounts_subpanel(f, Rect::new(0, 0, 40, 4), &[], &mut 0, &mut 0, false);
         })
         .unwrap();
         let mounts_col = first_content_indent(&term).expect("mounts has content");
@@ -2423,12 +2483,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
-        let state = crate::console::manager::state::ManagerState::from_config(
+        let mut state = crate::console::manager::state::ManagerState::from_config(
             &cfg,
             std::path::Path::new("/tmp"),
         );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &mut state);
         })
         .unwrap();
 
@@ -2483,12 +2543,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(72, 24);
         let mut term = Terminal::new(backend).unwrap();
-        let state = crate::console::manager::state::ManagerState::from_config(
+        let mut state = crate::console::manager::state::ManagerState::from_config(
             &cfg,
             std::path::Path::new("/tmp"),
         );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 72, 24), &summary(), &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 72, 24), &summary(), &cfg, &mut state);
         })
         .unwrap();
 
@@ -2524,12 +2584,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
-        let state = crate::console::manager::state::ManagerState::from_config(
+        let mut state = crate::console::manager::state::ManagerState::from_config(
             &cfg,
             std::path::Path::new("/tmp"),
         );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &mut state);
         })
         .unwrap();
 
@@ -2602,7 +2662,7 @@ mod subpanel_padding_tests {
         let backend = TestBackend::new(72, 24);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 72, 24), &summary, &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 72, 24), &summary, &cfg, &mut state);
         })
         .unwrap();
 
@@ -2645,12 +2705,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
-        let state = crate::console::manager::state::ManagerState::from_config(
+        let mut state = crate::console::manager::state::ManagerState::from_config(
             &cfg,
             std::path::Path::new("/tmp"),
         );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &mut state);
         })
         .unwrap();
 
@@ -2708,12 +2768,12 @@ mod subpanel_padding_tests {
 
         let backend = TestBackend::new(60, 24);
         let mut term = Terminal::new(backend).unwrap();
-        let state = crate::console::manager::state::ManagerState::from_config(
+        let mut state = crate::console::manager::state::ManagerState::from_config(
             &cfg,
             std::path::Path::new("/tmp"),
         );
         term.draw(|f| {
-            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &state);
+            super::render_details_pane(f, Rect::new(0, 0, 60, 24), &summary, &cfg, &mut state);
         })
         .unwrap();
 

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -3,16 +3,16 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
 use super::state::{ManagerListRow, ManagerStage, ManagerState};
 use crate::config::AppConfig;
 
 pub mod editor;
-mod global_mounts;
+pub(super) mod global_mounts;
 pub(super) mod list;
 pub(super) mod modal;
 
@@ -23,10 +23,7 @@ pub(super) use modal::modal_outer_rect;
 // while a modal is being dismissed (see `input::mod`).
 pub use editor::render_editor;
 
-pub(super) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-pub(super) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-pub(super) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-pub(super) const WHITE: Color = Color::Rgb(255, 255, 255);
+pub(super) use crate::console::widgets::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 
 // ── Footer item model ──────────────────────────────────────────────
 //
@@ -50,39 +47,131 @@ pub(super) enum FooterItem {
     GroupSep,
 }
 
-pub(super) fn footer_spans(items: &[FooterItem]) -> Vec<Span<'static>> {
+/// How many rows the footer needs to display all `items` within `width` columns.
+/// Minimum 1. Callers use this to size the footer area before running layout.
+#[must_use]
+pub(super) fn footer_height(items: &[FooterItem], width: u16) -> u16 {
+    footer_lines(items, width).len().max(1) as u16
+}
+
+pub(super) fn render_footer(frame: &mut Frame, area: Rect, items: &[FooterItem]) {
+    let lines = footer_lines(items, area.width);
+    let p = Paragraph::new(lines).alignment(Alignment::Center);
+    frame.render_widget(p, area);
+}
+
+/// Pack footer items into wrapped lines that fit within `width` columns.
+///
+/// Items are first split into "chunks" at every `Sep` and `GroupSep` boundary.
+/// Chunks are then greedily packed onto lines: if the next chunk (plus a
+/// separator) would overflow the line, it starts a new line. A `GroupSep`
+/// between two adjacent chunks on the same line renders as three spaces;
+/// a `Sep` renders as ` · `. Both separators take 3 columns.
+fn footer_lines(items: &[FooterItem], width: u16) -> Vec<Line<'static>> {
+    // A chunk = one logical hint unit (key + optional label), with the separator
+    // flavor that should precede it when it follows another chunk on the same line.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum SepKind {
+        Group,
+        Dot,
+    }
+
+    struct Chunk {
+        spans: Vec<Span<'static>>,
+        width: usize,
+        sep: SepKind,
+    }
+
     let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
     let text_style = Style::default().fg(PHOSPHOR_GREEN);
     let sep_style = Style::default().fg(PHOSPHOR_DARK);
     let dyn_style = Style::default().fg(PHOSPHOR_DIM);
 
-    let mut spans: Vec<Span<'static>> = Vec::with_capacity(items.len() * 2);
+    // Build chunks by accumulating spans until a Sep or GroupSep is hit.
+    let mut chunks: Vec<Chunk> = Vec::new();
+    let mut cur_spans: Vec<Span<'static>> = Vec::new();
+    let mut cur_w: usize = 0;
+    let mut next_sep = SepKind::Group;
+
+    let flush =
+        |chunks: &mut Vec<Chunk>, spans: &mut Vec<Span<'static>>, w: &mut usize, sep: SepKind| {
+            if !spans.is_empty() {
+                chunks.push(Chunk {
+                    spans: std::mem::take(spans),
+                    width: *w,
+                    sep,
+                });
+                *w = 0;
+            }
+        };
+
     for item in items {
         match item {
             FooterItem::Key(k) => {
-                spans.push(Span::styled((*k).to_string(), key_style));
+                cur_w += k.chars().count();
+                cur_spans.push(Span::styled((*k).to_string(), key_style));
             }
             FooterItem::Text(t) => {
-                spans.push(Span::styled(format!(" {t}"), text_style));
+                cur_w += 1 + t.chars().count();
+                cur_spans.push(Span::styled(format!(" {t}"), text_style));
             }
             FooterItem::Dyn(t) => {
-                spans.push(Span::styled(format!(" {t}"), dyn_style));
+                cur_w += 1 + t.chars().count();
+                cur_spans.push(Span::styled(format!(" {t}"), dyn_style));
             }
             FooterItem::Sep => {
-                spans.push(Span::styled(" \u{b7} ".to_string(), sep_style));
+                flush(&mut chunks, &mut cur_spans, &mut cur_w, next_sep);
+                next_sep = SepKind::Dot;
             }
             FooterItem::GroupSep => {
-                spans.push(Span::raw("   "));
+                flush(&mut chunks, &mut cur_spans, &mut cur_w, next_sep);
+                next_sep = SepKind::Group;
             }
         }
     }
-    spans
-}
+    flush(&mut chunks, &mut cur_spans, &mut cur_w, next_sep);
 
-pub(super) fn render_footer(frame: &mut Frame, area: Rect, items: &[FooterItem]) {
-    let line = Line::from(footer_spans(items));
-    let p = Paragraph::new(line).alignment(Alignment::Center);
-    frame.render_widget(p, area);
+    // Greedy line-packing: chunks go on the current line if they fit;
+    // otherwise start a new line. Separator costs 3 columns on same line.
+    let max_w = width as usize;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut line_spans: Vec<Span<'static>> = Vec::new();
+    let mut line_w: usize = 0;
+
+    for chunk in &chunks {
+        let needed = if line_spans.is_empty() {
+            chunk.width
+        } else {
+            3 + chunk.width
+        };
+
+        if !line_spans.is_empty() && line_w + needed > max_w {
+            lines.push(Line::from(std::mem::take(&mut line_spans)));
+            line_w = 0;
+        }
+
+        if !line_spans.is_empty() {
+            match chunk.sep {
+                SepKind::Dot => line_spans.push(Span::styled(" \u{b7} ".to_string(), sep_style)),
+                SepKind::Group => line_spans.push(Span::raw("   ")),
+            }
+            line_w += 3;
+        }
+
+        line_spans.extend(chunk.spans.iter().cloned());
+        line_w += chunk.width;
+    }
+
+    if !line_spans.is_empty() {
+        lines.push(Line::from(line_spans));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::raw(""));
+    }
+
+    lines
 }
 
 pub(super) fn line_width(line: &Line<'_>) -> usize {
@@ -90,6 +179,87 @@ pub(super) fn line_width(line: &Line<'_>) -> usize {
         .iter()
         .map(|span| span.content.chars().count())
         .sum()
+}
+
+#[cfg(test)]
+mod footer_wrap_tests {
+    use super::*;
+
+    fn text_content(lines: &[Line<'_>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn short_footer_fits_on_one_line() {
+        let items = vec![
+            FooterItem::Key("S"),
+            FooterItem::Text("save"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("back"),
+        ];
+        let lines = footer_lines(&items, 80);
+        assert_eq!(lines.len(), 1, "should fit on one line at 80 cols");
+    }
+
+    #[test]
+    fn long_footer_wraps_to_two_lines() {
+        // Construct items that definitely exceed a narrow terminal.
+        let items = vec![
+            FooterItem::Key("↑↓"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("D"),
+            FooterItem::Text("remove"),
+            FooterItem::Sep,
+            FooterItem::Key("A"),
+            FooterItem::Text("add"),
+            FooterItem::Sep,
+            FooterItem::Key("R"),
+            FooterItem::Text("toggle ro/rw"),
+            FooterItem::Sep,
+            FooterItem::Key("N"),
+            FooterItem::Text("rename"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Tab"),
+            FooterItem::Text("switch tab"),
+            FooterItem::GroupSep,
+            FooterItem::Key("S"),
+            FooterItem::Text("save settings"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("back"),
+        ];
+        let lines = footer_lines(&items, 60);
+        assert!(lines.len() > 1, "should wrap at 60 cols; lines={lines:?}");
+        // Every line should fit within 60 chars.
+        for line in &lines {
+            let w = line_width(line);
+            assert!(w <= 60, "line width {w} exceeds 60 cols: {line:?}");
+        }
+    }
+
+    #[test]
+    fn footer_height_matches_line_count() {
+        let items = vec![FooterItem::Key("S"), FooterItem::Text("save")];
+        assert_eq!(footer_height(&items, 80), 1);
+    }
+
+    #[test]
+    fn empty_items_produce_one_blank_line() {
+        let lines = footer_lines(&[], 80);
+        assert_eq!(lines.len(), 1);
+        let content = text_content(&lines);
+        assert_eq!(content[0], "");
+    }
 }
 
 pub(super) fn max_line_width(lines: &[Line<'_>]) -> usize {
@@ -138,10 +308,138 @@ pub(super) fn effective_scroll_x(content_width: usize, viewport: usize, scroll_x
     }
 }
 
+pub(super) fn effective_scroll_y(content_height: usize, viewport_h: usize, scroll_y: u16) -> u16 {
+    if viewport_h == 0 || content_height <= viewport_h {
+        0
+    } else {
+        scroll_y.min(
+            content_height
+                .saturating_sub(viewport_h)
+                .min(usize::from(u16::MAX)) as u16,
+        )
+    }
+}
+
 pub(super) fn clamp_scroll_x(content_width: usize, viewport: usize, scroll_x: &mut u16) -> u16 {
     let effective = effective_scroll_x(content_width, viewport, *scroll_x);
     *scroll_x = effective;
     effective
+}
+
+/// Adjust stored `scroll_y` so the cursor row stays inside the viewport.
+/// Returns the effective (clamped, cursor-following) `scroll_y` to use for rendering.
+pub(super) fn follow_cursor_y(
+    cursor: usize,
+    content_height: usize,
+    viewport_h: usize,
+    stored_scroll_y: u16,
+) -> u16 {
+    if viewport_h == 0 {
+        return 0;
+    }
+    let max_scroll = content_height.saturating_sub(viewport_h);
+    let raw = if cursor < stored_scroll_y as usize {
+        cursor as u16
+    } else if content_height > viewport_h && cursor >= stored_scroll_y as usize + viewport_h {
+        (cursor + 1 - viewport_h) as u16
+    } else {
+        stored_scroll_y
+    };
+    raw.min(max_scroll as u16)
+}
+
+/// Adjust `scroll_y` so `cursor` stays in the editor/settings content viewport.
+///
+/// The chrome constant 9 = header 3 + tab strip 2 + footer 2 + block borders 2.
+/// `usize::MAX` is passed as `content_height` because the rendered line count is
+/// not known at input-dispatch time; it is large enough that `follow_cursor_y`'s
+/// upper clamp (`raw.min(max_scroll)`) never fires — the `as u16` truncation in
+/// the caller means the effective ceiling is 65 535, well above any real viewport.
+pub(super) fn cursor_scroll_for_panel(
+    cursor: usize,
+    scroll_y: u16,
+    term: ratatui::layout::Rect,
+) -> u16 {
+    let viewport_h = (term.height.saturating_sub(9) as usize).max(1);
+    follow_cursor_y(cursor, usize::MAX, viewport_h, scroll_y)
+}
+
+pub(super) fn render_vertical_scrollbar(
+    frame: &mut Frame,
+    block_area: Rect,
+    content_height: usize,
+    scroll_y: u16,
+) {
+    let viewport = block_area.height.saturating_sub(2) as usize;
+    if viewport == 0 || content_height <= viewport {
+        return;
+    }
+    let position = scrollbar_position(content_height, viewport, scroll_y);
+    let mut state = ScrollbarState::new(content_height)
+        .position(position)
+        .viewport_content_length(viewport);
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .track_symbol(Some("·"))
+        .thumb_symbol("█")
+        .track_style(Style::default().fg(PHOSPHOR_DARK))
+        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
+    let area = Rect {
+        x: block_area.x + block_area.width.saturating_sub(1),
+        y: block_area.y + 1,
+        width: 1,
+        height: block_area.height.saturating_sub(2),
+    };
+    frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+/// Render lines inside a bordered scrollable block.
+///
+/// Border is `PHOSPHOR_GREEN` when `focused`, `PHOSPHOR_DARK` otherwise.
+/// Optional `title` renders `WHITE + BOLD` in the top border.
+/// Clamps `*scroll_x` and `*scroll_y` to their effective maximums in-place
+/// so callers never accumulate stale overshoot from past scroll events.
+pub(super) fn render_scrollable_block(
+    frame: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'_>>,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
+    focused: bool,
+    title: Option<&str>,
+) {
+    let border_color = if focused {
+        PHOSPHOR_GREEN
+    } else {
+        PHOSPHOR_DARK
+    };
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    if let Some(t) = title {
+        block = block.title(Span::styled(
+            t,
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    }
+    let content_width = max_line_width(&lines);
+    let content_height = lines.len();
+    let viewport_w = area.width.saturating_sub(2) as usize;
+    let viewport_h = area.height.saturating_sub(2) as usize;
+    let eff_x = effective_scroll_x(content_width, viewport_w, *scroll_x);
+    let eff_y = effective_scroll_y(content_height, viewport_h, *scroll_y);
+    *scroll_x = eff_x;
+    *scroll_y = eff_y;
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .style(Style::default().fg(PHOSPHOR_GREEN))
+            .scroll((eff_y, eff_x)),
+        area,
+    );
+    render_horizontal_scrollbar(frame, area, content_width, eff_x);
+    render_vertical_scrollbar(frame, area, content_height, eff_y);
 }
 
 fn scrollbar_position(content_width: usize, viewport: usize, scroll_x: u16) -> usize {
@@ -160,14 +458,15 @@ pub fn render(
     config: &AppConfig,
     cwd: &std::path::Path,
 ) {
+    let area = frame.area();
+    state.cached_term_size = area;
     if let ManagerStage::Editor(editor) = &mut state.stage {
-        clamp_editor_scroll_for_frame(frame.area(), editor);
+        clamp_editor_scroll_for_frame(area, editor);
         editor::render_editor(frame, editor, config, state.op_available);
-    } else if let ManagerStage::GlobalMounts(global) = &mut state.stage {
-        clamp_global_mounts_scroll_for_frame(frame.area(), global);
-        global_mounts::render_global_mounts(frame, global);
+    } else if let ManagerStage::Settings(settings) = &mut state.stage {
+        clamp_global_mounts_scroll_for_frame(area, &mut settings.mounts);
+        global_mounts::render_settings(frame, settings, state.op_available);
     } else {
-        let area = frame.area();
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -199,7 +498,7 @@ pub fn render(
                     if state.list_scroll_focus.is_some() {
                         items.push(FooterItem::GroupSep);
                         items.push(FooterItem::Key("←/→"));
-                        items.push(FooterItem::Text("scroll focused block"));
+                        items.push(FooterItem::Text("scroll block"));
                     }
                     items
                 } else if state.inline_role_picker.is_some() {
@@ -215,7 +514,7 @@ pub fn render(
                     if state.list_scroll_focus.is_some() {
                         items.push(FooterItem::GroupSep);
                         items.push(FooterItem::Key("←/→"));
-                        items.push(FooterItem::Text("scroll focused block"));
+                        items.push(FooterItem::Text("scroll block"));
                     }
                     items.push(FooterItem::GroupSep);
                     items.push(FooterItem::Key("Q"));
@@ -233,33 +532,54 @@ pub fn render(
                                     !super::github_mounts::resolve_for_workspace(ws).is_empty()
                                 });
 
-                    let mut items = vec![
-                        FooterItem::Key("\u{2191}\u{2193}"),
+                    let is_saved =
+                        matches!(state.selected_row(), ManagerListRow::SavedWorkspace(_));
+                    let scroll_focused = state.list_scroll_focus.is_some();
+
+                    // When a scrollable block is active, ↑↓/←→ scroll it.
+                    // When no block is focused, ↑↓ navigate the workspace list.
+                    let mut items: Vec<FooterItem> = if scroll_focused {
+                        vec![
+                            FooterItem::Key("\u{2191}\u{2193}/\u{2190}\u{2192}"),
+                            FooterItem::Text("scroll block"),
+                            FooterItem::GroupSep,
+                            FooterItem::Key("Enter"),
+                            FooterItem::Text("launch"),
+                            FooterItem::GroupSep,
+                        ]
+                    } else {
+                        vec![
+                            FooterItem::Key("\u{2191}\u{2193}"),
+                            FooterItem::Sep,
+                            FooterItem::Key("Enter"),
+                            FooterItem::Text("launch"),
+                            FooterItem::GroupSep,
+                        ]
+                    };
+                    if is_saved {
+                        items.extend([
+                            FooterItem::Key("E"),
+                            FooterItem::Text("edit"),
+                            FooterItem::Sep,
+                        ]);
+                    }
+                    items.extend([FooterItem::Key("N"), FooterItem::Text("new")]);
+                    if is_saved {
+                        items.extend([
+                            FooterItem::Sep,
+                            FooterItem::Key("D"),
+                            FooterItem::Text("delete"),
+                        ]);
+                    }
+                    items.extend([
                         FooterItem::Sep,
-                        FooterItem::Key("Enter"),
-                        FooterItem::Text("launch"),
-                        FooterItem::GroupSep,
-                        FooterItem::Key("E"),
-                        FooterItem::Text("edit"),
-                        FooterItem::Sep,
-                        FooterItem::Key("N"),
-                        FooterItem::Text("new"),
-                        FooterItem::Sep,
-                        FooterItem::Key("D"),
-                        FooterItem::Text("delete"),
-                        FooterItem::Sep,
-                        FooterItem::Key("G"),
-                        FooterItem::Text("global config"),
-                    ];
+                        FooterItem::Key("S"),
+                        FooterItem::Text("settings"),
+                    ]);
                     if show_open_hint {
                         items.push(FooterItem::Sep);
                         items.push(FooterItem::Key("O"));
                         items.push(FooterItem::Text("open in GitHub"));
-                    }
-                    if state.list_scroll_focus.is_some() {
-                        items.push(FooterItem::GroupSep);
-                        items.push(FooterItem::Key("←/→"));
-                        items.push(FooterItem::Text("scroll focused block"));
                     }
                     items.push(FooterItem::GroupSep);
                     items.push(FooterItem::Key("Q"));
@@ -284,7 +604,7 @@ pub fn render(
                 FooterItem::Text("cancel"),
             ],
             ManagerStage::Editor(_) => unreachable!("Editor has its own render path"),
-            ManagerStage::GlobalMounts(_) => unreachable!("Global mounts has its own render path"),
+            ManagerStage::Settings(_) => unreachable!("Settings has its own render path"),
         };
         render_footer(frame, chunks[2], &footer_items);
     }
@@ -315,16 +635,19 @@ pub fn render(
             } => {
                 // ConfirmState is a top-level field on the variant, not wrapped
                 // in Modal::Confirm, so render it directly.
-                let area = frame.area();
                 let modal_area = centered_rect_fixed(area, 60, 7);
                 super::super::widgets::confirm::render(frame, modal_area, confirm_state);
             }
             ManagerStage::List => {
                 // Handled above via the `is_list_stage` early branch.
             }
-            ManagerStage::GlobalMounts(global) => {
-                if let Some(modal) = &mut global.modal {
+            ManagerStage::Settings(settings) => {
+                if let Some(modal) = &mut settings.mounts.modal {
                     global_mounts::render_global_mount_modal(frame, modal);
+                } else if let Some(modal) = &mut settings.env.modal {
+                    global_mounts::render_settings_env_modal(frame, modal);
+                } else if let Some(modal) = &mut settings.auth.modal {
+                    global_mounts::render_settings_auth_modal(frame, modal);
                 }
             }
         }
@@ -359,13 +682,14 @@ fn clamp_global_mounts_scroll_for_frame(
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
+            Constraint::Length(2),
             Constraint::Min(10),
             Constraint::Length(2),
         ])
         .split(area);
     clamp_scroll_x(
         global_mounts::global_mounts_content_width(&global.pending),
-        chunks[1].width.saturating_sub(2) as usize,
+        chunks[2].width.saturating_sub(2) as usize,
         &mut global.scroll_x,
     );
 }
@@ -403,7 +727,6 @@ fn clamp_list_scroll_for_area(
             );
             state.list_global_mounts_scroll_x = 0;
             state.list_role_global_mounts_scroll_x = 0;
-            state.list_scroll_focus = None;
         }
         ManagerListRow::SavedWorkspace(i) => {
             let Some(summary) = state.workspaces.get(i) else {
@@ -440,6 +763,121 @@ fn clamp_list_scroll_for_area(
             state.list_mounts_scroll_x = 0;
             state.list_global_mounts_scroll_x = 0;
             state.list_role_global_mounts_scroll_x = 0;
+        }
+    }
+
+    // Fix 1: Clear stale scroll focus when the focused block no longer
+    // overflows after a terminal resize. Checked every render frame so the
+    // green border disappears as soon as the content fits in the viewport.
+    if state
+        .list_scroll_focus
+        .is_some_and(|f| !focused_block_still_scrollable(f, columns[1], state, config, cwd))
+    {
+        state.list_scroll_focus = None;
+    }
+
+    // Clamp left-pane name scroll to valid range.
+    let left_viewport_w = columns[0].width.saturating_sub(2) as usize;
+    if left_viewport_w == 0 {
+        state.list_names_scroll_x = 0;
+    } else {
+        let name_content_w = list_names_content_width(state);
+        if name_content_w <= left_viewport_w {
+            state.list_names_scroll_x = 0;
+            state.list_names_focused = false;
+        } else {
+            let max = (name_content_w - left_viewport_w) as u16;
+            if state.list_names_scroll_x > max {
+                state.list_names_scroll_x = max;
+            }
+        }
+    }
+}
+
+/// Compute the maximum content width of the left-pane workspace name list.
+fn list_names_content_width(state: &ManagerState<'_>) -> usize {
+    // Each row: "▸ " (2) + name. "Current directory" = 17, "+ New workspace" = 15.
+    let cwd_w = 2 + "Current directory".len();
+    let sentinel_w = 2 + "+ New workspace".len();
+    let max_ws = state
+        .workspaces
+        .iter()
+        .map(|w| 2 + w.name.len())
+        .max()
+        .unwrap_or(0);
+    cwd_w.max(sentinel_w).max(max_ws)
+}
+
+fn workspace_mounts_scrollable(
+    mounts: &[crate::workspace::MountConfig],
+    viewport_w: usize,
+) -> bool {
+    let w = list::workspace_mounts_content_width(mounts);
+    let data_rows: usize = mounts
+        .iter()
+        .map(|m| if m.src == m.dst { 1 } else { 2 })
+        .sum();
+    let content_h = 1 + data_rows.max(1);
+    let viewport_h = list::mount_block_height(mounts) as usize - 2;
+    w > viewport_w || content_h > viewport_h
+}
+
+/// Returns `true` when the focused block still overflows the right pane
+/// (either horizontally or vertically) after a resize. Used to clear
+/// `list_scroll_focus` when the terminal grows large enough that the
+/// content fits without scrolling.
+fn focused_block_still_scrollable(
+    focus: super::state::MountScrollFocus,
+    right_pane: Rect,
+    state: &ManagerState<'_>,
+    config: &AppConfig,
+    cwd: &std::path::Path,
+) -> bool {
+    use super::state::{ManagerListRow, MountScrollFocus};
+    let viewport_w = right_pane.width.saturating_sub(2) as usize;
+
+    match focus {
+        MountScrollFocus::Workspace => match state.selected_row() {
+            ManagerListRow::CurrentDirectory => {
+                let cwd_str = cwd.display().to_string();
+                let m = crate::workspace::MountConfig {
+                    src: cwd_str.clone(),
+                    dst: cwd_str,
+                    readonly: false,
+                    isolation: crate::isolation::MountIsolation::Shared,
+                };
+                workspace_mounts_scrollable(std::slice::from_ref(&m), viewport_w)
+            }
+            ManagerListRow::SavedWorkspace(i) => {
+                let Some(s) = state.workspaces.get(i) else {
+                    return false;
+                };
+                let Some(ws) = config.workspaces.get(&s.name) else {
+                    return false;
+                };
+                workspace_mounts_scrollable(ws.mounts.as_slice(), viewport_w)
+            }
+            ManagerListRow::NewWorkspace => false,
+        },
+        MountScrollFocus::Global | MountScrollFocus::RoleGlobal => {
+            // Global mounts change rarely; treat as always scrollable when focused
+            // to avoid computing the full mount list width here.
+            true
+        }
+        MountScrollFocus::Roles => {
+            let ws_config = match state.selected_row() {
+                ManagerListRow::SavedWorkspace(i) => state
+                    .workspaces
+                    .get(i)
+                    .and_then(|s| config.workspaces.get(&s.name)),
+                ManagerListRow::CurrentDirectory | ManagerListRow::NewWorkspace => None,
+            };
+            let agent_count = list::agents_block_agent_count(ws_config, config);
+            let roles_w = list::agents_block_content_width(ws_config, config);
+            let roles_h = 2 + agent_count;
+            let block_h = list::agents_block_height(agent_count) as usize;
+            let viewport_h = block_h.saturating_sub(2);
+            roles_w > viewport_w || roles_h > viewport_h
         }
     }
 }
@@ -537,7 +975,10 @@ mod horizontal_scrollbar_tests {
 
 #[cfg(test)]
 mod footer_tests {
-    use super::{FOOTER_KEY, FOOTER_SEP, FOOTER_TEXT, FooterItem, footer_spans};
+    use super::{FOOTER_KEY, FOOTER_SEP, FOOTER_TEXT, FooterItem, footer_lines};
+
+    // Use a wide terminal width so items stay on one line in these unit tests.
+    const WIDE: u16 = 200;
 
     // Sanity — the exported style colors match the palette.
     #[test]
@@ -553,7 +994,8 @@ mod footer_tests {
     #[test]
     fn key_and_text_render_with_distinct_styles() {
         let items = vec![FooterItem::Key("Enter"), FooterItem::Text("launch")];
-        let spans = footer_spans(&items);
+        let lines = footer_lines(&items, WIDE);
+        let spans = &lines[0].spans;
         assert_eq!(spans.len(), 2);
         assert_eq!(spans[0].content.as_ref(), "Enter");
         assert_eq!(spans[0].style.fg, Some(super::WHITE));
@@ -570,8 +1012,9 @@ mod footer_tests {
             FooterItem::Key("N"),
             FooterItem::Text("new"),
         ];
-        let spans = footer_spans(&items);
-        // third item is the Sep
+        let lines = footer_lines(&items, WIDE);
+        let spans = &lines[0].spans;
+        // spans: [E, edit, " · ", N, new]
         assert_eq!(spans[2].content.as_ref(), " \u{b7} ");
         assert_eq!(spans[2].style.fg, Some(super::PHOSPHOR_DARK));
     }
@@ -585,16 +1028,18 @@ mod footer_tests {
             FooterItem::Key("Q"),
             FooterItem::Text("quit"),
         ];
-        let spans = footer_spans(&items);
+        let lines = footer_lines(&items, WIDE);
+        let spans = &lines[0].spans;
+        // spans: [Enter, launch, "   ", Q, quit]
         assert_eq!(spans[2].content.as_ref(), "   ");
-        // GroupSep is styled with a plain ratatui::Style::default() — no fg set.
         assert_eq!(spans[2].style.fg, None);
     }
 
     #[test]
     fn dyn_item_uses_phosphor_dim() {
         let items = vec![FooterItem::Dyn("3 changes".to_string())];
-        let spans = footer_spans(&items);
+        let lines = footer_lines(&items, WIDE);
+        let spans = &lines[0].spans;
         assert_eq!(spans[0].content.as_ref(), " 3 changes");
         assert_eq!(spans[0].style.fg, Some(super::PHOSPHOR_DIM));
     }
@@ -621,7 +1066,8 @@ mod footer_tests {
             FooterItem::Key("Q"),
             FooterItem::Text("quit"),
         ];
-        let spans = footer_spans(&items);
+        let lines = footer_lines(&items, WIDE);
+        let spans: Vec<_> = lines.iter().flat_map(|l| l.spans.iter()).collect();
         // Every Key should be styled WHITE + BOLD; count them.
         let key_count = spans
             .iter()
@@ -654,7 +1100,8 @@ mod footer_tests {
             FooterItem::Key("Esc"),
             FooterItem::Text("cancel"),
         ];
-        let spans = footer_spans(&items);
+        let lines = footer_lines(&items, WIDE);
+        let spans: Vec<_> = lines.iter().flat_map(|l| l.spans.iter()).collect();
         let keys: Vec<&str> = spans
             .iter()
             .filter(|s| s.style.fg == Some(super::WHITE))

--- a/src/console/manager/render/modal.rs
+++ b/src/console/manager/render/modal.rs
@@ -8,31 +8,80 @@ use super::super::super::widgets::{
     auth_panel, confirm, confirm_save, error_popup, file_browser, github_picker, mount_dst_choice,
     op_picker, role_picker, save_discard, scope_picker, source_picker, text_input, workdir_pick,
 };
-use super::super::state::Modal;
+use super::super::state::{GlobalMountModal, Modal, SettingsAuthModal, SettingsEnvModal};
+use super::FooterItem;
 use super::centered_rect_fixed;
 
 // ── Modal dispatcher ────────────────────────────────────────────────
+
+pub(in crate::console::manager) fn text_input_rect(outer: Rect) -> Rect {
+    centered_rect_fixed(outer, 60, 5)
+}
+
+pub(in crate::console::manager) fn source_picker_rect(outer: Rect) -> Rect {
+    centered_rect_fixed(outer, 50, 5)
+}
+
+pub(in crate::console::manager) fn scope_picker_rect(outer: Rect) -> Rect {
+    centered_rect_fixed(outer, 50, 5)
+}
+
+pub(in crate::console::manager) fn op_picker_rect(outer: Rect) -> Rect {
+    centered_rect_fixed(outer, 80, 22)
+}
+
+pub(in crate::console::manager) fn role_picker_rect(
+    outer: Rect,
+    state: &role_picker::RolePickerState,
+) -> Rect {
+    let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
+    centered_rect_fixed(outer, 50, rows)
+}
+
+pub(in crate::console::manager) fn confirm_rect(
+    outer: Rect,
+    state: &confirm::ConfirmState,
+) -> Rect {
+    centered_rect_fixed(
+        outer,
+        confirm::width_pct(state),
+        confirm::required_height(state),
+    )
+}
+
+pub(in crate::console::manager) fn mount_choice_rect(outer: Rect) -> Rect {
+    let w = outer.width.min(80);
+    let h = 8.min(outer.height);
+    Rect {
+        x: outer.x + outer.width.saturating_sub(w) / 2,
+        y: outer.y + outer.height.saturating_sub(h) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+pub(in crate::console::manager) fn auth_form_rect(
+    outer: Rect,
+    state: &auth_panel::AuthForm,
+) -> Rect {
+    centered_rect_fixed(
+        outer,
+        80,
+        auth_panel::required_height(state, outer.width * 80 / 100),
+    )
+}
 
 /// Single source of truth for modal size + placement;
 /// `input::file_browser_modal_rect` re-uses it for mouse hit-testing
 /// so the two views stay in sync.
 pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Rect) -> Rect {
     if matches!(modal, Modal::MountDstChoice { .. }) {
-        let w = outer.width.min(80);
-        let h = 8.min(outer.height);
-        return Rect {
-            x: outer.x + outer.width.saturating_sub(w) / 2,
-            y: outer.y + outer.height.saturating_sub(h) / 2,
-            width: w,
-            height: h,
-        };
+        return mount_choice_rect(outer);
     }
 
     let (pct_w, height_rows) = match modal {
-        Modal::TextInput { .. } => (60, 6),
-        Modal::Confirm { state, .. } => {
-            (confirm::width_pct(state), confirm::required_height(state))
-        }
+        Modal::TextInput { .. } => return text_input_rect(outer),
+        Modal::Confirm { state, .. } => return confirm_rect(outer, state),
         Modal::SaveDiscardCancel { .. } => (70, 7),
         Modal::FileBrowser { .. } => (70, 22),
         Modal::WorkdirPick { .. } => (60, 12),
@@ -56,20 +105,20 @@ pub(in crate::console::manager) fn modal_outer_rect(modal: &Modal<'_>, outer: Re
                 error_popup::required_height(state, inner_width, max_rows),
             )
         }
-        Modal::OpPicker { .. } => (80, 22),
+        Modal::OpPicker { .. } => return op_picker_rect(outer),
         Modal::RolePicker { state }
         | Modal::RoleOverridePicker { state }
         | Modal::AuthRolePicker { state } => {
-            let rows = (state.filtered.len() as u16).saturating_add(6).min(15);
-            (50, rows)
+            return role_picker_rect(outer, state);
         }
-        Modal::SourcePicker { .. } | Modal::AuthSourcePicker { .. } | Modal::ScopePicker { .. } => {
-            (50, 7)
+        Modal::SourcePicker { .. } | Modal::AuthSourcePicker { .. } => {
+            return source_picker_rect(outer);
         }
+        Modal::ScopePicker { .. } => return scope_picker_rect(outer),
         // Hug the content: hide the credential block when the mode
         // doesn't need one so the dialog doesn't leave dead rows
         // below the hint line.
-        Modal::AuthForm { state, .. } => (80, auth_panel::required_height(state.as_ref())),
+        Modal::AuthForm { state, .. } => return auth_form_rect(outer, state.as_ref()),
     };
     centered_rect_fixed(outer, pct_w, height_rows)
 }
@@ -108,4 +157,323 @@ pub(super) fn render_modal(frame: &mut Frame, modal: &mut Modal<'_>) {
             auth_panel::render_form(frame, modal_area, state.as_ref(), *focus);
         }
     }
+}
+
+// ── Modal footer-item dispatch ──────────────────────────────────────────────
+//
+// When a modal is open the main footer must show the modal's keys, not the
+// "behind" content keys. These functions return `Vec<FooterItem>` for each
+// modal variant. Callers (render_editor, render_settings) check whether a
+// modal is open and delegate here before building contextual footer items.
+
+/// Footer items for an editor-stage `Modal`. Returns the keys valid while
+/// that modal has focus.
+#[allow(clippy::too_many_lines)]
+pub(super) fn modal_footer_items(modal: &Modal<'_>) -> Vec<FooterItem> {
+    match modal {
+        Modal::AuthForm { state, focus, .. } => auth_form_footer_items(state.as_ref(), *focus),
+        Modal::TextInput { .. } => vec![
+            FooterItem::Key("Enter"),
+            FooterItem::Text("confirm"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::FileBrowser { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("open"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::MountDstChoice { .. }
+        | Modal::SourcePicker { .. }
+        | Modal::AuthSourcePicker { .. }
+        | Modal::ScopePicker { .. } => vec![
+            FooterItem::Key("\u{2190}/\u{2192}"),
+            FooterItem::Text("move"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::WorkdirPick { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::GithubPicker { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("confirm"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::ConfirmSave { state } => {
+            let mut items = vec![
+                FooterItem::Key("S"),
+                FooterItem::Text("save"),
+                FooterItem::GroupSep,
+                FooterItem::Key("C/Esc"),
+                FooterItem::Text("cancel"),
+            ];
+            if !state.lines.is_empty() {
+                items.extend([
+                    FooterItem::GroupSep,
+                    FooterItem::Key("\u{2191}\u{2193}"),
+                    FooterItem::Text("scroll"),
+                ]);
+            }
+            items
+        }
+        Modal::SaveDiscardCancel { .. } => vec![
+            FooterItem::Key("S"),
+            FooterItem::Text("save"),
+            FooterItem::GroupSep,
+            FooterItem::Key("D"),
+            FooterItem::Text("discard"),
+            FooterItem::GroupSep,
+            FooterItem::Key("C/Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::ErrorPopup { .. } => vec![FooterItem::Key("Enter/Esc"), FooterItem::Text("dismiss")],
+        Modal::OpPicker { .. }
+        | Modal::RolePicker { .. }
+        | Modal::RoleOverridePicker { .. }
+        | Modal::AuthRolePicker { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("type"),
+            FooterItem::Text("filter"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        Modal::Confirm { .. } => vec![
+            FooterItem::Key("Y"),
+            FooterItem::Text("yes"),
+            FooterItem::GroupSep,
+            FooterItem::Key("N/Esc"),
+            FooterItem::Text("no"),
+        ],
+    }
+}
+
+/// Footer items for the three settings modal chains.
+pub(super) fn settings_mounts_modal_footer_items(modal: &GlobalMountModal<'_>) -> Vec<FooterItem> {
+    match modal {
+        GlobalMountModal::Text { .. } => vec![
+            FooterItem::Key("Enter"),
+            FooterItem::Text("confirm"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        GlobalMountModal::FileBrowser { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("open"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        GlobalMountModal::MountDstChoice { .. } | GlobalMountModal::ScopePicker { .. } => vec![
+            FooterItem::Key("\u{2190}/\u{2192}"),
+            FooterItem::Text("move"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        GlobalMountModal::RolePicker { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("type"),
+            FooterItem::Text("filter"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        GlobalMountModal::Confirm { .. } => vec![
+            FooterItem::Key("Y"),
+            FooterItem::Text("yes"),
+            FooterItem::GroupSep,
+            FooterItem::Key("N/Esc"),
+            FooterItem::Text("no"),
+        ],
+        GlobalMountModal::PreviewSave { state } => {
+            let mut items = vec![
+                FooterItem::Key("S"),
+                FooterItem::Text("save"),
+                FooterItem::GroupSep,
+                FooterItem::Key("C/Esc"),
+                FooterItem::Text("cancel"),
+            ];
+            if !state.lines.is_empty() {
+                items.extend([
+                    FooterItem::GroupSep,
+                    FooterItem::Key("\u{2191}\u{2193}"),
+                    FooterItem::Text("scroll"),
+                ]);
+            }
+            items
+        }
+    }
+}
+
+pub(super) fn settings_env_modal_footer_items(modal: &SettingsEnvModal<'_>) -> Vec<FooterItem> {
+    match modal {
+        SettingsEnvModal::Text { .. } => vec![
+            FooterItem::Key("Enter"),
+            FooterItem::Text("confirm"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        SettingsEnvModal::SourcePicker { .. } | SettingsEnvModal::ScopePicker { .. } => vec![
+            FooterItem::Key("\u{2190}/\u{2192}"),
+            FooterItem::Text("move"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        SettingsEnvModal::OpPicker { .. } | SettingsEnvModal::RolePicker { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("type"),
+            FooterItem::Text("filter"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        SettingsEnvModal::Confirm { .. } => vec![
+            FooterItem::Key("Y"),
+            FooterItem::Text("yes"),
+            FooterItem::GroupSep,
+            FooterItem::Key("N/Esc"),
+            FooterItem::Text("no"),
+        ],
+    }
+}
+
+pub(super) fn settings_auth_modal_footer_items(modal: &SettingsAuthModal<'_>) -> Vec<FooterItem> {
+    match modal {
+        SettingsAuthModal::AuthForm { state, focus, .. } => {
+            auth_form_footer_items(state.as_ref(), *focus)
+        }
+        SettingsAuthModal::TextInput { .. } => vec![
+            FooterItem::Key("Enter"),
+            FooterItem::Text("confirm"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        SettingsAuthModal::SourcePicker { .. } => vec![
+            FooterItem::Key("\u{2190}/\u{2192}"),
+            FooterItem::Text("move"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+        SettingsAuthModal::OpPicker { .. } => vec![
+            FooterItem::Key("\u{2191}\u{2193}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("type"),
+            FooterItem::Text("filter"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Esc"),
+            FooterItem::Text("cancel"),
+        ],
+    }
+}
+
+/// Convert the auth form hint logic into `Vec<FooterItem>` for the main footer.
+fn auth_form_footer_items(
+    form: &crate::console::widgets::auth_panel::form::AuthForm,
+    focus: crate::console::manager::state::AuthFormFocus,
+) -> Vec<FooterItem> {
+    use crate::console::manager::state::AuthFormFocus;
+    let mut items: Vec<FooterItem> = match focus {
+        AuthFormFocus::Mode => {
+            let mut v = vec![FooterItem::Key("Space"), FooterItem::Text("cycle")];
+            if form.shows_credential_block() {
+                v.extend([
+                    FooterItem::Sep,
+                    FooterItem::Key("\u{2193}"),
+                    FooterItem::Text("navigate"),
+                ]);
+            }
+            v.extend([
+                FooterItem::GroupSep,
+                FooterItem::Key("Tab"),
+                FooterItem::Text("button row"),
+            ]);
+            v
+        }
+        AuthFormFocus::CredentialSource => vec![
+            FooterItem::Key("Enter"),
+            FooterItem::Text("set"),
+            FooterItem::Sep,
+            FooterItem::Key("\u{2191}"),
+            FooterItem::Text("navigate"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Tab"),
+            FooterItem::Text("button row"),
+        ],
+        AuthFormFocus::Save | AuthFormFocus::Cancel | AuthFormFocus::Reset => vec![
+            FooterItem::Key("\u{2190}/\u{2192}"),
+            FooterItem::Text("move"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Tab"),
+            FooterItem::Text("fields"),
+            FooterItem::GroupSep,
+            FooterItem::Key("Enter"),
+            FooterItem::Text("select"),
+        ],
+    };
+    items.extend([
+        FooterItem::GroupSep,
+        FooterItem::Key("Esc"),
+        FooterItem::Text("cancel"),
+    ]);
+    items
 }

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -1,9 +1,11 @@
 //! Manager state machine. See docs/superpowers/specs/2026-04-23-workspace-manager-tui-design.md § 3.
 
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::rc::Rc;
+
+use ratatui::layout::Rect;
 
 use crate::config::AppConfig;
 use crate::console::op_cache::OpCache;
@@ -69,9 +71,16 @@ pub struct ManagerState<'a> {
         crate::console::widgets::agent_choice::AgentChoiceState,
     )>,
     pub list_mounts_scroll_x: u16,
+    pub list_mounts_scroll_y: u16,
     pub list_global_mounts_scroll_x: u16,
+    pub list_global_mounts_scroll_y: u16,
     pub list_role_global_mounts_scroll_x: u16,
+    pub list_role_global_mounts_scroll_y: u16,
+    pub list_roles_scroll_x: u16,
+    pub list_roles_scroll_y: u16,
     pub list_scroll_focus: Option<MountScrollFocus>,
+    pub list_names_scroll_x: u16,
+    pub list_names_focused: bool,
     pub list_split_pct: u16,
     pub drag_state: Option<DragState>,
     /// Process-lifetime cache of `op` structural metadata, threaded
@@ -82,6 +91,10 @@ pub struct ManagerState<'a> {
     /// startup) so the Secrets-tab editor can disable the
     /// source-picker's 1Password choice without re-probing.
     pub op_available: bool,
+    /// Last known terminal size, updated at the top of every render
+    /// frame. Used by keyboard handlers to compute `viewport_h` for
+    /// cursor-to-viewport scroll adjustment without needing a render pass.
+    pub cached_term_size: Rect,
     /// Throttle the per-tick `InstanceIndex::read_or_rebuild` poll —
     /// state on disk can't change at the 20 Hz render cadence and the
     /// rebuild path walks every container directory.
@@ -96,6 +109,7 @@ pub enum MountScrollFocus {
     Workspace,
     Global,
     RoleGlobal,
+    Roles,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -124,7 +138,7 @@ pub const fn clamp_split(pct: u16) -> u16 {
 pub enum ManagerStage<'a> {
     List,
     Editor(EditorState<'a>),
-    GlobalMounts(GlobalMountsState<'a>),
+    Settings(SettingsState<'a>),
     CreatePrelude(CreatePreludeState<'a>),
     ConfirmDelete { name: String, state: ConfirmState },
 }
@@ -139,8 +153,179 @@ pub struct GlobalMountsState<'a> {
     pub error: Option<String>,
     pub success: Option<String>,
     pub scroll_x: u16,
+    pub scroll_y: u16,
+    pub scroll_focused: bool,
     /// Dispatcher pops back to the workspace list when set.
     pub exit_requested: bool,
+}
+
+#[derive(Debug)]
+pub struct SettingsState<'a> {
+    pub active_tab: SettingsTab,
+    /// W3C ARIA Tabs: when true, focus is on the tab list (←/→ cycle tabs,
+    /// Tab/↓ enters content); when false, focus is in the tab panel.
+    pub tab_bar_focused: bool,
+    pub mounts: GlobalMountsState<'a>,
+    pub env: SettingsEnvState<'a>,
+    pub auth: SettingsAuthState,
+    pub trust: SettingsTrustState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsTab {
+    Mounts,
+    Environments,
+    Auth,
+    Trust,
+}
+
+impl SettingsTab {
+    pub const ALL: [Self; 4] = [Self::Mounts, Self::Environments, Self::Auth, Self::Trust];
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Mounts => "Mounts",
+            Self::Environments => "Environments",
+            Self::Auth => "Auth",
+            Self::Trust => "Trust",
+        }
+    }
+
+    #[must_use]
+    pub fn next(self) -> Self {
+        let idx = Self::ALL.iter().position(|t| *t == self).unwrap_or(0);
+        Self::ALL[(idx + 1) % Self::ALL.len()]
+    }
+
+    #[must_use]
+    pub fn previous(self) -> Self {
+        let idx = Self::ALL.iter().position(|t| *t == self).unwrap_or(0);
+        Self::ALL[(idx + Self::ALL.len() - 1) % Self::ALL.len()]
+    }
+}
+
+#[derive(Debug)]
+pub struct SettingsEnvState<'a> {
+    pub selected: usize,
+    pub pending: SettingsEnvConfig,
+    pub original: SettingsEnvConfig,
+    pub modal: Option<SettingsEnvModal<'a>>,
+    pub pending_env_key: Option<(SettingsEnvScope, String)>,
+    pub pending_picker_target: Option<(SettingsEnvScope, Option<String>)>,
+    pub pending_picker_value: Option<crate::operator_env::EnvValue>,
+    pub unmasked_rows: BTreeSet<(SettingsEnvScope, String)>,
+    pub expanded: BTreeSet<String>,
+    pub error: Option<String>,
+    pub scroll_y: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsEnvConfig {
+    pub env: BTreeMap<String, crate::operator_env::EnvValue>,
+    pub roles: BTreeMap<String, BTreeMap<String, crate::operator_env::EnvValue>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SettingsEnvScope {
+    Global,
+    Role(String),
+}
+
+#[derive(Debug)]
+pub enum SettingsEnvModal<'a> {
+    Text {
+        target: SettingsEnvTextTarget,
+        state: Box<TextInputState<'a>>,
+    },
+    SourcePicker {
+        state: SourcePickerState,
+    },
+    OpPicker {
+        state: Box<OpPickerState>,
+    },
+    RolePicker {
+        state: RolePickerState,
+    },
+    ScopePicker {
+        state: ScopePickerState,
+    },
+    Confirm {
+        action: SettingsEnvConfirm,
+        state: ConfirmState,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsEnvConfirm {
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsEnvTextTarget {
+    EnvKey {
+        scope: SettingsEnvScope,
+    },
+    EnvValue {
+        scope: SettingsEnvScope,
+        key: String,
+    },
+}
+
+#[derive(Debug)]
+pub struct SettingsAuthState {
+    pub selected: usize,
+    pub selected_kind: Option<crate::console::manager::auth_kind::AuthKind>,
+    pub pending: Vec<SettingsAuthRow>,
+    pub original: Vec<SettingsAuthRow>,
+    pub github_env: BTreeMap<String, crate::operator_env::EnvValue>,
+    pub original_github_env: BTreeMap<String, crate::operator_env::EnvValue>,
+    pub modal: Option<SettingsAuthModal<'static>>,
+    pub pending_auth_form_return: Option<AuthFormReturnPath>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsAuthRow {
+    pub kind: crate::console::manager::auth_kind::AuthKind,
+    pub mode: crate::console::manager::auth_kind::AuthMode,
+}
+
+#[derive(Debug)]
+pub enum SettingsAuthModal<'a> {
+    TextInput {
+        state: Box<TextInputState<'a>>,
+    },
+    SourcePicker {
+        state: SourcePickerState,
+    },
+    OpPicker {
+        state: Box<OpPickerState>,
+    },
+    AuthForm {
+        target: AuthFormTarget,
+        state: Box<AuthForm>,
+        focus: AuthFormFocus,
+        literal_buffer: String,
+    },
+}
+
+#[derive(Debug)]
+pub struct SettingsTrustState {
+    pub selected: usize,
+    pub pending: Vec<SettingsTrustRow>,
+    pub original: Vec<SettingsTrustRow>,
+    pub error: Option<String>,
+    pub scroll_x: u16,
+    pub scroll_y: u16,
+    pub scroll_focused: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsTrustRow {
+    pub role: String,
+    pub git: String,
+    pub trusted: bool,
 }
 
 #[derive(Debug, Default)]
@@ -157,9 +342,27 @@ pub enum GlobalMountModal<'a> {
         target: GlobalMountTextTarget,
         state: Box<TextInputState<'a>>,
     },
+    FileBrowser {
+        state: Box<FileBrowserState>,
+    },
+    MountDstChoice {
+        state: MountDstChoiceState,
+    },
+    ScopePicker {
+        state: ScopePickerState,
+    },
+    RolePicker {
+        state: RolePickerState,
+    },
     Confirm {
         action: GlobalMountConfirm,
         state: ConfirmState,
+    },
+    /// Full change-preview dialog shown before committing a settings save.
+    /// Reuses the `ConfirmSave` widget so the operator sees the same
+    /// scrollable diff format as the workspace editor.
+    PreviewSave {
+        state: crate::console::widgets::confirm_save::ConfirmSaveState,
     },
 }
 
@@ -173,10 +376,10 @@ pub enum GlobalMountConfirm {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GlobalMountTextTarget {
+    AddScope,
     AddName,
     AddSource,
     AddDestination,
-    AddScope,
     Source,
     Destination,
     Scope,
@@ -198,6 +401,9 @@ pub struct WorkspaceSummary {
 pub struct EditorState<'a> {
     pub mode: EditorMode,
     pub active_tab: EditorTab,
+    /// W3C ARIA Tabs: when true, focus is on the tab list (←/→ cycle tabs,
+    /// Tab/↓ enters content); when false, focus is in the tab panel.
+    pub tab_bar_focused: bool,
     pub active_field: FieldFocus,
     pub original: WorkspaceConfig,
     pub pending: WorkspaceConfig,
@@ -255,6 +461,16 @@ pub struct EditorState<'a> {
     pub pending_auth_form_return: Option<AuthFormReturnPath>,
     pub workspace_mounts_scroll_x: u16,
     pub workspace_mounts_scroll_focused: bool,
+    /// Vertical scroll offset shared across all editor content tabs.
+    /// Reset to 0 on every tab change so each tab starts at the top.
+    pub tab_scroll_y: u16,
+    /// Whether the non-Mounts tab content block has keyboard/click focus
+    /// (green border). Updated each click via `update_scroll_focus`.
+    pub tab_content_scroll_focused: bool,
+    /// Last rendered line count for the active non-Mounts tab content block.
+    /// Written by the render function; read by `update_scroll_focus` to
+    /// determine whether the block is actually scrollable.
+    pub tab_content_height: usize,
 }
 
 /// Captured auth-form context to re-mount the form after a side
@@ -324,6 +540,8 @@ impl GlobalMountsState<'_> {
             error: None,
             success: None,
             scroll_x: 0,
+            scroll_y: 0,
+            scroll_focused: false,
             exit_requested: false,
         }
     }
@@ -357,6 +575,357 @@ impl GlobalMountsState<'_> {
         self.original = self.pending.clone();
         Ok(config)
     }
+}
+
+impl SettingsState<'_> {
+    pub fn from_config(config: &AppConfig) -> Self {
+        Self {
+            active_tab: SettingsTab::Mounts,
+            tab_bar_focused: true,
+            mounts: GlobalMountsState::from_config(config),
+            env: SettingsEnvState::from_config(config),
+            auth: SettingsAuthState::from_config(config),
+            trust: SettingsTrustState::from_config(config),
+        }
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.mounts.is_dirty()
+            || self.env.is_dirty()
+            || self.auth.is_dirty()
+            || self.trust.is_dirty()
+    }
+
+    #[must_use]
+    pub fn change_count(&self) -> usize {
+        self.mounts_change_count()
+            + self.env.change_count()
+            + settings_vec_change_count(&self.auth.original, &self.auth.pending)
+            + env_change_count(&self.auth.original_github_env, &self.auth.github_env)
+            + settings_vec_change_count(&self.trust.original, &self.trust.pending)
+    }
+
+    fn mounts_change_count(&self) -> usize {
+        settings_vec_change_count(&self.mounts.original, &self.mounts.pending)
+    }
+
+    pub fn discard(&mut self) {
+        self.mounts.discard();
+        self.env.discard();
+        self.auth.discard();
+        self.trust.discard();
+    }
+
+    pub fn save_to_config(
+        &mut self,
+        paths: &crate::paths::JackinPaths,
+    ) -> anyhow::Result<AppConfig> {
+        AppConfig::validate_global_mount_rows(&self.mounts.pending)?;
+        validate_settings_env(&self.env.pending, &self.trust.pending)?;
+        let mut editor = crate::config::ConfigEditor::open(paths)?;
+
+        for row in &self.mounts.original {
+            editor.remove_mount(&row.name, row.scope.as_deref());
+        }
+        for row in &self.mounts.pending {
+            editor.add_mount(&row.name, row.mount.clone(), row.scope.as_deref());
+        }
+
+        for key in self.env.original.env.keys() {
+            editor.remove_env_var(&crate::config::EnvScope::Global, key);
+        }
+        for (role, env) in &self.env.original.roles {
+            for key in env.keys() {
+                editor.remove_env_var(&crate::config::EnvScope::Role(role.clone()), key);
+            }
+        }
+        for (key, value) in &self.env.pending.env {
+            editor.set_env_var(&crate::config::EnvScope::Global, key, value.clone())?;
+        }
+        for (role, env) in &self.env.pending.roles {
+            for (key, value) in env {
+                editor.set_env_var(
+                    &crate::config::EnvScope::Role(role.clone()),
+                    key,
+                    value.clone(),
+                )?;
+            }
+        }
+
+        for row in &self.auth.pending {
+            match row.kind {
+                crate::console::manager::auth_kind::AuthKind::Claude
+                | crate::console::manager::auth_kind::AuthKind::Codex
+                | crate::console::manager::auth_kind::AuthKind::Amp => {
+                    let Some(agent) = row.kind.agent() else {
+                        continue;
+                    };
+                    let Some(mode) = row.mode.to_auth_forward() else {
+                        anyhow::bail!(
+                            "auth mode {} is not supported for {}",
+                            row.mode.as_str(),
+                            row.kind.label()
+                        );
+                    };
+                    editor.set_global_auth_forward(agent, mode);
+                }
+                crate::console::manager::auth_kind::AuthKind::Github => {
+                    let Some(mode) = row.mode.to_github() else {
+                        anyhow::bail!(
+                            "auth mode {} is not supported for {}",
+                            row.mode.as_str(),
+                            row.kind.label()
+                        );
+                    };
+                    editor.set_global_github_auth_forward(mode);
+                }
+            }
+        }
+        for key in self.auth.original_github_env.keys() {
+            editor.remove_global_github_env_var(key);
+        }
+        for (key, value) in &self.auth.github_env {
+            editor.set_global_github_env_var(key, value.clone())?;
+        }
+
+        for row in &self.trust.pending {
+            editor.set_agent_trust(&row.role, row.trusted);
+        }
+
+        let config = editor.save()?;
+        self.mounts.original = self.mounts.pending.clone();
+        self.env.original = self.env.pending.clone();
+        self.auth.original = self.auth.pending.clone();
+        self.auth.original_github_env = self.auth.github_env.clone();
+        self.trust.original = self.trust.pending.clone();
+        Ok(config)
+    }
+}
+
+fn settings_vec_change_count<T: PartialEq>(original: &[T], pending: &[T]) -> usize {
+    let common_changes = original
+        .iter()
+        .zip(pending.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    common_changes + original.len().abs_diff(pending.len())
+}
+
+impl SettingsEnvState<'_> {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let pending = SettingsEnvConfig {
+            env: config.env.clone(),
+            roles: config
+                .roles
+                .iter()
+                .map(|(role, source)| (role.clone(), source.env.clone()))
+                .collect(),
+        };
+        Self {
+            selected: 0,
+            original: pending.clone(),
+            pending,
+            modal: None,
+            pending_env_key: None,
+            pending_picker_target: None,
+            pending_picker_value: None,
+            unmasked_rows: BTreeSet::default(),
+            expanded: BTreeSet::default(),
+            error: None,
+            scroll_y: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.pending != self.original
+    }
+
+    pub fn discard(&mut self) {
+        self.pending = self.original.clone();
+        self.selected = self
+            .selected
+            .min(settings_env_flat_row_count(self).saturating_sub(1));
+        self.modal = None;
+        self.pending_env_key = None;
+        self.pending_picker_target = None;
+        self.pending_picker_value = None;
+        self.unmasked_rows.clear();
+        self.expanded.clear();
+        self.error = None;
+    }
+
+    #[must_use]
+    pub fn change_count(&self) -> usize {
+        env_change_count(&self.original.env, &self.pending.env)
+            + self
+                .original
+                .roles
+                .keys()
+                .chain(self.pending.roles.keys())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .map(|role| {
+                    let empty = BTreeMap::new();
+                    let original = self.original.roles.get(role).unwrap_or(&empty);
+                    let pending = self.pending.roles.get(role).unwrap_or(&empty);
+                    env_change_count(original, pending)
+                })
+                .sum::<usize>()
+    }
+}
+
+impl SettingsAuthState {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let pending = [
+            crate::console::manager::auth_kind::AuthKind::Claude,
+            crate::console::manager::auth_kind::AuthKind::Codex,
+            crate::console::manager::auth_kind::AuthKind::Amp,
+            crate::console::manager::auth_kind::AuthKind::Github,
+        ]
+        .into_iter()
+        .map(|kind| SettingsAuthRow {
+            kind,
+            mode: match kind {
+                crate::console::manager::auth_kind::AuthKind::Claude
+                | crate::console::manager::auth_kind::AuthKind::Codex
+                | crate::console::manager::auth_kind::AuthKind::Amp => kind.agent().map_or(
+                    crate::console::manager::auth_kind::AuthMode::Sync,
+                    |agent| {
+                        crate::console::manager::auth_kind::AuthMode::from_auth_forward(
+                            crate::config::resolve_mode(config, agent, "", ""),
+                        )
+                    },
+                ),
+                crate::console::manager::auth_kind::AuthKind::Github => {
+                    crate::console::manager::auth_kind::AuthMode::from_github(
+                        crate::config::resolve_github_mode(config, "", ""),
+                    )
+                }
+            },
+        })
+        .collect::<Vec<_>>();
+        Self {
+            selected: 0,
+            selected_kind: None,
+            original: pending.clone(),
+            pending,
+            github_env: config
+                .github
+                .as_ref()
+                .map(|github| github.env.clone())
+                .unwrap_or_default(),
+            original_github_env: config
+                .github
+                .as_ref()
+                .map(|github| github.env.clone())
+                .unwrap_or_default(),
+            modal: None,
+            pending_auth_form_return: None,
+            error: None,
+        }
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.pending != self.original || self.github_env != self.original_github_env
+    }
+
+    pub fn discard(&mut self) {
+        self.pending = self.original.clone();
+        self.github_env = self.original_github_env.clone();
+        self.selected_kind = None;
+        self.selected = self.selected.min(self.pending.len().saturating_sub(1));
+        self.modal = None;
+        self.pending_auth_form_return = None;
+        self.error = None;
+    }
+}
+
+impl SettingsTrustState {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let pending = config
+            .roles
+            .iter()
+            .map(|(role, source)| SettingsTrustRow {
+                role: role.clone(),
+                git: source.git.clone(),
+                trusted: source.trusted,
+            })
+            .collect::<Vec<_>>();
+        Self {
+            selected: 0,
+            original: pending.clone(),
+            pending,
+            error: None,
+            scroll_x: 0,
+            scroll_y: 0,
+            scroll_focused: false,
+        }
+    }
+
+    #[must_use]
+    pub fn is_dirty(&self) -> bool {
+        self.pending != self.original
+    }
+
+    pub fn discard(&mut self) {
+        self.pending = self.original.clone();
+        self.selected = self.selected.min(self.pending.len().saturating_sub(1));
+        self.error = None;
+    }
+}
+
+fn validate_settings_env(
+    env: &SettingsEnvConfig,
+    roles: &[SettingsTrustRow],
+) -> anyhow::Result<()> {
+    let registered: std::collections::BTreeSet<&str> =
+        roles.iter().map(|r| r.role.as_str()).collect();
+    validate_settings_env_keys("global", env.env.keys())?;
+    for (role, role_env) in &env.roles {
+        if !registered.contains(role.as_str()) {
+            anyhow::bail!("role {role:?} is not registered");
+        }
+        validate_settings_env_keys(role, role_env.keys())?;
+    }
+    Ok(())
+}
+
+fn validate_settings_env_keys<'a>(
+    scope: &str,
+    keys: impl Iterator<Item = &'a String>,
+) -> anyhow::Result<()> {
+    for key in keys {
+        if key.trim().is_empty() {
+            anyhow::bail!("env var key cannot be empty");
+        }
+        if crate::env_model::is_reserved(key) {
+            anyhow::bail!(
+                "env name {key:?} in {scope} is reserved by the jackin runtime and cannot be set"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn settings_env_flat_row_count(env: &SettingsEnvState<'_>) -> usize {
+    let mut rows = env.pending.env.len();
+    if !env.pending.env.is_empty() {
+        rows += 1;
+    }
+    rows += 1;
+    for (role, role_env) in &env.pending.roles {
+        if role_env.is_empty() {
+            continue;
+        }
+        rows += 2;
+        if env.expanded.contains(role) {
+            rows += role_env.len() + 2;
+        }
+    }
+    rows
 }
 
 #[derive(Debug, Clone)]
@@ -657,14 +1226,33 @@ impl ManagerState<'_> {
             MountScrollFocus::Workspace => &mut self.list_mounts_scroll_x,
             MountScrollFocus::Global => &mut self.list_global_mounts_scroll_x,
             MountScrollFocus::RoleGlobal => &mut self.list_role_global_mounts_scroll_x,
+            MountScrollFocus::Roles => &mut self.list_roles_scroll_x,
+        }
+    }
+
+    pub(in crate::console::manager) const fn list_scroll_y_mut(
+        &mut self,
+        focus: MountScrollFocus,
+    ) -> &mut u16 {
+        match focus {
+            MountScrollFocus::Workspace => &mut self.list_mounts_scroll_y,
+            MountScrollFocus::Global => &mut self.list_global_mounts_scroll_y,
+            MountScrollFocus::RoleGlobal => &mut self.list_role_global_mounts_scroll_y,
+            MountScrollFocus::Roles => &mut self.list_roles_scroll_y,
         }
     }
 
     pub(in crate::console::manager) const fn reset_list_scroll(&mut self) {
         self.list_mounts_scroll_x = 0;
+        self.list_mounts_scroll_y = 0;
         self.list_global_mounts_scroll_x = 0;
+        self.list_global_mounts_scroll_y = 0;
         self.list_role_global_mounts_scroll_x = 0;
+        self.list_role_global_mounts_scroll_y = 0;
+        self.list_roles_scroll_x = 0;
+        self.list_roles_scroll_y = 0;
         self.list_scroll_focus = None;
+        self.list_names_scroll_x = 0;
     }
 
     /// Allocates a fresh empty cache and assumes `op` unavailable —
@@ -714,13 +1302,26 @@ impl ManagerState<'_> {
             inline_role_picker: None,
             inline_agent_picker: None,
             list_mounts_scroll_x: 0,
+            list_mounts_scroll_y: 0,
             list_global_mounts_scroll_x: 0,
+            list_global_mounts_scroll_y: 0,
             list_role_global_mounts_scroll_x: 0,
+            list_role_global_mounts_scroll_y: 0,
+            list_roles_scroll_x: 0,
+            list_roles_scroll_y: 0,
             list_scroll_focus: None,
+            list_names_scroll_x: 0,
+            list_names_focused: false,
             list_split_pct: DEFAULT_SPLIT_PCT,
             drag_state: None,
             op_cache,
             op_available,
+            cached_term_size: Rect {
+                x: 0,
+                y: 0,
+                width: 80,
+                height: 24,
+            },
             instances_last_refresh: None,
             instances_last_error: None,
         }
@@ -865,6 +1466,16 @@ impl ManagerState<'_> {
         {
             state.poll_load();
         }
+        if let ManagerStage::Settings(settings) = &mut self.stage
+            && let Some(SettingsEnvModal::OpPicker { state }) = settings.env.modal.as_mut()
+        {
+            state.poll_load();
+        }
+        if let ManagerStage::Settings(settings) = &mut self.stage
+            && let Some(SettingsAuthModal::OpPicker { state }) = settings.auth.modal.as_mut()
+        {
+            state.poll_load();
+        }
     }
 }
 
@@ -873,6 +1484,7 @@ impl EditorState<'_> {
         Self {
             mode: EditorMode::Edit { name },
             active_tab: EditorTab::General,
+            tab_bar_focused: true,
             active_field: FieldFocus::Row(0),
             original: ws.clone(),
             pending: ws,
@@ -890,6 +1502,9 @@ impl EditorState<'_> {
             pending_auth_form_return: None,
             workspace_mounts_scroll_x: 0,
             workspace_mounts_scroll_focused: false,
+            tab_scroll_y: 0,
+            tab_content_scroll_focused: false,
+            tab_content_height: 0,
         }
     }
 
@@ -898,6 +1513,7 @@ impl EditorState<'_> {
         Self {
             mode: EditorMode::Create,
             active_tab: EditorTab::General,
+            tab_bar_focused: true,
             active_field: FieldFocus::Row(0),
             original: empty.clone(),
             pending: empty,
@@ -915,6 +1531,9 @@ impl EditorState<'_> {
             pending_auth_form_return: None,
             workspace_mounts_scroll_x: 0,
             workspace_mounts_scroll_focused: false,
+            tab_scroll_y: 0,
+            tab_content_scroll_focused: false,
+            tab_content_height: 0,
         }
     }
 

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -172,8 +172,8 @@ const fn consumes_letter_input(state: &ConsoleState) -> bool {
     {
         return true;
     }
-    if let ManagerStage::GlobalMounts(global) = &ms.stage
-        && let Some(modal) = &global.modal
+    if let ManagerStage::Settings(settings) = &ms.stage
+        && let Some(modal) = &settings.mounts.modal
         && matches!(modal, GlobalMountModal::Text { .. })
     {
         return true;
@@ -230,11 +230,28 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
         crate::console::manager::state::ManagerStage::ConfirmDelete { .. } => {
             "confirm-delete".to_string()
         }
-        crate::console::manager::state::ManagerStage::GlobalMounts(global) => {
-            let modal = global.modal.as_ref().map_or("none", |modal| match modal {
-                crate::console::manager::state::GlobalMountModal::Text { .. } => "text-input",
-                crate::console::manager::state::GlobalMountModal::Confirm { action, .. } => {
-                    match action {
+        crate::console::manager::state::ManagerStage::Settings(settings) => {
+            let modal = settings
+                .mounts
+                .modal
+                .as_ref()
+                .map_or("none", |modal| match modal {
+                    crate::console::manager::state::GlobalMountModal::Text { .. } => "text-input",
+                    crate::console::manager::state::GlobalMountModal::FileBrowser { .. } => {
+                        "file-browser"
+                    }
+                    crate::console::manager::state::GlobalMountModal::MountDstChoice { .. } => {
+                        "mount-dst-choice"
+                    }
+                    crate::console::manager::state::GlobalMountModal::ScopePicker { .. } => {
+                        "scope-picker"
+                    }
+                    crate::console::manager::state::GlobalMountModal::RolePicker { .. } => {
+                        "role-picker"
+                    }
+                    crate::console::manager::state::GlobalMountModal::Confirm {
+                        action, ..
+                    } => match action {
                         crate::console::manager::state::GlobalMountConfirm::Remove => {
                             "confirm-remove"
                         }
@@ -245,10 +262,15 @@ fn console_location_debug(console_state: &ConsoleState) -> String {
                         crate::console::manager::state::GlobalMountConfirm::Discard => {
                             "confirm-discard"
                         }
+                    },
+                    crate::console::manager::state::GlobalMountModal::PreviewSave { .. } => {
+                        "preview-save"
                     }
-                }
-            });
-            format!("global-mounts selected={} modal={modal}", global.selected)
+                });
+            format!(
+                "settings tab={:?} selected={} modal={modal}",
+                settings.active_tab, settings.mounts.selected
+            )
         }
     };
     format!("{location}{list_modal}")

--- a/src/console/widgets/agent_choice/mod.rs
+++ b/src/console/widgets/agent_choice/mod.rs
@@ -7,13 +7,11 @@ use crate::console::widgets::ModalOutcome;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
 #[derive(Debug, Clone)]
 pub struct AgentChoiceState {

--- a/src/console/widgets/auth_panel/mod.rs
+++ b/src/console/widgets/auth_panel/mod.rs
@@ -14,5 +14,5 @@ pub mod render;
 pub mod state;
 
 pub use form::{AuthForm, AuthFormOutcome, CredentialInput};
-pub(crate) use render::{DANGER_RED, PHOSPHOR_DARK, WHITE, mode_str};
+pub(crate) use render::{DANGER_RED, mode_str};
 pub use render::{render_form, required_height};

--- a/src/console/widgets/auth_panel/render.rs
+++ b/src/console/widgets/auth_panel/render.rs
@@ -16,10 +16,10 @@ use crate::console::manager::auth_kind::AuthMode;
 use crate::console::manager::render::editor::push_op_breadcrumb_spans;
 use crate::console::manager::state::AuthFormFocus;
 
-pub(crate) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
+const OAUTH_TOKEN_TIP: &str =
+    "tip: run jackin workspace claude-token setup <workspace> --vault <vault> from your shell";
+
+use super::super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 pub(crate) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 // Width chosen so the longest credential env-var name
 // (`CLAUDE_CODE_OAUTH_TOKEN`, 23 chars) fits without overflow and the
@@ -59,7 +59,10 @@ pub fn render_form(frame: &mut Frame, area: Rect, form: &AuthForm, focus: AuthFo
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    for (idx, row) in build_form_lines(form, focus).into_iter().enumerate() {
+    for (idx, row) in build_form_lines(form, focus, inner.width)
+        .into_iter()
+        .enumerate()
+    {
         let y = inner.y.saturating_add(idx as u16);
         if y >= inner.y.saturating_add(inner.height) {
             break;
@@ -106,14 +109,17 @@ impl FormLine {
 /// modal so its vertical layout hugs the content rather than leaving
 /// dead space below the hint line.
 #[must_use]
-pub const fn required_height(form: &AuthForm) -> u16 {
-    // Layout (without credential block):
-    //   blank, Mode, blank, buttons, blank, hint = 6 inner rows
-    // With credential block, +1 (cred row) = 7 inner rows.
-    // With the OAuth-token setup tip, +1 more.
-    let mut inner: u16 = if form.shows_credential_block() { 7 } else { 6 };
+pub fn required_height(form: &AuthForm, outer_modal_width: u16) -> u16 {
+    // Layout (without tip):
+    //   blank, Mode, [cred,] blank, buttons, blank = 5 or 6 inner rows
+    // With the OAuth-token setup tip, the tip moves above the buttons:
+    //   blank, Mode, [cred,] blank, TIP…, blank, buttons, blank
+    // Each wrapped tip line is +1 row; the extra blank after the tip is +1.
+    let mut inner: u16 = if form.shows_credential_block() { 6 } else { 5 };
     if shows_oauth_token_setup_tip(form) {
-        inner += 1;
+        let inner_w = outer_modal_width.saturating_sub(2).max(1);
+        let wrapped_lines = (OAUTH_TOKEN_TIP.len() as u16).div_ceil(inner_w);
+        inner += wrapped_lines + 1; // wrapped tip lines + blank after tip
     }
     inner + 2
 }
@@ -135,7 +141,7 @@ const fn shows_oauth_token_setup_tip(form: &AuthForm) -> bool {
     )
 }
 
-fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
+fn build_form_lines(form: &AuthForm, focus: AuthFormFocus, inner_width: u16) -> Vec<FormLine> {
     let mut lines: Vec<FormLine> = Vec::new();
 
     lines.push(FormLine::left(Line::from("")));
@@ -163,33 +169,46 @@ fn build_form_lines(form: &AuthForm, focus: AuthFormFocus) -> Vec<FormLine> {
     }
 
     lines.push(FormLine::left(Line::from("")));
+
+    // Tip renders above the buttons when present, wrapping to fit inner_width.
+    if shows_oauth_token_setup_tip(form) {
+        for tip_line in wrap_tip_lines(inner_width) {
+            lines.push(FormLine::centered(tip_line));
+        }
+        lines.push(FormLine::left(Line::from("")));
+    }
+
     lines.push(FormLine::centered(action_buttons_line(
         form.can_save(),
         focus,
     )));
-    if shows_oauth_token_setup_tip(form) {
-        lines.push(FormLine::centered(oauth_token_setup_tip_line()));
-    }
     lines.push(FormLine::left(Line::from("")));
-    lines.push(FormLine::centered(form_hint_line(form, focus)));
     lines
 }
 
-/// Render the inline "wire this slot from the shell" tip shown when
-/// the operator has picked `oauth_token` mode but has not yet
-/// supplied a credential. The CLI command is rendered verbatim so
-/// the operator can copy it directly.
-fn oauth_token_setup_tip_line() -> Line<'static> {
+/// Break the OAuth-token setup tip into word-wrapped lines that each fit
+/// within `inner_width` columns. Falls back to one long line when width=0.
+fn wrap_tip_lines(inner_width: u16) -> Vec<Line<'static>> {
     let dim = Style::default().fg(PHOSPHOR_DIM);
-    let cmd = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    Line::from(vec![
-        Span::styled("tip: run ", dim),
-        Span::styled(
-            "jackin workspace claude-token setup <workspace> --vault <vault>",
-            cmd,
-        ),
-        Span::styled(" from your shell", dim),
-    ])
+    let full = OAUTH_TOKEN_TIP;
+    let w = inner_width.max(20) as usize;
+    let mut result = Vec::new();
+    let mut current = String::new();
+    for word in full.split_whitespace() {
+        if current.is_empty() {
+            current = word.to_string();
+        } else if current.len() + 1 + word.len() <= w {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            result.push(Line::from(Span::styled(current, dim)));
+            current = word.to_string();
+        }
+    }
+    if !current.is_empty() {
+        result.push(Line::from(Span::styled(current, dim)));
+    }
+    result
 }
 
 fn credential_env_line(env_var: &str, cred: &CredentialInput, selected: bool) -> Line<'static> {
@@ -265,35 +284,6 @@ fn action_buttons_line(can_save: bool, focus: AuthFormFocus) -> Line<'static> {
             ),
         ),
     ])
-}
-
-fn form_hint_line(form: &AuthForm, focus: AuthFormFocus) -> Line<'static> {
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let mut spans = match focus {
-        AuthFormFocus::Mode => vec![
-            Span::styled("Space", key_style),
-            Span::styled(" cycle mode", text_style),
-        ],
-        AuthFormFocus::CredentialSource => vec![
-            Span::styled("Enter", key_style),
-            Span::styled(" set credential", text_style),
-        ],
-        AuthFormFocus::Save | AuthFormFocus::Cancel | AuthFormFocus::Reset => vec![
-            Span::styled("Enter", key_style),
-            Span::styled(" select", text_style),
-        ],
-    };
-    if form.shows_credential_block() {
-        spans.push(Span::styled(" · ", sep_style));
-        spans.push(Span::styled("↑/↓", key_style));
-        spans.push(Span::styled(" navigate", text_style));
-    }
-    spans.push(Span::styled(" · ", sep_style));
-    spans.push(Span::styled("Esc", key_style));
-    spans.push(Span::styled(" cancel", text_style));
-    Line::from(spans)
 }
 
 fn cursor_span(selected: bool) -> Span<'static> {

--- a/src/console/widgets/confirm.rs
+++ b/src/console/widgets/confirm.rs
@@ -88,24 +88,21 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 const WARNING_YELLOW: Color = Color::Rgb(255, 216, 94);
 
 /// Height (rows) this Confirm modal wants, given its current contents.
 ///
-/// `Default` kind: N prompt lines + 6 chrome rows (top/bottom border = 2,
-/// spacer, buttons, spacer, hint). `RoleTrust` uses a fixed 12-row layout
-/// matching the structured renderer in `render_role_trust`.
+/// `Default` kind: N prompt lines + 4 chrome rows (top/bottom border = 2,
+/// spacer, buttons). `RoleTrust` uses a fixed 11-row layout matching the
+/// structured renderer in `render_role_trust`.
 #[must_use]
 pub fn required_height(state: &ConfirmState) -> u16 {
     match &state.kind {
-        ConfirmKind::RoleTrust { .. } => 12,
+        ConfirmKind::RoleTrust { .. } => 11,
         ConfirmKind::Default { prompt } => {
             let prompt_lines = prompt.lines().count().max(1) as u16;
-            prompt_lines + 6
+            prompt_lines + 4
         }
     }
 }
@@ -149,8 +146,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
             Constraint::Length(prompt_lines), // prompt (may span multiple lines)
             Constraint::Length(1),            // spacer
             Constraint::Length(1),            // button row
-            Constraint::Length(1),            // spacer between buttons and hint
-            Constraint::Length(1),            // footer hint
         ])
         .split(inner);
 
@@ -200,23 +195,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmState) {
         Paragraph::new(button_line).alignment(Alignment::Center),
         chunks[2],
     );
-
-    // Footer hint — same key/text/sep scheme as the main TUI footer.
-    let key = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text = Style::default().fg(PHOSPHOR_GREEN);
-    let sep = Style::default().fg(PHOSPHOR_DARK);
-    let hint = Paragraph::new(ratatui::text::Line::from(vec![
-        Span::styled("Y", key),
-        Span::styled(" yes", text),
-        Span::styled(" \u{b7} ", sep),
-        Span::styled("N", key),
-        Span::styled(" no", text),
-        Span::styled(" \u{b7} ", sep),
-        Span::styled("Esc", key),
-        Span::styled(" cancel", text),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, chunks[4]);
 }
 
 fn render_role_trust(
@@ -235,7 +213,6 @@ fn render_role_trust(
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(2),
-            Constraint::Length(1),
             Constraint::Length(1),
         ])
         .split(inner);
@@ -295,7 +272,6 @@ fn render_role_trust(
     );
 
     render_buttons(frame, rows[6], state);
-    render_hint(frame, rows[7]);
 }
 
 const fn inset(area: Rect, x: u16) -> Rect {
@@ -339,24 +315,6 @@ fn render_buttons(frame: &mut Frame, area: Rect, state: &ConfirmState) {
         Paragraph::new(button_line).alignment(Alignment::Center),
         area,
     );
-}
-
-fn render_hint(frame: &mut Frame, area: Rect) {
-    let key = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text = Style::default().fg(PHOSPHOR_GREEN);
-    let sep = Style::default().fg(PHOSPHOR_DARK);
-    let hint = Paragraph::new(ratatui::text::Line::from(vec![
-        Span::styled("Y", key),
-        Span::styled(" yes", text),
-        Span::styled(" \u{b7} ", sep),
-        Span::styled("N", key),
-        Span::styled(" no", text),
-        Span::styled(" \u{b7} ", sep),
-        Span::styled("Esc", key),
-        Span::styled(" cancel", text),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, area);
 }
 
 #[cfg(test)]

--- a/src/console/widgets/confirm_save.rs
+++ b/src/console/widgets/confirm_save.rs
@@ -17,9 +17,7 @@ use ratatui::{
 
 use super::ModalOutcome;
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SaveChoice {
@@ -43,14 +41,15 @@ pub enum ConfirmSaveFocus {
 pub struct ConfirmSaveState {
     pub lines: Vec<Line<'static>>,
     pub focus: ConfirmSaveFocus,
+    /// Vertical scroll offset — how many lines are hidden above the visible window.
+    pub scroll_offset: usize,
     /// `plan_edit`'s `effective_removals`, forwarded into
     /// `edit_workspace`. Empty for Create flows.
     pub effective_removals: Vec<String>,
     /// `plan_create`'s collapsed mount set. Empty (meaning "no override
     /// needed") for Edit flows.
     pub final_mounts: Option<Vec<crate::workspace::MountConfig>>,
-    /// `true` when the plan carries mount-collapses — used by the hint
-    /// row to make clear the confirm covers the collapse too.
+    /// `true` when the plan carries mount-collapses.
     pub has_collapses: bool,
 }
 
@@ -62,6 +61,7 @@ impl ConfirmSaveState {
         Self {
             lines,
             focus: ConfirmSaveFocus::Save,
+            scroll_offset: 0,
             effective_removals: Vec::new(),
             final_mounts: None,
             has_collapses: false,
@@ -72,7 +72,17 @@ impl ConfirmSaveState {
         match key.code {
             KeyCode::Char('s' | 'S') => ModalOutcome::Commit(SaveChoice::Save),
             KeyCode::Char('c' | 'C') | KeyCode::Esc => ModalOutcome::Cancel,
-            // Tab / BackTab / Right / l-h / Left — only two buttons,
+            // Up/Down/j/k scroll the content preview.
+            KeyCode::Up | KeyCode::Char('k' | 'K') => {
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                ModalOutcome::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j' | 'J') => {
+                self.scroll_offset = self.scroll_offset.saturating_add(1);
+                // Clamped to valid range in render.
+                ModalOutcome::Continue
+            }
+            // Tab / BackTab / Right / Left — only two buttons,
             // so every "move focus" key just toggles between them.
             KeyCode::Tab
             | KeyCode::BackTab
@@ -95,12 +105,11 @@ impl ConfirmSaveState {
 }
 
 /// Total rows the `ConfirmSave` modal wants given its current line count.
-/// Layout: top border + blank + N content lines + blank + buttons + blank
-/// + hint + bottom border = N + 7.
+/// Layout: top border + blank + N content lines + blank + buttons + bottom border = N + 5.
 #[must_use]
 pub fn required_height(state: &ConfirmSaveState) -> u16 {
     let lines = u16::try_from(state.lines.len()).unwrap_or(u16::MAX);
-    lines.saturating_add(7)
+    lines.saturating_add(5)
 }
 
 pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmSaveState) {
@@ -115,14 +124,21 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmSaveState) {
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
-    // Compute how many content rows we can afford. The widget clips
-    // if the caller hands us more lines than the frame can fit — paired
-    // with the `required_height` hint the manager uses to size the
-    // outer Rect, this should only trigger on tiny terminals.
-    let content_rows = inner.height.saturating_sub(4); // blank, blank, buttons, hint
+    // Compute how many content rows we can afford, then apply the scroll
+    // offset so the operator can page through long diffs.
+    let content_rows = inner.height.saturating_sub(3); // blank, blank, buttons
     let content_rows = content_rows.saturating_sub(1); // bottom-of-content blank
     let visible = content_rows as usize;
-    let clipped: Vec<Line> = state.lines.iter().take(visible).cloned().collect();
+    let total = state.lines.len();
+    let max_offset = total.saturating_sub(visible);
+    let offset = state.scroll_offset.min(max_offset);
+    let clipped: Vec<Line> = state
+        .lines
+        .iter()
+        .skip(offset)
+        .take(visible)
+        .cloned()
+        .collect();
     let visible_u16 = u16::try_from(clipped.len()).unwrap_or(0);
 
     let chunks = Layout::default()
@@ -132,8 +148,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmSaveState) {
             Constraint::Length(visible_u16),
             Constraint::Length(1), // blank
             Constraint::Length(1), // buttons
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // hint
         ])
         .split(inner);
 
@@ -179,20 +193,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ConfirmSaveState) {
         Paragraph::new(button_line).alignment(Alignment::Center),
         chunks[3],
     );
-
-    // Hint — `S save · C/Esc cancel` per batch-22 convention.
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let hint = Paragraph::new(Line::from(vec![
-        Span::styled("S", key_style),
-        Span::styled(" save", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("C/Esc", key_style),
-        Span::styled(" cancel", text_style),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, chunks[5]);
 }
 
 #[cfg(test)]
@@ -308,8 +308,7 @@ mod tests {
             Line::from("two"),
             Line::from("three"),
         ]);
-        // 3 content lines + 7 chrome rows (2 borders + top blank + after-content blank
-        // + buttons + after-buttons blank + hint)
-        assert_eq!(required_height(&s), 10);
+        // 3 content lines + 5 chrome rows (2 borders + top blank + after-content blank + buttons)
+        assert_eq!(required_height(&s), 8);
     }
 }

--- a/src/console/widgets/error_popup.rs
+++ b/src/console/widgets/error_popup.rs
@@ -17,9 +17,7 @@ use ratatui::{
 
 use super::ModalOutcome;
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 
 #[derive(Debug, Clone)]

--- a/src/console/widgets/file_browser/mod.rs
+++ b/src/console/widgets/file_browser/mod.rs
@@ -19,16 +19,9 @@
 
 use ratatui::style::Color;
 
-/// Phosphor green — matches jackin's primary colour.
-pub(super) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-/// Dimmed phosphor — used for the ` (git)` suffix and italic metadata.
-pub(super) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-/// Bright white — used for cwd titles + focus highlights.
-pub(super) const WHITE: Color = Color::Rgb(255, 255, 255);
+pub(super) use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 /// Sandbox-rejection / error red.
 pub(super) const DANGER_RED: Color = Color::Rgb(255, 94, 122);
-/// Dark phosphor — block borders, separator glyphs.
-pub(super) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
 
 /// Directories excluded from the listing when browsing $HOME.
 pub(super) const EXCLUDED: &[&str] = &[

--- a/src/console/widgets/github_picker.rs
+++ b/src/console/widgets/github_picker.rs
@@ -64,16 +64,13 @@ impl GithubPickerState {
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, WHITE};
 
 pub fn render(frame: &mut Frame, area: Rect, state: &GithubPickerState) {
     // Title style matches WorkdirPick (WHITE + BOLD) so the modal feels
@@ -91,15 +88,11 @@ pub fn render(frame: &mut Frame, area: Rect, state: &GithubPickerState) {
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
-    // Inner layout: blank / list / blank / hint — matches the canonical
-    // list-modal layout used by WorkdirPick.
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // top padding
             Constraint::Min(1),    // list
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // hint
         ])
         .split(inner);
 
@@ -143,23 +136,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &GithubPickerState) {
         .collect();
 
     frame.render_widget(Paragraph::new(lines), rows[1]);
-
-    // Hint line — canonical list-modal hint (↑↓ navigate · Enter confirm · Esc cancel).
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let hint = Paragraph::new(Line::from(vec![
-        Span::styled("\u{2191}\u{2193}", key_style),
-        Span::styled(" navigate", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Enter", key_style),
-        Span::styled(" confirm", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Esc", key_style),
-        Span::styled(" cancel", text_style),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, rows[3]);
 }
 
 #[cfg(test)]

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -7,6 +7,14 @@
 //! exposes only a single shared `dir_style`). All are consumed by both
 //! the manager (PR 2) and the Secrets tab (PR 3).
 
+use ratatui::style::Color;
+
+/// Canonical phosphor-green palette used across every TUI surface.
+pub(crate) const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
+pub(crate) const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
+pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
+pub(crate) const WHITE: Color = Color::Rgb(255, 255, 255);
+
 pub mod agent_choice;
 pub mod auth_panel;
 pub mod confirm;
@@ -63,16 +71,9 @@ mod consistency_tests {
     //! `┌ Title ─...` renders with breathing room, and a hint footer
     //! whose separator glyphs use `PHOSPHOR_DARK`. These tests pin that
     //! contract so a future drift doesn't silently degrade the look.
-    use ratatui::{
-        Terminal,
-        backend::TestBackend,
-        buffer::Buffer,
-        layout::Rect,
-        style::{Color, Modifier},
-    };
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer, layout::Rect};
 
-    const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-    const WHITE: Color = Color::Rgb(255, 255, 255);
+    use super::{PHOSPHOR_DARK, WHITE};
 
     /// Render a closure into a fresh `TestBackend` and return the resulting
     /// buffer. Size is chosen to comfortably fit every modal under test.
@@ -145,47 +146,11 @@ mod consistency_tests {
         }
     }
 
-    /// Find the bottom-most non-blank content row inside `area` (excluding
-    /// the top/bottom border rows) and assert that its first styled span is
-    /// a bold-white "key" glyph — matching the canonical
-    /// `<KEY> <verb> ... Esc cancel` hint format.
-    ///
-    /// We can't easily inspect the whole hint line's styles without knowing
-    /// each widget's exact hint text; instead we look for at least one
-    /// WHITE+BOLD cell followed by a `PHOSPHOR_GREEN` label cell on the hint
-    /// row. That matches every canonical hint (`Enter commit`, `Enter
-    /// confirm`, `↑↓ navigate`, etc.) and rejects any widget that forgets
-    /// the hint entirely.
-    fn assert_hint_row_present(buf: &Buffer, area: Rect, widget: &str) {
-        let phosphor_green = Color::Rgb(0, 255, 65);
-        let bottom_inner = area.y + area.height - 2; // row above bottom border
-        let top_inner = area.y + 1; // row below top border
-        // Scan bottom-up for the first non-blank inner row.
-        for y in (top_inner..=bottom_inner).rev() {
-            let mut saw_key = false;
-            let mut saw_label = false;
-            for x in (area.x + 1)..(area.x + area.width - 1) {
-                let cell = &buf[(x, y)];
-                if cell.symbol().is_empty() || cell.symbol() == " " {
-                    continue;
-                }
-                if cell.fg == WHITE && cell.modifier.contains(Modifier::BOLD) {
-                    saw_key = true;
-                } else if cell.fg == phosphor_green {
-                    saw_label = true;
-                }
-            }
-            if saw_key && saw_label {
-                return; // canonical hint found
-            }
-            assert!(
-                !(saw_key || saw_label),
-                "{widget}: hint row at y={y} has key={saw_key}/label={saw_label}; \
-                 expected both WHITE+BOLD key and PHOSPHOR_GREEN label cells"
-            );
-        }
-        panic!("{widget}: no hint row found inside {area:?}");
-    }
+    // Note: the former `assert_hint_row_present` helper and
+    // `all_modal_hint_rows_use_canonical_styles` test were removed when hint
+    // lines moved out of widget interiors into the main footer. Widgets no
+    // longer render an internal hint row; the footer is the single source of
+    // truth for available key hints.
 
     /// Build and render the `SaveDiscardCancel` modal into a full-area
     /// buffer. Returns (buffer, area).
@@ -326,22 +291,5 @@ mod consistency_tests {
         }
     }
 
-    /// Every modal renders a canonical hint row with WHITE+BOLD keys and
-    /// `PHOSPHOR_GREEN` labels.
-    #[test]
-    fn all_modal_hint_rows_use_canonical_styles() {
-        for (name, (buf, area)) in [
-            ("SaveDiscardCancel", render_save_discard()),
-            ("Confirm", render_confirm()),
-            ("MountDstChoice", render_mount_dst()),
-            ("TextInput", render_text_input()),
-            ("WorkdirPick", render_workdir_pick()),
-            ("GithubPicker", render_github_picker()),
-            ("AgentPicker", render_role_picker()),
-            ("ConfirmSave", render_confirm_save()),
-            ("AgentChoice", render_agent_choice()),
-        ] {
-            assert_hint_row_present(&buf, area, name);
-        }
-    }
+    // `all_modal_hint_rows_use_canonical_styles` test removed — hints moved to footer.
 }

--- a/src/console/widgets/op_picker/render.rs
+++ b/src/console/widgets/op_picker/render.rs
@@ -3,19 +3,15 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
 use crate::operator_env::OpField;
 
+use super::super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 use super::{OpLoadState, OpPickerError, OpPickerFatalState, OpPickerStage, OpPickerState};
-
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
 
 const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -89,23 +85,8 @@ fn modal_block<'a>(title: impl Into<String>) -> Block<'a> {
     );
     Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PHOSPHOR_DARK))
+        .border_style(Style::default().fg(PHOSPHOR_GREEN))
         .title(title_span)
-}
-
-fn footer_line(pairs: &[(&str, &str)]) -> Line<'static> {
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    for (i, (k, t)) in pairs.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::styled(" \u{b7} ", sep_style));
-        }
-        spans.push(Span::styled((*k).to_string(), key_style));
-        spans.push(Span::styled(format!(" {t}"), text_style));
-    }
-    Line::from(spans)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -135,8 +116,6 @@ fn render_pane(frame: &mut Frame, area: Rect, state: &OpPickerState) {
         Constraint::Length(1),             // filter row
         Constraint::Length(1),             // spacer
         Constraint::Min(1),                // list
-        Constraint::Length(1),             // spacer
-        Constraint::Length(1),             // footer
     ];
     let rows = Layout::default()
         .direction(Direction::Vertical)
@@ -185,12 +164,13 @@ fn render_pane(frame: &mut Frame, area: Rect, state: &OpPickerState) {
         OpPickerStage::Item => render_item_lines(state),
         OpPickerStage::Field => render_field_lines(state),
     };
-    let list_para = if list_lines.is_empty() {
-        Paragraph::new(Line::from(Span::styled(
+    let (list_para, scroll_info) = if list_lines.is_empty() {
+        let para = Paragraph::new(Line::from(Span::styled(
             "(no matches)",
             Style::default().fg(PHOSPHOR_DIM),
         )))
-        .alignment(Alignment::Center)
+        .alignment(Alignment::Center);
+        (para, None)
     } else {
         let selected = match state.stage {
             OpPickerStage::Account => state.account_list_state.selected,
@@ -203,51 +183,36 @@ fn render_pane(frame: &mut Frame, area: Rect, state: &OpPickerState) {
         let offset = viewport_offset(selected.unwrap_or(0), height, total);
         let take = height.min(total.saturating_sub(offset));
         let visible: Vec<Line<'static>> = list_lines.into_iter().skip(offset).take(take).collect();
-        Paragraph::new(visible)
+        (Paragraph::new(visible), Some((total, offset, height)))
     };
     frame.render_widget(list_para, rows[3]);
 
-    let pairs: Vec<(&str, &str)> = match state.stage {
-        OpPickerStage::Account => vec![
-            ("\u{2191}\u{2193}", "navigate"),
-            ("type", "filter"),
-            ("Enter", "select"),
-            ("r", "refresh"),
-            ("Esc", "cancel"),
-        ],
-        OpPickerStage::Vault => {
-            let esc_label = if multi_account {
-                "back to accounts"
-            } else {
-                "cancel"
-            };
-            vec![
-                ("\u{2191}\u{2193}", "navigate"),
-                ("type", "filter"),
-                ("Enter", "select"),
-                ("r", "refresh"),
-                ("Esc", esc_label),
-            ]
-        }
-        OpPickerStage::Item => vec![
-            ("\u{2191}\u{2193}", "navigate"),
-            ("Backspace", "clear filter"),
-            ("Enter", "select"),
-            ("r", "refresh"),
-            ("Esc", "back to vaults"),
-        ],
-        OpPickerStage::Field => vec![
-            ("\u{2191}\u{2193}", "navigate"),
-            ("type", "filter"),
-            ("Enter", "select"),
-            ("r", "refresh"),
-            ("Esc", "back"),
-        ],
-    };
-    frame.render_widget(
-        Paragraph::new(footer_line(&pairs)).alignment(Alignment::Center),
-        rows[5],
-    );
+    // Vertical scrollbar on the right edge of the list area.
+    if let Some((total, position, viewport)) = scroll_info
+        && total > viewport
+    {
+        let scrolled = position
+            .saturating_mul(total.saturating_sub(1))
+            .checked_div(total.saturating_sub(viewport))
+            .unwrap_or(0);
+        let mut sb_state = ScrollbarState::new(total)
+            .position(scrolled)
+            .viewport_content_length(viewport);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .track_symbol(Some("·"))
+            .thumb_symbol("█")
+            .track_style(Style::default().fg(PHOSPHOR_DARK))
+            .thumb_style(Style::default().fg(PHOSPHOR_DIM));
+        let sb_area = Rect {
+            x: rows[3].x + rows[3].width.saturating_sub(1),
+            y: rows[3].y,
+            width: 1,
+            height: rows[3].height,
+        };
+        frame.render_stateful_widget(scrollbar, sb_area, &mut sb_state);
+    }
 }
 
 fn render_account_lines(state: &OpPickerState) -> Vec<Line<'static>> {
@@ -435,12 +400,7 @@ fn render_loading(frame: &mut Frame, area: Rect, state: &OpPickerState, tick: u8
 
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ])
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
         .split(inner);
 
     let body = Line::from(vec![
@@ -449,9 +409,6 @@ fn render_loading(frame: &mut Frame, area: Rect, state: &OpPickerState, tick: u8
         Span::styled(descriptor, Style::default().fg(PHOSPHOR_DIM)),
     ]);
     frame.render_widget(Paragraph::new(body).alignment(Alignment::Center), rows[1]);
-
-    let footer = footer_line(&[("running op", "subcommand"), ("Esc", "cancel")]);
-    frame.render_widget(Paragraph::new(footer).alignment(Alignment::Center), rows[3]);
 }
 
 fn render_fatal(frame: &mut Frame, area: Rect, fatal: &OpPickerFatalState) {
@@ -526,21 +483,13 @@ fn render_fatal(frame: &mut Frame, area: Rect, fatal: &OpPickerFatalState) {
 
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ])
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
         .split(inner);
 
     frame.render_widget(
         Paragraph::new(body_lines).alignment(Alignment::Center),
         rows[1],
     );
-
-    let footer = footer_line(&[("Esc", "close")]);
-    frame.render_widget(Paragraph::new(footer).alignment(Alignment::Center), rows[3]);
 }
 
 #[cfg(test)]

--- a/src/console/widgets/role_picker.rs
+++ b/src/console/widgets/role_picker.rs
@@ -101,16 +101,13 @@ impl RolePickerState {
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 
 pub fn render(frame: &mut Frame, area: Rect, state: &RolePickerState) {
     // Filter row stays out of the title — see RULES.md "TUI List
@@ -134,8 +131,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &RolePickerState) {
             Constraint::Length(1), // filter row
             Constraint::Length(1), // spacer
             Constraint::Min(1),    // list
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // footer
         ])
         .split(inner);
 
@@ -180,26 +175,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &RolePickerState) {
         })
         .collect();
     frame.render_widget(Paragraph::new(lines), rows[2]);
-
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let confirm_label = format!(" {}", state.confirm_label);
-    let hint = Paragraph::new(Line::from(vec![
-        Span::styled("\u{2191}\u{2193}", key_style),
-        Span::styled(" navigate", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("type", key_style),
-        Span::styled(" filter", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Enter", key_style),
-        Span::styled(confirm_label, text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Esc", key_style),
-        Span::styled(" cancel", text_style),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, rows[4]);
 }
 
 #[cfg(test)]
@@ -378,33 +353,6 @@ mod tests {
         assert!(
             !top.contains("smi"),
             "live filter must NOT bleed into the title; top row:\n{top}"
-        );
-    }
-
-    #[test]
-    fn agent_picker_footer_uses_configured_confirm_label() {
-        let s_launch =
-            RolePickerState::with_confirm_label(roles(&["chainargos/agent-smith"]), "launch");
-        let frame = dump(&s_launch, 60, 12);
-        assert!(
-            frame.contains("Enter") && frame.contains("launch"),
-            "launch-context footer must read `Enter launch`; frame:\n{frame}"
-        );
-        assert!(
-            !frame.contains(" select"),
-            "launch-context footer must not say `select`; frame:\n{frame}"
-        );
-
-        let s_select =
-            RolePickerState::with_confirm_label(roles(&["chainargos/agent-smith"]), "select");
-        let frame = dump(&s_select, 60, 12);
-        assert!(
-            frame.contains("Enter") && frame.contains("select"),
-            "select-context footer must read `Enter select`; frame:\n{frame}"
-        );
-        assert!(
-            !frame.contains(" launch"),
-            "select-context footer must not say `launch`; frame:\n{frame}"
         );
     }
 

--- a/src/console/widgets/save_discard.rs
+++ b/src/console/widgets/save_discard.rs
@@ -93,8 +93,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
             Constraint::Length(1), // prompt
             Constraint::Length(1), // spacer
             Constraint::Length(1), // buttons
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // hint
         ])
         .split(inner);
 
@@ -142,25 +140,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
     frame.render_widget(
         Paragraph::new(button_line).alignment(Alignment::Center),
         chunks[2],
-    );
-
-    // Hint — same key/text/sep scheme as the main TUI footer.
-    let key_style = Style::default().fg(white).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(phosphor);
-    let sep_style = Style::default().fg(phosphor_dark);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("S", key_style),
-            Span::styled(" save", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("D", key_style),
-            Span::styled(" discard", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("C/Esc", key_style),
-            Span::styled(" cancel", text_style),
-        ]))
-        .alignment(Alignment::Center),
-        chunks[4],
     );
 }
 

--- a/src/console/widgets/scope_picker.rs
+++ b/src/console/widgets/scope_picker.rs
@@ -13,6 +13,7 @@ pub enum ScopeChoice {
 #[derive(Debug, Clone)]
 pub struct ScopePickerState {
     pub focused: ScopeChoice,
+    pub title: &'static str,
 }
 
 impl Default for ScopePickerState {
@@ -26,6 +27,15 @@ impl ScopePickerState {
     pub const fn new() -> Self {
         Self {
             focused: ScopeChoice::AllAgents,
+            title: " New environment variable ",
+        }
+    }
+
+    #[must_use]
+    pub const fn with_title(title: &'static str) -> Self {
+        Self {
+            focused: ScopeChoice::AllAgents,
+            title,
         }
     }
 
@@ -66,28 +76,16 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ScopePickerState) {
     let phosphor_dark = Color::Rgb(0, 80, 18);
     let white = Color::Rgb(255, 255, 255);
 
-    let title = " New environment variable ".to_string();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(phosphor_dark))
         .title(Span::styled(
-            title,
+            state.title,
             Style::default().fg(white).add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
-        ])
-        .split(inner);
 
     let focused_style = Style::default()
         .bg(white)
@@ -111,27 +109,18 @@ pub fn render(frame: &mut Frame, area: Rect, state: &ScopePickerState) {
         Span::raw("    "),
         Span::styled("  Specific role  ", specific_style),
     ]);
+    // inner area is 3 rows (5 outer − 2 border): blank, button, blank.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // top blank
+            Constraint::Length(1), // button
+            Constraint::Length(1), // bottom blank
+        ])
+        .split(inner);
     frame.render_widget(
         Paragraph::new(button_line).alignment(Alignment::Center),
         chunks[1],
-    );
-
-    let key_style = Style::default().fg(white).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(phosphor);
-    let sep_style = Style::default().fg(phosphor_dark);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("\u{2190}/\u{2192}", key_style),
-            Span::styled(" navigate", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("Enter", key_style),
-            Span::styled(" select", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("Esc", key_style),
-            Span::styled(" cancel", text_style),
-        ]))
-        .alignment(Alignment::Center),
-        chunks[4],
     );
 }
 

--- a/src/console/widgets/source_picker.rs
+++ b/src/console/widgets/source_picker.rs
@@ -98,8 +98,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SourcePickerState) {
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
         ])
         .split(inner);
 
@@ -142,24 +140,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SourcePickerState) {
             chunks[2],
         );
     }
-
-    let key_style = Style::default().fg(white).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(phosphor);
-    let sep_style = Style::default().fg(phosphor_dark);
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("\u{2190}/\u{2192}", key_style),
-            Span::styled(" navigate", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("Enter", key_style),
-            Span::styled(" select", text_style),
-            Span::styled(" \u{b7} ", sep_style),
-            Span::styled("Esc", key_style),
-            Span::styled(" cancel", text_style),
-        ]))
-        .alignment(Alignment::Center),
-        chunks[4],
-    );
 }
 
 #[cfg(test)]

--- a/src/console/widgets/text_input.rs
+++ b/src/console/widgets/text_input.rs
@@ -131,9 +131,7 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 const DANGER_RED: Color = Color::Rgb(255, 94, 122);
 /// Almost-invisible dim background so the input region is visible
 /// even when empty.
@@ -141,7 +139,7 @@ const INPUT_BG_DIM: Color = Color::Rgb(20, 24, 22);
 
 pub fn render(frame: &mut Frame, area: Rect, state: &TextInputState) {
     use ratatui::{
-        layout::{Alignment, Constraint, Direction, Layout},
+        layout::{Constraint, Direction, Layout},
         widgets::Paragraph,
     };
 
@@ -168,7 +166,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &TextInputState) {
         .constraints([
             Constraint::Length(1),
             Constraint::Min(1),
-            Constraint::Length(1),
             Constraint::Length(1),
         ])
         .split(inner);
@@ -214,35 +211,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &TextInputState) {
         );
         frame.render_widget(warn, rows[2]);
     }
-
-    // Hide `Enter confirm` whenever Enter wouldn't commit — telling
-    // the operator a key works that doesn't is worse than a shorter
-    // hint.
-    let hint_spans: Vec<Span> = if state.is_valid() {
-        vec![
-            Span::styled(
-                "Enter",
-                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" confirm", Style::default().fg(PHOSPHOR_GREEN)),
-            Span::styled(" \u{b7} ", Style::default().fg(PHOSPHOR_DARK)),
-            Span::styled(
-                "Esc",
-                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" cancel", Style::default().fg(PHOSPHOR_GREEN)),
-        ]
-    } else {
-        vec![
-            Span::styled(
-                "Esc",
-                Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" cancel", Style::default().fg(PHOSPHOR_GREEN)),
-        ]
-    };
-    let hint = ratatui::text::Line::from(hint_spans);
-    frame.render_widget(Paragraph::new(hint).alignment(Alignment::Center), rows[3]);
 }
 
 #[cfg(test)]

--- a/src/console/widgets/workdir_pick.rs
+++ b/src/console/widgets/workdir_pick.rs
@@ -107,16 +107,13 @@ impl WorkdirPickState {
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
 
-const PHOSPHOR_GREEN: Color = Color::Rgb(0, 255, 65);
-const PHOSPHOR_DIM: Color = Color::Rgb(0, 140, 30);
-const PHOSPHOR_DARK: Color = Color::Rgb(0, 80, 18);
-const WHITE: Color = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, WHITE};
 
 pub fn render(frame: &mut Frame, area: Rect, state: &WorkdirPickState) {
     // Block title styled WHITE + BOLD to match the main-screen block titles
@@ -134,15 +131,11 @@ pub fn render(frame: &mut Frame, area: Rect, state: &WorkdirPickState) {
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
-    // Inner layout: blank / list / blank / hint — matches the canonical
-    // list-modal layout used by GithubPicker.
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // top padding
             Constraint::Min(1),    // list
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // hint
         ])
         .split(inner);
 
@@ -190,23 +183,6 @@ pub fn render(frame: &mut Frame, area: Rect, state: &WorkdirPickState) {
         .take(visible)
         .collect();
     frame.render_widget(Paragraph::new(lines), rows[1]);
-
-    // Hint line — canonical list-modal hint (↑↓ navigate · Enter confirm · Esc cancel).
-    let key_style = Style::default().fg(WHITE).add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(PHOSPHOR_GREEN);
-    let sep_style = Style::default().fg(PHOSPHOR_DARK);
-    let hint = Paragraph::new(Line::from(vec![
-        Span::styled("\u{2191}\u{2193}", key_style),
-        Span::styled(" navigate", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Enter", key_style),
-        Span::styled(" confirm", text_style),
-        Span::styled(" \u{b7} ", sep_style),
-        Span::styled("Esc", key_style),
-        Span::styled(" cancel", text_style),
-    ]))
-    .alignment(Alignment::Center);
-    frame.render_widget(hint, rows[3]);
 }
 
 #[cfg(test)]

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -91,6 +91,7 @@ fn manager_on_secrets_tab<'a>(config: &AppConfig, cwd: &std::path::Path) -> Mana
         .clone();
     let mut editor = EditorState::new_edit("big-monorepo".into(), ws);
     editor.active_tab = EditorTab::Secrets;
+    editor.tab_bar_focused = false;
     editor.active_field = FieldFocus::Row(0);
     state.stage = ManagerStage::Editor(editor);
     state
@@ -2978,6 +2979,7 @@ fn auth_role_header_left_right_toggles_expansion() -> Result<()> {
     let mut state = ManagerState::from_config(&config, cwd);
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.tab_bar_focused = false;
     ed.auth_selected_kind = Some(AuthKind::Claude);
     let header_idx = auth_row_idx(&ed, &config, |r| matches!(r, AuthRow::RoleHeader { .. }));
     ed.active_field = FieldFocus::Row(header_idx);
@@ -3195,9 +3197,11 @@ fn auth_tab_cycle_off_auth_clears_selected_agent() -> Result<()> {
     let ws = config.workspaces.get("big-monorepo").unwrap().clone();
     let mut ed = EditorState::new_edit("big-monorepo".into(), ws);
     ed.active_tab = EditorTab::Auth;
+    ed.tab_bar_focused = false;
     ed.auth_selected_kind = Some(AuthKind::Claude);
     state.stage = ManagerStage::Editor(ed);
 
+    // Tab from content returns to tab bar and advances to next tab (General).
     handle_key(&mut state, &mut config, &paths, cwd, key(KeyCode::Tab))?;
     let ed = editor(&state);
     assert_ne!(ed.active_tab, EditorTab::Auth);


### PR DESCRIPTION
## Summary

This ships the console Settings TUI for existing `jackin config` surfaces: `S` opens a workspace-editor-style Settings screen with Mounts, Environments, Auth, and Trust tabs. Settings Mounts now uses the workspace mount table and add flow after a global-only role-scope choice; role selection reuses the shared `Select Role` picker, and global mounts remain shared-only with no isolation dialog, column, field, or keybinding. Settings Environments copies the workspace Environments row layout, add flow, masking, shared text/source/1Password modal geometry, and shared role picker behavior, including hiding empty role sections until a role actually has environment entries. Settings Auth now mirrors the workspace Auth root/detail visuals, uses Enter-only mode editing, polls the same 1Password picker as workspace Auth, and persists global auth config. Settings Trust toggles each focused role directly between `trusted` and `untrusted`.

This PR also adds an `AGENTS.md` rule requiring identical TUI flows to reuse shared widgets/renderers/input helpers instead of drifting through copy-paste.

## Hard rule: host-side effects

This PR honours the host-mutation rule from `AGENTS.md`: Settings only writes jackin's own config through explicit save confirmation, and it does not add silent host-side git, credential, dotfile, or repository mutations. The smoke recipe below runs with `HOME` pointed at a throwaway `.verify-home/settings-tui` directory so the operator can verify saves without touching their real `~/.config/jackin/config.toml`.

## What's deferred (follow-up PRs)

- Settings Auth is intentionally global-only here. Workspace role overrides remain in the workspace editor's Auth tab because `config.toml` has no global role-auth override schema.
- No new config schema fields, CLI commands, or compatibility/migration logic.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/settings-tui:refs/remotes/origin/feature/settings-tui
git checkout -B feature/settings-tui refs/remotes/origin/feature/settings-tui
```

### Static Checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

Expected result: both commands exit 0. `cargo fmt --check` prints nothing when formatting is clean; `cargo clippy` finishes without warnings.

### Tests

```sh
cargo nextest run -E 'test(/console::manager::/)'
cargo nextest run
cargo nextest run --all-features
```

Expected result: the focused console manager suite passes, then the default and all-features suites pass.

### User Smoke

Seed a disposable config that has data for every Settings tab. This uses a throwaway `HOME` inside the checkout, not your real home directory:

```sh
export JACKIN_VERIFY_HOME="$PWD/.verify-home/settings-tui"
rm -rf "$JACKIN_VERIFY_HOME"
mkdir -p "$JACKIN_VERIFY_HOME/.config/jackin" "$JACKIN_VERIFY_HOME/.jackin-verify/cache" "$JACKIN_VERIFY_HOME/.jackin-verify/scoped" "$JACKIN_VERIFY_HOME/.jackin-verify/new-cache"
cat > "$JACKIN_VERIFY_HOME/.config/jackin/config.toml" <<'TOML'
version = "v1alpha2"

[claude]
auth_forward = "sync"

[codex]
auth_forward = "api_key"

[amp]
auth_forward = "ignore"

[github]
auth_forward = "token"

[github.env]
GH_TOKEN = "$JACKIN_SETTINGS_TUI_GH_TOKEN"

[env]
GLOBAL_ALPHA = "one"
GLOBAL_BRAVO = "$JACKIN_SETTINGS_TUI_BRAVO"

[roles.agent-smith]
git = "https://github.com/jackin-project/jackin-agent-smith.git"
trusted = true

[roles.the-architect]
git = "https://github.com/jackin-project/jackin-the-architect.git"
trusted = true

[roles."verify/external"]
git = "https://example.invalid/verify/external.git"

[roles."verify/empty"]
git = "https://example.invalid/verify/empty.git"

[roles.agent-smith.env]
ROLE_ALPHA = "two"

[docker.mounts]
verify-cache = { src = "~/.jackin-verify/cache", dst = "/verify/cache", readonly = true }

[docker.mounts.agent-smith]
verify-scoped = { src = "~/.jackin-verify/scoped", dst = "/verify/scoped" }
TOML
```

Start the console against that disposable config:

```sh
HOME="$JACKIN_VERIFY_HOME" cargo run --bin jackin -- console --debug
```

Walk these checks in the TUI:

- Press `S` from the workspace list. Expected: Settings opens with header `settings` only, and the tab strip shows `Mounts`, `Environments`, `Auth`, and `Trust`.
- On `Mounts`, expected: the global mount table has `Destination`, `Mode`, and `Type` columns, plus host-source continuation rows. It must not show an `Isolation` column.
- On an existing mount row, press `R`; expected mode toggles between `ro` and `rw`. Press `R` again to return it to the seeded value. There should be no `I cycle isolation` footer item for global mounts.
- Press `A`, or move to `+ Add mount` and press `Enter`. Expected: the first modal asks `Which agent role do you want to add?` Choose `All roles`; expected the next step is the file browser, not an isolation dialog. Choose `.jackin-verify/new-cache`, choose `Edit destination`, enter `/verify/new-cache`, and press `Enter`. Expected: the new mount appears in the same table, defaults to shared in persisted config, and the footer shows a dirty change count.
- Press `A` again. Choose `Specific role`; expected the modal is the shared workspace role picker titled `Select Role`, with a `Filter:` input, role rows, and the same `↑↓ navigate · type filter · Enter select · Esc cancel` hint. Choose a role; expected the same file-browser and destination flow continues. Press `Esc` to cancel.
- Press `Tab` to `Environments`. Expected rows: global `GLOBAL_ALPHA`, global `GLOBAL_BRAVO`, `+ Add environment variable`, and the `agent-smith` role section because it has `ROLE_ALPHA`. Expected absence: registered roles with no env entries, including `the-architect`, `verify/external`, and `verify/empty`, should not appear as empty role rows.
- On `Environments`, focus `+ Add environment variable`, press `Enter`; expected first modal is the same scope picker used by workspace Environments. Press `Esc` to cancel.
- Focus `+ Add environment variable`, press `Enter`, choose `Specific role`; expected the modal is the shared workspace role picker titled `Select Role`, with a `Filter:` input, role rows, and the same footer hint. Choose `agent-smith`; expected the next prompt is `New agent-smith environment key` using the same centered text-input geometry as workspace Environments. Press `Esc` to cancel.
- Focus `GLOBAL_ALPHA`, press `A`; expected a direct `New global environment key` prompt, matching the workspace row-context add flow. The key prompt should use the same compact centered modal size and placement as `New workspace environment key`. Press `Esc` to cancel.
- Focus `GLOBAL_ALPHA`, press `Enter`; expected the `Value for GLOBAL_ALPHA` prompt uses the same compact centered modal size and placement as the workspace value prompt. Change the value to `updated-one`, and press `Enter`. Expected: the footer shows a dirty change count.
- Focus the `agent-smith` role header, press `Enter` or `Right`; expected it expands and shows `ROLE_ALPHA` plus `+ Add agent-smith environment variable`. Press `Left`; expected it collapses.
- Focus `GLOBAL_ALPHA`, press `M`; expected the value toggles between masked and visible. Press `M` again before saving.
- If `op` is installed and signed in, focus an environment row or add sentinel and press `P`; expected the same 1Password picker used by workspace Environments. Press `Esc` to cancel.
- Press `Tab` to `Auth`. Expected root rows match workspace Auth: `▸ Claude Code`, `Codex`, `Amp`, and `GitHub CLI`, with no `Global auth forwarding` panel title and footer `Enter manage auth`.
- Press `Enter` on `Claude Code`. Expected: the detail panel is titled `Claude Code`, the selected row renders as `▸ Mode`, and the footer says `Enter edit mode`. Press `Space`; expected no mode change and no dirty change count. Press `Enter`; expected the same Auth form used by workspace Auth. In the form, use the mode row to choose `api_key`, then save the form. Expected: the credential source row appears. Press `Enter` on the source row; expected the same credential-source form. Press `Esc` to cancel the form, then press `Esc` again to return to the Auth root.
- If `op` is installed and signed in, use the Auth credential-source form to choose 1Password. Expected: the picker leaves `loading accounts...` and shows the same account list UI as workspace Auth. Press `Esc` to cancel.
- Move to `GitHub CLI`, press `Enter`; expected the detail view shows token mode and a source row backed by `[github.env] GH_TOKEN`. Press `Enter` on the source row; expected the same credential-source form. Press `Esc` to cancel the form, then press `Esc` to return to the Auth root.
- Press `Tab` to `Trust`. Expected rows include built-ins `agent-smith` / `the-architect` and external roles `verify/external` / `verify/empty`. Focus any row and press `Space`; expected trust toggles between `trusted` and `untrusted`. Press `Space` again if you want to restore the previous state before saving.
- Press `S`, then confirm the save. Expected: Settings exits back to the workspace list with a saved toast. Press `Q` to quit the console.

Verify the save hit only the disposable config:

```sh
printf '\n--- disposable config after Settings save ---\n'
sed -n '1,180p' "$JACKIN_VERIFY_HOME/.config/jackin/config.toml"
```

Expected persisted changes in that printed file:

- `[docker.mounts]` contains the new all-role mount for `/verify/new-cache` and no `isolation` field.
- `[env] GLOBAL_ALPHA = "updated-one"`.
- `[claude] auth_forward = "api_key"` if you left the Claude Code mode cycled to `api_key` before saving.
- A trust row you toggled reflects the final `trusted` / `untrusted` value.
- No changes to your real `~/.config/jackin/config.toml`, because every smoke command above ran with `HOME="$JACKIN_VERIFY_HOME"`.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run build
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/commands/console/**  
UPDATED page. Confirm the console overview says Settings manages operator-level config through `Mounts`, `Environments`, `Auth`, and `Trust`.

**http://localhost:4321/reference/roadmap/**  
UPDATED page. Confirm `Settings TUI` appears in Completed work, not Partially implemented.

**http://localhost:4321/reference/roadmap/settings-tui/**  
UPDATED page. Confirm status is Implemented and the current shape documents the same four tabs that the TUI shows.

## Migration notes

None. This only adds a TUI/editor surface over existing `config.toml` fields; no schema version bump or migration fixture is required.
