### PR TITLE
fix(console): confirm role before launch

### DIFF
--- a/docs/src/content/docs/commands/console.mdx
+++ b/docs/src/content/docs/commands/console.mdx
@@ -26,7 +26,7 @@ Running `jackin` with no subcommand opens the same console when stdout is attach
 
 The console opens directly to a workspace manager list — no separate workspace-picker stage. From there you can:
 
-- **Launch an agent into a workspace.** Each workspace row launches a container running the workspace's allowed roles and agents. When the workspace has a single eligible role and agent, launch is one keystroke. When there's ambiguity, the console asks you to pick.
+- **Launch an agent into a workspace.** Each workspace row opens the role picker in the sidebar, even when there is only one eligible role. Confirm the highlighted role to launch. If the selected role supports multiple agent runtimes, the console asks for that runtime next.
 - **Use your current directory as a workspace.** A synthetic row at the top of the manager list mounts your `cwd` at the same path inside the container. Useful for quick one-off launches without saving a workspace definition.
 - **Recover active and preserved instances.** Workspace and current-directory detail panes show an Instances panel when jackin-managed local state exists for that scope, with instance ID, status, agent runtime, and role. From that row, `r` reconnects or recovers, `s` starts another foreground agent session in a running instance, `i` prints a read-only state report, and `p` purges local recovery state when the guarded `purge` rules allow it.
 - **Open the workspace editor.** Edit the workspace's roles, environment variables, and authentication settings. Each editor surface lives on its own tab inside the editor.

--- a/docs/src/content/docs/commands/workspace.mdx
+++ b/docs/src/content/docs/commands/workspace.mdx
@@ -28,7 +28,7 @@ Create a new workspace definition.
 | `--workdir <PATH>` | Working directory inside the container |
 | `--mount <SPEC>` | Bind-mount spec (repeatable, at least one required) |
 | `--allowed-role <NAME>` | Restrict to these roles (repeatable) |
-| `--default-role <NAME>` | Role to auto-select |
+| `--default-role <NAME>` | Role to preselect in interactive pickers and CLI context loading |
 | `--default-agent <claude\|codex\|amp\|opencode>` | Default agent for this workspace |
 | `--mount-isolation <DST>=<TYPE>` | Set per-mount isolation by container destination. Repeatable. `<TYPE>` is `shared`, `worktree`, or `clone`. The `<DST>` must match a mount destination present in the final mount plan; an unknown `<DST>` is a hard error. |
 | `--keep-awake` | macOS only: opt this workspace into the keep-awake reconciler. While any agent in the workspace is running, jackin keeps a single detached `caffeinate -imsu` alive so the host stays awake. No-op on Linux/Windows. See [Keeping the host awake](/guides/workspaces/#keeping-the-host-awake). |
@@ -83,7 +83,7 @@ Modify an existing workspace.
 | `--remove-destination <PATH>` | Remove a mount by container path (repeatable) |
 | `--allowed-role <NAME>` | Grant role access (repeatable) |
 | `--remove-allowed-role <NAME>` | Revoke role access (repeatable) |
-| `--default-role <NAME>` | Set default role |
+| `--default-role <NAME>` | Set the default role for picker preselection and CLI context loading |
 | `--clear-default-role` | Clear the default role |
 | `--default-agent <claude\|codex\|amp\|opencode>` | Set default agent |
 | `--clear-default-agent` | Clear the explicit default agent and fall back to Claude |

--- a/docs/src/content/docs/getting-started/concepts.mdx
+++ b/docs/src/content/docs/getting-started/concepts.mdx
@@ -86,7 +86,7 @@ A **workspace** defines how your project directories are mounted into an agent c
 - **workdir** — the working directory inside the container
 - **mounts** — which host directories to mount, where, and with what permissions
 - **allowed roles** — optionally restrict which roles can use this workspace
-- **default role** — which role to auto-select when loading this workspace
+- **default role** — which role to highlight first in the console picker, and which role CLI context loading can use automatically
 
 Think of a workspace as answering: "Which project files can this agent see, and where do they appear in the container?"
 

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -220,7 +220,7 @@ jackin workspace create secure-api \
 ```
 
 - `--allowed-role` — only these roles can load this workspace (repeatable)
-- `--default-role` — auto-selected role when you open this workspace in the operator console
+- `--default-role` — role highlighted first in the operator console picker, and used automatically by CLI context loading when no role is passed
 - `--default-agent` — default agent used by `jackin load` unless `--agent` is passed for that launch
 
 This is especially useful when one workspace should only be used with a very specific tool profile, such as a production-infra role or a security-review role.

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -17,6 +17,7 @@ pub use state::ConsoleState;
 pub use state::WorkspaceChoice;
 pub use state::build_workspace_choice;
 
+use crate::app::context::preferred_agent_index;
 use crate::config::AppConfig;
 use crate::paths::JackinPaths;
 use crate::selector::RoleSelector;
@@ -40,9 +41,9 @@ pub enum ConsoleInstanceAction {
 }
 
 impl ConsoleState {
-    /// Default role → launch; one eligible → launch; multiple →
-    /// open `Modal::RolePicker`. `WorkspaceChoice` is built fresh
-    /// each call so manager edits take effect immediately.
+    /// Open the inline role picker for every eligible role count except zero.
+    /// `WorkspaceChoice` is built fresh each call so manager edits take effect
+    /// immediately.
     pub fn dispatch_launch_for_workspace(
         &mut self,
         config: &AppConfig,
@@ -54,56 +55,41 @@ impl ConsoleState {
             // Workspace was deleted between keypress and dispatch.
             return Ok(None);
         };
-        let mut roles = choice.allowed_roles.clone();
-        let default_role = choice.default_role.clone();
+        let roles = choice.allowed_roles.clone();
 
-        if let Some(default_key) = default_role.as_deref()
-            && let Some(role) = roles.iter().find(|a| a.key() == default_key).cloned()
-        {
-            let workspace = preview::resolve_selected_workspace(config, cwd, &choice, &role)?;
+        if roles.is_empty() {
+            // Toast + stay so the operator can fix `allowed_roles`
+            // — a single Enter shouldn't terminate the TUI.
+            let name = choice.name;
+            if let ConsoleStage::Manager(ms) = &mut self.stage {
+                ms.toast = Some(crate::console::manager::state::Toast {
+                    message: format!("no eligible roles for workspace \"{name}\""),
+                    kind: crate::console::manager::state::ToastKind::Error,
+                    shown_at: std::time::Instant::now(),
+                });
+            }
             self.pending_launch = None;
             self.pending_launch_role = None;
-            return Ok(Some((role, workspace, None)));
-        }
-
-        match roles.len() {
-            0 => {
-                // Toast + stay so the operator can fix `allowed_roles`
-                // — a single Enter shouldn't terminate the TUI.
-                let name = choice.name;
-                if let ConsoleStage::Manager(ms) = &mut self.stage {
-                    ms.toast = Some(crate::console::manager::state::Toast {
-                        message: format!("no eligible roles for workspace \"{name}\""),
-                        kind: crate::console::manager::state::ToastKind::Error,
-                        shown_at: std::time::Instant::now(),
-                    });
-                }
-                self.pending_launch = None;
-                self.pending_launch_role = None;
-                Ok(None)
-            }
-            1 => {
-                let role = roles.swap_remove(0);
-                let workspace = preview::resolve_selected_workspace(config, cwd, &choice, &role)?;
-                self.pending_launch = None;
-                self.pending_launch_role = None;
-                Ok(Some((role, workspace, None)))
-            }
-            _ => {
-                // Multiple eligible: pin `pending_launch` so the
-                // `LaunchWithAgent` arm rebuilds the choice on commit.
-                self.pending_launch = Some(input);
-                self.pending_launch_role = None;
-                if let ConsoleStage::Manager(ms) = &mut self.stage {
-                    ms.inline_role_picker = Some(
-                        crate::console::widgets::role_picker::RolePickerState::with_confirm_label(
-                            roles, "launch",
-                        ),
+        } else {
+            let selected = preferred_agent_index(
+                &roles,
+                choice.last_role.as_deref(),
+                choice.default_role.as_deref(),
+            );
+            self.pending_launch = Some(input);
+            self.pending_launch_role = None;
+            if let ConsoleStage::Manager(ms) = &mut self.stage {
+                let mut picker =
+                    crate::console::widgets::role_picker::RolePickerState::with_confirm_label(
+                        roles, "launch",
                     );
+                if let Some(selected) = selected {
+                    picker.list_state.select(Some(selected));
                 }
-                Ok(None)
+                ms.inline_role_picker = Some(picker);
             }
         }
+        Ok(None)
     }
 }
 

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -1409,10 +1409,10 @@ fn agent_picker_opens_when_multiple_agents_available() -> Result<()> {
     Ok(())
 }
 
-/// `default_role` set on the workspace must short-circuit the picker
-/// and produce an `Ok(Some(_))` direct launch outcome — no modal opens.
+/// `default_role` set on the workspace must preselect that role in the
+/// inline picker instead of launching without confirmation.
 #[test]
-fn agent_picker_skipped_when_default_agent_set() -> Result<()> {
+fn agent_picker_opens_with_default_agent_preselected() -> Result<()> {
     let temp = tempdir()?;
     let paths = JackinPaths::for_tests(temp.path());
     let config = seed_config_with_agents(
@@ -1429,21 +1429,27 @@ fn agent_picker_skipped_when_default_agent_set() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws, _agent) = outcome.expect("default_role must short-circuit to a direct launch");
-    assert_eq!(role.key(), "chainargos/agent-smith");
-    let ConsoleStage::Manager(ms) = &state.stage;
     assert!(
-        ms.list_modal.is_none(),
-        "default_role dispatch must NOT open the picker; got {:?}",
-        ms.list_modal
+        outcome.is_none(),
+        "default_role dispatch must stay in the run-loop so the operator confirms"
     );
+    let ConsoleStage::Manager(ms) = &state.stage;
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("default_role dispatch must open the inline picker");
+    let selected = picker
+        .list_state
+        .selected
+        .expect("default role should be selected");
+    assert_eq!(picker.filtered[selected].key(), "chainargos/agent-smith");
     Ok(())
 }
 
-/// Exactly one eligible role must short-circuit the picker — same
-/// direct-launch outcome as the default-role path.
+/// Exactly one eligible role still opens the picker so the operator confirms
+/// the role before launch.
 #[test]
-fn agent_picker_skipped_when_single_eligible_agent() -> Result<()> {
+fn agent_picker_opens_when_single_eligible_agent() -> Result<()> {
     let temp = tempdir()?;
     let paths = JackinPaths::for_tests(temp.path());
     let config = seed_config_with_agents(&paths, temp.path(), &["chainargos/agent-smith"], None)?;
@@ -1455,11 +1461,17 @@ fn agent_picker_skipped_when_single_eligible_agent() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws, _agent) =
-        outcome.expect("single eligible role must short-circuit to a direct launch");
-    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(
+        outcome.is_none(),
+        "single eligible role must open the picker, not direct-launch"
+    );
     let ConsoleStage::Manager(ms) = &state.stage;
-    assert!(ms.list_modal.is_none());
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("single eligible role must open the inline picker");
+    assert_eq!(picker.roles.len(), 1);
+    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
     Ok(())
 }
 
@@ -2473,21 +2485,25 @@ fn launch_after_create_workspace_uses_fresh_data() -> Result<()> {
         config = ce.save()?;
     }
 
-    // Dispatch a launch against the freshly-created name. With the bug,
-    // `ConsoleState.workspaces` would not contain "freshly-created" and
-    // the dispatcher would return Ok(None). With the fix, the dispatcher
-    // builds the choice from the current `config` and short-circuits on
-    // the single eligible role.
+    // Dispatch a launch against the freshly-created name. The dispatcher
+    // must build the choice from the current `config` and open the picker
+    // for that workspace even though `ConsoleState` was created earlier.
     let outcome = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("freshly-created".into()),
     )?;
-    let (role, _ws, _agent) = outcome.expect(
-        "freshly-created workspace must resolve through the dispatcher; under the bug, \
-         ConsoleState.workspaces was a startup snapshot and didn't include the new name",
+    assert!(
+        outcome.is_none(),
+        "freshly-created workspace must resolve into an inline picker; under the bug, \
+         ConsoleState.workspaces was a startup snapshot and didn't include the new name"
     );
-    assert_eq!(role.key(), "chainargos/agent-smith");
+    let ConsoleStage::Manager(ms) = &state.stage;
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("freshly-created workspace must open the inline picker");
+    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
     Ok(())
 }
 
@@ -2518,15 +2534,23 @@ fn launch_after_rename_uses_new_name() -> Result<()> {
         config = ce.save()?;
     }
 
-    // Dispatch against the new name — must resolve and short-circuit
-    // (single eligible role + default_role set).
+    // Dispatch against the new name — must resolve and open the picker
+    // for confirmation (single eligible role + default_role set).
     let outcome = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("renamed-ws".into()),
     )?;
-    let (role, _ws, _agent) = outcome.expect("renamed workspace must resolve under the new name");
-    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(
+        outcome.is_none(),
+        "renamed workspace must resolve under the new name and stay in the picker flow"
+    );
+    let ConsoleStage::Manager(ms) = &state.stage;
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("renamed workspace must open the inline picker");
+    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
 
     // OLD name must not resolve — under the snapshot bug it did.
     let stale_outcome = state.dispatch_launch_for_workspace(
@@ -2541,10 +2565,9 @@ fn launch_after_rename_uses_new_name() -> Result<()> {
     Ok(())
 }
 
-/// Post-edit `default_role` must short-circuit dispatch from picker
-/// to direct launch.
+/// Post-edit `default_role` must preselect the new default in the picker.
 #[test]
-fn launch_after_default_agent_change_uses_new_default() -> Result<()> {
+fn launch_after_default_agent_change_preselects_new_default() -> Result<()> {
     let temp = tempdir()?;
     let paths = JackinPaths::for_tests(temp.path());
     let mut config = seed_config_with_agents(
@@ -2589,23 +2612,26 @@ fn launch_after_default_agent_change_uses_new_default() -> Result<()> {
     }
 
     // Dispatch again — with the new default_role in config, the
-    // dispatcher must short-circuit to a direct launch outcome.
+    // dispatcher must preselect that role in the picker.
     let after = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    let (role, _ws, _agent) = after.expect(
-        "after default_role is set, dispatch must short-circuit to a direct launch outcome; \
-         under the bug, the snapshot's default_role: None forced the picker open",
-    );
-    assert_eq!(role.key(), "chainargos/agent-smith");
-    let ConsoleStage::Manager(ms) = &state.stage;
     assert!(
-        ms.list_modal.is_none(),
-        "post-default direct-launch must NOT have opened the picker; got {:?}",
-        ms.list_modal
+        after.is_none(),
+        "after default_role is set, dispatch must keep the operator in the picker flow"
     );
+    let ConsoleStage::Manager(ms) = &state.stage;
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("post-default dispatch must open the inline picker");
+    let selected = picker
+        .list_state
+        .selected
+        .expect("default role should be selected");
+    assert_eq!(picker.filtered[selected].key(), "chainargos/agent-smith");
     Ok(())
 }
 
@@ -2663,14 +2689,22 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
          got {outcome:?}"
     );
 
-    // Sanity: the surviving workspace still resolves.
+    // Sanity: the surviving workspace still resolves into the picker flow.
     let alive = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("survivor-ws".into()),
     )?;
-    let (role, _ws, _agent) = alive.expect("survivor-ws must still resolve");
-    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(
+        alive.is_none(),
+        "survivor-ws must still resolve into the inline picker"
+    );
+    let ConsoleStage::Manager(ms) = &state.stage;
+    let picker = ms
+        .inline_role_picker
+        .as_ref()
+        .expect("survivor-ws must open the inline picker");
+    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Console workspace launches now always stop on the sidebar role picker before starting a session, even when only one role is eligible. Operators get an explicit confirmation point for single-role workspaces, while default and last-used roles still help by preselecting the highlighted row; the console, workspace, guide, and concepts docs now describe that behavior.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin codex/confirm-role-picker-before-launch:refs/remotes/origin/codex/confirm-role-picker-before-launch
git checkout -B codex/confirm-role-picker-before-launch refs/remotes/origin/codex/confirm-role-picker-before-launch
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --all-targets
```

### Tests

```sh
cargo nextest run --all-features
```

### User smoke

```sh
export JACKIN_VERIFY_HOME="$PWD/.verify-home/confirm-role-picker"
rm -rf "$JACKIN_VERIFY_HOME"
mkdir -p "$JACKIN_VERIFY_HOME/.config/jackin/workspaces"
cat > "$JACKIN_VERIFY_HOME/.config/jackin/config.toml" <<'TOML'
version = "v1alpha2"

[roles.the-architect]
git = "https://github.com/jackin-project/jackin-the-architect.git"
trusted = true
TOML
cat > "$JACKIN_VERIFY_HOME/.config/jackin/workspaces/single-role.toml" <<TOML
version = "v1alpha2"
workdir = "$PWD"
allowed_roles = ["the-architect"]
last_role = "the-architect"

[[mounts]]
src = "$PWD"
dst = "$PWD"
readonly = false
isolation = "shared"
TOML
HOME="$JACKIN_VERIFY_HOME" cargo run --bin jackin -- console --debug
```

In the console, highlight `single-role`, press Enter once, and confirm the left sidebar changes to the role picker with `the-architect` highlighted instead of launching immediately. Press Esc to return to the workspace list.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run build
bun run check:repo-links
bunx --bun tsc --noEmit
bun test
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/commands/console/**  
UPDATED page. The console launch description should say every workspace row opens the role picker, including single-role workspaces.

**http://localhost:4321/commands/workspace/**  
UPDATED page. The `--default-role` option should describe picker preselection and CLI context loading, not silent console launch.

**http://localhost:4321/getting-started/concepts/**  
UPDATED page. The Workspaces section should describe default role as console preselection plus CLI context loading, not automatic console launch.

**http://localhost:4321/guides/workspaces/**  
UPDATED page. The role-restriction guidance should describe `--default-role` as highlighting the console picker row and helping CLI context loading.

## Migration notes

None.
