### PR TITLE
fix(manifest): allow compatible older role manifests

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -343,6 +343,7 @@ export default defineConfig({
                   collapsed: true,
                   items: [
                     { label: 'Config versioning and migration', slug: 'reference/roadmap/config-versioning-migration' },
+                    { label: 'Role authoring CLI', slug: 'reference/roadmap/role-authoring-cli' },
                   ],
                 },
                 {

--- a/docs/src/content/docs/developing/creating-roles.mdx
+++ b/docs/src/content/docs/developing/creating-roles.mdx
@@ -28,7 +28,7 @@ Creating a custom agent lets you define a specialized environment for a specific
 2. **Create the manifest file**
 
    ```toml
-   version = "v1alpha2"
+   version = "v1alpha3"
    dockerfile = "Dockerfile"
 
    [claude]
@@ -126,7 +126,7 @@ USER agent
 Role repos can declare Claude Code plugins to install. Add them to the `[claude]` section in your manifest:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -142,7 +142,7 @@ These plugin IDs are written into the agent's runtime state and installed automa
 If you need plugins from a custom marketplace, declare the marketplace separately and keep plugin IDs fully qualified:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -171,7 +171,7 @@ jackin adds each declared marketplace at container startup, then installs each p
 An role can support more than one agent while keeping one shared Dockerfile:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp", "opencode"]
 

--- a/docs/src/content/docs/developing/role-manifest.mdx
+++ b/docs/src/content/docs/developing/role-manifest.mdx
@@ -16,12 +16,12 @@ roles never edit this file.
 
 Every role repo must contain a `jackin.role.toml` file at the repository root. This manifest tells jackin' how to build, configure, and identify the agent.
 
-jackin' enforces **strict parsing** — unknown fields are rejected with an error. This catches typos and prevents silent misconfiguration. Top-level `version` is required; use `jackin-validate --migrate <role-repo-path>` to update an older local manifest. See [Schema Versions](/reference/schema-versions/) for the full version history and migration matrix.
+jackin' enforces **strict parsing** — unknown fields are rejected with an error. This catches typos and prevents silent misconfiguration. Top-level `version` records the minimum manifest schema the file requires; older stamps remain valid until the manifest uses a newer field or enum value. Use `jackin-validate --migrate <role-repo-path>` to update a local manifest before adopting newer schema features. See [Schema Versions](/reference/schema-versions/) for the full version history and migration matrix.
 
 ## Full schema
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp", "opencode"]
 
@@ -72,7 +72,7 @@ default = "feature/${env.PROJECT}"
 
 | Field | Required | Description |
 |---|---|---|
-| `version` | Yes | Manifest schema version. Current value is `v1alpha2`. |
+| `version` | Yes | Manifest schema version. Current value is `v1alpha3`. |
 | `dockerfile` | Yes | Relative path to the Dockerfile within the repo |
 | `agents` | No | Non-empty list of agent slugs this role supports: `"claude"`, `"codex"`, `"amp"`, or `"opencode"`. When omitted, jackin treats the manifest as Claude-only. |
 
@@ -86,7 +86,7 @@ The Dockerfile path must:
 Every agent listed in `agents` must have a matching `[<agent>]` table, even when that table is empty. A manifest with `agents = ["claude", "codex", "amp", "opencode"]` needs `[claude]`, `[codex]`, `[amp]`, and `[opencode]`.
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp", "opencode"]
 
@@ -112,7 +112,7 @@ model = "gpt-5"
 Example values:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -143,7 +143,7 @@ The `[codex]` table is required when `"codex"` appears in `agents`.
 | `model` | No | Optional Codex model passed to `codex -m` at launch |
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["codex"]
 
@@ -156,7 +156,7 @@ model = "gpt-5"
 The `[amp]` table is required when `"amp"` appears in `agents`. It is empty today and reserved for future Amp-specific settings.
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["amp"]
 
@@ -174,7 +174,7 @@ The `[opencode]` table is required when `"opencode"` appears in `agents`.
 OpenCode is a terminal-based AI coding agent installed from [GitHub Releases](https://github.com/opencode-ai/opencode/releases). It authenticates via `~/.local/share/opencode/auth.json`, which stores provider-level credentials — for example, a Z.AI Coding Plan subscription (see [z.ai/subscribe](https://z.ai/subscribe)). jackin forwards these credentials into the container using the same `sync` / `api_key` / `ignore` auth-forwarding modes as the other agents. The `OPENCODE_API_KEY` env var is used for `api_key` mode.
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 agents = ["opencode"]
 
@@ -389,7 +389,7 @@ Interactive prompts happen before the Docker image build, so you won't wait thro
 The smallest valid manifest:
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -399,7 +399,7 @@ plugins = []
 ## Complete example
 
 ```toml title="jackin.role.toml"
-version = "v1alpha2"
+version = "v1alpha3"
 dockerfile = "docker/Dockerfile.agent"
 
 [identity]

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -98,6 +98,10 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, `Amp`, and `
 - **[Move documentation to a separate repository](/reference/roadmap/docs-separate-repository/)** — promote `docs/` out of the CLI repo into its own `jackin-project/jackin-docs` repo so the ecosystem-level docs have an ecosystem-level home; the load-bearing question is how to keep the docs as fresh as same-repo co-location makes them today (status: deferred — needs design pass on the cross-repo freshness story)
 - **[Rustdoc → Starlight integration](/reference/roadmap/rustdoc-json-starlight/)** — surface rustdoc JSON inside the Starlight docs site (status: deferred — Phase 3)
 
+### Configuration ergonomics
+
+- **[Role authoring CLI](/reference/roadmap/role-authoring-cli/)** — add `jackin role validate`, `jackin role migrate`, and `jackin role create` so local role authors can validate, migrate, and scaffold role repos through Jackin itself while keeping the standalone validator available for GitHub workflows (status: open — design proposal)
+
 <Aside type="tip">
 Detailed design documents for individual TODO items are linked from the sidebar under **Roadmap** (each open category — `Agent Orchestrator Research`, `Codebase health`, `Agent runtimes & authentication`, `Isolation & security`, `Infrastructure`, `Documentation tooling`, `Configuration ergonomics`) and **Roadmap → Resolved** for shipped items. Each page is a self-contained proposal with problem statement, options, and related files.
 </Aside>

--- a/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
+++ b/docs/src/content/docs/reference/roadmap/config-versioning-migration.mdx
@@ -30,7 +30,7 @@ A file with no `version` is ambiguous: it could be a file that was never created
 `config.toml` and every per-workspace file use a top-level Kubernetes-style `version` field:
 
 ```toml
-version = "v1alpha2"
+version = "v1alpha3"
 
 [claude]
 auth_forward = "sync"
@@ -87,8 +87,8 @@ Migration is **always automatic for config files** — operators do not need to 
 
 Role manifests live in role repos that jackin does not own. The policy is:
 
-- **Version matches**: proceed as today.
-- **Version absent or older than expected**: jackin refuses to use the role and emits a human-readable error: `role "the-architect" manifest is at {old}, expected {current}; run "jackin-validate --migrate <role-repo-path>" to upgrade the local copy`.
+- **Version is current or older**: jackin loads the role when the manifest only uses fields and enum values available at that version.
+- **Older-stamped manifest uses a newer feature**: jackin refuses to use the role and emits a feature-specific error with `jackin-validate --migrate <role-repo-path>`. For example, `opencode` requires `v1alpha3`; a `v1alpha2` manifest that declares `agents = ["opencode"]` must be migrated before launch.
 - **Version newer than expected**: jackin refuses and emits: `role manifest is at {new}, this binary only understands up to {current}; upgrade jackin`.
 
 The `jackin-validate --migrate <role-repo-path>` binary applies the manifest migration chain to the local role clone and writes the result back. The operator can then inspect the diff, commit, and push.
@@ -106,8 +106,8 @@ This makes it practical for the jackin maintainer to migrate all first-party rol
 
 | Situation | Config file | Role manifest |
 |---|---|---|
-| `version` absent | Treat as legacy; migrate automatically | Treat as legacy; error + suggest `--migrate` |
-| `version` < current | Migrate automatically on startup | Error + suggest `--migrate` |
+| `version` absent | Treat as legacy; migrate automatically | Treat as legacy; load if no newer feature is used |
+| `version` < current | Migrate automatically on startup | Load if no newer feature is used; otherwise error + suggest `--migrate` |
 | `version` == current | Load normally | Load normally |
 | `version` > current | Error: binary too old | Error: binary too old |
 

--- a/docs/src/content/docs/reference/roadmap/role-authoring-cli.mdx
+++ b/docs/src/content/docs/reference/roadmap/role-authoring-cli.mdx
@@ -1,0 +1,53 @@
+---
+title: "Role authoring CLI"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — design proposal (Configuration ergonomics)
+
+## Problem
+
+Role maintenance currently splits across surfaces. Jackin itself loads role repos, but local manifest validation and migration live in the separate `jackin-validate` binary, which is shaped for GitHub workflow usage rather than day-to-day operator and role-author usage. Role authors also scaffold new role repos by hand, repeating the same `Dockerfile`, `jackin.role.toml`, README, and GitHub Actions setup each time.
+
+That split makes sense for CI, but it is awkward locally. Jackin should provide the normal local role-management workflow itself: validate a checked-out role repo, migrate a role manifest when its schema needs a restamp or feature unlock, and create a new role repository skeleton in the operator's project area.
+
+## Proposed CLI shape
+
+Add a `jackin role` command family:
+
+```sh
+jackin role validate [<role-repo-path>]
+jackin role migrate [<role-repo-path>]
+jackin role create <role-name-or-namespace/name> [<projects-dir>]
+```
+
+`validate` checks the same role-repo contract as the current validator: manifest parsing, feature-version compatibility, Dockerfile path safety, final construct base image, hook paths, env declarations, and agent/table consistency. It should default `<role-repo-path>` to the current directory.
+
+`migrate` applies the manifest migration registry to the local role repo and writes the updated `jackin.role.toml` back to that repo. It should be the command Jackin points to in local operator errors. The standalone `jackin-validate --migrate <role-repo-path>` path remains useful for GitHub Actions and compatibility, but Jackin's own CLI should advertise `jackin role migrate <role-repo-path>`.
+
+`create` scaffolds a role repo. `jackin role create frontend-engineer .` creates `./jackin-frontend-engineer`; `jackin role create ChainArgos/frontend-engineer "$HOME/Projects"` creates `$HOME/Projects/ChainArgos/jackin-frontend-engineer`. When the projects directory is omitted, Jackin should use `JACKIN_PROJECTS_DIR`, defaulting to `$HOME/Projects`.
+
+## Scaffolding output
+
+The generated role repo should include:
+
+- `jackin.role.toml` stamped with the current manifest version.
+- A minimal `Dockerfile` based on `projectjackin/construct:trixie`.
+- A README that explains the role's purpose and local validation command.
+- `.gitignore` and `.dockerignore` defaults suitable for a role repo.
+- A GitHub Actions workflow that runs role validation on pull requests.
+
+The scaffold should be intentionally small. It should create a valid role authors can run immediately, without hiding the fact that they still own the Dockerfile and manifest choices.
+
+## Open questions
+
+- Should `jackin role migrate` support bulk mode for every cached role clone under Jackin's role cache, or should that be a separate `jackin role migrate --cached` / `--all` path?
+- Should `jackin role create ChainArgos/frontend-engineer` initialize Git automatically, or only write files and let the operator choose when to commit?
+- Should org/name casing be preserved in the directory path (`ChainArgos`) while role slugs remain lowercase (`jackin-frontend-engineer`), or should Jackin normalize both?
+- Should `JACKIN_PROJECTS_DIR` also affect workspace creation later, or stay scoped to role scaffolding until there is a broader project-location policy?
+
+## Related files
+
+- <RepoFile path="src/bin/validate.rs" /> — current standalone validation and migration binary.
+- <RepoFile path="src/manifest/mod.rs" /> — role manifest parsing and feature-version compatibility.
+- <RepoFile path="src/manifest/migrations.rs" /> — role manifest migration registry.

--- a/docs/src/content/docs/reference/schema-versions.mdx
+++ b/docs/src/content/docs/reference/schema-versions.mdx
@@ -17,7 +17,7 @@ Breaking changes to schemas are expected — that is how the project explores id
 - **Operator-owned files migrate automatically.** `config.toml` and `~/.config/jackin/workspaces/<name>.toml` are rewritten in place on startup; the operator does nothing.
 - **Role-owned files migrate explicitly.** Role authors run `jackin-validate --migrate <role-repo-path>` to rewrite a `jackin.role.toml` against the latest schema, then commit and push the result. Jackin never writes back into a role repo on its own — that would silently mutate someone else's source tree.
 - **Migrations are a hard PR-review rule.** Every change to one of the three versioned files must bump the corresponding `CURRENT_*_VERSION`, add a migration step, and update this page. Adding a new enum variant counts as a schema-breaking change: old binaries cannot parse manifests that use the new variant. The full rule lives in <RepoFile path="AGENTS.md" /> and <RepoFile path="PULL_REQUESTS.md" />.
-- **Version mismatches produce actionable errors.** The version check runs before full TOML deserialization, so old binaries always surface a clear message rather than a cryptic parse error. When a manifest's `version` is newer than what the binary knows about, jackin rejects it with: `role manifest is at {version}, this binary only understands up to {CURRENT_MANIFEST_VERSION}; upgrade jackin`. When the manifest is older than expected (role author has not yet run `jackin-validate --migrate`), jackin says: `role "{role_name}" manifest is at {version}, expected {CURRENT_MANIFEST_VERSION}; run "jackin-validate --migrate <role-repo-path>" to upgrade the local copy`.
+- **Version mismatches produce actionable errors.** The version check runs before full TOML deserialization, so old binaries always surface a clear message rather than a cryptic parse error. When a manifest's `version` is newer than what the binary knows about, jackin rejects it with: `role manifest is at {version}, this binary only understands up to {CURRENT_MANIFEST_VERSION}; upgrade jackin`. Current binaries accept older role manifests when the file only uses fields and enum values that existed at that older version. If an older-stamped manifest uses a newer feature, jackin rejects it with a feature-specific `jackin-validate --migrate <role-repo-path>` hint.
 
 The split-workspace layout described in [Configuration File](/reference/configuration/#one-file-per-workspace-by-design) makes per-file migration tractable: legacy global files and per-workspace files migrate independently, so a dotfile repo that is partially old still upgrades cleanly.
 
@@ -39,7 +39,7 @@ Each entry is one upgrade path the current binary applies. <RepoFile path="tests
 |---|---|---|---|
 | Manifest (`jackin.role.toml`) | `v1alpha2` | Explicit `jackin-validate --migrate <role-repo-path>` | <RepoFile path="tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml" /> |
 
-**Summary**: formalizes OpenCode agent support. The `opencode` enum variant in `agents` and the `[opencode]` config table were added to the binary in the previous schema version without a corresponding manifest version bump — this version corrects that oversight. The migration is a no-op restamp: no field renames, no data moved.
+**Summary**: formalizes OpenCode agent support. The `opencode` enum variant in `agents` and the `[opencode]` config table require `v1alpha3`; older-stamped manifests still load as long as they do not use OpenCode. The migration is a no-op restamp: no field renames, no data moved.
 
 **Before** (v1alpha2 manifest with OpenCode):
 

--- a/src/manifest/migrations.rs
+++ b/src/manifest/migrations.rs
@@ -44,17 +44,16 @@ pub fn migrate_manifest_file(path: &Path) -> anyhow::Result<Option<(String, Stri
     Ok(outcome.map(|old| (old.to_string(), CURRENT_MANIFEST_VERSION.to_string())))
 }
 
-pub(crate) fn validate_manifest_version(doc: &DocumentMut, role_name: &str) -> anyhow::Result<()> {
+pub(crate) fn validate_manifest_version(
+    doc: &DocumentMut,
+) -> anyhow::Result<crate::config::migrations::SchemaVersion> {
     let version = crate::config::migrations::doc_version(doc, "role manifest")?;
     let current = crate::config::migrations::parse_version(CURRENT_MANIFEST_VERSION)?;
     match version.cmp(&current) {
-        std::cmp::Ordering::Less => bail!(
-            "role \"{role_name}\" manifest is at {version}, expected {CURRENT_MANIFEST_VERSION}; run \"jackin-validate --migrate <role-repo-path>\" to upgrade the local copy"
-        ),
         std::cmp::Ordering::Greater => bail!(
             "role manifest is at {version}, this binary only understands up to {CURRENT_MANIFEST_VERSION}; upgrade jackin"
         ),
-        std::cmp::Ordering::Equal => Ok(()),
+        std::cmp::Ordering::Less | std::cmp::Ordering::Equal => Ok(version),
     }
 }
 
@@ -129,23 +128,20 @@ mod tests {
     #[test]
     fn validate_manifest_version_accepts_current() {
         let doc: DocumentMut = "version = \"v1alpha3\"\n".parse().unwrap();
-        validate_manifest_version(&doc, "test-role").unwrap();
+        validate_manifest_version(&doc).unwrap();
     }
 
     #[test]
-    fn validate_manifest_version_rejects_legacy_with_migrate_hint() {
+    fn validate_manifest_version_accepts_legacy() {
         let doc: DocumentMut = "dockerfile = \"Dockerfile\"\n".parse().unwrap();
-        let err = validate_manifest_version(&doc, "the-architect").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("\"the-architect\""), "{msg}");
-        assert!(msg.contains("at legacy"), "{msg}");
-        assert!(msg.contains("jackin-validate --migrate"), "{msg}");
+        let version = validate_manifest_version(&doc).unwrap();
+        assert_eq!(version.to_string(), "legacy");
     }
 
     #[test]
     fn validate_manifest_version_rejects_newer() {
         let doc: DocumentMut = "version = \"v2alpha1\"\n".parse().unwrap();
-        let err = validate_manifest_version(&doc, "test-role").unwrap_err();
+        let err = validate_manifest_version(&doc).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("only understands up to v1alpha3"), "{msg}");
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -174,10 +174,11 @@ impl ManifestWarning {
 
 impl RoleManifest {
     /// Parse `jackin.role.toml` and pin the load-time invariants other code
-    /// relies on: `version` matches `CURRENT_MANIFEST_VERSION` (operator
-    /// gets a `--migrate` hint on mismatch) and the `agents` / `[<agent>]`
-    /// tables are consistent (so `instance::prepare` can dereference
-    /// `manifest.codex` / `manifest.claude` without re-checking).
+    /// relies on: `version` is not newer than this binary understands,
+    /// version-gated features match the manifest's declared minimum schema,
+    /// and the `agents` / `[<agent>]` tables are consistent (so
+    /// `instance::prepare` can dereference `manifest.codex` /
+    /// `manifest.claude` without re-checking).
     ///
     /// Env-var validation, interpolation cycle detection, and the rest of
     /// `validate()` still need explicit calls — they emit warnings the load
@@ -189,10 +190,13 @@ impl RoleManifest {
         let doc: toml_edit::DocumentMut = contents
             .parse()
             .with_context(|| format!("parsing {}", manifest_path.display()))?;
-        crate::manifest::migrations::validate_manifest_version(&doc, &display_role_name(repo_dir))
+        let role_name = display_role_name(repo_dir);
+        let manifest_version = crate::manifest::migrations::validate_manifest_version(&doc)
             .with_context(|| format!("validating version of {}", manifest_path.display()))?;
         let manifest: Self = toml::from_str(&contents)
             .with_context(|| format!("parsing {} as RoleManifest", manifest_path.display()))?;
+        validate_feature_versions(&manifest, &manifest_version, &role_name)
+            .with_context(|| format!("validating version of {}", manifest_path.display()))?;
         let _warnings = crate::manifest::validate::validate_agent_consistency(&manifest)?;
         Ok(manifest)
     }
@@ -223,6 +227,26 @@ fn display_role_name(repo_dir: &Path) -> String {
         (_, Some(name)) => name.to_string(),
         _ => repo_dir.display().to_string(),
     }
+}
+
+fn validate_feature_versions(
+    manifest: &RoleManifest,
+    manifest_version: &crate::config::migrations::SchemaVersion,
+    role_name: &str,
+) -> anyhow::Result<()> {
+    let opencode_version = crate::config::migrations::parse_version("v1alpha3")?;
+    if manifest_version < &opencode_version
+        && (manifest
+            .agents
+            .as_ref()
+            .is_some_and(|agents| agents.contains(&crate::agent::Agent::Opencode))
+            || manifest.opencode.is_some())
+    {
+        anyhow::bail!(
+            "role \"{role_name}\" manifest is at {manifest_version} but uses opencode, which requires v1alpha3; run \"jackin-validate --migrate <role-repo-path>\" to upgrade the local copy"
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -267,7 +291,7 @@ plugins = []
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
-            r#"version = "v1alpha3"
+            r#"version = "v1alpha2"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -349,7 +373,7 @@ plugins = []
     }
 
     #[test]
-    fn rejects_legacy_manifest_without_migrate() {
+    fn loads_unversioned_manifest_without_newer_features() {
         let temp = tempdir().unwrap();
         std::fs::write(
             temp.path().join("jackin.role.toml"),
@@ -361,10 +385,11 @@ plugins = []
         )
         .unwrap();
 
-        let err = RoleManifest::load(temp.path()).unwrap_err();
-        let chain = format!("{err:#}");
-        assert!(chain.contains("manifest is at legacy"), "{chain}");
-        assert!(chain.contains("jackin-validate --migrate"), "{chain}");
+        let manifest = RoleManifest::load(temp.path()).unwrap();
+        assert_eq!(
+            manifest.supported_agents(),
+            vec![crate::agent::Agent::Claude]
+        );
     }
 
     #[test]
@@ -384,6 +409,47 @@ plugins = []
         let err = RoleManifest::load(temp.path()).unwrap_err();
         let chain = format!("{err:#}");
         assert!(chain.contains("only understands up to v1alpha3"), "{chain}");
+    }
+
+    #[test]
+    fn rejects_old_manifest_version_using_opencode_agent() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.role.toml"),
+            r#"version = "v1alpha2"
+dockerfile = "Dockerfile"
+agents = ["opencode"]
+
+[opencode]
+"#,
+        )
+        .unwrap();
+
+        let err = RoleManifest::load(temp.path()).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(chain.contains("requires v1alpha3"), "{chain}");
+        assert!(chain.contains("jackin-validate --migrate"), "{chain}");
+    }
+
+    #[test]
+    fn rejects_old_manifest_version_with_opencode_table() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("jackin.role.toml"),
+            r#"version = "v1alpha2"
+dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+
+[opencode]
+"#,
+        )
+        .unwrap();
+
+        let err = RoleManifest::load(temp.path()).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(chain.contains("requires v1alpha3"), "{chain}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Jackin now accepts older role manifests when they only use schema features available at their declared version, while still rejecting future manifest versions and older-stamped manifests that opt into newer features such as OpenCode. The role-authoring and schema docs now describe `version` as a minimum required manifest capability, and the roadmap tracks a future `jackin role` CLI for local validation, migration, and scaffolding so the standalone validator can stay focused on GitHub workflow usage.

## What's deferred (follow-up PRs)

- Implement `jackin role validate`, `jackin role migrate`, and `jackin role create` as first-class local CLI commands.
- Decide whether role migration should support bulk cached-role mode through `--all` / `--cached` or a separate subcommand.
- Update local migration error text to prefer `jackin role migrate` after that command exists.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/role-manifest-compat:refs/remotes/origin/feature/role-manifest-compat
git checkout -B feature/role-manifest-compat refs/remotes/origin/feature/role-manifest-compat
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-343"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-343"
```

### Static checks

```sh
cargo fmt --check
```

### Tests

```sh
cargo test -q manifest
cargo test -q --test validate_cli
```

These cover compatible older manifest loading, feature-version rejection for older-stamped OpenCode manifests, future-version rejection, and the existing standalone validator migration path.

### User smoke

```sh
cargo run --bin jackin -- load the-architect . --debug
```

The launch should get past role manifest validation when the selected role repo is stamped with an older compatible manifest version. Cancel before agent handoff if you only need to verify the validation gate.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/developing/role-manifest/**  
UPDATED. Confirms role manifests describe `version` as the minimum schema capability and examples use the current manifest stamp.

**http://localhost:4321/developing/creating-roles/**  
UPDATED. Confirms role creation examples use the current manifest stamp.

**http://localhost:4321/reference/schema-versions/**  
UPDATED. Confirms older role manifests are accepted unless they use newer schema features.

**http://localhost:4321/reference/roadmap/config-versioning-migration/**  
UPDATED. Confirms the roadmap policy matches the new role-manifest compatibility behavior.

**http://localhost:4321/reference/roadmap/role-authoring-cli/**  
NEW page under Behind jackin' — Internals → Roadmap → Configuration ergonomics. Confirms the planned `jackin role` command family, create-path defaults, and open design questions.

**http://localhost:4321/reference/roadmap/**  
UPDATED. Confirms the new Role authoring CLI item appears under Configuration ergonomics.

## Migration notes

None. Existing role manifests do not need to be restamped unless they use a newer feature than their declared schema version allows.
