### PR TITLE
fix(tui): proportional scrollbar thumb via direct scroll offset

### DIFF
--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -276,9 +276,8 @@ pub(super) fn render_horizontal_scrollbar(
     if viewport == 0 || content_width <= viewport {
         return;
     }
-    let position = scrollbar_position(content_width, viewport, scroll_x);
     let mut state = ScrollbarState::new(content_width)
-        .position(position)
+        .position(usize::from(scroll_x))
         .viewport_content_length(viewport);
     let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
         .begin_symbol(None)
@@ -374,9 +373,8 @@ pub(super) fn render_vertical_scrollbar(
     if viewport == 0 || content_height <= viewport {
         return;
     }
-    let position = scrollbar_position(content_height, viewport, scroll_y);
     let mut state = ScrollbarState::new(content_height)
-        .position(position)
+        .position(usize::from(scroll_y))
         .viewport_content_length(viewport);
     let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .begin_symbol(None)
@@ -440,15 +438,6 @@ pub(super) fn render_scrollable_block(
     );
     render_horizontal_scrollbar(frame, area, content_width, eff_x);
     render_vertical_scrollbar(frame, area, content_height, eff_y);
-}
-
-fn scrollbar_position(content_width: usize, viewport: usize, scroll_x: u16) -> usize {
-    let scroll_x = usize::from(effective_scroll_x(content_width, viewport, scroll_x));
-    let max_scroll = content_width.saturating_sub(viewport);
-    scroll_x
-        .saturating_mul(content_width.saturating_sub(1))
-        .checked_div(max_scroll)
-        .unwrap_or(0)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -945,19 +934,7 @@ pub(super) fn centered_rect_fixed(outer: Rect, pct_w: u16, rows: u16) -> Rect {
 
 #[cfg(test)]
 mod horizontal_scrollbar_tests {
-    use super::{clamp_scroll_x, scrollbar_position};
-
-    #[test]
-    fn text_scroll_end_maps_to_scrollbar_end() {
-        assert_eq!(scrollbar_position(100, 60, 0), 0);
-        assert_eq!(scrollbar_position(100, 60, 20), 49);
-        assert_eq!(scrollbar_position(100, 60, 40), 99);
-    }
-
-    #[test]
-    fn scrollbar_position_clamps_overscroll_to_end() {
-        assert_eq!(scrollbar_position(100, 60, 400), 99);
-    }
+    use super::clamp_scroll_x;
 
     #[test]
     fn stored_scroll_offset_clamps_to_visible_end() {


### PR DESCRIPTION
## Summary

Scrollbar thumbs in the workspace detail panel now move proportionally — a small thumb means a lot to scroll, a large thumb means a little — matching browser scrollbar semantics. The old `scrollbar_position` helper remapped the scroll offset into the full content-length range before handing it to ratatui, which caused ratatui to place the thumb at `position / content_length` of the bar. Blocks with few scrollable steps (Mounts, with max_scroll = 2) jumped the thumb by roughly half the bar per keypress; blocks with many scrollable steps (Global mounts) felt smooth by accident. Removing the remapping and passing the raw scroll offset directly lets ratatui compute thumb size from `viewport_content_length / content_length`, fixing both the jump and the inconsistency across blocks.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jackin-jackin-thearchitect-6x8h5ecc:refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-6x8h5ecc
git checkout -B jackin/scratch/jackin-jackin-thearchitect-6x8h5ecc refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-6x8h5ecc
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run -E 'test(horizontal_scrollbar)'
cargo nextest run --all-features
```

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Select the `jackin` workspace (or any workspace with a small number of mounts). Navigate right to focus the detail panel, then press `↓`/`↑` inside the **Mounts** block. The scrollbar thumb should move by a small, proportional step per keypress — not jump to the end. Compare with the **Global mounts** block: both should now scroll smoothly with thumb size inversely proportional to the amount of content.
