### PR TITLE
fix(console): auto-select single role; Q quits from role picker; tighten checkbox spacing

### DIFF
--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -331,6 +331,7 @@ pub(super) fn handle_inline_role_picker(
             scroll_list_horizontal(state, 8);
             InputOutcome::Continue
         }
+        KeyCode::Char('q' | 'Q') => InputOutcome::ExitJackin,
         _ => match picker.handle_key(key) {
             ModalOutcome::Commit(role) => {
                 state.inline_role_picker = None;

--- a/src/console/manager/render/editor.rs
+++ b/src/console/manager/render/editor.rs
@@ -686,7 +686,7 @@ fn render_roles_tab(
         let check = if effectively_allowed { "[x]" } else { "[ ]" };
         let star = if is_default { "★" } else { " " };
         let prefix = if selected { "▸ " } else { "  " };
-        let text = format!("{prefix}{check}  {star} {role_name}");
+        let text = format!("{prefix}{check} {star} {role_name}");
         let style = if selected {
             Style::default()
                 .fg(PHOSPHOR_GREEN)

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -70,6 +70,11 @@ impl ConsoleState {
             }
             self.pending_launch = None;
             self.pending_launch_role = None;
+        } else if roles.len() == 1 {
+            // Single role — skip picker and proceed directly to agent selection.
+            let role = roles.into_iter().next().unwrap();
+            return preview::resolve_selected_workspace(config, cwd, &choice, &role)
+                .map(|workspace| Some((role, workspace, None)));
         } else {
             let selected = preferred_agent_index(
                 &roles,

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -2483,24 +2483,19 @@ fn launch_after_create_workspace_uses_fresh_data() -> Result<()> {
     }
 
     // Dispatch a launch against the freshly-created name. The dispatcher
-    // must build the choice from the current `config` and open the picker
-    // for that workspace even though `ConsoleState` was created earlier.
+    // must build the choice from the current `config` and auto-select the
+    // single role, proving it reads fresh data rather than a startup snapshot.
     let outcome = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("freshly-created".into()),
     )?;
-    assert!(
-        outcome.is_none(),
-        "freshly-created workspace must resolve into an inline picker; under the bug, \
-         ConsoleState.workspaces was a startup snapshot and didn't include the new name"
+    let (role, _workspace, agent) = outcome.expect(
+        "freshly-created workspace must auto-select and return directly; under the bug, \
+         ConsoleState.workspaces was a startup snapshot and didn't include the new name",
     );
-    let ConsoleStage::Manager(ms) = &state.stage;
-    let picker = ms
-        .inline_role_picker
-        .as_ref()
-        .expect("freshly-created workspace must open the inline picker");
-    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
+    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(agent.is_none());
     Ok(())
 }
 
@@ -2531,23 +2526,17 @@ fn launch_after_rename_uses_new_name() -> Result<()> {
         config = ce.save()?;
     }
 
-    // Dispatch against the new name — must resolve and open the picker
-    // for confirmation (single eligible role + default_role set).
+    // Dispatch against the new name — must resolve and auto-select the
+    // single eligible role, proving the dispatcher uses the new name.
     let outcome = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("renamed-ws".into()),
     )?;
-    assert!(
-        outcome.is_none(),
-        "renamed workspace must resolve under the new name and stay in the picker flow"
-    );
-    let ConsoleStage::Manager(ms) = &state.stage;
-    let picker = ms
-        .inline_role_picker
-        .as_ref()
-        .expect("renamed workspace must open the inline picker");
-    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
+    let (role, _workspace, agent) = outcome
+        .expect("renamed workspace must resolve under the new name and auto-select the role");
+    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(agent.is_none());
 
     // OLD name must not resolve — under the snapshot bug it did.
     let stale_outcome = state.dispatch_launch_for_workspace(
@@ -2686,22 +2675,16 @@ fn launch_after_delete_workspace_does_not_resolve_old_choice() -> Result<()> {
          got {outcome:?}"
     );
 
-    // Sanity: the surviving workspace still resolves into the picker flow.
+    // Sanity: the surviving workspace still resolves and auto-selects its single role.
     let alive = state.dispatch_launch_for_workspace(
         &config,
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("survivor-ws".into()),
     )?;
-    assert!(
-        alive.is_none(),
-        "survivor-ws must still resolve into the inline picker"
-    );
-    let ConsoleStage::Manager(ms) = &state.stage;
-    let picker = ms
-        .inline_role_picker
-        .as_ref()
-        .expect("survivor-ws must open the inline picker");
-    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
+    let (role, _workspace, agent) =
+        alive.expect("survivor-ws must still resolve and auto-select its role");
+    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(agent.is_none());
     Ok(())
 }
 

--- a/tests/manager_flow.rs
+++ b/tests/manager_flow.rs
@@ -1446,8 +1446,7 @@ fn agent_picker_opens_with_default_agent_preselected() -> Result<()> {
     Ok(())
 }
 
-/// Exactly one eligible role still opens the picker so the operator confirms
-/// the role before launch.
+/// Exactly one eligible role skips the picker and returns the role directly.
 #[test]
 fn agent_picker_opens_when_single_eligible_agent() -> Result<()> {
     let temp = tempdir()?;
@@ -1461,17 +1460,15 @@ fn agent_picker_opens_when_single_eligible_agent() -> Result<()> {
         cwd,
         jackin::workspace::LoadWorkspaceInput::Saved("multi-role-ws".into()),
     )?;
-    assert!(
-        outcome.is_none(),
-        "single eligible role must open the picker, not direct-launch"
-    );
+    let (role, _workspace, agent) = outcome
+        .expect("single eligible role must auto-select and return directly, not open picker");
+    assert_eq!(role.key(), "chainargos/agent-smith");
+    assert!(agent.is_none(), "agent must not be pre-selected");
     let ConsoleStage::Manager(ms) = &state.stage;
-    let picker = ms
-        .inline_role_picker
-        .as_ref()
-        .expect("single eligible role must open the inline picker");
-    assert_eq!(picker.roles.len(), 1);
-    assert_eq!(picker.filtered[0].key(), "chainargos/agent-smith");
+    assert!(
+        ms.inline_role_picker.is_none(),
+        "picker must not be open after single-role auto-select"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- **Auto-select single role**: when a workspace has exactly one eligible role, `dispatch_launch_for_workspace` now skips the role picker entirely and proceeds directly to agent selection. No point making the operator confirm the only available option.
- **Q in inline role picker**: `KeyCode::Char('q' | 'Q')` was falling through to `picker.handle_key`, which treats every printable char as a filter input. This appended `'q'` to the filter, emptied the visible list, and left the screen in a broken state with no exit path. Added an explicit intercept arm returning `ExitJackin` before the `_` fallthrough — consistent with Q behaviour everywhere else in the manager.
- **Checkbox spacing**: Double space between `[x]`/`[ ]` and the default-role star in the roles editor tab reduced to one space.

## Hard-rule callout

No schema changes. No host-side mutations.

## What's deferred

Nothing.

## Verify locally

```bash
cargo run --bin jackin -- console --debug
```

- Navigate to a workspace with exactly one role → Enter skips straight to agent selection without showing the role picker.
- Open a workspace with multiple roles → inline role picker appears → press Q → TUI exits cleanly.
- Open workspace editor → Roles tab → checkbox column is `[x] ★ name` not `[x]  ★ name`.

## Migration notes

None.