### PR TITLE
docs(roadmap): re-analyze codebase readability program against current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,14 @@ Until the listed agents emit their trailers automatically, the trailer must be a
   Co-authored-by: Amp <amp@ampcode.com>
   ```
 
+- **OpenCode** (OpenCode CLI, regardless of underlying GLM model):
+
+  ```text
+  Co-authored-by: opencode-agent[bot] <opencode-agent[bot]@users.noreply.github.com>
+  ```
+
+  This matches the GitHub App identity used by OpenCode when it creates commits, as defined in the `anomalyco/opencode` repository. Do not alter the format — match what OpenCode emits.
+
 Amp may additionally emit an `Amp-Thread-ID:` metadata trailer; that is acceptable alongside the single `Co-authored-by: Amp` trailer because the thread ID identifies the conversation, not a second agent.
 
 If you are uncertain which agent is creating the commit, ask — the trailer is how the operator tracks which agent produced which change, and wrong attribution is worse than no attribution.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -62,7 +62,7 @@ git push --force-with-lease origin <branch>
 ```
 
 The `Signed-off-by` trailer must match the commit author, not any
-`Co-authored-by` trailer (Claude, Codex, etc.). If `git config user.email`
+`Co-authored-by` trailer (Claude, Codex, Amp, OpenCode, etc.). If `git config user.email`
 is not set to the expected personal address, correct it **before**
 committing — do not paper over a wrong-author commit with an unrelated
 sign-off.

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -88,7 +88,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, and `Amp` sh
 
 ### Codebase health
 
-- **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, module-contract refactors, and test coverage. The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
+- **[Codebase readability program](/reference/roadmap/codebase-readability/)** — multi-phase internal-quality work covering documentation/setup, behavioral specs, DRY deduplication, module-contract refactors, and test coverage. Re-analyzed May 2026 against the current codebase (~91K lines of production Rust, 13 files over 1000 lines, pervasive TUI/auth/Docker duplication). The full leaf list lives in the program doc and in the sidebar under **Reference → Roadmap → Codebase health**.
 - **[Cargo workspace split](/reference/roadmap/cargo-workspace-split/)** — deferred multi-crate Cargo workspace plan for when LOC, compile time, or external-consumer triggers make crate boundaries worth the overhead (status: deferred to Phase 3 — trigger not yet met, but architecture is ready)
 - **[Open review findings catalog](/reference/roadmap/open-review-findings/)** — living backlog of review findings with accepted-exception annotations. Code review and automated scanning consult this catalog (see <RepoFile path="AGENTS.md" /> → "Code review & automated scanning").
 

--- a/docs/src/content/docs/reference/roadmap/behavioral-spec-op-picker.mdx
+++ b/docs/src/content/docs/reference/roadmap/behavioral-spec-op-picker.mdx
@@ -7,7 +7,9 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/console/widgets/op_picker/mod.rs" /> is AI-generated, ~775L production, and has a 7-line `//!` doc but no INV-format invariant contract. The 4-level drill-down state machine has subtle invariants around the `op://` reference format and the absence of secret values in the picker path.
+<RepoFile path="src/console/widgets/op_picker/mod.rs" /> is now **2331L** total (was ~1712L at original analysis — +36% growth). It has a `//!` doc but no INV-format invariant contract. The 4-level drill-down state machine has subtle invariants around the `op://` reference format and the absence of secret values in the picker path.
+
+The render counterpart <RepoFile path="src/console/widgets/op_picker/render.rs" /> is **865L** (separate file).
 
 ## Key invariants
 
@@ -30,5 +32,6 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Related files
 
-- <RepoFile path="src/console/widgets/op_picker/mod.rs" /> — 1712L total, ~775L production
-- <RepoFile path="src/operator_env.rs" /> — uses `RawOpField`; exhaustive destructure test at ~line 2055
+- <RepoFile path="src/console/widgets/op_picker/mod.rs" /> — 2331L total (state machine + loader + key handler)
+- <RepoFile path="src/console/widgets/op_picker/render.rs" /> — 865L (render logic)
+- <RepoFile path="src/operator_env.rs" /> — uses `RawOpField`; exhaustive destructure test

--- a/docs/src/content/docs/reference/roadmap/behavioral-spec-runtime-launch.mdx
+++ b/docs/src/content/docs/reference/roadmap/behavioral-spec-runtime-launch.mdx
@@ -7,7 +7,9 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/runtime/launch.rs" /> is the `jackin load` critical path (~1319L production, ~3047L total, no `//!` doc) and is targeted for a structural split. Without a behavioral spec, there is no oracle to verify that a refactor preserved the launch pipeline, auth checks, workspace materialization, and post-attach cleanup rules.
+<RepoFile path="src/runtime/launch.rs" /> is the `jackin load` critical path — now **7575L** total (was ~5494L at original analysis — 38% growth). It is targeted for a structural split. Without a behavioral spec, there is no oracle to verify that a refactor preserved the launch pipeline, auth checks, workspace materialization, and post-attach cleanup rules.
+
+The file has grown significantly due to: instance identity support, Kimi agent runtime, expanded error reporting with mode traces, and additional test coverage.
 
 ## Verified invariants
 
@@ -39,7 +41,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Why this must come before the split
 
-The spec is the verification oracle. If <RepoFile path="src/runtime/launch.rs" /> is split before the spec exists, there is no contract against which to verify the split preserved all invariants.
+The spec is the verification oracle. If <RepoFile path="src/runtime/launch.rs" /> is split before the spec exists, there is no contract against which to verify the split preserved all invariants. At 7575L, this file is the single most error-prone split in the entire roadmap.
 
 ## Key file
 

--- a/docs/src/content/docs/reference/roadmap/cargo-workspace-split.mdx
+++ b/docs/src/content/docs/reference/roadmap/cargo-workspace-split.mdx
@@ -2,16 +2,21 @@
 title: "Cargo Workspace Split"
 ---
 import RepoFile from '../../../../components/RepoFile.astro'
+import { Aside } from '@astrojs/starlight/components'
 
 **Status**: Deferred — Phase 3 (trigger not yet met, but architecture is ready)
 
 ## When to do this
 
-`jackin` today is ~49,754L of Rust source — still below the ~150K threshold where a multi-crate Cargo workspace outweighs its overhead. This item is not ready to execute. The trigger conditions are:
+`jackin` today is **~91K lines of production Rust** (116 files in `src/`) — still below the ~150K threshold where a multi-crate Cargo workspace outweighs its overhead, but growing fast (was ~50K at original analysis — 82% growth). This item is not ready to execute. The trigger conditions are:
 
 - LOC exceeds ~150K, **or**
 - A sub-component needs external consumers for third-party agent manifest tooling, **or**
 - Compile times on the CI `check` job exceed 5 minutes cold cache
+
+<Aside type="caution">
+**The original claim "`console/` has zero imports from `runtime/` in production code" is FALSE.** The re-analysis found 2 production-code dependencies: `crate::runtime::register_agent_repo` and `crate::runtime::RepoError` in `console/manager/input/editor.rs`. The Cargo workspace split will need these 2 sites addressed first — either through a trait abstraction or by moving the shared function to a common module.
+</Aside>
 
 ## Target 6-crate structure
 
@@ -31,25 +36,21 @@ jackin/
 └── validate/              ← jackin-validate binary
 ```
 
-## Key structural insight
-
-`console/` has **zero imports from `runtime/` in production code** — this pre-existing clean boundary is the most important structural asset. `jackin-console` and `jackin-runtime` can become separate crates without moving any logic; current coupling is limited to test helpers such as `crate::runtime::FakeRunner`.
-
-Starting point: extract just these two crates first. The Cargo workspace boundary makes the existing clean boundary enforced by the compiler rather than policed by convention.
-
 ## Dependency tiers (verified)
 
 - **Tier 0** (no cross-module deps): `workspace/`, `manifest/`, `docker.rs`, `paths.rs`, `selector.rs`
 - **Tier 1**: `config/`, `tui/`, `instance/`, `env_resolver/`
 - **Tier 2**: `operator_env/`, `runtime/`, `repo/`
-- **Tier 3**: `console/` — no import from `runtime/`
+- **Tier 3**: `console/` — **almost** no import from `runtime/` (2 call sites need fixing first)
 
-## Do Phase 2 file splits first
+## Prerequisites before this phase
 
-The Phase 2 file splits (split-input-editor, split-operator-env, split-app-mod, split-runtime-launch) establish clean internal module boundaries that make the workspace migration easier.
+1. **Phase 2 file splits** — establish clean internal module boundaries
+2. **Phase 1.5 DRY extractions** — reduce duplication that would otherwise be frozen into crate APIs
+3. **Fix the 2 console→runtime dependencies** — `register_agent_repo` and `RepoError` must move to a shared module or through a trait
 
 ## Related files
 
 - <RepoFile path="Cargo.toml" /> — target: convert to virtual workspace manifest
-- <RepoFile path="src/console/mod.rs" /> — zero imports from `runtime/`
-- <RepoFile path="src/runtime/launch.rs" /> — the runtime entry point
+- <RepoFile path="src/console/manager/input/editor.rs" /> — contains the 2 runtime dependencies that must be resolved
+- <RepoFile path="src/runtime/launch.rs" /> — the runtime entry point (7575L)

--- a/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
+++ b/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
@@ -2,67 +2,191 @@
 title: "Codebase readability & restructuring"
 ---
 import RepoFile from '../../../../components/RepoFile.astro'
+import { Aside } from '@astrojs/starlight/components'
 
-**Status**: Open — active program (Phase 1 → Phase 3)
+**Status**: Open — active program (re-analyzed May 2026)
 
 ## Goal
 
-Make AI-generated code verifiable. More than half of source files still have no `//!` module contracts; no behavioral specs exist; no systematic way to answer "did the AI implement this correctly?" PR review is hard because files are large and concerns are mixed.
+Make AI-generated code verifiable and maintainable. The codebase has grown to ~91K lines of production Rust (116 files in `src/`) with significant AI-assisted development. The core problems are:
 
-The work is organized in three phases. Each item below links to its dedicated page with steps, file references, and confirmation requirements.
+1. **Files have outgrown their module boundaries** — 13 files exceed 1000 lines; the largest is 7575L
+2. **Pervasive copy-paste duplication** — TUI rendering (120 `Style::default()` chains, 192 `Span` constructions), auth provisioning (5 copy-pasted provision functions), Docker command construction (40 invocations with no shared builder), test infrastructure (100+ Dockerfile literals, 11 independent mock structs)
+3. **Weak module contracts** — 63 of 116 files (54%) still lack `//!` orientation docs; no behavioral specs exist
+4. **Stale roadmap assumptions** — file sizes, LOC counts, and structural claims in this program have drifted significantly since the original analysis
 
-## Phase 1 — Documentation & setup (low risk)
+## Codebase Maintainability Assessment
+
+### Strongest parts
+
+- **Layered config resolution** — global / workspace / workspace×role env resolution is well-structured in `config/roles.rs`
+- **Instance identity system** — `instance/naming.rs` provides centralized container name generation used consistently
+- **Migration framework** — `config/migrations.rs` and `manifest/migrations.rs` provide versioned schema upgrades with fixture-tested chains
+- **Isolation boundary** — `isolation/materialize.rs` ↔ `isolation/finalize.rs` have clean complementary responsibilities with shared state types
+
+### Weakest parts (highest duplication / entropy risk)
+
+- **TUI render layer** — `console/manager/render/` has extreme boilerplate duplication (see Phase 1.5 findings)
+- **Auth provisioning** — `instance/auth.rs` contains 5 near-identical provision functions differentiated only by file paths and agent-specific surfaces
+- **Docker command construction** — 40 `runner.run("docker", ...)` calls across 7 files, zero shared builders
+- **Test infrastructure** — 11 separate mock/fake struct definitions; `FROM projectjackin/construct:trixie\n` appears 100+ times; role-repo seeding is copy-pasted 41+ times
+- **`runtime/launch.rs`** — at 7575L it is the single hardest file to review in the codebase
+
+### Biggest long-term risks
+
+- Agent-generated entropy accelerating: each new agent runtime (Kimi was added recently) duplicates auth provision patterns, TUI tab handling, and match-arm dispatch
+- The "clean console/runtime boundary" claim was never enforced and now has 2 production dependencies — the window for a clean Cargo workspace split is narrowing
+- No snapshot tests exist, so Phase 2 file splits risk silent render regressions
+
+## Phase 0 — MSRV & toolchain (DONE)
+
+[MSRV & toolchain pin](/reference/roadmap/msrv-toolchain/) — `rust-toolchain.toml` enforced in CI, MSRV floor verified. **Resolved.**
+
+## Phase 1 — Documentation & setup (low risk, no structural code changes)
 
 These items require no structural code changes and can be done in any order within the phase (with the dependency notes below):
 
 | Item | Purpose | Depends on |
 |---|---|---|
-| [Module contracts](/reference/roadmap/module-contracts/) | Write `//!` docs for 10 priority files | — |
-| [Behavioral spec: runtime/launch.rs](/reference/roadmap/behavioral-spec-runtime-launch/) | Verified invariants for the `jackin load` critical path | Module contracts first |
-| [Behavioral spec: op_picker](/reference/roadmap/behavioral-spec-op-picker/) | Invariants for the 1Password picker state machine | — |
+| [Module contracts](/reference/roadmap/module-contracts/) | Write `//!` docs for priority files (54% currently missing) | — |
+| [Behavioral spec: runtime/launch.rs](/reference/roadmap/behavioral-spec-runtime-launch/) | Verified invariants for the `jackin load` critical path (7575L) | Module contracts first |
+| [Behavioral spec: op_picker](/reference/roadmap/behavioral-spec-op-picker/) | Invariants for the 1Password picker state machine (2331L) | — |
 | [Per-directory README](/reference/roadmap/per-directory-readme/) | AI-native orientation files + per-crate AGENTS.md | — |
 | [Developer Reference setup](/reference/roadmap/developer-reference-setup/) | `jackin.tailrocks.com/internal/` Starlight section | — |
 | [Update PROJECT_STRUCTURE.md](/reference/roadmap/project-structure-update/) | Refresh the navigation map so it matches the current tree | — |
 | [CI gate: PROJECT_STRUCTURE.md](/reference/roadmap/ci-project-structure-gate/) | Fail PRs that add modules without updating the map | Project structure update first |
-| [pub(crate) visibility pass](/reference/roadmap/pub-crate-visibility/) | Tighten obviously over-wide visibilities after clarifying the library surface | — |
-| [MSRV & toolchain pin](/reference/roadmap/msrv-toolchain/) | `rust-toolchain.toml` + verified MSRV CI step | — |
+| [pub(crate) visibility pass](/reference/roadmap/pub-crate-visibility/) | Tighten over-wide visibilities after clarifying the library surface | — |
 | [Architecture Decision Records](/reference/roadmap/architecture-decision-records/) | ADRs for single-crate, toolchain, ratatui decisions | Developer Reference setup |
 | [Snapshot tests for TUI](/reference/roadmap/snapshot-tests-tui/) | Regression net before Phase 2 file splits | — |
-| [Agent workflow: cc-sdd](/reference/roadmap/agent-workflow-cc-sdd/) | Define a repo-committed spec workflow, optionally with `cc-sdd` as a wrapper | Developer Reference setup |
+| [Agent workflow: cc-sdd](/reference/roadmap/agent-workflow-cc-sdd/) | Define a repo-committed spec workflow | Developer Reference setup |
 | [Publish CONTRIBUTING + TESTING](/reference/roadmap/move-contributing-testing/) | Mirror contributor docs into the browsable Starlight section | Developer Reference setup |
+
+## Phase 1.5 — DRY & deduplication pass (NEW)
+
+<Aside type="caution">
+This phase was added after the May 2026 re-analysis found pervasive copy-paste duplication across the codebase. These extractions are grounded in measured duplication — no speculative abstractions.
+</Aside>
+
+Before splitting files in Phase 2, reduce the duplication within them. Every extraction below has 3+ real call sites that benefit.
+
+### TUI rendering deduplication
+
+| Extraction | Current duplication | Files affected | Impact |
+|---|---|---|---|
+| `fn titled_block(title, focused) -> Block` | 18 `Block::default().borders(ALL)` + 15 border_style chains + 13 title constructions (78 total sites) | `render/editor.rs`, `render/list.rs`, `render/global_mounts.rs` | Collapses 78 boilerplate chains into named calls |
+| Named style constants (`BOLD_WHITE`, `DIM`, `GREEN`) | 120 `Style::default().fg(...)` chains; `Style::default().fg(WHITE).add_modifier(BOLD)` alone appears 26 times | All render files + `input/save.rs` | Eliminates 120 inline style constructions |
+| `fn app_layout(area) -> Rc<[Rect]>` for header/body/footer | 4 identical `Layout::default()` splits with `[Length(3), Min(..), Length(2)]` | `render/mod.rs`, `render/global_mounts.rs` | Removes 4 exact-duplicate layout constructions |
+| Deduplicate breadcrumb logic | `push_op_breadcrumb_spans()` at `render/editor.rs:1427` is fully duplicated inline at lines 1058–1091 | `render/editor.rs` | One function call replaces ~30 lines of duplicated vault/item/field rendering |
+
+**Color constant re-declarations**: `input/save.rs` re-declares `phosphor_green`, `phosphor_dim`, `white` locally instead of importing from `render/mod.rs`. Remove 3 local copies.
+
+### Auth provisioning deduplication
+
+| Extraction | Current duplication | File affected |
+|---|---|---|
+| Generic `fn provision_file_credential(target, host_path, mode) -> (Outcome, MountDecision)` | The Sync arm (read host file → write to role-state → `HostMissing` on `NotFound`) is copy-pasted across Codex, Amp, and GitHub provisioners in <RepoFile path="src/instance/auth.rs" />. The wipe-then-return for `ApiKey`/`Ignore` is identical across 4 agents. | <RepoFile path="src/instance/auth.rs" /> (2607L) |
+| `AgentRuntimeState::model()` accessor | 3 identical match-body methods (`claude_model()`, `codex_model()`, `kimi_model()`) in <RepoFile path="src/instance/mod.rs" /> | <RepoFile path="src/instance/mod.rs" /> |
+
+### Docker command deduplication
+
+| Extraction | Current duplication | Files affected |
+|---|---|---|
+| `DockerResources::from_container_name(name)` struct with `dind`, `network`, `certs_volume` fields | 44 inline `format!("{name}-dind")` / `format!("{name}-net")` derivations across 5 files | `launch.rs`, `attach.rs`, `cleanup.rs`, `app/mod.rs`, `app/context.rs` |
+| `fn run_dind_sidecar(runner, name, network, role_label, certs)` | Identical DinD sidecar `docker run` arg list at `launch.rs:777-799` and `attach.rs:472-498` | `runtime/launch.rs`, `runtime/attach.rs` |
+| `fn resolve_mode_with_trace()` returning both mode and layer trace | `build_mode_resolution()` in `launch.rs:2977-3011` duplicates the 3-layer × 4-agent match (12 arms) from `config/roles.rs:22-56` (`resolve_mode`) solely to capture the resolution trace for error reporting | `runtime/launch.rs`, `config/roles.rs` |
+
+### Test infrastructure consolidation
+
+| Extraction | Current duplication | Files affected |
+|---|---|---|
+| Promote `FakeRunner` to `pub` or move to `src/test_support.rs` | 3 independent `FakeRunner` definitions in `runtime/test_support.rs` (pub(super)), `tests/amp_launch.rs`, `tests/codex_launch.rs`; `tests/per_mount_isolation_e2e.rs` has its own `ScriptedRunner` | 4 test files |
+| `fn seed_minimal_role_repo(paths, selector, manifest_toml)` test helper | 41+ copy-pasted 4-line seeding blocks across 10 files; `"FROM projectjackin/construct:trixie\n"` literal appears 100+ times; `version = "v1alpha3"` appears 153+ times | 10+ test files |
+| `fn test_workspace(repo_dir) -> ResolvedWorkspace` + `fn isolated_workspace(repo_dir, dst, isolation)` | 14+ inline `ResolvedWorkspace { ... }` constructions across 6 files | 6 test files |
+| `fn simple_mount(src, dst, iso) -> MountConfig` | 9 local `fn mount()` helpers across 8 files, each constructing a `MountConfig` with slight variations | 8 test files |
+| Consolidate `fake_runner_with_running` | 2 near-identical helpers in `app/context.rs` and `input/save.rs` with a subtle format difference (trailing newline) | 2 files |
+
+<Aside type="note">
+**Why this phase comes before Phase 2:** File splits on files that are 30–50% boilerplate produce smaller modules that still contain the same duplication. Extracting shared patterns first means the splits land on genuinely focused code. It also reduces the LOC of each file, making splits safer and easier to review.
+</Aside>
 
 ## Phase 2 — File splits (confirmation required)
 
-Split the four largest files. Do snapshot tests (Phase 1) first — they are the regression net.
+Split the largest files. Snapshot tests (Phase 1) and DRY extractions (Phase 1.5) must land first — they are the regression net and shrink the files before splitting.
 
-Do the behavioral spec for `runtime/launch.rs` before splitting it.
+The original Phase 2 listed 4 files. The re-analysis found the codebase now has **13 files exceeding 1000 lines**, with **6 files exceeding 2000 lines**. The table below reflects current reality.
 
-| Item | Current LOC | Benefit |
-|---|---|---|
-| [Split console/manager/input/editor.rs](/reference/roadmap/split-input-editor/) | ~3796L | One file per editor tab; audit Secrets-tab behavior independently |
-| [Split app/mod.rs](/reference/roadmap/split-app-mod/) | ~1243L | Separate dispatch, workspace, and config command handlers |
-| [Split operator_env.rs](/reference/roadmap/split-operator-env/) | ~2975L | Separate shared API, CLI client, env resolution, diagnostics, and picker metadata |
-| [Split runtime/launch.rs](/reference/roadmap/split-runtime-launch/) | ~5494L | Separate trust, terminal setup, launch pipeline, and slot/finalizer helpers |
+| Item | Current LOC (May 2026) | Original LOC | Growth | Benefit |
+|---|---|---|---|---|
+| [Split runtime/launch.rs](/reference/roadmap/split-runtime-launch/) | **7575L** | ~5494L | +38% | Separate trust, terminal setup, launch pipeline, slot/finalizer helpers. Still the hardest file to split safely. |
+| [Split input/editor.rs](/reference/roadmap/split-input-editor/) | **3955L** | ~3796L | +4% | One file per editor tab; audit Secrets-tab behavior independently |
+| [Split operator_env.rs](/reference/roadmap/split-operator-env/) | **3573L** | ~2975L | +20% | Separate shared API, CLI client, env resolution, diagnostics, and picker metadata |
+| [Split render/editor.rs](/reference/roadmap/split-input-editor/) | **3231L** | *(not listed)* | NEW | Per-tab render extraction; currently paired with input/editor.rs |
+| [Split render/list.rs](/reference/roadmap/split-input-editor/) | **2816L** | *(not listed)* | NEW | Split sentinel rendering from workspace detail rendering |
+| [Split app/mod.rs](/reference/roadmap/split-app-mod/) | **2767L** | ~1243L | +123% | Separate dispatch, workspace, and config command handlers. **More than doubled since original analysis.** |
+| [Split input/save.rs](/reference/roadmap/split-input-editor/) | **2734L** | *(not listed)* | NEW | Split save flow from validation from commit planning |
+| [Split instance/auth.rs](/reference/roadmap/split-input-editor/) | **2607L** | ~2401L | +9% | Separate per-agent provision functions after DRY extraction |
+| [Split state.rs](/reference/roadmap/split-input-editor/) | **2477L** | *(not listed)* | NEW | Separate state machine enums from modal definitions from workspace state |
+| [Split isolation/materialize.rs](/reference/roadmap/split-input-editor/) | **2392L** | ~2392L | — | Separate worktree creation from clone setup from isolation record writing |
+| [Split op_picker/mod.rs](/reference/roadmap/behavioral-spec-op-picker/) | **2331L** | ~1712L | +36% | Separate state machine from loader from key handler |
+| [Split config/editor.rs](/reference/roadmap/split-input-editor/) | **2260L** | *(not listed)* | NEW | Separate TOML manipulation from field validation from save logic |
+| [Split input/global_mounts.rs](/reference/roadmap/split-input-editor/) | **1984L** | *(not listed)* | NEW | Per-subtab key handlers for the global mounts editor |
+
+### Recommended split order
+
+1. **`app/mod.rs`** (2767L, +123% growth) — highest growth; pure dispatch, lowest risk
+2. **`instance/auth.rs`** (2607L) — after Phase 1.5 DRY extraction reduces it significantly
+3. **`operator_env.rs`** (3573L) — cross-cutting but well-understood dependency graph
+4. **`input/editor.rs` + `render/editor.rs`** (3955L + 3231L) — paired split; do together
+5. **`isolation/materialize.rs`** (2392L) — clean internal seams already identified
+6. **`config/editor.rs`** (2260L) — after the editor split patterns are established
+7. **Remaining 1000L+ files** — `state.rs`, `render/list.rs`, `input/save.rs`, `input/global_mounts.rs`, `op_picker/mod.rs`
+8. **`runtime/launch.rs`** (7575L) — **LAST**; hardest file, most complex test suite, behavioral spec must exist
 
 ## Phase 3 — Future (deferred)
 
 | Item | Trigger |
 |---|---|
-| [Cargo workspace split](/reference/roadmap/cargo-workspace-split/) | LOC > 150K or external consumers |
+| [Cargo workspace split](/reference/roadmap/cargo-workspace-split/) | LOC > 150K or external consumers (currently ~91K production Rust) |
 | [rustdoc JSON → Starlight pipeline](/reference/roadmap/rustdoc-json-starlight/) | After `//!` coverage sprint |
 
 ## Execution order (recommended)
 
 1. **Phase 1 prerequisites for safe refactors** — snapshot tests, refreshed `PROJECT_STRUCTURE.md`, and the `runtime/launch.rs` behavioral spec
-2. **Phase 2 file splits** — biggest readability gain per effort; do `runtime/launch.rs` last among the four
-3. **Documentation follow-through** — `//!` module contracts, per-directory README files, Developer Reference scaffolding, and ADRs
-4. **Policy / workflow cleanup** — `PROJECT_STRUCTURE.md` CI gate, contributor-doc publishing, and any spec-workflow migration
-5. **Phase 3 deferred items** — workspace split and generated API docs once the earlier structure/docs work has landed
+2. **Phase 1.5 DRY extractions** — shrink the files before splitting them; focus on TUI boilerplate first (highest duplication density), then auth provisioning, then Docker commands, then test infrastructure
+3. **Phase 2 file splits** — biggest readability gain per effort; follow the recommended split order above; do `runtime/launch.rs` absolutely last
+4. **Documentation follow-through** — `//!` module contracts, per-directory README files, Developer Reference scaffolding, and ADRs
+5. **Policy / workflow cleanup** — `PROJECT_STRUCTURE.md` CI gate, contributor-doc publishing, and any spec-workflow migration
+6. **Phase 3 deferred items** — workspace split and generated API docs once the earlier structure/docs work has landed
 
-## Key structural insight
+## Key structural insight — corrected
 
-`console/` has **zero imports from `runtime/` in production code** — this pre-existing clean boundary is the most important structural asset. The Cargo workspace split can enforce this boundary with the Rust compiler without moving any logic, only directories.
+<Aside type="caution">
+**The original claim "`console/` has zero imports from `runtime/` in production code" is FALSE.**
+</Aside>
+
+The re-analysis found 2 production-code dependencies from `console/` into `runtime/`:
+
+1. `src/console/manager/input/editor.rs:1445` — calls `crate::runtime::register_agent_repo(...)` when the operator types a role selector in the TUI editor
+2. `src/console/manager/input/editor.rs:1536-1547` — references `crate::runtime::RepoError` variants in `friendly_role_resolution_error()`
+
+There are zero `use crate::runtime::...` import statements — all references are fully-qualified paths. The boundary is **almost clean** (2 call sites) but not **clean**. The Cargo workspace split will need these 2 sites addressed first (either through a trait abstraction or by moving `register_agent_repo` to a shared module).
+
+## Current metrics (May 2026)
+
+| Metric | Value | Original analysis |
+|---|---|---|
+| Production Rust (`src/`) | **90,949L** (116 files) | ~49,754L |
+| Test code (`tests/`) | **6,758L** (15 files) | — |
+| Total Rust | **97,707L** | — |
+| Files > 2000 lines | **12** | 4 |
+| Files > 1000 lines | **21** | — |
+| Files with `//!` docs | **53 of 116** (46%) | ~47% |
+| Files missing `//!` docs | **63** (54%) | ~53% |
+| `pub fn` vs `pub(crate) fn` | 383 vs 42 (9.9% `pub(crate)`) | — |
+| Snapshot test infrastructure | **None** | — |
+| ADR directory | **None** | — |
+| Per-directory README/AGENTS.md | **None** | — |
 
 ## Research archive
 
-Full 2343L research document and 40-iteration history archived in git at commit `b7e9fc2` on `analysis/code-readability`.
+Full 2343L research document and 40-iteration history archived in git at commit `b7e9fc2` on `analysis/code-readability`. May 2026 re-analysis findings are grounded in the commit at the head of `roadmap/codebase-readability-reanalysis`.

--- a/docs/src/content/docs/reference/roadmap/developer-reference-setup.mdx
+++ b/docs/src/content/docs/reference/roadmap/developer-reference-setup.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-Internal developer docs (behavioral specs, ADRs, architecture notes, code tour) are not browsable on the live site. Today the committed design material is split between roadmap pages and `docs/superpowers/specs/`, so there is no single browsable developer-reference section in Starlight.
+Internal developer docs (behavioral specs, ADRs, architecture notes, code tour) are not browsable on the live site. The committed design material is split between roadmap pages and code-level comments, so there is no single browsable developer-reference section in Starlight.
 
 ## Goal
 

--- a/docs/src/content/docs/reference/roadmap/module-contracts.mdx
+++ b/docs/src/content/docs/reference/roadmap/module-contracts.mdx
@@ -7,28 +7,37 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-About 47% of source files have `//!` orientation docs. The remaining 53% give AI agents and contributors no orientation when they open the file — purpose, scope, and key invariants must be reverse-engineered from the code.
+About 46% of source files (53 of 116) have `//!` orientation docs. The remaining 54% (63 files) give AI agents and contributors no orientation when they open the file — purpose, scope, and key invariants must be reverse-engineered from the code. This has barely improved since the original analysis.
 
 ## Priority files (current largest / most central undocumented modules)
 
-| File | Production LOC | Why urgent |
+| File | Current LOC (May 2026) | Original LOC | Growth | Why urgent |
+|---|---|---|---|---|
+| <RepoFile path="src/runtime/launch.rs" /> | **7575** | ~5494 | +38% | Largest undocumented production file, `jackin load` critical path |
+| <RepoFile path="src/app/mod.rs" /> | **2767** | ~1243 | +123% | CLI dispatch entry point — more than doubled |
+| <RepoFile path="src/app/context.rs" /> | **1466** | ~1022 | +43% | Target resolution and workspace/agent context helpers |
+| <RepoFile path="src/instance/auth.rs" /> | **2607** | ~2401 | +9% | Credential forwarding and auth provisioning logic |
+| <RepoFile path="src/isolation/materialize.rs" /> | **2392** | ~2392 | — | Central mount-materialization flow with many invariants |
+| <RepoFile path="src/isolation/finalize.rs" /> | **1819** | ~1819 | — | Foreground-session cleanup / preservation policy |
+| <RepoFile path="src/config/mod.rs" /> | **1407** | ~1254 | +12% | Main config schema and auth/source policy |
+| <RepoFile path="src/workspace/mod.rs" /> | **1056** | ~905 | +17% | Core workspace types and validation rules |
+| <RepoFile path="src/runtime/cleanup.rs" /> | 687 | ~637 | +8% | Container/class cleanup semantics |
+| <RepoFile path="src/derived_image.rs" /> | **983** | ~989 | — | Dockerfile generation, UID/GID remapping |
+
+Notable new entries not in original list:
+
+| File | Current LOC | Why urgent |
 |---|---|---|
-| <RepoFile path="src/runtime/launch.rs" /> | ~5494 | Largest undocumented production file, `jackin load` critical path |
-| <RepoFile path="src/instance/auth.rs" /> | ~2401 | Credential forwarding and auth provisioning logic |
-| <RepoFile path="src/isolation/materialize.rs" /> | ~2392 | Central mount-materialization flow with many invariants |
-| <RepoFile path="src/isolation/finalize.rs" /> | ~1819 | Foreground-session cleanup / preservation policy |
-| <RepoFile path="src/config/mod.rs" /> | ~1254 | Main config schema and auth/source policy |
-| <RepoFile path="src/app/mod.rs" /> | ~1243 | CLI dispatch entry point |
-| <RepoFile path="src/app/context.rs" /> | ~1022 | Target resolution and workspace/agent context helpers |
-| <RepoFile path="src/workspace/mod.rs" /> | ~905 | Core workspace types and validation rules |
-| <RepoFile path="src/runtime/cleanup.rs" /> | ~637 | Container/class cleanup semantics |
-| <RepoFile path="src/tui/animation.rs" /> | ~582 | Shared intro/outro animation behavior |
+| <RepoFile path="src/console/manager/state.rs" /> | **2477** | Central state machine for the entire console — enums, modal definitions, workspace state. No `//!`. |
+| <RepoFile path="src/console/manager/input/save.rs" /> | **2734** | Save flow, validation, commit planning. Grew from zero to 2734L. No `//!`. |
+| <RepoFile path="src/console/manager/input/global_mounts.rs" /> | **1984** | Global mounts editor input handling. Grew from ~344L to 1984L. No `//!`. |
+| <RepoFile path="src/manifest/validate.rs" /> | **1222** | Role manifest validation logic. No `//!`. |
 
 ## Steps
 
 1. For each file, read the first 50 lines and the public item list.
 2. Write a `//!` block at the top: purpose, scope claim, key invariants, what callers can assume.
-3. Model on `env_model.rs` (the 3-element exemplar: purpose + scope + history).
+3. Model on <RepoFile path="src/env_model.rs" /> (the 3-element exemplar: purpose + scope + history).
 4. Do not add `///` item-level docs in this pass — only `//!` module-level.
 
 ## What a good `//!` block says
@@ -39,4 +48,4 @@ About 47% of source files have `//!` orientation docs. The remaining 53% give AI
 
 ## Caveats
 
-Purely additive — no behavior change, no CI risk. Do before the behavioral specs (ITEM-002, 003) since the spec presupposes the module has a stated contract.
+Purely additive — no behavior change, no CI risk. Do before the behavioral specs since the spec presupposes the module has a stated contract.

--- a/docs/src/content/docs/reference/roadmap/per-directory-readme.mdx
+++ b/docs/src/content/docs/reference/roadmap/per-directory-readme.mdx
@@ -15,17 +15,20 @@ AI coding agents (Claude Code, Copilot, Cursor) load `README.md` automatically w
 |---|---|
 | `src/` | Top-level module map + entry points (`load_agent`, `run_console`, `validate`). Link to PROJECT_STRUCTURE.md. |
 | `src/runtime/` | Container bootstrap pipeline. Entry: `load_agent()` in `launch.rs`. 4-step sequence. |
-| `src/console/` | Operator console TUI. Entry: `run_console()`. Two subsystems: `manager/` and `widgets/`. No import from `runtime/`. |
+| `src/console/` | Operator console TUI. Entry: `run_console()`. Two subsystems: `manager/` and `widgets/`. **Note: has 2 production dependencies on `runtime/`** (`register_agent_repo`, `RepoError`). |
 | `src/console/manager/` | Workspace manager TUI. 3-layer: `state.rs` (data), `input/` (dispatch), `render/` (drawing). |
 | `src/console/widgets/` | Reusable TUI widget library. Each widget is a self-contained state machine. |
-| `docs/` | Astro Starlight docs site. Public docs live in `src/content/docs/`; current design/spec material still lives in `docs/superpowers/specs/` until the Developer Reference section exists. |
+| `src/config/` | Configuration loading, persistence, editing. TOML schema, migrations, workspace files. |
+| `src/instance/` | Per-instance state: container identity, auth provisioning, manifests. 5 agent-specific provision functions. |
+| `src/isolation/` | Mount isolation: materialize, finalize, cleanup, state records. |
+| `docs/` | Astro Starlight docs site. Public docs live in `src/content/docs/`. |
 
 ## AGENTS.md per crate (after workspace split)
 
 When the Cargo workspace split creates `crates/jackin-console/`, `crates/jackin-runtime/`, etc., each crate should get its own `AGENTS.md` with crate-specific rules — shorter and more focused than the root `AGENTS.md`. Examples:
 
 - `crates/jackin-core/AGENTS.md` — "this crate has no I/O, no `std::process::Command`; keep it that way"
-- `crates/jackin-console/AGENTS.md` — "no import from `jackin-runtime`; this is enforced by Cargo"
+- `crates/jackin-console/AGENTS.md` — "no import from `jackin-runtime` except through the 2 approved call sites; this is enforced by Cargo"
 - `crates/jackin-runtime/AGENTS.md` — "all Docker operations go through `CommandRunner`; never shell out directly"
 
 ## Steps

--- a/docs/src/content/docs/reference/roadmap/pub-crate-visibility.mdx
+++ b/docs/src/content/docs/reference/roadmap/pub-crate-visibility.mdx
@@ -7,18 +7,23 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-`jackin` does have a real library surface: <RepoFile path="src/lib.rs" /> publicly exports most top-level modules and <RepoFile path="src/bin/validate.rs" /> consumes the library. That means a blanket "binary crate ⇒ convert everything to `pub(crate)`" pass would be wrong. The actual readability problem is narrower: some items are still wider than needed, but `unreachable_pub` only catches the subset that is currently public without being reachable from the crate root.
+`jackin` has a real library surface: <RepoFile path="src/lib.rs" /> publicly exports most top-level modules and <RepoFile path="src/bin/validate.rs" /> consumes the library. That means a blanket "binary crate ⇒ convert everything to `pub(crate)`" pass would be wrong. The actual readability problem is narrower: some items are still wider than needed.
 
-## Verified numbers
+## Verified numbers (May 2026)
 
-- <RepoFile path="src/lib.rs" /> currently exports 21 top-level modules plus `app::run`
-- `RUSTFLAGS='-W unreachable_pub' cargo check` currently reports 10 warnings on `main`
-- the current warnings cluster in <RepoFile path="src/workspace/planner.rs" />, <RepoFile path="src/console/manager/agent_allow.rs" />, <RepoFile path="src/runtime/launch.rs" />, <RepoFile path="src/config/roles.rs" />, and <RepoFile path="src/config/mounts.rs" />
-- 0 `unreachable_pub` enforcement exists in the normal lint configuration today
+| Declaration | `pub` | `pub(crate)` |
+|---|---|---|
+| `fn` | 383 | 42 (9.9%) |
+| `struct` | 124 | 3 |
+| `enum` | 91 | 3 |
+
+- <RepoFile path="src/lib.rs" /> currently exports 22 top-level modules (grew from 21) plus `app::run`
+- There are **zero** `pub(crate) mod` declarations — all 22 modules use bare `pub mod`
+- `RUSTFLAGS='-W unreachable_pub' cargo check` reported 10 warnings at the original analysis; the count may have changed — re-verify before starting
 
 ## Current low-hanging fruit
 
-| File | Warning count / scope | Notes |
+| File | Scope | Notes |
 |---|---|---|
 | <RepoFile path="src/workspace/planner.rs" /> | 5 current warnings | Plan structs/helpers are only consumed inside the crate today |
 | <RepoFile path="src/console/manager/agent_allow.rs" /> | 2 current warnings | Manager helper fns can likely tighten to `pub(super)` |
@@ -28,16 +33,17 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Steps
 
-1. Decide the intended library surface in <RepoFile path="src/lib.rs" /> first: what truly needs to stay `pub` for `main.rs`, `jackin-validate`, and tests?
-2. Add to <RepoFile path="Cargo.toml" /> `[lints.rust]` section:
+1. Re-run `RUSTFLAGS='-W unreachable_pub' cargo check` to get the current warning set.
+2. Decide the intended library surface in <RepoFile path="src/lib.rs" /> first: what truly needs to stay `pub` for `main.rs`, `jackin-validate`, and tests?
+3. Add to <RepoFile path="Cargo.toml" /> `[lints.rust]` section:
    ```toml
    [lints.rust]
    unreachable_pub = "warn"
    ```
-3. Run `cargo check` — compiler lists the items that are public but unreachable from the crate root.
-4. Convert each flagged item to the narrowest workable visibility (`pub(crate)` or `pub(super)` as appropriate).
-5. If a larger pass is still desired, shrink or reorganize the `lib.rs` export surface first, then rerun the lint.
-6. Verify `cargo nextest run` still passes and `cargo check` is warning-free.
+4. Run `cargo check` — compiler lists the items that are public but unreachable from the crate root.
+5. Convert each flagged item to the narrowest workable visibility (`pub(crate)` or `pub(super)` as appropriate).
+6. If a larger pass is still desired, shrink or reorganize the `lib.rs` export surface first, then rerun the lint.
+7. Verify `cargo nextest run` still passes and `cargo check` is warning-free.
 
 ## What stays `pub`
 

--- a/docs/src/content/docs/reference/roadmap/snapshot-tests-tui.mdx
+++ b/docs/src/content/docs/reference/roadmap/snapshot-tests-tui.mdx
@@ -7,15 +7,30 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-The TUI already has meaningful `TestBackend`-based render tests, but it still has no snapshot-style regression net for the largest composite panes. There are currently 17 `#[allow(clippy::too_many_lines)]` suppressions across the repo, and refactoring <RepoFile path="src/console/manager/render/list.rs" /> (2069L) or <RepoFile path="src/console/manager/render/editor.rs" /> (1682L) can still silently change TUI appearance without a crisp before/after review artifact.
+The TUI has no snapshot-style regression net for the largest composite panes. The render layer has grown significantly since the original analysis:
 
-## Three target functions
+- <RepoFile path="src/console/manager/render/editor.rs" /> is now **3231L** (was ~1682L — nearly doubled)
+- <RepoFile path="src/console/manager/render/list.rs" /> is now **2816L** (was ~2069L)
+- <RepoFile path="src/console/manager/render/mod.rs" /> is now **1165L** (was ~500L)
+- <RepoFile path="src/console/manager/render/global_mounts.rs" /> is now **839L** (new sub-module)
 
-| Function | File | Line | What to snapshot |
-|---|---|---|---|
-| `render_sentinel_description_pane` | <RepoFile path="src/console/manager/render/list.rs" /> | 360 | Static "+ New workspace" panel. Zero state. 80×10 terminal. |
-| `render_tab_strip` | <RepoFile path="src/console/manager/render/editor.rs" /> | 278 | Tab bar with `EditorTab` active. 4 variants × 1 snapshot each. 80×3 terminal. |
-| `render_mounts_subpanel` | <RepoFile path="src/console/manager/render/list.rs" /> | 461 | Mount list subpanel. 3 cases: empty, 1 mount, 3 mounts. 60×20 terminal. |
+No `insta` or other snapshot testing library exists in the dependency tree. All render testing uses manual `TestBackend` + `assert!` assertions against buffer contents.
+
+## Three target functions (updated from original)
+
+| Function | File | What to snapshot |
+|---|---|---|
+| `render_sentinel_description_pane` | <RepoFile path="src/console/manager/render/list.rs" /> | Static "+ New workspace" panel. Zero state. 80×10 terminal. |
+| `render_tab_strip` | <RepoFile path="src/console/manager/render/editor.rs" /> | Tab bar with `EditorTab` active. 4 variants × 1 snapshot each. 80×3 terminal. |
+| `render_mounts_subpanel` | <RepoFile path="src/console/manager/render/list.rs" /> | Mount list subpanel. 3 cases: empty, 1 mount, 3 mounts. 60×20 terminal. |
+
+**Additional high-value targets identified in re-analysis:**
+
+| Function | File | What to snapshot |
+|---|---|---|
+| Global mounts editor rendering | <RepoFile path="src/console/manager/render/global_mounts.rs" /> | Per-subtab renders. New 839L file with no snapshot coverage. |
+| Per-tab editor body renders | <RepoFile path="src/console/manager/render/editor.rs" /> | At minimum: General, Mounts, Agents, Secrets tab body renders. |
+| Workspace list renders | <RepoFile path="src/console/manager/render/list.rs" /> | Active workspace detail panel with various mount configurations. |
 
 ## Implementation
 
@@ -30,10 +45,10 @@ Use `insta` for snapshot storage + review workflow; `ratatui::backend::TestBacke
 ## Steps
 
 1. Add `insta` to `[dev-dependencies]` in <RepoFile path="Cargo.toml" />.
-2. Write 3 test modules (one per target function) using `TestBackend` + `insta::assert_snapshot!()`.
+2. Write test modules using `TestBackend` + `insta::assert_snapshot!()`. Start with the 3 original targets, then add the new targets.
 3. Run `cargo insta review` to accept the initial snapshots.
 4. `cargo nextest run` already runs snapshot comparisons — no additional CI step needed.
 
 ## Why before Phase 2
 
-These snapshot tests are the regression net for the Phase 2 file splits. Existing render assertions still help, but snapshots make layout regressions obvious during review instead of forcing reviewers to infer them from low-level buffer assertions.
+These snapshot tests are the regression net for the Phase 2 file splits AND the Phase 1.5 DRY extractions. The TUI render layer has extreme boilerplate duplication (120 `Style::default()` chains, 18 `Block::default()` constructions, 192 `Span` constructions) — snapshot tests make it safe to extract shared helpers without silently changing TUI appearance.

--- a/docs/src/content/docs/reference/roadmap/split-app-mod.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-app-mod.mdx
@@ -7,7 +7,9 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/app/mod.rs" /> is now 1243L total, ~1180L production (tests start at line 1181). Nearly all production code is the `run()` dispatch function with a large match on CLI commands. A reviewer auditing "does `jackin workspace create` correctly validate the workdir?" still has to scan a thousand-plus lines of mixed-command dispatch.
+<RepoFile path="src/app/mod.rs" /> is now **2767L** total — more than **double** the 1243L at the original analysis (+123% growth). It is the second-largest file in the codebase after `runtime/launch.rs`. Nearly all production code is the `run()` dispatch function with a giant match on CLI commands, but the file has accumulated substantial new command handling, error recovery, and test coverage.
+
+<RepoFile path="src/app/context.rs" /> (1466L) has also grown and now contains significant instance management, workspace resolution, and Docker interaction logic.
 
 ## Proposed split
 
@@ -17,21 +19,35 @@ src/app/
   dispatch.rs      ← the giant match on cli::Command (~700L)
   workspace_cmd.rs ← workspace subcommand handlers (~150L)
   config_cmd.rs    ← config subcommand handlers (~100L)
+  load_cmd.rs      ← load/hardline/eject command handlers (new — extracted from dispatch)
+  instance_cmd.rs  ← instance management commands (new — instance recovery/purge flows)
 ```
 
-Note: <RepoFile path="src/app/context.rs" /> already implements the impl-extension pattern and stays as-is.
+Note: <RepoFile path="src/app/context.rs" /> already implements the impl-extension pattern and stays as-is, though it may need its own split analysis if it continues growing.
 
-## Import notes
+## Duplication found
 
-- <RepoFile path="src/main.rs" /> currently calls `jackin::run(...)` through the library crate export; that external call shape stays the same if `app/mod.rs` becomes a thinner internal dispatcher
-- `dispatch.rs` is `mod dispatch` inside `app/`; `run()` calls `dispatch::dispatch_command(args)`
-- `context.rs` already lives in `app/` — no change, just updated import paths within the module tree
+- `app/mod.rs` contains its own `FakeOpWriter` (stripped version) that duplicates the fuller one in <RepoFile path="src/workspace/token_setup.rs" />. Should use a shared test utility.
+- 4 inline `format!("{name}-dind")` / `format!("{name}-net")` derivations that should use a shared naming helper.
+- `fake_runner_with_running` helper is near-identical to one in `console/manager/input/save.rs` but with a subtle trailing-newline difference — potential copy-paste bug.
 
 ## What needs confirmation
 
 - Whether `run()` stays in `mod.rs` or also moves to `dispatch.rs`
 - The exact boundary between `dispatch.rs` and `workspace_cmd.rs` (some workspace handling is interleaved in the dispatch match)
+- Whether `load_cmd.rs` and `instance_cmd.rs` are worth separate files or should stay in `dispatch.rs`
+- Whether `context.rs` (1466L) also needs splitting or is manageable at its current size
 
 ## Auditability gain
 
-To audit "does `jackin workspace create` correctly validate the workdir?", a reviewer reads `workspace_cmd.rs` instead of scanning ~1180L of mixed-command dispatch.
+To audit "does `jackin workspace create` correctly validate the workdir?", a reviewer reads `workspace_cmd.rs` instead of scanning ~2700L of mixed-command dispatch.
+
+## Recommended priority
+
+**Split first among Phase 2 targets** — it has the highest growth rate (+123%), pure dispatch structure (lowest risk), and its split will establish patterns for the remaining file splits.
+
+## Related files
+
+- <RepoFile path="src/app/mod.rs" /> — target file (2767L)
+- <RepoFile path="src/app/context.rs" /> — impl-extension module (1466L)
+- <RepoFile path="src/cli/dispatch.rs" /> — CLI argument types consumed by the dispatch match

--- a/docs/src/content/docs/reference/roadmap/split-input-editor.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-input-editor.mdx
@@ -7,7 +7,9 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/console/manager/input/editor.rs" /> is still one of the biggest concentrated editor-state files: ~1727L production, 3796L total, with tests starting at line 1728. It handles keyboard dispatch for all 4 editor tabs (General, Mounts, Agents, Secrets). A reviewer auditing "did the AI correctly implement the Secrets tab?" still has to scan well over a thousand lines of mixed-tab production code.
+<RepoFile path="src/console/manager/input/editor.rs" /> is **3955L** total (was ~3796L at original analysis). It handles keyboard dispatch for all editor tabs (General, Mounts, Agents, Secrets) and is one of the biggest concentrated editor-state files.
+
+Its render counterpart <RepoFile path="src/console/manager/render/editor.rs" /> is now **3231L** (was ~1682L — nearly doubled). Both files should be split together as a paired operation.
 
 ## Proposed split
 
@@ -20,6 +22,16 @@ src/console/manager/input/editor/
   secrets.rs  ← Secrets tab key handlers (~500L — the AI-generated section)
 ```
 
+The render counterpart would split similarly:
+```
+src/console/manager/render/editor/
+  mod.rs      ← re-exports, render_editor dispatcher
+  general.rs  ← General tab rendering
+  mounts.rs   ← Mounts tab rendering
+  agents.rs   ← Agents tab rendering
+  secrets.rs  ← Secrets tab rendering
+```
+
 ## Key technical details
 
 - `handle_editor_key` — main dispatcher; stays in `mod.rs`
@@ -27,18 +39,25 @@ src/console/manager/input/editor/
 - Both functions dispatch to tab-specific helpers; the helpers move to per-tab files
 - After split, helper imports such as `super::super::agent_allow::allows_all_agents` should switch to a stable absolute path (`crate::console::manager::agent_allow::allows_all_agents`) because `editor/` becomes one level deeper
 
+## Duplication found within this file
+
+- `config_with_agents` test helper is defined identically 4 times across `render/editor.rs` (3 copies) and `input/editor.rs` (1 copy) — extract to shared test utility
+- Breadcrumb rendering logic at `render/editor.rs:1427-1455` (`push_op_breadcrumb_spans`) is fully duplicated inline at lines 1058–1091 inside `secrets_key_row_spans` — the inline version should call the shared function
+- The file crosses the console/runtime boundary at 2 production-code sites: `crate::runtime::register_agent_repo` (line ~1445) and `crate::runtime::RepoError` (lines ~1536-1547)
+
 ## What needs confirmation
 
 Should `handle_editor_modal` stay in `mod.rs` or move to a `modal.rs` sub-file? This depends on its size post-split and whether it's a "modal concern" or a "dispatch concern".
 
 ## Auditability gain
 
-To audit "did the AI correctly implement the Secrets tab?", a reviewer reads only `secrets.rs` instead of scanning ~1727L of mixed-tab production code.
+To audit "did the AI correctly implement the Secrets tab?", a reviewer reads only `secrets.rs` instead of scanning ~3955L of mixed-tab production code.
 
 ## Steps
 
-1. Complete snapshot tests item first (regression net).
-2. Create `src/console/manager/input/editor/` directory.
-3. Move each tab's handlers to the appropriate file, keeping `mod.rs` as the dispatcher.
-4. Fix import paths (the `super::super::` depth changes).
-5. Verify `cargo nextest run` passes.
+1. Complete Phase 1.5 TUI rendering DRY extractions first (named styles, `titled_block` helper).
+2. Complete snapshot tests item first (regression net).
+3. Create `src/console/manager/input/editor/` and `src/console/manager/render/editor/` directories.
+4. Move each tab's handlers to the appropriate file, keeping `mod.rs` as the dispatcher.
+5. Fix import paths (the `super::super::` depth changes).
+6. Verify `cargo nextest run` passes.

--- a/docs/src/content/docs/reference/roadmap/split-operator-env.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-operator-env.mdx
@@ -7,7 +7,7 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/operator_env.rs" /> is 2975L total and has grown into a shared cross-cutting module. It now serves runtime launch, config validation/persistence, console widgets, and the console op-cache layer. The file mixes public traits/parsers, subprocess client logic, metadata parsing for the picker, env-layer composition, launch diagnostics, and tests.
+<RepoFile path="src/operator_env.rs" /> is **3573L** total (was 2975L at original analysis — +20% growth). It has grown into a shared cross-cutting module that serves runtime launch, config validation/persistence, console widgets, and the console op-cache layer. The file mixes public traits/parsers, subprocess client logic, metadata parsing for the picker, env-layer composition, launch diagnostics, and tests.
 
 ## Proposed split
 
@@ -27,6 +27,11 @@ src/operator_env/
 - console widgets / op-cache need the picker metadata types and `OpStructRunner`
 - re-exports from `mod.rs` should preserve current call sites while the internals split
 
+## Duplication found
+
+- `operator_env.rs` does NOT duplicate work done by `instance/auth.rs` or `workspace/token_setup.rs` — these three files handle distinct responsibilities (env resolution vs credential provisioning vs token orchestration). The split is clean.
+- The file's own internal structure is well-factored already — the split is about physical file organization, not logical separation.
+
 ## Migration note
 
 After split, existing callers such as `use crate::operator_env::resolve_operator_env` and `use crate::operator_env::OpField` should continue to work because `mod.rs` re-exports the public surface. The goal is an internal split, not a crate-wide rename churn.
@@ -38,6 +43,6 @@ After split, existing callers such as `use crate::operator_env::resolve_operator
 
 ## Related files
 
-- <RepoFile path="src/operator_env.rs" /> — target file
+- <RepoFile path="src/operator_env.rs" /> — target file (3573L)
 - <RepoFile path="src/runtime/launch.rs" /> — resolves operator env and emits launch diagnostics
 - <RepoFile path="src/console/widgets/op_picker/mod.rs" /> — uses `OpStructRunner` / picker metadata

--- a/docs/src/content/docs/reference/roadmap/split-runtime-launch.mdx
+++ b/docs/src/content/docs/reference/roadmap/split-runtime-launch.mdx
@@ -7,7 +7,16 @@ import RepoFile from '../../../../components/RepoFile.astro'
 
 ## Problem
 
-<RepoFile path="src/runtime/launch.rs" /> is now 5494L total, with tests starting at line 2272. It no longer mixes just 4 concerns: the file now owns the public load API, trust verification, terminal setup, operator-env / auth handling, container slot claiming, workspace materialization, launch orchestration, and attach/finalizer cleanup. It is still the hardest file to split safely because any error here blocks all runtime changes.
+<RepoFile path="src/runtime/launch.rs" /> is **7575L** total (was 5494L at original analysis — 38% growth). It is the single largest file in the codebase and the hardest to review. It owns: the public load API, trust verification, terminal setup, operator-env / auth handling, container slot claiming, workspace materialization, DinD sidecar launch, Docker network management, launch orchestration, attach/finalizer cleanup, env resolution with trace (duplicated from `config/roles.rs`), and extensive test infrastructure.
+
+The file has grown significantly since the original analysis due to new agent runtime support (Kimi), instance identity features, and expanded error reporting.
+
+## Duplication found within this file
+
+- `build_mode_resolution()` at ~line 2977 duplicates the 3-layer × 4-agent match (12 arms) from <RepoFile path="src/config/roles.rs" /> `resolve_mode()` solely to capture the resolution trace for error rendering. Extract `resolve_mode_with_trace()` in `config/roles.rs` instead.
+- DinD sidecar launch args (~line 777) are duplicated identically in <RepoFile path="src/runtime/attach.rs" /> at ~line 472. Extract shared `fn run_dind_sidecar()`.
+- 17 inline `format!("{name}-dind")` / `format!("{name}-net")` derivations that should use a shared `DockerResources` naming helper.
+- The role container `docker run -d -it` argument list (~180 lines starting ~line 865) is a monolithic block interleaving env var injection, mount construction, and label assignment.
 
 ## Proposed split
 
@@ -17,12 +26,15 @@ src/runtime/
   launch_pipeline.rs ← fn load_agent_with, LaunchContext, StepCounter, LoadCleanup, workspace materialization / finalize flow
   terminfo.rs        ← `resolve_terminal_setup`, `export_host_terminfo`
   trust.rs           ← `confirm_agent_trust` — already isolated via FnOnce injection
-  launch_slot.rs     ← claim_container_name + verify_token_env_present (if they still feel like a coherent seam)
+  launch_slot.rs     ← claim_container_name + verify_token_env_present
+  launch_dind.rs     ← DinD sidecar launch, Docker network creation (shared with attach.rs)
 ```
+
+A new `launch_dind.rs` is added to the original proposal because the DinD sidecar + network logic is now duplicated between `launch.rs` and `attach.rs`.
 
 ## Why the split is safe — FnOnce injection pattern
 
-`confirm_agent_trust` is passed to `load_agent_with` as a `FnOnce` argument at line 553–560:
+`confirm_agent_trust` is passed to `load_agent_with` as a `FnOnce` argument:
 
 ```rust
 fn load_agent_with(..., confirm_trust: impl FnOnce(...) -> anyhow::Result<()>)
@@ -35,19 +47,24 @@ fn load_agent_with(..., confirm_trust: impl FnOnce(...) -> anyhow::Result<()>)
 - `terminfo.rs`: only imports from `std` — zero crate dependencies
 - `trust.rs`: imports from `std`, `owo_colors`, `dialoguer`, `crate::config` — no runtime dependency
 - `launch_pipeline.rs`: imports from `crate::config`, `crate::instance`, `crate::tui`, `crate::operator_env`, and isolation helpers
-- `launch.rs` (thin API): imports from `launch_pipeline`, `trust`, `terminfo`, and possibly `launch_slot`
+- `launch_dind.rs`: imports from `crate::runtime::naming` — no dependency on launch_pipeline
+- `launch.rs` (thin API): imports from `launch_pipeline`, `trust`, `terminfo`, `launch_slot`, `launch_dind`
 
 ## What needs confirmation
 
 - Exact placement of `LoadCleanup` (pipeline concern or launch concern?)
-- Whether `claim_container_name` and `verify_token_env_present` stay in the main pipeline file or move into a small helper seam such as `launch_slot.rs`
-- Whether operator-env resolution / auth diagnostic logic should stay in the main pipeline file or split again later if it still dominates the module
+- Whether `claim_container_name` and `verify_token_env_present` stay in the main pipeline file or move into `launch_slot.rs`
+- Whether operator-env resolution / auth diagnostic logic should stay in the main pipeline file or split again later
+- Whether `launch_dind.rs` is the right factoring or if the DinD/network logic belongs in a shared Docker module
 
 ## Ordering note
 
-Do **last** among the Phase 2 splits. The test suite is the most complex and any compilation error here blocks all runtime changes. The behavioral spec must exist first — it is the verification oracle.
+Do **last** among the Phase 2 splits. The test suite is the most complex (tests span ~3500 lines) and any compilation error here blocks all runtime changes. The behavioral spec must exist first — it is the verification oracle. The Phase 1.5 DRY extractions (`resolve_mode_with_trace`, `DockerResources`, `run_dind_sidecar`) should land first to reduce the file's LOC before splitting.
 
 ## Related files
 
-- <RepoFile path="src/runtime/launch.rs" /> — target file
+- <RepoFile path="src/runtime/launch.rs" /> — target file (7575L)
+- <RepoFile path="src/runtime/attach.rs" /> — shares DinD sidecar and network logic (1130L)
 - <RepoFile path="src/runtime/test_support.rs" /> — `FakeRunner` used by the test suite
+- <RepoFile path="src/runtime/cleanup.rs" /> — shares container teardown pattern
+- <RepoFile path="src/config/roles.rs" /> — `resolve_mode()` duplicated for trace in launch.rs


### PR DESCRIPTION
## Summary

Re-analyzed the entire codebase readability roadmap against the current codebase (~91K lines production Rust, 116 files) after significant growth since the original analysis (~50K lines). Updated all 14 roadmap files with current metrics, corrected structural assumptions, and added a new Phase 1.5 DRY extraction phase grounded in measured duplication findings.

## Key findings that drove the updates

**Stale LOC counts everywhere** — `app/mod.rs` more than doubled (1243L → 2767L, +123%), `runtime/launch.rs` grew 38% (5494L → 7575L), 13 files now exceed 1000 lines (was 4 at original analysis).

**False structural claim** — the claim "console/ has zero imports from runtime/ in production code" is false. Two production dependencies exist in `console/manager/input/editor.rs`: `crate::runtime::register_agent_repo` and `crate::runtime::RepoError`. The Cargo workspace split (Phase 3) needs these resolved first.

**Pervasive TUI duplication** — 120 `Style::default()` chains, 18 `Block::default()` constructions, 192 `Span` constructions, 4 identical header/body/footer layout triples across render files. Named style constants and a `titled_block()` helper would collapse 78+ boilerplate sites.

**Auth provision copy-paste** — 5 near-identical provision functions in `instance/auth.rs` (2607L), 3 identical model accessor methods, 12 duplicated match arms between `launch.rs` and `config/roles.rs`.

**Docker command entropy** — 40 `runner.run("docker", ...)` calls with no shared builder, 44 inline `format!("{name}-dind")` derivations across 5 files, identical DinD sidecar launch args copy-pasted between `launch.rs` and `attach.rs`.

**Test infrastructure sprawl** — 11 independent mock/fake struct definitions, `FROM projectjackin/construct:trixie\n` appears 100+ times, 41+ copy-pasted role-repo seeding blocks, a subtle trailing-newline difference between two `fake_runner_with_running` helpers.

## What changed

- **codebase-readability.mdx** (umbrella): Major rewrite with current metrics, new Phase 1.5 (DRY extraction), corrected structural claim, expanded Phase 2 table (4 → 13 files), updated execution order, and maintainability assessment
- **split-runtime-launch.mdx**: Updated 5494L → 7575L, added duplication findings, added `launch_dind.rs` to proposed split
- **split-app-mod.mdx**: Updated 1243L → 2767L, noted +123% growth, added new proposed sub-files and duplication findings
- **split-input-editor.mdx**: Updated 3796L → 3955L, added paired render/editor.rs split (3231L), noted console/runtime boundary crossing
- **split-operator-env.mdx**: Updated 2975L → 3573L, confirmed no cross-file duplication with auth/token_setup
- **module-contracts.mdx**: Updated priority file list with current LOC, added 4 new entries that grew into the >1000L range
- **behavioral-spec-runtime-launch.mdx**: Updated 5494L → 7575L, reinforced urgency
- **behavioral-spec-op-picker.mdx**: Updated 1712L → 2331L, noted render.rs split
- **snapshot-tests-tui.mdx**: Updated render file sizes, added new high-value targets (global mounts, per-tab editor bodies)
- **pub-crate-visibility.mdx**: Updated to current numbers (22 modules, 383 pub fn vs 42 pub(crate) fn)
- **cargo-workspace-split.mdx**: Corrected boundary claim, updated LOC from ~50K to ~91K, added prerequisites for fixing the 2 console→runtime deps
- **per-directory-readme.mdx**: Added new target directories (config/, instance/, isolation/), corrected boundary note
- **developer-reference-setup.mdx**: Fixed stale `docs/superpowers/specs/` reference (directory no longer exists)
- **roadmap.mdx**: Updated codebase health description to reference the re-analysis

## What's deferred

- Phase 1.5 DRY extraction implementation (the roadmap now describes what to extract and why; separate PRs will implement)
- Phase 2 file splits (awaiting Phase 1 snapshot tests and Phase 1.5 extractions)
- Phase 3 workspace split (trigger not yet met at ~91K LOC)

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin roadmap/codebase-readability-reanalysis:refs/remotes/origin/roadmap/codebase-readability-reanalysis
git checkout -B roadmap/codebase-readability-reanalysis refs/remotes/origin/roadmap/codebase-readability-reanalysis
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/roadmap/codebase-readability/**  
UPDATED umbrella page. Check: current metrics table, Phase 1.5 section with extraction tables, corrected structural insight, Phase 2 expanded table with growth percentages.

**http://localhost:4321/reference/roadmap/**  
UPDATED overview. Check: Codebase health section mentions re-analysis and current scope.

**http://localhost:4321/reference/roadmap/split-runtime-launch/**  
UPDATED. Check: 7575L current size, duplication findings section, launch_dind.rs in proposed split.

**http://localhost:4321/reference/roadmap/split-app-mod/**  
UPDATED. Check: 2767L (+123% growth), new proposed sub-files.

**http://localhost:4321/reference/roadmap/module-contracts/**  
UPDATED. Check: new priority files table with growth metrics.

## Migration notes

None — documentation-only changes.