### PR TITLE
docs(roadmap): expand reproducibility-pinning brainstorm for operator review

### DIFF
--- a/docs/src/content/docs/reference/roadmap/reproducibility-pinning.mdx
+++ b/docs/src/content/docs/reference/roadmap/reproducibility-pinning.mdx
@@ -4,93 +4,78 @@ title: "Reproducibility and Provenance Pinning"
 import RepoFile from '../../../../components/RepoFile.astro'
 
 
-**Status**: Needs design — brainstorming required before implementation
+**Status**: Open — agent brainstorm, not yet reviewed by the operator
 
 ## Problem
 
-The current role repo flow tracks moving branches (typically `main`) by default. There is no mechanism to pin to a specific version, verify provenance, or control when updates are pulled.
+When jackin loads a role today (`agent-smith`, `the-architect`, or any third-party role), it clones the role repo and tracks whatever sits at the tip of the default branch. Every `jackin load` runs `git pull` and silently picks up whatever the upstream pushed since the last run.
 
-## Why It Matters
+That has three concrete consequences:
 
-- An agent's behavior can change between runs without the operator's knowledge
-- No way to reproduce a previous run's exact environment
-- No audit trail of which version was used for a given session
+1. **Behaviour drifts between runs without operator awareness.** Yesterday `the-architect` behaved one way; today the upstream merged a refactor and now it behaves another. The operator did not request, see, or approve the change.
+2. **Past runs are not reproducible.** If something worked Tuesday and broke Thursday, nothing on disk records *which* role-repo commit Tuesday's run actually used. The session state, the launch summary, and the config file all describe "the role" but not "this specific snapshot of the role".
+3. **Trust is granted to a moving target.** The operator may have marked a role `trusted = true` last month after reading the code at one commit. The remote has since moved 40 commits. The trust flag still says `true`, but it is now applied to code that has never been reviewed.
 
-## Desired Behavior
+## Why it matters
 
-- Pin agents to a specific version so behavior is reproducible across runs
-- Display the resolved version during agent launch
-- Introduce explicit `--update` flag to pull latest (rather than auto-updating)
-- Record the version used in runtime state for audit/debugging
-- Integrate with the trust model: trust is granted at a specific version, `--update` re-evaluates trust
+This is the foundation for treating role repos as supply-chain artefacts rather than "always-latest from the internet". Without pinning, the audit trail in `~/.config/jackin/config.toml` does not capture *what was actually run* — only *which repo it came from*. That is fine for prototyping but rules out reproducing a session, bisecting an agent regression, or trusting a third-party role beyond a single read-through.
 
-## Open Questions
+## Proposed approach (brainstorm — pending operator approval)
 
-- What is the right unit of pinning — git tags (semantic versions) or raw commit SHAs?
-- Should `--update` advance to the latest tag, or to HEAD of the default branch?
-- How does this interact with built-in agents vs third-party agents?
-- Should the operator be able to pin to a specific version from the CLI (e.g. `--version v1.2.0`)?
+Pin role repos to an immutable commit SHA on first resolve, prefer human-readable tags when present, and require an explicit `jackin load --update` to advance the pin (which also resets trust so the operator re-confirms against the new code). This is the "Option 3 (hybrid)" sketch from the original brainstorm; the open questions in the previous draft of this page are folded into the implementation sketch below.
 
-## Options
+### Schema sketch
 
-### Option 1: Git Tag Versioning
+Add two optional fields to the role-source entry in `config.toml`:
 
-Role repos use git tags (e.g. `v1.0.0`, `v1.2.3`) as the release mechanism. jackin' resolves and pins to tags rather than branches.
+```toml
+[roles.agent-smith]
+git = "https://github.com/jackin-project/jackin-agent-smith.git"
+commit = "a1b2c3d4e5f6…"   # resolved SHA, runtime-written
+version = "v1.2.3"          # tag at HEAD, when one exists
+trusted = true
+```
 
-- First load: resolve the latest tag, record it in config
-- Subsequent loads: check out the pinned tag (no auto-update)
-- `--update`: fetch tags, resolve latest, re-pin
-- Config: `version = "v1.2.3"` in `AgentSource`
-- Agents without tags fall back to branch tracking (current behavior)
+Both fields are optional and additive. A role that has never been resolved omits both; the runtime fills them in after the first successful clone. `commit` is the source of truth for what gets checked out; `version` is purely cosmetic (launch summary line).
 
-Pros:
-- Familiar model (Cargo, npm, Docker tags)
-- Human-readable versions in config and launch output
-- Agent authors can publish releases with changelogs
-- Natural integration with semver constraints in the future (e.g. `version = "^1.0"`)
+### Runtime behaviour sketch
 
-Cons:
-- Requires agent authors to tag releases — adds process
-- Need to decide how to handle repos with no tags
-- Tag-based resolution adds complexity (latest tag selection, pre-release handling)
+- **First resolve** (no `commit` recorded): clone the repo, then capture HEAD SHA via `git rev-parse HEAD` and any tag exactly at HEAD via `git describe --tags --exact-match HEAD` (best-effort; absence is fine). Persist both back into the operator's `config.toml`.
+- **Subsequent loads** (with `commit` set): `git fetch` (no merge), then `git checkout <commit>` in detached-HEAD mode. No auto-pull, no auto-advance.
+- **`jackin load --update`** (new flag): `git fetch`, then re-pin. Resolution rule: if the repo has any tag, pick the highest semver-sorted `v*` tag; otherwise re-pin to the default branch's HEAD. Reset `trusted = false` so the operator must re-confirm trust against the new code.
+- **`--role-branch <name>`** (existing flag) keeps its current bypass behaviour — does not write a pin, used for ad-hoc PR testing.
+- **Built-in roles** follow the same rules; the only special case is that `trusted = true` is asserted by the binary on every sync.
+- **Launch summary** prints `Role: <key> @ <version-or-short-sha>` so the operator sees the resolved version on every run.
 
-### Option 2: Commit SHA Pinning
+### Config schema migration
 
-Lockfile-style pinning to raw commit SHAs, similar to `flake.lock` or Go module checksums.
+Per the project's pre-release schema rule (see <RepoFile path="AGENTS.md" />), any change to a serde-bearing config struct requires a version bump and a migration registry entry, even when the change is purely additive. This work would bump `CURRENT_CONFIG_VERSION` from `v1alpha2` to `v1alpha3`, add a no-op `MigrationStep`, ship a new `from-v1alpha2/` fixture, and re-bake the existing `from-legacy/` and `from-v1alpha1/` fixtures so their migration chains end at `v1alpha3`. Existing operator config files keep parsing without modification because the new fields are `Option<String>` with serde defaults.
 
-- First load: clone/pull, record HEAD SHA in config
-- Subsequent loads: fetch + checkout pinned SHA
-- `--update`: pull latest, re-pin to new HEAD
-- Config: `commit = "a1b2c3d4e5f6..."` in `AgentSource`
+### Open questions for operator review
 
-Pros:
-- Works with any repo, no tagging discipline required
-- Exact reproducibility (SHAs are immutable)
-- Simple implementation
+- Is the `--update` resolution rule "highest `v*` tag, fall back to default branch HEAD" the right default? Or should the operator have to opt into tag-following with a separate flag, with the default being "advance to default-branch HEAD"?
+- Should `--update` also accept an explicit target — e.g. `jackin load --update v1.3.0` to pin to a specific tag, or `jackin load --update <sha>` to pin to a specific commit?
+- Should re-pinning always reset `trusted = false`, or only when the new commit is outside the previously-trusted commit's ancestry (i.e. a force-push or unrelated commit)? The current sketch is conservative ("any movement re-prompts trust"); a finer-grained rule is possible but adds complexity.
+- For built-in roles, should the binary ship a *default pin* (so a fresh install lands on a known-good commit rather than HEAD), or continue to resolve on first load? Shipping defaults adds release-engineering work but removes the first-launch network surprise.
 
-Cons:
-- SHAs are opaque — no sense of "which version am I on" or "how far behind am I"
-- No concept of releases, changelogs, or upgrade paths
-- Harder for operators to reason about
+### Files that would change
 
-### Option 3: Hybrid
+Code:
 
-Support both — prefer tags when available, fall back to commit SHAs.
+- <RepoFile path="src/config/mod.rs" /> — add `commit`, `version` fields to `RoleSource`.
+- <RepoFile path="src/config/migrations.rs" /> — version bump and registry step.
+- <RepoFile path="src/config/roles.rs" /> — `sync_builtin_agents` must update fields in place rather than overwriting the whole `RoleSource`, so a re-pinned built-in survives a binary upgrade.
+- <RepoFile path="src/runtime/repo_cache.rs" /> — capture-pin helper, fetch+checkout-detached path for pinned commits, `--update` path, persist callback into config.
+- <RepoFile path="src/runtime/launch.rs" /> — wire the `--update` flag, include resolved version/SHA in the launch summary.
 
-- If the repo has tags: resolve latest tag, pin by tag name, record the tag's SHA for verification
-- If the repo has no tags: fall back to commit SHA pinning
-- Config could store both: `version = "v1.2.3"` and `commit = "a1b2c3d..."` (tag + verification SHA)
+Docs:
 
-Pros:
-- Best of both worlds
-- Graceful degradation for untagged repos
+- This page — convert from brainstorm to design proposal once approved, then to "Resolved" once shipped.
+- A new operator-facing note for `--update` on the `jackin load` page.
+- A new timeline entry on the schema-versions reference page for `v1alpha3`.
 
-Cons:
-- More complex config and resolution logic
-- Two code paths to maintain
+## Related files
 
-## Related Files
-
-- <RepoFile path="src/config/roles.rs" /> — `resolve_agent_source()`; `AgentSource` (defined in <RepoFile path="src/config/mod.rs" />) would need version/commit fields
-- <RepoFile path="src/runtime/repo_cache.rs" /> — `resolve_agent_repo`, repo checkout logic; calls into config layer to resolve source
-- <RepoFile path="src/manifest/mod.rs" /> — version/provenance metadata
+- <RepoFile path="src/config/roles.rs" /> — `resolve_agent_source()`; `AgentSource` (defined in <RepoFile path="src/config/mod.rs" />) would gain the new fields.
+- <RepoFile path="src/runtime/repo_cache.rs" /> — repo checkout logic; calls into config layer to resolve source.
+- <RepoFile path="src/manifest/mod.rs" /> — version/provenance metadata.


### PR DESCRIPTION
## Summary

Reframes the **Reproducibility and Provenance Pinning** roadmap item from a one-line "needs design — brainstorming required" placeholder into a full agent-authored brainstorm: problem statement, why-it-matters, a proposed hybrid (tag-preferred, SHA-fallback) implementation sketch, the schema-migration impact, open questions for operator review, and the touch list of code/doc files. Status stays `Open` and is explicitly labelled "agent brainstorm, not yet reviewed by the operator" so the operator can read, edit, or reshape it into an approved design proposal before any code is written. No code, no schema bump, no fixtures — only the roadmap MDX page changes.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/reproducibility-pinning:refs/remotes/origin/feature/reproducibility-pinning
git checkout -B feature/reproducibility-pinning refs/remotes/origin/feature/reproducibility-pinning
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/roadmap/reproducibility-pinning/**
UPDATED roadmap item. Confirm the new Status line reads "Open — agent brainstorm, not yet reviewed by the operator", that the Problem / Why it matters / Proposed approach / Open questions sections render, and that the schema sketch TOML block and the `<RepoFile />` links to `src/config/mod.rs`, `src/config/migrations.rs`, `src/config/roles.rs`, `src/runtime/repo_cache.rs`, and `src/runtime/launch.rs` all resolve.

**http://localhost:4321/reference/roadmap/**
UPDATED overview page (no edit needed in this PR). Confirm the entry still appears under its existing open-work category and is *not* in **Completed** — the brainstorm is intentionally not approved yet.

## Migration notes

None.
