### PR TITLE
fix(schema): bump manifest to v1alpha3, formalize opencode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Jackin has no released version — it is a proof-of-concept. **Breaking changes 
 4. Re-bake of every existing fixture's `after.toml` so it walks through the new step too. The fixture for the oldest supported `from_version` is the load-bearing test for users delayed by months — its diff is the proof the new chain is composable.
 5. A new entry at the top of the **Timeline** section in `docs/src/content/docs/reference/schema-versions.mdx` with date, predecessor, fixture link, summary, and a before/after example.
 
-A non-additive change (renamed field, removed field, type change, restructured table) without these five artifacts is incomplete; reviewers block merge until they appear or the change is reshaped to be additive (new optional field with a serde default). Operator config and per-workspace files migrate automatically during `AppConfig::load_or_init` at startup; role manifests migrate via `jackin-validate --migrate <role-repo-path>`.
+A non-additive change (renamed field, removed field, type change, added enum variant, restructured table) without these five artifacts is incomplete; reviewers block merge until they appear or the change is reshaped to be additive (new optional field with a serde default). Operator config and per-workspace files migrate automatically during `AppConfig::load_or_init` at startup; role manifests migrate via `jackin-validate --migrate <role-repo-path>`.
 
 Do not memorialize old shapes in code comments ("formerly named X", "old location was Y") or in documentation files outside the changelog. The git history is the record of what changed; the code should describe only the current shape.
 

--- a/docs/src/content/docs/reference/schema-versions.mdx
+++ b/docs/src/content/docs/reference/schema-versions.mdx
@@ -16,7 +16,8 @@ Breaking changes to schemas are expected — that is how the project explores id
 - **Each schema file carries its own `version` stamp.** When jackin reads the file, it compares the on-disk version against the binary's `CURRENT_*_VERSION` and applies any pending migration steps before parsing, so operators see a working setup after every upgrade.
 - **Operator-owned files migrate automatically.** `config.toml` and `~/.config/jackin/workspaces/<name>.toml` are rewritten in place on startup; the operator does nothing.
 - **Role-owned files migrate explicitly.** Role authors run `jackin-validate --migrate <role-repo-path>` to rewrite a `jackin.role.toml` against the latest schema, then commit and push the result. Jackin never writes back into a role repo on its own — that would silently mutate someone else's source tree.
-- **Migrations are a hard PR-review rule.** Every change to one of the three versioned files must bump the corresponding `CURRENT_*_VERSION`, add a migration step, and update this page. The full rule lives in <RepoFile path="AGENTS.md" /> and <RepoFile path="PULL_REQUESTS.md" />.
+- **Migrations are a hard PR-review rule.** Every change to one of the three versioned files must bump the corresponding `CURRENT_*_VERSION`, add a migration step, and update this page. Adding a new enum variant counts as a schema-breaking change: old binaries cannot parse manifests that use the new variant. The full rule lives in <RepoFile path="AGENTS.md" /> and <RepoFile path="PULL_REQUESTS.md" />.
+- **Version mismatches produce actionable errors.** The version check runs before full TOML deserialization, so old binaries always surface a clear message rather than a cryptic parse error. When a manifest's `version` is newer than what the binary knows about, jackin rejects it with: `role manifest is at {version}, this binary only understands up to {CURRENT_MANIFEST_VERSION}; upgrade jackin`. When the manifest is older than expected (role author has not yet run `jackin-validate --migrate`), jackin says: `role "{role_name}" manifest is at {version}, expected {CURRENT_MANIFEST_VERSION}; run "jackin-validate --migrate <role-repo-path>" to upgrade the local copy`.
 
 The split-workspace layout described in [Configuration File](/reference/configuration/#one-file-per-workspace-by-design) makes per-file migration tractable: legacy global files and per-workspace files migrate independently, so a dotfile repo that is partially old still upgrades cleanly.
 
@@ -26,11 +27,47 @@ The split-workspace layout described in [Configuration File](/reference/configur
 |---|---|---|---|
 | `~/.config/jackin/config.toml` | `v1alpha2` | jackin | Automatic on startup |
 | `~/.config/jackin/workspaces/<name>.toml` | `v1alpha2` | jackin | Automatic on startup |
-| `jackin.role.toml` | `v1alpha2` | Role repository | Explicit `jackin-validate --migrate <role-repo-path>` |
+| `jackin.role.toml` | `v1alpha3` | Role repository | Explicit `jackin-validate --migrate <role-repo-path>` |
 
 ## Timeline
 
 Each entry is one upgrade path the current binary applies. <RepoFile path="tests/migration_fixtures.rs" /> walks every fixture on every CI run, so a regression breaks here before it breaks on a delayed operator's machine. Newest first; append, never edit.
+
+### `v1alpha3` — 2026-05-14
+
+| File kind | Predecessor | Migration mode | Fixture |
+|---|---|---|---|
+| Manifest (`jackin.role.toml`) | `v1alpha2` | Explicit `jackin-validate --migrate <role-repo-path>` | <RepoFile path="tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml" /> |
+
+**Summary**: formalizes OpenCode agent support. The `opencode` enum variant in `agents` and the `[opencode]` config table were added to the binary in the previous schema version without a corresponding manifest version bump — this version corrects that oversight. The migration is a no-op restamp: no field renames, no data moved.
+
+**Before** (v1alpha2 manifest with OpenCode):
+
+```toml
+version = "v1alpha2"
+dockerfile = "Dockerfile"
+agents = ["claude", "opencode"]
+
+[claude]
+plugins = []
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+```
+
+**After** (v1alpha3):
+
+```toml
+version = "v1alpha3"
+dockerfile = "Dockerfile"
+agents = ["claude", "opencode"]
+
+[claude]
+plugins = []
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+```
 
 ### `v1alpha2` — 2026-05-11
 
@@ -206,14 +243,14 @@ does not auto-write role repositories during normal role loading. Run
 | Removed | None |
 | Renamed | None |
 
-### `v1alpha2`
+### `v1alpha3`
 
 | Field | Type | Required | Since | Notes |
 |---|---|---|---|---|
-| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha2` |
+| `version` | string | Yes | `v1alpha1` | Current value: `v1alpha3` |
 | `dockerfile` | string | Yes | `legacy` | Relative path to role Dockerfile |
 | `published_image` | string | No | `legacy` | Pre-built role image override |
-| `agents` | string array | No | `legacy` | `claude`, `codex`, `amp`, and/or `opencode`; omitted means Claude-only |
+| `agents` | string array | No | `legacy` | `claude`, `codex`, or `amp`; `opencode` added in `v1alpha3`; omitted means Claude-only |
 | `[identity].name` | string | No | `legacy` | Display name |
 | `[claude].model` | string | No | `legacy` | Claude model override |
 | `[claude].plugins` | string array | No | `legacy` | Claude plugin identifiers |
@@ -222,7 +259,7 @@ does not auto-write role repositories during normal role loading. Run
 | `[[claude.marketplaces]].sparse` | string array | No | `legacy` | Sparse checkout paths |
 | `[codex].model` | string | No | `legacy` | Codex model override |
 | `[amp]` | table | No | `legacy` | Empty marker table for Amp support |
-| `[opencode].model` | string | No | `legacy` | `OpenCode` model override in `provider/model` format (e.g. `zai-coding-plan/glm-5.1`) |
+| `[opencode].model` | string | No | `v1alpha3` | `OpenCode` model override in `provider/model` format (e.g. `zai-coding-plan/glm-5.1`) |
 | `[hooks].setup_once` | string | No | `legacy` | Relative path to a one-time install script that runs on first launch only |
 | `[hooks].source` | string | No | `legacy` | Relative path to a script dot-sourced into the entrypoint shell so `export` and `PATH` mutations reach the launched agent |
 | `[hooks].preflight` | string | No | `legacy` | Relative path to a per-start preflight script |

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -1361,7 +1361,7 @@ mod tests {
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -1387,7 +1387,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -1419,7 +1419,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("the-architect").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -1445,7 +1445,7 @@ plugins = []
         let selector = crate::selector::RoleSelector::parse("solo").unwrap();
         write_role_manifest(
             &crate::repo::CachedRepo::new(&paths, &selector).repo_dir,
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -1906,7 +1906,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/derived_image.rs
+++ b/src/derived_image.rs
@@ -832,7 +832,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -864,7 +864,7 @@ source = "hooks/source.sh"
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -903,7 +903,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -932,7 +932,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -965,7 +965,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -941,7 +941,7 @@ mod tests {
     fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::RoleManifest {
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -527,7 +527,7 @@ mod tests {
     fn simple_manifest(temp: &tempfile::TempDir) -> crate::manifest::RoleManifest {
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -603,7 +603,7 @@ plugins = []
 
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -669,7 +669,7 @@ model = "gpt-5"
 
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 

--- a/src/manifest/migrations.rs
+++ b/src/manifest/migrations.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::bail;
 use toml_edit::DocumentMut;
 
-pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha2";
+pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha3";
 
 const MANIFEST_MIGRATIONS: &[crate::config::migrations::MigrationStep] = &[
     crate::config::migrations::MigrationStep {
@@ -13,6 +13,11 @@ const MANIFEST_MIGRATIONS: &[crate::config::migrations::MigrationStep] = &[
     },
     crate::config::migrations::MigrationStep {
         from: "v1alpha1",
+        to: "v1alpha2",
+        migrate: crate::config::migrations::noop_migration,
+    },
+    crate::config::migrations::MigrationStep {
+        from: "v1alpha2",
         to: CURRENT_MANIFEST_VERSION,
         migrate: crate::config::migrations::noop_migration,
     },
@@ -69,14 +74,14 @@ mod tests {
         let parsed: toml::Value = toml::from_str(&out).unwrap();
 
         assert_eq!(old, "legacy");
-        assert_eq!(new, "v1alpha2");
-        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha2");
-        assert!(out.starts_with("version = \"v1alpha2\""), "{out}");
+        assert_eq!(new, "v1alpha3");
+        assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha3");
+        assert!(out.starts_with("version = \"v1alpha3\""), "{out}");
         assert!(out.contains("# keep me"), "{out}");
     }
 
     #[test]
-    fn migrates_v1alpha1_manifest_to_v1alpha2() {
+    fn migrates_v1alpha1_manifest_to_current() {
         let temp = tempdir().unwrap();
         let path = temp.path().join("jackin.role.toml");
         std::fs::write(
@@ -89,15 +94,15 @@ mod tests {
         let out = std::fs::read_to_string(&path).unwrap();
 
         assert_eq!(old, "v1alpha1");
-        assert_eq!(new, "v1alpha2");
-        assert!(out.starts_with("version = \"v1alpha2\""), "{out}");
+        assert_eq!(new, "v1alpha3");
+        assert!(out.starts_with("version = \"v1alpha3\""), "{out}");
     }
 
     #[test]
     fn current_manifest_migration_is_noop() {
         let temp = tempdir().unwrap();
         let path = temp.path().join("jackin.role.toml");
-        let manifest = "version = \"v1alpha2\"\ndockerfile = \"Dockerfile\"\n";
+        let manifest = "version = \"v1alpha3\"\ndockerfile = \"Dockerfile\"\n";
         std::fs::write(&path, manifest).unwrap();
 
         assert!(migrate_manifest_file(&path).unwrap().is_none());
@@ -116,14 +121,14 @@ mod tests {
 
         let err = migrate_manifest_file(&path).unwrap_err();
         assert!(
-            err.to_string().contains("only understands up to v1alpha2"),
+            err.to_string().contains("only understands up to v1alpha3"),
             "{err}"
         );
     }
 
     #[test]
     fn validate_manifest_version_accepts_current() {
-        let doc: DocumentMut = "version = \"v1alpha2\"\n".parse().unwrap();
+        let doc: DocumentMut = "version = \"v1alpha3\"\n".parse().unwrap();
         validate_manifest_version(&doc, "test-role").unwrap();
     }
 
@@ -142,7 +147,7 @@ mod tests {
         let doc: DocumentMut = "version = \"v2alpha1\"\n".parse().unwrap();
         let err = validate_manifest_version(&doc, "test-role").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("only understands up to v1alpha2"), "{msg}");
+        assert!(msg.contains("only understands up to v1alpha3"), "{msg}");
     }
 
     #[test]

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -235,7 +235,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp"]
 
@@ -267,7 +267,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -287,7 +287,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -307,7 +307,7 @@ model = "gpt-5"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["opencode"]
 
@@ -330,7 +330,7 @@ model = "zai-coding-plan/glm-5.1"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "foo"]
 
@@ -383,7 +383,7 @@ plugins = []
 
         let err = RoleManifest::load(temp.path()).unwrap_err();
         let chain = format!("{err:#}");
-        assert!(chain.contains("only understands up to v1alpha2"), "{chain}");
+        assert!(chain.contains("only understands up to v1alpha3"), "{chain}");
     }
 
     #[test]
@@ -391,7 +391,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -413,7 +413,7 @@ plugins = ["code-review@claude-plugins-official"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -447,7 +447,7 @@ sparse = ["plugins", ".claude-plugin"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -477,7 +477,7 @@ source = "jackin-project/jackin-marketplace"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -499,7 +499,7 @@ source = "obra/superpowers-marketplace"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -521,7 +521,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -543,7 +543,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -562,7 +562,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -585,7 +585,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -604,7 +604,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 unknown_field = true
 
@@ -624,7 +624,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -644,7 +644,7 @@ typo = "oops"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -701,7 +701,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -728,7 +728,7 @@ preflight = "hooks/preflight.sh"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -747,7 +747,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -769,7 +769,7 @@ post_launch = "bad"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -794,7 +794,7 @@ default = "docker"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -821,7 +821,7 @@ options = ["project1", "project2"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -851,7 +851,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -876,7 +876,7 @@ prompt = "API key (optional):"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -895,7 +895,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/manifest/validate.rs
+++ b/src/manifest/validate.rs
@@ -262,7 +262,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = []
 
@@ -281,7 +281,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -300,7 +300,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "amp"]
 
@@ -319,7 +319,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -341,7 +341,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 
@@ -365,7 +365,7 @@ model = "gpt-5"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 
@@ -390,7 +390,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -412,7 +412,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -435,7 +435,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -460,7 +460,7 @@ options = ["a", "b"]
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -486,7 +486,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -512,7 +512,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -543,7 +543,7 @@ prompt = "B:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -573,7 +573,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -607,7 +607,7 @@ default = "main"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -631,7 +631,7 @@ default = "docker"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -662,7 +662,7 @@ default = "sidecar"
             std::fs::write(
                 temp.path().join("jackin.role.toml"),
                 format!(
-                    r#"version = "v1alpha2"
+                    r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -691,7 +691,7 @@ default = "override"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -716,7 +716,7 @@ prompt = "This is ignored"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -741,7 +741,7 @@ skippable = true
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -772,7 +772,7 @@ default = "feature/${env.PROJECT}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -798,7 +798,7 @@ prompt = "Branch for ${env.NONEXISTENT}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -830,7 +830,7 @@ prompt = "Branch for ${env.PROJECT}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -857,7 +857,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -881,7 +881,7 @@ default = "value"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -905,7 +905,7 @@ default = "value"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -934,7 +934,7 @@ default = "c"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -971,7 +971,7 @@ prompt = "Branch:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -996,7 +996,7 @@ prompt = "Value (use ${other.THING} for other):"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1029,7 +1029,7 @@ default = "feature/${env.PROJECT}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1060,7 +1060,7 @@ prompt = "Label for ${env.PROJECT} in ${env.MISSING}:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1085,7 +1085,7 @@ prompt = "Value: ${env.}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1116,7 +1116,7 @@ prompt = "Value: ${env.MY-VAR}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1142,7 +1142,7 @@ default = "prefix-${env.}"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1168,7 +1168,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -1199,7 +1199,7 @@ prompt = "Value:"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -226,7 +226,7 @@ mod tests {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -245,7 +245,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "../Dockerfile"
 
 [claude]
@@ -268,7 +268,7 @@ plugins = []
         std::os::unix::fs::symlink(outside.path(), temp.path().join("escape")).unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "escape/Dockerfile"
 
 [claude]
@@ -293,7 +293,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -331,7 +331,7 @@ echo hello
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -374,7 +374,7 @@ preflight = "hooks/preflight.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -406,7 +406,7 @@ preflight = "hooks/preflight.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -433,7 +433,7 @@ preflight = "../escape.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -460,7 +460,7 @@ preflight = "hooks/missing.sh"
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -507,7 +507,7 @@ preflight = "/etc/evil.sh"
         std::fs::write(
             temp.path().join("jackin.role.toml"),
             format!(
-                r#"version = "v1alpha2"
+                r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -541,7 +541,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -3490,7 +3490,7 @@ mod tests {
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3550,7 +3550,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3620,7 +3620,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -3672,7 +3672,7 @@ plugins = []
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -3723,7 +3723,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -3781,7 +3781,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -3828,7 +3828,7 @@ agents = ["codex"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -3887,7 +3887,7 @@ agents = ["amp"]
         let manifest_temp = tempdir().unwrap();
         std::fs::write(
             manifest_temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -4341,7 +4341,7 @@ echo "pulled $2"
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4449,7 +4449,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4537,7 +4537,7 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4591,7 +4591,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4673,7 +4673,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4756,7 +4756,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -4844,7 +4844,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -4897,7 +4897,7 @@ agents = ["codex"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -4969,7 +4969,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5037,7 +5037,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5084,7 +5084,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5134,7 +5134,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -5184,7 +5184,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -5243,7 +5243,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5321,7 +5321,7 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5392,7 +5392,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5504,7 +5504,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5614,7 +5614,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5681,7 +5681,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -5735,7 +5735,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -5795,7 +5795,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [identity]
@@ -5854,7 +5854,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5910,7 +5910,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -5969,7 +5969,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -6073,7 +6073,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -6145,7 +6145,7 @@ dst = "/workspace"
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -6248,7 +6248,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [env.OPERATOR_SMOKE]
@@ -6328,7 +6328,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -6425,7 +6425,7 @@ trusted = true
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -632,7 +632,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -674,7 +674,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -705,7 +705,7 @@ plugins = []
                 .unwrap();
                 std::fs::write(
                     repo_dir_clone.join("jackin.role.toml"),
-                    r#"version = "v1alpha2"
+                    r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -747,7 +747,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -792,7 +792,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -832,7 +832,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -855,7 +855,7 @@ plugins = []
                 .unwrap();
                 std::fs::write(
                     repo_dir_clone.join("jackin.role.toml"),
-                    r#"version = "v1alpha2"
+                    r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -896,7 +896,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -993,7 +993,7 @@ plugins = []
         .unwrap();
         std::fs::write(
             repo_dir.join("jackin.role.toml"),
-            r#"version = "v1alpha2"
+            r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]

--- a/tests/agent_validation.rs
+++ b/tests/agent_validation.rs
@@ -6,7 +6,7 @@ fn rejects_supported_agent_without_corresponding_table() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -33,7 +33,7 @@ fn legacy_manifest_passes_validation() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -56,7 +56,7 @@ fn codex_only_manifest_with_codex_table_passes() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -79,7 +79,7 @@ fn amp_only_manifest_with_amp_table_passes() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 

--- a/tests/amp_launch.rs
+++ b/tests/amp_launch.rs
@@ -83,7 +83,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -181,7 +181,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 

--- a/tests/codex_launch.rs
+++ b/tests/codex_launch.rs
@@ -82,7 +82,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 
@@ -186,7 +186,7 @@ trusted = true
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex"]
 

--- a/tests/dind_e2e.rs
+++ b/tests/dind_e2e.rs
@@ -182,7 +182,7 @@ fn seed_agent_smith_role_repo(path: &Path) {
     std::fs::write(path.join("fake-curl"), fake_curl()).unwrap();
     std::fs::write(
         path.join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 

--- a/tests/fixtures/migrations/manifest/from-legacy/after.toml
+++ b/tests/fixtures/migrations/manifest/from-legacy/after.toml
@@ -1,4 +1,4 @@
-version = "v1alpha2"
+version = "v1alpha3"
 # Sample role manifest carried through the legacy migration chain.
 
 dockerfile = "Dockerfile"

--- a/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
@@ -1,4 +1,4 @@
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 

--- a/tests/fixtures/migrations/manifest/from-v1alpha2/after.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha2/after.toml
@@ -1,0 +1,9 @@
+version = "v1alpha3"
+dockerfile = "Dockerfile"
+agents = ["claude", "opencode"]
+
+[claude]
+plugins = []
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"

--- a/tests/fixtures/migrations/manifest/from-v1alpha2/before.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha2/before.toml
@@ -1,0 +1,9 @@
+version = "v1alpha2"
+dockerfile = "Dockerfile"
+agents = ["claude", "opencode"]
+
+[claude]
+plugins = []
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"

--- a/tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml
+++ b/tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml
@@ -1,0 +1,4 @@
+from_version = "v1alpha2"
+target_version = "v1alpha3"
+target_version_shipped = "2026-05-14"
+summary = "Restamps role manifest as v1alpha3 and moves version to the first line. Formalizes OpenCode agent support: the opencode enum variant and [opencode] table were introduced into the binary without a manifest version bump; this version corrects that oversight."

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -12,7 +12,7 @@ fn validate_passes_for_valid_agent_repo() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -41,7 +41,7 @@ fn validate_fails_for_wrong_base_image() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -70,7 +70,7 @@ fn validate_allows_missing_dockerignore() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -98,7 +98,7 @@ fn validate_fails_for_invalid_manifest() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 unknown_field = true
 
@@ -129,7 +129,7 @@ fn validate_passes_when_manifest_uses_dockerfile_in_subdirectory() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -156,7 +156,7 @@ fn validate_fails_for_invalid_preflight_hook() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha2"
+        r#"version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [hooks]
@@ -206,7 +206,7 @@ fn validate_migrate_accepts_flag_after_path() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest legacy -> v1alpha2",
+            "Migrated manifest legacy -> v1alpha3",
         ));
 }
 
@@ -220,7 +220,7 @@ fn validate_migrate_is_noop_for_current_manifest() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        "version = \"v1alpha2\"\ndockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
+        "version = \"v1alpha3\"\ndockerfile = \"Dockerfile\"\n\n[claude]\nplugins = []\n",
     )
     .unwrap();
 
@@ -253,7 +253,7 @@ fn validate_migrate_rejects_newer_manifest_version() {
         .args(["--migrate", temp.path().to_str().unwrap()])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("only understands up to v1alpha2"));
+        .stderr(predicate::str::contains("only understands up to v1alpha3"));
 }
 
 #[test]
@@ -323,10 +323,10 @@ fn validate_migrate_updates_legacy_manifest() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest legacy -> v1alpha2",
+            "Migrated manifest legacy -> v1alpha3",
         ))
         .stdout(predicate::str::contains("All checks passed"));
 
     let out = std::fs::read_to_string(temp.path().join("jackin.role.toml")).unwrap();
-    assert!(out.contains(r#"version = "v1alpha2""#), "{out}");
+    assert!(out.contains(r#"version = "v1alpha3""#), "{out}");
 }


### PR DESCRIPTION
## Summary

Bumps `CURRENT_MANIFEST_VERSION` to `v1alpha3` to correct an oversight from PR #338: that PR added the `opencode` variant to the `Agent` enum and the `[opencode]` config table — both non-additive changes to the manifest serde shape — without bumping the manifest version. Operators running a stale jackin binary received a cryptic TOML `unknown variant 'opencode'` error instead of the clear "upgrade jackin" message the version-mismatch guard is designed to surface. With this fix the version check fires before TOML deserialization, so old binaries always see `role manifest is at v1alpha3, this binary only understands up to v1alpha2; upgrade jackin`.

## Hard rule: versioned-schema migration rule

The AGENTS.md migration rule now explicitly names "added enum variant" alongside renamed field, removed field, type change, and restructured table as changes requiring all five migration artifacts. The schema-versions.mdx "Why versioning" section documents both version-mismatch error strings so role authors and operators know exactly what they will see at runtime.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jackin-jackin-thearchitect-tcqe52ar:refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-tcqe52ar
git checkout -B jackin/scratch/jackin-jackin-thearchitect-tcqe52ar refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-tcqe52ar
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-342"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-342"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run -E 'test(manifest)'
cargo nextest run --all-features
```

Covers the migration chain (`from-legacy`, `from-v1alpha1`, `from-v1alpha2`), the `validate_manifest_version` rejection paths in both directions, and all manifest-loading tests updated to `v1alpha3`.

### User smoke

This PR specifically improves the error when a stale binary encounters a newer manifest. The live `~/.jackin/roles/the-architect/default/jackin.role.toml` currently has `version = "v1alpha2"` — the exact scenario that triggered the original bug. Running the new binary against it shows the improvement:

```sh
cargo run --bin jackin -- console --debug
```

Expected: `role "the-architect" manifest is at v1alpha2, expected v1alpha3; run "jackin-validate --migrate <role-repo-path>" to upgrade the local copy` — clear and actionable instead of the former TOML parse error.

To verify the "binary too old" path, temporarily set `version = "v2alpha1"` in the cached manifest file and rerun; expect: `role manifest is at v2alpha1, this binary only understands up to v1alpha3; upgrade jackin`.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Page to walk:

**http://localhost:4321/reference/schema-versions/**  
UPDATED. Verify: `v1alpha3` entry appears first in the Timeline with correct before/after examples; "Why versioning" section has the new bullet about enum variants being breaking changes and both error strings; current versions table shows `v1alpha3` for `jackin.role.toml`; field table heading is `v1alpha3` with `[opencode].model` showing `Since: v1alpha3`.

## Migration notes

Role manifests at `v1alpha2` are not automatically migrated — role repos migrate explicitly via `jackin-validate --migrate`. The `jackin-the-architect` role repo should run `jackin-validate --migrate` and push the result so the `version` field advances to `v1alpha3`. Operator config and workspace files are unaffected — those remain at `v1alpha2`.
