### PR TITLE
feat(naming+prune): jk- prefix, id-first naming, jackin prune command

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
             { label: 'eject', slug: 'commands/eject' },
             { label: 'exile', slug: 'commands/exile' },
             { label: 'purge', slug: 'commands/purge' },
+            { label: 'prune', slug: 'commands/prune' },
             { label: 'workspace', slug: 'commands/workspace' },
             { label: 'config', slug: 'commands/config' },
             { label: 'role', slug: 'commands/role' },
@@ -137,6 +138,7 @@ export default defineConfig({
           items: [
             { label: 'Architecture', slug: 'reference/architecture' },
             { label: 'Runtime Instance Model', slug: 'reference/runtime-instance-model' },
+            { label: 'Instance and Resource Naming', slug: 'reference/instance-resource-naming' },
             { label: 'Configuration File', slug: 'reference/configuration' },
             { label: 'Schema Versions', slug: 'reference/schema-versions' },
             { label: 'Codebase Map', slug: 'reference/codebase-map' },

--- a/docs/src/content/docs/commands/eject.mdx
+++ b/docs/src/content/docs/commands/eject.mdx
@@ -41,7 +41,7 @@ jackin eject agent-smith --purge
 jackin eject k7p9m2xq
 
 # Stop a specific container by name
-jackin eject jackin-agentsmith-k7p9m2xq
+jackin eject jk-k7p9m2xq-agentsmith
 ```
 
 ## What gets cleaned up

--- a/docs/src/content/docs/commands/eject.mdx
+++ b/docs/src/content/docs/commands/eject.mdx
@@ -49,6 +49,7 @@ jackin eject jk-k7p9m2xq-agentsmith
 When you eject an agent:
 - The agent container is stopped and removed
 - The DinD sidecar container is stopped and removed
+- The TLS certs volume (`{container}-dind-certs`) is removed
 - The per-agent Docker network is removed
 
 When you add `--purge`:

--- a/docs/src/content/docs/commands/hardline.mdx
+++ b/docs/src/content/docs/commands/hardline.mdx
@@ -19,7 +19,7 @@ When `SELECTOR` is omitted, `jackin hardline` resolves the current saved workspa
 
 | Argument | Required | Description |
 |---|---|---|
-| `SELECTOR` | No | Role selector (e.g., `agent-smith`), instance ID, or full container name (e.g., `jackin-agent-smith-k7p9m2xq`) |
+| `SELECTOR` | No | Role selector (e.g., `agent-smith`), instance ID, or full container name (e.g., `jk-k7p9m2xq-agentsmith`) |
 
 ## Options
 
@@ -84,7 +84,7 @@ jackin hardline --new
 jackin hardline --new --agent codex k7p9m2xq
 
 # Reconnect to a specific container by name
-jackin hardline jackin-agent-smith-k7p9m2xq
+jackin hardline jk-k7p9m2xq-agentsmith
 
 # Reconnect to a namespaced agent
 jackin hardline chainargos/backend-engineer

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -1,0 +1,111 @@
+---
+title: jackin prune
+description: "Delete cached or stale jackin data in bulk"
+---
+
+## Synopsis
+
+```bash
+jackin prune <SUBCOMMAND>
+```
+
+`jackin prune` removes cached or stale data that jackin manages on your host machine. Unlike `jackin purge`, which targets a specific instance by selector, `prune` operates in bulk across a category of data.
+
+## Subcommands
+
+| Subcommand | What it removes |
+|---|---|
+| `roles` | Cached role repositories |
+| `cache` | Shared caches (terminfo, version-check results) |
+| `images` | Unused jackin-managed Docker images |
+| `instances` | On-disk state for terminated instances |
+| `all` | All of the above, in order |
+
+## `jackin prune roles`
+
+```bash
+jackin prune roles
+```
+
+Removes the local role-repo cache. Role repos are re-cloned automatically the next time a role that uses them is launched.
+
+## `jackin prune cache`
+
+```bash
+jackin prune cache
+```
+
+Removes the shared cache directory, including compiled terminfo entries and version-check results. All caches regenerate automatically on the next jackin invocation that needs them.
+
+## `jackin prune images`
+
+```bash
+jackin prune images
+```
+
+Removes `jk-*` Docker images that have no containers — running or stopped — that depend on them. Images still in use by any container are skipped silently. Because Docker images are rebuilt from the role Dockerfile on the next `jackin load`, removing an unused image does not lose any data.
+
+## `jackin prune instances`
+
+```bash
+jackin prune instances
+```
+
+Removes on-disk state and index entries for instances in terminal statuses:
+
+| Status | Pruned? |
+|---|---|
+| `clean_exited` | Yes |
+| `superseded` | Yes |
+| `failed_setup` | Yes |
+| `purged` (tombstones) | Yes — cleared from the index |
+| `crashed` | No — use `jackin eject <selector> --purge` |
+| `preserved_dirty` | No — instance has uncommitted changes |
+| `preserved_unpushed` | No — instance has unpushed commits |
+| `restore_available` | No — local state is still recoverable |
+| `active` / `running` | No — instance is live |
+
+Instances that cannot be pruned because Docker resources are still present are listed with a suggestion to use `jackin eject <selector> --purge` instead.
+
+## `jackin prune all`
+
+```bash
+jackin prune all [--yes]
+```
+
+Runs all four subcommands in order: `instances` → `images` → `roles` → `cache`. Prompts for confirmation before proceeding unless `--yes` is passed.
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--yes`, `-y` | Skip the confirmation prompt |
+
+## Examples
+
+```bash
+# Free up disk space from terminated instances
+jackin prune instances
+
+# Remove Docker images that are no longer used by any container
+jackin prune images
+
+# Remove cloned role repos (will be re-cloned on next launch)
+jackin prune roles
+
+# Full cleanup in one command
+jackin prune all
+
+# Non-interactive full cleanup (for scripts)
+jackin prune all --yes
+```
+
+## What `prune` does not touch
+
+- **Running instances** — containers that are currently attached or running are never stopped or purged by `prune`.
+- **Stopped instances with recovery state** — instances with status `restore_available`, `crashed`, `preserved_dirty`, or `preserved_unpushed` are skipped. Use `jackin hardline` to reconnect or `jackin eject <selector> --purge` to explicitly remove them.
+- **Operator config** — `~/.config/jackin/config.toml` and saved workspaces are never modified by `prune`.
+
+## Relationship to `jackin purge`
+
+`jackin purge` targets a single instance by selector and requires an explicit role, instance ID, or container name. `jackin prune instances` does the same job in bulk for every instance already in a terminal state, without requiring the operator to name each one.

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -59,7 +59,7 @@ Removes on-disk state and index entries for instances in terminal statuses:
 | `superseded` | Yes |
 | `failed_setup` | Yes |
 | `purged` (tombstones) | Yes — cleared from the index |
-| `crashed` | No — use `jackin eject <selector> --purge` |
+| `crashed` | No — not a terminal status; use `jackin eject <selector> --purge` to remove |
 | `preserved_dirty` | No — instance has uncommitted changes |
 | `preserved_unpushed` | No — instance has unpushed commits |
 | `restore_available` | No — local state is still recoverable |

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -43,7 +43,7 @@ Removes the shared cache directory, including compiled terminfo entries and vers
 jackin prune images
 ```
 
-Removes `jk-*` Docker images that have no containers — running or stopped — that depend on them. Images still in use by any container are skipped silently. Because Docker images are rebuilt from the role Dockerfile on the next `jackin load`, removing an unused image does not lose any data.
+Removes `jk-*` Docker images that have no containers — running or stopped — that depend on them. Images still in use by any container are skipped; the final summary reports the count of images removed and skipped. Because Docker images are rebuilt from the role Dockerfile on the next `jackin load`, removing an unused image does not lose any data.
 
 ## `jackin prune instances`
 

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -59,7 +59,7 @@ Removes on-disk state and index entries for instances in terminal statuses:
 | `superseded` | Yes |
 | `failed_setup` | Yes |
 | `purged` (tombstones) | Yes — cleared from the index |
-| `crashed` | No — not a terminal status; use `jackin eject <selector> --purge` to remove |
+| `crashed` | No — has Docker resources present; use `jackin eject <selector> --purge` to remove |
 | `preserved_dirty` | No — instance has uncommitted changes |
 | `preserved_unpushed` | No — instance has unpushed commits |
 | `restore_available` | No — local state is still recoverable |

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -43,7 +43,7 @@ Removes the shared cache directory, including compiled terminfo entries and vers
 jackin prune images
 ```
 
-Removes `jk-*` Docker images that have no containers — running or stopped — that depend on them. Images still in use by any container are skipped; the final summary reports the count of images removed and skipped. Because Docker images are rebuilt from the role Dockerfile on the next `jackin load`, removing an unused image does not lose any data.
+Removes `jk_*` Docker images that have no role containers — running or stopped — that depend on them. Images still in use by a role container are skipped; the final summary reports the count of images removed and skipped. Because Docker images are rebuilt from the role Dockerfile on the next `jackin load`, removing an unused image does not lose any data.
 
 ## `jackin prune instances`
 
@@ -59,7 +59,7 @@ Removes on-disk state and index entries for instances in terminal statuses:
 | `superseded` | Yes |
 | `failed_setup` | Yes |
 | `purged` (tombstones) | Yes — cleared from the index |
-| `crashed` | No — has Docker resources present; use `jackin eject <selector> --purge` to remove |
+| `crashed` | No — has recoverable state; use `jackin hardline <selector>` to return or `jackin eject <selector> --purge` to discard |
 | `preserved_dirty` | No — instance has uncommitted changes |
 | `preserved_unpushed` | No — instance has unpushed commits |
 | `restore_available` | No — local state is still recoverable |

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -85,7 +85,8 @@ Every fresh launch gets a unique DNS-safe instance identity. Existing running or
 
 1. the agent container
 2. the DinD sidecar
-3. the per-agent network
+3. the TLS certs volume (`{container}-dind-certs`)
+4. the per-agent network
 
 Persisted state remains unless you also purge it.
 

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -138,7 +138,7 @@ On first worktree creation for a host repo, jackin' enables `extensions.worktree
 Materialized isolated mounts are recorded at:
 
 ```
-<data_dir>/jk-<container>/.jackin/isolation.json
+<data_dir>/<container>/.jackin/isolation.json
 ```
 
 The file lives next to the per-container agent state and `.jackin/` metadata and is the source of truth for `purge` after the operator has changed (or removed) the workspace config. Each record contains at least:

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -137,7 +137,7 @@ On first worktree creation for a host repo, jackin' enables `extensions.worktree
 Materialized isolated mounts are recorded at:
 
 ```
-<data_dir>/jackin-<container>/.jackin/isolation.json
+<data_dir>/jk-<container>/.jackin/isolation.json
 ```
 
 The file lives next to the per-container agent state and `.jackin/` metadata and is the source of truth for `purge` after the operator has changed (or removed) the workspace config. Each record contains at least:
@@ -174,9 +174,9 @@ The same finalizer runs after `hardline` attaches, so the cleanup decision is in
 ```
 ~/.jackin/
 ├── roles/                         # Cached role repos
-│   └── github.com/
-│       └── jackin-project/
-│           └── jackin-agent-smith/
+│   ├── agent-smith/               # Flat role (no namespace)
+│   └── chainargos/                # Namespace directory
+│       └── agent-brown/           # Namespaced role
 ├── cache/                         # Shared caches (terminfo, version checks)
 │   └── terminfo/
 ├── data/

--- a/docs/src/content/docs/reference/codebase-map.mdx
+++ b/docs/src/content/docs/reference/codebase-map.mdx
@@ -79,7 +79,7 @@ Instance-local state helpers live in `src/instance/`:
 
 - <RepoFile path="src/instance/mod.rs" /> — role state preparation and auth materialization re-exports.
 - <RepoFile path="src/instance/auth.rs" /> — Claude, Codex, Amp, OpenCode, and GitHub auth file provisioning.
-- <RepoFile path="src/instance/naming.rs" /> — DNS-safe container name generation (`jk-{id}-{workspace?}-{role}`), image tag derivation, instance-ID extraction, and role-family matching.
+- <RepoFile path="src/instance/naming.rs" /> — DNS-safe container name generation (`jk-{id}-{workspace?}-{role}`), instance-ID extraction, and role-family matching. Image tag derivation (`jk_…`) lives in <RepoFile path="src/runtime/naming.rs" />.
 - <RepoFile path="src/instance/manifest.rs" /> — per-instance `instance.json` identity records, lifecycle status, and the rebuildable `instances.json` lookup index.
 
 The end-to-end shape of "what happens when you run `jackin load`" is

--- a/docs/src/content/docs/reference/codebase-map.mdx
+++ b/docs/src/content/docs/reference/codebase-map.mdx
@@ -45,6 +45,7 @@ Start at <RepoFile path="src/cli/mod.rs" /> — the top-level `Cli` and
 | `load` / `hardline` / `console` | <RepoFile path="src/cli/role.rs" /> |
 | `role` | <RepoFile path="src/cli/role.rs" /> and <RepoFile path="src/role_authoring.rs" /> |
 | `eject` / `purge` | <RepoFile path="src/cli/cleanup.rs" /> |
+| `prune` | <RepoFile path="src/cli/prune.rs" /> |
 | `workspace` | <RepoFile path="src/cli/workspace.rs" /> |
 | `config` | <RepoFile path="src/cli/config.rs" /> |
 | `exile` (unit variant) | <RepoFile path="src/cli/mod.rs" /> |
@@ -67,7 +68,7 @@ The container lifecycle lives in `src/runtime/`:
 - <RepoFile path="src/runtime/attach.rs" /> — the attach + reconnect path
   (`hardline`).
 - <RepoFile path="src/runtime/cleanup.rs" /> — `eject`, `exile`, `purge`,
-  and orphan GC.
+  `prune` (roles/cache/images/instances), and orphan GC.
 - <RepoFile path="src/runtime/image.rs" /> — `docker build` invocation.
 - <RepoFile path="src/runtime/repo_cache.rs" /> — the role-repo cache lock
   + fetch logic.

--- a/docs/src/content/docs/reference/codebase-map.mdx
+++ b/docs/src/content/docs/reference/codebase-map.mdx
@@ -78,7 +78,7 @@ Instance-local state helpers live in `src/instance/`:
 
 - <RepoFile path="src/instance/mod.rs" /> — role state preparation and auth materialization re-exports.
 - <RepoFile path="src/instance/auth.rs" /> — Claude, Codex, Amp, OpenCode, and GitHub auth file provisioning.
-- <RepoFile path="src/instance/naming.rs" /> — role image names, legacy name matching, and DNS-safe unique container names.
+- <RepoFile path="src/instance/naming.rs" /> — DNS-safe container name generation (`jk-{id}-{workspace?}-{role}`), image tag derivation, instance-ID extraction, and role-family matching.
 - <RepoFile path="src/instance/manifest.rs" /> — per-instance `instance.json` identity records, lifecycle status, and the rebuildable `instances.json` lookup index.
 
 The end-to-end shape of "what happens when you run `jackin load`" is

--- a/docs/src/content/docs/reference/instance-resource-naming.mdx
+++ b/docs/src/content/docs/reference/instance-resource-naming.mdx
@@ -69,41 +69,43 @@ DNS-sensitive environment variables (`DOCKER_HOST`, `JACKIN_DIND_HOSTNAME`, `DOC
 The Docker image is built once per role and rebuilt only when the role changes. It is stable across sessions.
 
 ```text
-Namespaced role:  jk-{namespace}_{role-name}
-Flat role:        jk-{role-name}
+Namespaced role:  jk_{namespace}_{role-name}
+Flat role:        jk_{role-name}
 ```
 
-The underscore (`_`) separates namespace from role name. This is collision-safe: role segment names are validated to `[a-z0-9-]` only, so `_` can never appear in a role name and unambiguously marks the namespace boundary.
+All structural separators in image names are `_`. Role segment names are validated to `[a-z0-9-]` only, so `_` never appears in a role or namespace name — `_` always marks a structural boundary, never a word break inside a component.
 
 **Examples:**
 
 ```text
-jk-chainargos_agent-brown   ← chainargos/agent-brown
-jk-agent-smith              ← agent-smith (no namespace)
-jk-scentbird_the-architect  ← scentbird/the-architect
+jk_chainargos_agent-brown   ← chainargos/agent-brown
+jk_agent-smith              ← agent-smith (no namespace)
+jk_scentbird_the-architect  ← scentbird/the-architect
 ```
 
-**Collision safety:** `chainargos/agent-brown` produces `jk-chainargos_agent-brown` while a flat role literally named `chainargos-agent-brown` produces `jk-chainargos-agent-brown`. The underscore vs hyphen difference makes them distinct.
+**Collision safety:** `chainargos/agent-brown` produces `jk_chainargos_agent-brown` while a flat role literally named `chainargos-agent-brown` produces `jk_chainargos-agent-brown`. The underscore vs hyphen difference makes them distinct.
+
+**Image vs container names:** Container names use `jk-{id}-…` with `-` separators (required for DNS label validity). Image names use `jk_…` with `_` separators. Both start with `jk` but use a different delimiter, so they are visually distinct in `docker ps` and `docker images` output.
 
 ### Branch-specific build tags
 
-When a role is built from a specific branch (`jackin load --branch`), the image tag adds the branch slug after a second `_` separator:
+When a role is built from a specific branch (`jackin load --branch`), the image tag adds the branch slug after a `_` separator:
 
 ```text
-Namespaced role:  jk-{namespace}_{role-name}_{branch-slug}
-Flat role:        jk-{role-name}_{branch-slug}
+Namespaced role:  jk_{namespace}_{role-name}_{branch-slug}
+Flat role:        jk_{role-name}_{branch-slug}
 ```
 
-Branch slashes become dashes in the slug. The `_` between role slug and branch slug follows the same convention as the namespace separator — unambiguous because branch slugs contain only `[a-z0-9-]`.
+Branch slashes become dashes in the slug. All separators are `_` — unambiguous because branch slugs contain only `[a-z0-9-]`.
 
 **Examples:**
 
 ```text
-jk-the-architect_feat-my-pr          ← the-architect, branch feat/my-pr
-jk-chainargos_agent-brown_feat-my-pr ← chainargos/agent-brown, branch feat/my-pr
+jk_the-architect_feat-my-pr          ← the-architect, branch feat/my-pr
+jk_chainargos_agent-brown_feat-my-pr ← chainargos/agent-brown, branch feat/my-pr
 ```
 
-Branch-specific images do not replace the stable image — they coexist with `jk-the-architect` under a distinct tag.
+Branch-specific images do not replace the stable image — they coexist with `jk_the-architect` under a distinct tag.
 
 ## State directory
 

--- a/docs/src/content/docs/reference/instance-resource-naming.mdx
+++ b/docs/src/content/docs/reference/instance-resource-naming.mdx
@@ -1,0 +1,165 @@
+---
+title: Instance and Resource Naming
+description: Contributor reference for how jackin names containers, images, derived Docker resources, on-disk state, lock files, and role repos.
+---
+
+import RepoFile from '../../../components/RepoFile.astro';
+
+All naming logic lives in <RepoFile path="src/instance/naming.rs" /> (container names, instance IDs, role-family matching) and <RepoFile path="src/runtime/naming.rs" /> (image tags, derived resource names, display formatting).
+
+## Container name
+
+Every fresh launch claims a unique, DNS-safe container name:
+
+```text
+jk-{instance_id}-{workspace_compact}-{role_compact}   ← saved workspace
+jk-{instance_id}-{role_compact}                       ← ad-hoc launch (no workspace)
+```
+
+**Components:**
+
+| Component | Value | Rules |
+|---|---|---|
+| `jk-` | Fixed prefix | Identifies all jackin-managed Docker resources |
+| `instance_id` | 8 chars | Crockford base32, cryptographically random, collision-resistant |
+| `workspace_compact` | Variable | Original workspace name with non-alphanumeric characters stripped, lowercased |
+| `role_compact` | Variable | Role name with non-alphanumeric characters stripped, lowercased |
+
+**Budget:** The total base name must fit within 58 characters so that `{base}-dind` stays within Docker's 63-character DNS label limit. The budget for workspace and role combined is `58 - 2 (jk) - 8 (id) - 3 (separators) = 45 characters`. If the two compact components together exceed 45 characters they are split evenly and each is truncated with a 4-character SHA-256 suffix to keep the result deterministic.
+
+**Examples:**
+
+```text
+jk-1vft0hkh-chainargosblockchainnodes-agentbrown
+  └─ workspace: chainargos-blockchain-nodes
+  └─ role:      agent-brown
+
+jk-1vft0hkh-agentbrown
+  └─ ad-hoc launch, no workspace
+
+jk-1vft0hkh-scentbird-thearchitect
+  └─ workspace: scentbird
+  └─ role:      the-architect
+```
+
+## Derived Docker resources
+
+Every container launch also creates three Docker resources derived by appending a suffix to the base name:
+
+```text
+Role container:  {base}
+DinD sidecar:    {base}-dind
+Docker network:  {base}-net
+TLS certs vol:   {base}-dind-certs
+```
+
+Example:
+
+```text
+jk-1vft0hkh-chainargosblockchainnodes-agentbrown
+jk-1vft0hkh-chainargosblockchainnodes-agentbrown-dind
+jk-1vft0hkh-chainargosblockchainnodes-agentbrown-net
+jk-1vft0hkh-chainargosblockchainnodes-agentbrown-dind-certs
+```
+
+DNS-sensitive environment variables (`DOCKER_HOST`, `JACKIN_DIND_HOSTNAME`, `DOCKER_TLS_SAN`, `NO_PROXY`, `no_proxy`, `TESTCONTAINERS_HOST_OVERRIDE`) use the DinD name as the hostname.
+
+## Docker image name
+
+The Docker image is built once per role and rebuilt only when the role changes. It is stable across sessions.
+
+```text
+Namespaced role:  jk-{namespace}_{role-name}
+Flat role:        jk-{role-name}
+```
+
+The underscore (`_`) separates namespace from role name. This is collision-safe: role segment names are validated to `[a-z0-9-]` only, so `_` can never appear in a role name and unambiguously marks the namespace boundary.
+
+**Examples:**
+
+```text
+jk-chainargos_agent-brown   ← chainargos/agent-brown
+jk-agent-smith              ← agent-smith (no namespace)
+jk-scentbird_the-architect  ← scentbird/the-architect
+```
+
+**Collision safety:** `chainargos/agent-brown` produces `jk-chainargos_agent-brown` while a flat role literally named `chainargos-agent-brown` produces `jk-chainargos-agent-brown`. The underscore vs hyphen difference makes them distinct.
+
+## State directory
+
+The per-instance state directory on the host always has the same name as the container:
+
+```text
+~/.jackin/data/{container_name}/
+```
+
+Example:
+
+```text
+~/.jackin/data/jk-1vft0hkh-chainargosblockchainnodes-agentbrown/
+```
+
+Set once at launch time, never renamed. The Docker container name and the state directory name are always identical — they are derived from the same string in <RepoFile path="src/instance/mod.rs" />.
+
+## Repo lock files
+
+The repo cache uses a stable per-role lock file to serialize concurrent git clone/fetch operations for the same role:
+
+```text
+~/.jackin/data/{namespace}_{role-name}.repo.lock
+~/.jackin/data/{namespace}_{role-name}.locks/
+```
+
+Example:
+
+```text
+~/.jackin/data/chainargos_agent-brown.repo.lock
+~/.jackin/data/chainargos_agent-brown.locks/
+```
+
+The same `_` separator as image names makes these stable across sessions and collision-safe between namespaced and flat selectors.
+
+## Roles cache
+
+Cloned role repos are cached under `~/.jackin/roles/` using the selector's namespace and name directly:
+
+```text
+~/.jackin/roles/{role-name}/           ← flat role
+~/.jackin/roles/{namespace}/{role-name}/ ← namespaced role
+```
+
+Example:
+
+```text
+~/.jackin/roles/agent-smith/
+~/.jackin/roles/chainargos/agent-brown/
+```
+
+## GitHub role repository names
+
+By convention, role repos on GitHub are named `jackin-{role-name}`. This is a GitHub naming convention only — it has no effect on Docker container names or image tags.
+
+```text
+https://github.com/ChainArgos/jackin-agent-brown
+https://github.com/jackin-project/jackin-the-architect
+https://github.com/jackin-project/jackin-agent-smith
+```
+
+When `jackin role new` scaffolds a new role repo, it creates the directory at:
+
+```text
+{projects_dir}/{namespace}/jackin-{role-name}   ← namespaced
+{projects_dir}/jackin-{role-name}               ← flat
+```
+
+## CLI selector formats
+
+`jackin hardline`, `jackin eject`, and `jackin purge` accept three forms:
+
+```text
+chainargos/agent-brown              ← role selector: finds running containers for this role
+jk-1vft0hkh-agentbrown             ← full container name: exact match
+1vft0hkh                           ← instance ID: resolved via the instance index
+```
+
+When a role selector matches exactly one running container, the command proceeds directly. When it matches multiple containers, jackin asks the operator to choose by showing each container's workspace or working directory.

--- a/docs/src/content/docs/reference/instance-resource-naming.mdx
+++ b/docs/src/content/docs/reference/instance-resource-naming.mdx
@@ -164,4 +164,4 @@ jk-1vft0hkh-agentbrown             ← full container name: exact match
 1vft0hkh                           ← instance ID: resolved via the instance index
 ```
 
-When a role selector matches exactly one running container, the command proceeds directly. When it matches multiple containers, jackin asks the operator to choose by showing each container's workspace or working directory.
+When a role selector matches exactly one running container, the command proceeds directly. When it matches multiple containers, the command fails with an error that lists the matching container names and asks the operator to pass a specific container name or instance ID instead.

--- a/docs/src/content/docs/reference/instance-resource-naming.mdx
+++ b/docs/src/content/docs/reference/instance-resource-naming.mdx
@@ -85,6 +85,26 @@ jk-scentbird_the-architect  ← scentbird/the-architect
 
 **Collision safety:** `chainargos/agent-brown` produces `jk-chainargos_agent-brown` while a flat role literally named `chainargos-agent-brown` produces `jk-chainargos-agent-brown`. The underscore vs hyphen difference makes them distinct.
 
+### Branch-specific build tags
+
+When a role is built from a specific branch (`jackin load --branch`), the image tag adds the branch slug after a second `_` separator:
+
+```text
+Namespaced role:  jk-{namespace}_{role-name}_{branch-slug}
+Flat role:        jk-{role-name}_{branch-slug}
+```
+
+Branch slashes become dashes in the slug. The `_` between role slug and branch slug follows the same convention as the namespace separator — unambiguous because branch slugs contain only `[a-z0-9-]`.
+
+**Examples:**
+
+```text
+jk-the-architect_feat-my-pr          ← the-architect, branch feat/my-pr
+jk-chainargos_agent-brown_feat-my-pr ← chainargos/agent-brown, branch feat/my-pr
+```
+
+Branch-specific images do not replace the stable image — they coexist with `jk-the-architect` under a distinct tag.
+
 ## State directory
 
 The per-instance state directory on the host always has the same name as the container:

--- a/docs/src/content/docs/reference/instance-resource-naming.mdx
+++ b/docs/src/content/docs/reference/instance-resource-naming.mdx
@@ -106,15 +106,17 @@ Set once at launch time, never renamed. The Docker container name and the state 
 The repo cache uses a stable per-role lock file to serialize concurrent git clone/fetch operations for the same role:
 
 ```text
-~/.jackin/data/{namespace}_{role-name}.repo.lock
+~/.jackin/data/{role-name}.repo.lock             ← flat role
+~/.jackin/data/{namespace}_{role-name}.repo.lock ← namespaced role
+~/.jackin/data/{role-name}.locks/
 ~/.jackin/data/{namespace}_{role-name}.locks/
 ```
 
 Example:
 
 ```text
+~/.jackin/data/agent-smith.repo.lock
 ~/.jackin/data/chainargos_agent-brown.repo.lock
-~/.jackin/data/chainargos_agent-brown.locks/
 ```
 
 The same `_` separator as image names makes these stable across sessions and collision-safe between namespaced and flat selectors.

--- a/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
+++ b/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
@@ -329,7 +329,7 @@ The decision to support both worktree mode (Option B) and clone mode is delibera
   [jackin] preserved isolated worktree for jk-k7p9m2xq-thearchitect:
            /.../.jackin/data/jk-k7p9m2xq-thearchitect/git/worktree/repo/workspace/jackin/jk-k7p9m2xq-thearchitect
            reason: uncommitted changes
-           run `jackin hardline the-architect` to return, inspect the path above directly, or `jackin purge the-architect` to discard
+           run `jackin hardline k7p9m2xq` to return, inspect the path above directly, or `jackin purge k7p9m2xq` to discard
   ```
 
   The `reason:` field reads `unpushed commits on a local branch` for the clean-tree-but-unpushed case.

--- a/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
+++ b/docs/src/content/docs/reference/roadmap/per-mount-isolation.mdx
@@ -57,10 +57,10 @@ The mode vocabulary is `shared | worktree | clone`. `shared` is the canonical sp
 
 Branch naming (Model B — full container name verbatim):
 
-- Instance: `jackin/scratch/jackin-thearchitect-k7p9m2xq`
-- Workspace-scoped instance: `jackin/scratch/jackin-myproject-thearchitect-a1b2c3d4`
+- Instance: `jackin/scratch/jk-k7p9m2xq-thearchitect`
+- Workspace-scoped instance: `jackin/scratch/jk-a1b2c3d4-myproject-thearchitect`
 
-The branch leaf is the **full container name verbatim**. Container names are workspace-unique by construction in <RepoFile path="src/instance/naming.rs" /> (random 8-char instance ID per launch), so the branch ref inherits that uniqueness without a separate derivation step. The trade-off is **trivial 1:1 mapping** (container → branch, no derivation logic, no instance-suffix stripping) at the cost of a mildly redundant `jackin-` prefix under the `jackin/scratch/` namespace. The branch intentionally says `scratch`: it is jackin-managed, disposable, and stable enough for recovery until the agent or operator renames it.
+The branch leaf is the **full container name verbatim**. Container names are workspace-unique by construction in <RepoFile path="src/instance/naming.rs" /> (random 8-char instance ID per launch), so the branch ref inherits that uniqueness without a separate derivation step. The trade-off is **trivial 1:1 mapping** (container → branch, no derivation logic, no instance-suffix stripping). The branch intentionally says `scratch`: it is jackin-managed, disposable, and stable enough for recovery until the agent or operator renames it.
 
 ## CLI Surface
 
@@ -122,8 +122,8 @@ Beyond the per-type validation:
 
 When the operator runs `jackin load <agent> <workspace>` and a workspace mount has `isolation = "worktree"`:
 
-1. **On the host, before the container starts**: `git worktree add` creates a per-container worktree under `<data_dir>/jackin-<container>/git/worktree/repo/<dst-tree>/<container>/`. The branch is `jackin/scratch/<container>` (Model B), branched from the host repo's current `HEAD`. A record is written to `<data_dir>/jackin-<container>/.jackin/isolation.json` so `purge` can clean up later even if the operator changes the workspace config.
-2. **Two override files are written** under `<data_dir>/jackin-<container>/git/overrides/<dst-tree>/`: a `.git` file pointing to `/jackin/host/<dst-tree>/.git/worktrees/<container>` and a `gitdir` back-pointer naming `<dst>/.git`. These exist because git stores **absolute paths** in worktree pointer files, and the absolute path that resolves on the host doesn't resolve inside the container — these two override files re-express the same relationships in container-side absolute paths.
+1. **On the host, before the container starts**: `git worktree add` creates a per-container worktree under `<data_dir>/<container>/git/worktree/repo/<dst-tree>/<container>/`. The branch is `jackin/scratch/<container>` (Model B), branched from the host repo's current `HEAD`. A record is written to `<data_dir>/<container>/.jackin/isolation.json` so `purge` can clean up later even if the operator changes the workspace config.
+2. **Two override files are written** under `<data_dir>/<container>/git/overrides/<dst-tree>/`: a `.git` file pointing to `/jackin/host/<dst-tree>/.git/worktrees/<container>` and a `gitdir` back-pointer naming `<dst>/.git`. These exist because git stores **absolute paths** in worktree pointer files, and the absolute path that resolves on the host doesn't resolve inside the container — these two override files re-express the same relationships in container-side absolute paths.
 3. **The container starts with four bind mounts** for the isolated mount: the worktree at `<dst>` (rw), the host repo's `.git/` at `/jackin/host/<dst-tree>/.git` (rw, includes the per-worktree admin entry at `worktrees/<container>/` natively), and the two override files (`:ro`, layered over the worktree's `.git` and the admin's `gitdir`).
 4. **Inside the container**, `git status`, `git log`, `git commit`, `git push` all work normally. The agent never sees the host's main checkout, only the per-container worktree. Commits go to the scratch branch, which is visible on the host immediately via `git branch -a` (refs and objects are shared with the host repo — that's the worktree contract).
 5. **On clean exit**, jackin' removes the worktree and scratch branch automatically when no work would be lost. Dirty/unpushed exits preserve the worktree on disk; the operator runs `jackin hardline` to return, inspects the printed worktree path directly, or runs `jackin purge` to discard.
@@ -132,10 +132,10 @@ The rest of this section drills into each step. For the rationale behind this sp
 
 ### Per-container state layout
 
-Worktrees live inside the existing per-container state tree, matching the flat `<data_dir>/jackin-<container>/` layout already in use for `.claude/`, `.jackin/`, and other per-agent state:
+Worktrees live inside the existing per-container state tree, matching the flat `<data_dir>/<container>/` layout already in use for `.claude/`, `.jackin/`, and other per-agent state:
 
 ```
-<data_dir>/jackin-<container>/
+<data_dir>/<container>/
   .claude/                # existing
   .jackin/                # existing
     isolation.json        # materialized isolated-mount state for purge/cd
@@ -191,7 +191,7 @@ For each isolated worktree, jackin' wires up:
 The two override files are jackin-owned and live alongside the materialized worktree on host. Per-mount on-disk layout groups all git-related artifacts for one mount under one dst-tree subtree:
 
 ```text
-<data_dir>/jackin-<container>/git/
+<data_dir>/<container>/git/
 ├── worktree/repo/<dst-stripped>/<container>/    ← the materialized worktree
 │                                                  (basename = container; the `repo/`
 │                                                  segment marks the subtree as
@@ -209,11 +209,11 @@ Host-side worktree files (`<wt>/.git` and `<host_repo>/.git/worktrees/<container
 For parallel containers loading isolation against the same host repo:
 
 ```text
-Container jackin-thearchitect-k7p9m2xq → admin: <host>/.git/worktrees/jackin-thearchitect-k7p9m2xq/
-Container jackin-thearchitect-a1b2c3d4 → admin: <host>/.git/worktrees/jackin-thearchitect-a1b2c3d4/
+Container jk-k7p9m2xq-thearchitect → admin: <host>/.git/worktrees/jk-k7p9m2xq-thearchitect/
+Container jk-a1b2c3d4-thearchitect  → admin: <host>/.git/worktrees/jk-a1b2c3d4-thearchitect/
 ```
 
-**Branch naming uses the full container name.** Branch ref = `jackin/scratch/<container>` (e.g. `jackin/scratch/jackin-thearchitect-k7p9m2xq`). Container name is the disambiguator because branch refs live in the host repo's shared `<host>/.git/refs/heads/` namespace and `git worktree add -b` fails hard on branch collisions (no auto-suffix like admin entries get). Includes the `jackin-` prefix because the container name is used verbatim — the prefix is mildly redundant under the `jackin/scratch/` namespace but the trade is **trivial 1:1 mapping** (container name → branch leaf, no derivation logic).
+**Branch naming uses the full container name.** Branch ref = `jackin/scratch/<container>` (e.g. `jackin/scratch/jk-k7p9m2xq-thearchitect`). Container name is the disambiguator because branch refs live in the host repo's shared `<host>/.git/refs/heads/` namespace and `git worktree add -b` fails hard on branch collisions (no auto-suffix like admin entries get). The trade is **trivial 1:1 mapping** (container name → branch leaf, no derivation logic).
 
 **Mount permissions, summarized.** The host `.git/` mount is read-write (refs, objects, HEAD/index/logs are all written under it on every commit/branch/fetch). Both override files are mounted **read-only** as defensive hardening: git only reads them during normal agent work, and a misbehaving agent could otherwise rewrite the worktree's `.git` pointer to redirect operations at a different gitdir entirely. The only legitimate writes to those files (`git worktree repair`, `git worktree move`, `git init` inside the worktree) are maintenance commands that have no place in normal agent workflows.
 
@@ -259,7 +259,7 @@ We can't replicate that absolute-path equivalence in a Docker container without 
 
 ### Option B — Indirect mount + `.git` pointer override (chosen)
 
-The worktree stays at `<data_dir>/jackin-<container>/git/worktree/repo/<dst-stripped>/<container>/` (jackin's data-dir-based layout, with the `worktree/repo/` segments marking the subtree as git-managed). The container sees the worktree at `<dst>` (matching operator expectations exactly). Three extra bind mounts make git work inside the container: one for the host's `.git/` at `/jackin/host/<dst-stripped>/.git` (which natively includes the per-worktree admin entry at `worktrees/<container>/`), plus two override files (the worktree's `.git` pointer and git's admin-dir back-pointer) so the gitdir relationship is consistent inside the container.
+The worktree stays at `<data_dir>/<container>/git/worktree/repo/<dst-stripped>/<container>/` (jackin's data-dir-based layout, with the `worktree/repo/` segments marking the subtree as git-managed). The container sees the worktree at `<dst>` (matching operator expectations exactly). Three extra bind mounts make git work inside the container: one for the host's `.git/` at `/jackin/host/<dst-stripped>/.git` (which natively includes the per-worktree admin entry at `worktrees/<container>/`), plus two override files (the worktree's `.git` pointer and git's admin-dir back-pointer) so the gitdir relationship is consistent inside the container.
 
 Why this fits jackin' specifically:
 
@@ -314,8 +314,8 @@ The decision to support both worktree mode (Option B) and clone mode is delibera
 - **Unsafe clean-exit cleanup** — if safe cleanup would lose work and stdin is interactive, jackin' asks what to do before deleting anything. The prompt wording branches on a `PreservedReason` discriminator so the operator sees the actual risk; for a dirty working tree:
 
   ```text
-  Isolated worktree for jackin-the-architect has uncommitted changes:
-    /.../.jackin/data/jackin-the-architect/git/worktree/repo/workspace/jackin/jackin-the-architect
+  Isolated worktree for jk-k7p9m2xq-thearchitect has uncommitted changes:
+    /.../.jackin/data/jk-k7p9m2xq-thearchitect/git/worktree/repo/workspace/jackin/jk-k7p9m2xq-thearchitect
 
   What do you want to do?
     1. Return to agent to address it
@@ -326,8 +326,8 @@ The decision to support both worktree mode (Option B) and clone mode is delibera
   For a clean tree with at least one local branch carrying unpushed commits the wording becomes "has unpushed commits on a local branch" instead — same three actions, but the operator no longer sees "uncommitted changes" alongside a tree that obviously has none. Returning to the agent means restarting the just-exited container before teardown, attaching again, and retrying safe cleanup after the agent exits again. This works the same whether the foreground session came from `load`, `launch`, `hardline`, or a future console UI. Preserving means leaving the stopped container/DinD recovery state and isolated worktree in place so `jackin hardline <container>` can return to it later, the operator can inspect the preserved worktree directly on disk (path printed in the warning), and `jackin purge <container>` can discard it. Force delete uses the same destructive cleanup path as `purge` for the selected isolated worktree and runtime state. If stdin is non-interactive, jackin' preserves the recovery state, prints the worktree path plus the per-reason phrasing, and tells the operator how to return, inspect, or discard. This lives behind a shared runtime finalization helper rather than only inside <RepoFile path="src/runtime/launch.rs" />; <RepoFile path="src/runtime/attach.rs" /> calls the same helper after `hardline` attaches. Non-interactive warning shape:
 
   ```text
-  [jackin] preserved isolated worktree for jackin-the-architect:
-           /.../.jackin/data/jackin-the-architect/git/worktree/repo/workspace/jackin/jackin-the-architect
+  [jackin] preserved isolated worktree for jk-k7p9m2xq-thearchitect:
+           /.../.jackin/data/jk-k7p9m2xq-thearchitect/git/worktree/repo/workspace/jackin/jk-k7p9m2xq-thearchitect
            reason: uncommitted changes
            run `jackin hardline the-architect` to return, inspect the path above directly, or `jackin purge the-architect` to discard
   ```
@@ -363,9 +363,9 @@ Ship:
 - Runtime source-drift guard: `load` errors when a saved workspace mount reuses a materialized isolated `dst` with a different `src`; CLI/TUI workspace edits should detect the same drift before saving and ask whether to delete preserved state or cancel. Non-interactive edits require `--delete-isolated-state` to delete affected preserved state.
 - Clean-exit cleanup deletes clean worktrees automatically when no commits would be lost, including clean branches whose local commits are already reachable from their upstream/remote tracking branch. Preserved states use `active | preserved_dirty | preserved_unpushed`; successful cleanup removes the state record.
 - `extensions.worktreeConfig` enabled on the host repo on first worktree creation.
-- For each isolated worktree, **four** bind mounts wired up at Docker run time so git works inside the container: the worktree at `<dst>` (rw), host's `.git/` at `/jackin/host/<dst-stripped>/.git` (rw, includes the per-worktree admin dir natively), plus two jackin-owned `:ro` override files (replacement `.git` pointer at `<dst>/.git`, replacement back-pointer at the admin's `gitdir`). The override files live at `<data_dir>/jackin-<container>/git/overrides/<dst-stripped>/{.git,gitdir}` with filenames matching their docker mount destinations. The materialized worktree lives at `<data_dir>/jackin-<container>/git/worktree/repo/<dst-stripped>/<container>/` — `repo/` marks the subtree as git-managed, `<container>` basename ensures globally unique admin entries in the host repo's `.git/worktrees/`. See [Container-side mount layout](#host-side-materialization) and [Design Decision: Worktree Materialization Layout](#design-decision-worktree-materialization-layout).
-- For each isolated clone, one bind mount is enough: the materialized clone at `<data_dir>/jackin-<container>/git/clone/repo/<dst-stripped>/<container>/` is mounted at `<dst>` (rw). The clone carries its own `.git/`, so no host `.git/` auxiliary mounts or override files are needed.
-- Branch naming uses the full container name verbatim: `jackin/scratch/<container>` (e.g. `jackin/scratch/jackin-thearchitect-k7p9m2xq`). Globally unique by construction; trivial container → branch mapping; no instance-suffix derivation logic.
+- For each isolated worktree, **four** bind mounts wired up at Docker run time so git works inside the container: the worktree at `<dst>` (rw), host's `.git/` at `/jackin/host/<dst-stripped>/.git` (rw, includes the per-worktree admin dir natively), plus two jackin-owned `:ro` override files (replacement `.git` pointer at `<dst>/.git`, replacement back-pointer at the admin's `gitdir`). The override files live at `<data_dir>/<container>/git/overrides/<dst-stripped>/{.git,gitdir}` with filenames matching their docker mount destinations. The materialized worktree lives at `<data_dir>/<container>/git/worktree/repo/<dst-stripped>/<container>/` — `repo/` marks the subtree as git-managed, `<container>` basename ensures globally unique admin entries in the host repo's `.git/worktrees/`. See [Container-side mount layout](#host-side-materialization) and [Design Decision: Worktree Materialization Layout](#design-decision-worktree-materialization-layout).
+- For each isolated clone, one bind mount is enough: the materialized clone at `<data_dir>/<container>/git/clone/repo/<dst-stripped>/<container>/` is mounted at `<dst>` (rw). The clone carries its own `.git/`, so no host `.git/` auxiliary mounts or override files are needed.
+- Branch naming uses the full container name verbatim: `jackin/scratch/<container>` (e.g. `jackin/scratch/jk-k7p9m2xq-thearchitect`). Globally unique by construction; trivial container → branch mapping; no instance-suffix derivation logic.
 - `validate_isolation_layout` rejects two worktree mounts that resolve to the same host repository within one workspace. Clone mounts can share the same host repository because each has an independent `.git/`.
 - `load` materializes, foreground session finalization safely removes throwaway isolated worktrees when no work would be lost, unsafe clean-exit cleanup asks interactive operators whether to return to the agent, preserve recovery state, or force-delete, `eject` leaves worktrees alone, and `purge` force-deletes everything (container, DinD sidecar, the per-container `git/` tree, worktree, local branch).
 - `purge` refuses on running agents (also closes the pre-existing gap for `shared` mode).

--- a/docs/src/content/docs/reference/runtime-instance-model.mdx
+++ b/docs/src/content/docs/reference/runtime-instance-model.mdx
@@ -38,11 +38,13 @@ The runtime instance model is the source of truth for how jackin names container
 Fresh launches use DNS-safe base names:
 
 ```text
-jackin-<workspace-name>-<agent-role>-<unique-id>
-jackin-<agent-role>-<unique-id>
+jk-<unique-id>-<workspace-name>-<agent-role>
+jk-<unique-id>-<agent-role>
 ```
 
-The first form is for saved workspaces. The second form is for ad-hoc launches. Workspace and role components are compact lowercase ASCII alphanumeric strings. The unique ID makes concurrent launches distinct and removes the old deterministic `clone-N` slot model.
+The first form is for saved workspaces. The second form is for ad-hoc launches. The `jk-` prefix identifies all jackin-managed Docker resources. The unique ID comes second so all resources from the same session share a common prefix. Workspace and role components are compact lowercase ASCII alphanumeric strings derived by stripping non-alphanumeric characters (hyphens, slashes, underscores) from the source names. The unique ID makes concurrent launches distinct.
+
+The total base name fits within 58 characters so that `<base>-dind` stays within the 63-character DNS label limit. If the compacted workspace and role components together exceed the available budget they are truncated with a 4-character SHA-256 suffix to keep names deterministic.
 
 Derived Docker resources use the base name:
 
@@ -55,7 +57,7 @@ cert volume:     <base>-dind-certs
 
 DNS-sensitive values such as `DOCKER_HOST`, `JACKIN_DIND_HOSTNAME`, `DOCKER_TLS_SAN`, `NO_PROXY`, `no_proxy`, and `TESTCONTAINERS_HOST_OVERRIDE` use the DNS-safe DinD name. The role-container base must fit the DinD label budget because `<base>-dind` is used as a network hostname.
 
-Implementation lives in <RepoFile path="src/instance/naming.rs" /> and <RepoFile path="src/runtime/naming.rs" />.
+Implementation lives in <RepoFile path="src/instance/naming.rs" /> and <RepoFile path="src/runtime/naming.rs" />. The full naming reference — including image names, derived resource names, lock files, roles cache layout, CLI selector formats, and worked examples — is in [Instance and Resource Naming](/reference/instance-resource-naming/).
 
 ## State Layout
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -1000,7 +1000,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: "jk-k7p9m2xq-myapp-agentsmith".to_string(),
                 dind_container: "jk-k7p9m2xq-myapp-agentsmith-dind".to_string(),
@@ -1042,7 +1042,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: "jk-k7p9m2xq-agentsmith".to_string(),
                 dind_container: "jk-k7p9m2xq-agentsmith-dind".to_string(),
@@ -1078,7 +1078,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -1124,7 +1124,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Codex,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -947,7 +947,7 @@ mod tests {
         std::fs::create_dir_all(&nested_dir).unwrap();
 
         let config = config_with_workspace(&project_dir, vec!["agent-smith".to_string()], None);
-        let running = "jackin-agentsmith-k7p9m2xq";
+        let running = "jk-k7p9m2xq-agentsmith";
         let mut runner = fake_runner_with_running_agents(&[running]);
 
         let paths = paths::JackinPaths::for_tests(temp.path());
@@ -969,8 +969,8 @@ mod tests {
             vec!["agent-smith".to_string(), "the-architect".to_string()],
             Some("the-architect".to_string()),
         );
-        let smith = "jackin-agentsmith-k7p9m2xq";
-        let architect = "jackin-thearchitect-a1b2c3d4";
+        let smith = "jk-k7p9m2xq-agentsmith";
+        let architect = "jk-a1b2c3d4-thearchitect";
         let mut runner = fake_runner_with_running_agents(&[smith, architect]);
 
         let paths = paths::JackinPaths::for_tests(temp.path());
@@ -990,7 +990,7 @@ mod tests {
 
         let config = config_with_workspace(&project_dir, vec!["agent-smith".to_string()], None);
         let manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
-            container_base: "jackin-myapp-agentsmith-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-myapp-agentsmith",
             workspace_name: Some("my-app"),
             workspace_label: "my-app",
             workdir: "/workspace",
@@ -1000,12 +1000,12 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
-                role_container: "jackin-myapp-agentsmith-k7p9m2xq".to_string(),
-                dind_container: "jackin-myapp-agentsmith-k7p9m2xq-dind".to_string(),
-                network: "jackin-myapp-agentsmith-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-myapp-agentsmith-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-myapp-agentsmith".to_string(),
+                dind_container: "jk-k7p9m2xq-myapp-agentsmith-dind".to_string(),
+                network: "jk-k7p9m2xq-myapp-agentsmith-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-myapp-agentsmith-dind-certs".to_string(),
             },
         });
         let state_dir = paths.data_dir.join(&manifest.container_base);
@@ -1018,7 +1018,7 @@ mod tests {
             resolve_running_container_from_context(&paths, &config, &project_dir, &mut runner)
                 .unwrap();
 
-        assert_eq!(container, "jackin-myapp-agentsmith-k7p9m2xq");
+        assert_eq!(container, "jk-k7p9m2xq-myapp-agentsmith");
     }
 
     #[test]
@@ -1032,7 +1032,7 @@ mod tests {
 
         let config = AppConfig::default();
         let manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
-            container_base: "jackin-agentsmith-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-agentsmith",
             workspace_name: None,
             workspace_label: &project,
             workdir: &project,
@@ -1042,12 +1042,12 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
-                role_container: "jackin-agentsmith-k7p9m2xq".to_string(),
-                dind_container: "jackin-agentsmith-k7p9m2xq-dind".to_string(),
-                network: "jackin-agentsmith-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-agentsmith-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-agentsmith".to_string(),
+                dind_container: "jk-k7p9m2xq-agentsmith-dind".to_string(),
+                network: "jk-k7p9m2xq-agentsmith-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-agentsmith-dind-certs".to_string(),
             },
         });
         let state_dir = paths.data_dir.join(&manifest.container_base);
@@ -1059,14 +1059,14 @@ mod tests {
             resolve_running_container_from_context(&paths, &config, &project_dir, &mut runner)
                 .unwrap();
 
-        assert_eq!(container, "jackin-agentsmith-k7p9m2xq");
+        assert_eq!(container, "jk-k7p9m2xq-agentsmith");
     }
 
     #[test]
     fn hardline_candidate_prompt_label_includes_manifest_and_docker_state() {
         let temp = tempfile::tempdir().unwrap();
         let paths = paths::JackinPaths::for_tests(temp.path());
-        let container = "jackin-myapp-agentsmith-k7p9m2xq";
+        let container = "jk-k7p9m2xq-myapp-agentsmith";
         let mut manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
             container_base: container,
             workspace_name: Some("my-app"),
@@ -1078,7 +1078,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -1112,7 +1112,7 @@ mod tests {
     fn hardline_candidate_prompt_label_counts_running_agent_sessions() {
         let temp = tempfile::tempdir().unwrap();
         let paths = paths::JackinPaths::for_tests(temp.path());
-        let container = "jackin-myapp-agentsmith-k7p9m2xq";
+        let container = "jk-k7p9m2xq-myapp-agentsmith";
         let manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
             container_base: container,
             workspace_name: Some("my-app"),
@@ -1124,7 +1124,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Codex,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -1175,7 +1175,7 @@ mod tests {
 
         let config = config_with_workspace(&project_dir, vec!["agent-smith".to_string()], None);
         // the-architect is running but not allowed in this workspace.
-        let mut runner = fake_runner_with_running_agents(&["jackin-the-architect"]);
+        let mut runner = fake_runner_with_running_agents(&["jk-the-architect"]);
 
         let paths = paths::JackinPaths::for_tests(temp.path());
         let err =
@@ -1195,7 +1195,7 @@ mod tests {
         let project_dir = temp.path().join("project");
         std::fs::create_dir_all(&project_dir).unwrap();
         let config = config_with_workspace(&project_dir, vec!["agent-smith".to_string()], None);
-        let mut runner = fake_runner_with_running_agents(&["jackin-agent-smith"]);
+        let mut runner = fake_runner_with_running_agents(&["jk-agent-smith"]);
 
         let paths = paths::JackinPaths::for_tests(temp.path());
         let err = resolve_running_container_from_context(&paths, &config, &unrelated, &mut runner)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2186,7 +2186,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agentsmith".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agentsmith-dind".to_string(),
@@ -2221,7 +2221,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agentsmith".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agentsmith-dind".to_string(),
@@ -2440,7 +2440,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: "jk-k7p9m2xq-agentsmith".to_string(),
                 dind_container: "jk-k7p9m2xq-agentsmith-dind".to_string(),
@@ -2466,7 +2466,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -2510,7 +2510,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jk-agent-smith",
+            image_tag: "jk_agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1640,7 +1640,7 @@ fn resolve_role_to_container(
 ) -> Result<String> {
     let candidates = runtime::matching_family(class, &runtime::list_managed_role_names(runner)?);
     match candidates.len() {
-        1 => Ok(candidates.into_iter().next().expect("invariant: len == 1")),
+        1 => Ok(candidates.into_iter().next().unwrap()),
         0 => anyhow::bail!("no managed container found for role `{}`", class.key()),
         _ => anyhow::bail!(
             "multiple containers found for role `{}`: {}; pass a specific container name",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1198,10 +1198,14 @@ pub fn run(cli: Cli) -> Result<()> {
                 // Docker error doesn't leave the role cache and shared cache
                 // untouched.
                 let results = [
-                    runtime::prune_instances(&paths, &mut runner),
-                    runtime::prune_images(&mut runner),
-                    runtime::prune_roles(&paths),
-                    runtime::prune_cache(&paths),
+                    runtime::prune_instances(&paths, &mut runner)
+                        .context("prune instances"),
+                    runtime::prune_images(&mut runner)
+                        .context("prune images"),
+                    runtime::prune_roles(&paths)
+                        .context("prune roles"),
+                    runtime::prune_cache(&paths)
+                        .context("prune cache"),
                 ];
                 let errors: Vec<anyhow::Error> =
                     results.into_iter().filter_map(Result::err).collect();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1198,14 +1198,10 @@ pub fn run(cli: Cli) -> Result<()> {
                 // Docker error doesn't leave the role cache and shared cache
                 // untouched.
                 let results = [
-                    runtime::prune_instances(&paths, &mut runner)
-                        .context("prune instances"),
-                    runtime::prune_images(&mut runner)
-                        .context("prune images"),
-                    runtime::prune_roles(&paths)
-                        .context("prune roles"),
-                    runtime::prune_cache(&paths)
-                        .context("prune cache"),
+                    runtime::prune_instances(&paths, &mut runner).context("prune instances"),
+                    runtime::prune_images(&mut runner).context("prune images"),
+                    runtime::prune_roles(&paths).context("prune roles"),
+                    runtime::prune_cache(&paths).context("prune cache"),
                 ];
                 let errors: Vec<anyhow::Error> =
                     results.into_iter().filter_map(Result::err).collect();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub mod context;
 
 use anyhow::{Context, Result};
+use owo_colors::OwoColorize;
 
 use crate::cli::cleanup::{EjectArgs, PurgeArgs};
 use crate::cli::role::{ConsoleArgs, HardlineArgs, LoadArgs};
@@ -1208,7 +1209,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     Ok(())
                 } else {
                     for err in &errors {
-                        eprintln!("prune error: {err:#}");
+                        eprintln!("{} {err:#}", "error:".red().bold());
                     }
                     anyhow::bail!("{} prune step(s) failed", errors.len())
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1640,7 +1640,7 @@ fn resolve_role_to_container(
 ) -> Result<String> {
     let candidates = runtime::matching_family(class, &runtime::list_managed_role_names(runner)?);
     match candidates.len() {
-        1 => Ok(candidates.into_iter().next().unwrap()),
+        1 => Ok(candidates.into_iter().next().expect("invariant: len == 1")),
         0 => anyhow::bail!("no managed container found for role `{}`", class.key()),
         _ => anyhow::bail!(
             "multiple containers found for role `{}`: {}; pass a specific container name",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::cli::cleanup::{EjectArgs, PurgeArgs};
 use crate::cli::role::{ConsoleArgs, HardlineArgs, LoadArgs};
-use crate::cli::{self, Cli, Command, WorkspaceCommand};
+use crate::cli::{self, Cli, Command, PruneCommand, WorkspaceCommand};
 use crate::config::{self, AppConfig};
 use crate::console;
 use crate::docker::ShellRunner;
@@ -196,7 +196,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 } else {
                     match Selector::parse(&sel)? {
                         Selector::Container(name) => name,
-                        Selector::Role(class) => instance::primary_container_name(&class),
+                        Selector::Role(class) => resolve_role_to_container(&class, &mut runner)?,
                     }
                 }
             } else {
@@ -277,7 +277,7 @@ pub fn run(cli: Cli) -> Result<()> {
                                 &runtime::list_managed_role_names(&mut runner)?,
                             )
                         } else {
-                            vec![instance::primary_container_name(&class)]
+                            vec![resolve_role_to_container(&class, &mut runner)?]
                         }
                     }
                 }
@@ -890,13 +890,13 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
                 if let Some(v) = keep_awake_change {
                     changes.push(format!(
-                        "keep_awake → {}",
+                        "keep-awake → {}",
                         if v { "enabled" } else { "disabled" }
                     ));
                 }
                 if let Some(v) = git_pull_change {
                     changes.push(format!(
-                        "git_pull_on_entry → {}",
+                        "git-pull-on-entry → {}",
                         if v { "enabled" } else { "disabled" }
                     ));
                 }
@@ -1168,7 +1168,7 @@ pub fn run(cli: Cli) -> Result<()> {
                         runtime::purge_class_data(&paths, &class, &mut runner)?;
                         println!("Purged all state for {}.", class.key());
                     } else {
-                        let container = instance::primary_container_name(&class);
+                        let container = resolve_role_to_container(&class, &mut runner)?;
                         runtime::purge_container_state(&paths, &container, &mut runner)?;
                         println!("Purged state for {container}.");
                     }
@@ -1176,6 +1176,44 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
             }
         }
+        Command::Prune(cmd) => match cmd {
+            PruneCommand::Roles => runtime::prune_roles(&paths),
+            PruneCommand::Cache => runtime::prune_cache(&paths),
+            PruneCommand::Images => runtime::prune_images(&mut runner),
+            PruneCommand::Instances => runtime::prune_instances(&paths, &mut runner),
+            PruneCommand::All(args) => {
+                if !args.yes {
+                    let confirmed = dialoguer::Confirm::new()
+                        .with_prompt(
+                            "Remove all prunable data? (instances, images, role cache, shared cache)",
+                        )
+                        .default(false)
+                        .interact()?;
+                    if !confirmed {
+                        anyhow::bail!("aborted by operator");
+                    }
+                }
+                // Run every step regardless of individual failures so a single
+                // Docker error doesn't leave the role cache and shared cache
+                // untouched.
+                let results = [
+                    runtime::prune_instances(&paths, &mut runner),
+                    runtime::prune_images(&mut runner),
+                    runtime::prune_roles(&paths),
+                    runtime::prune_cache(&paths),
+                ];
+                let errors: Vec<anyhow::Error> =
+                    results.into_iter().filter_map(Result::err).collect();
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    for err in &errors {
+                        eprintln!("prune error: {err:#}");
+                    }
+                    anyhow::bail!("{} prune step(s) failed", errors.len())
+                }
+            }
+        },
         Command::Help { .. } => {
             // Handled upstream in dispatch before reaching this function.
             unreachable!("Command::Help is dispatched to Action::PrintHelp before run() is called")
@@ -1593,6 +1631,22 @@ const fn hardline_action_options() -> [(&'static str, HardlineAction); 4] {
         ("Inspect state without attaching", HardlineAction::Inspect),
         ("Cancel", HardlineAction::Cancel),
     ]
+}
+
+fn resolve_role_to_container(
+    class: &RoleSelector,
+    runner: &mut impl crate::docker::CommandRunner,
+) -> Result<String> {
+    let candidates = runtime::matching_family(class, &runtime::list_managed_role_names(runner)?);
+    match candidates.len() {
+        1 => Ok(candidates.into_iter().next().unwrap()),
+        0 => anyhow::bail!("no managed container found for role `{}`", class.key()),
+        _ => anyhow::bail!(
+            "multiple containers found for role `{}`: {}; pass a specific container name",
+            class.key(),
+            candidates.join(", ")
+        ),
+    }
 }
 
 fn resolve_instance_reference(paths: &JackinPaths, input: &str) -> Result<Option<String>> {
@@ -2121,7 +2175,7 @@ mod auth_set_tests {
         let temp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
-            container_base: "jackin-workspace-agentsmith-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agentsmith",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -2131,12 +2185,12 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
-                role_container: "jackin-workspace-agentsmith-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agentsmith-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agentsmith-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agentsmith-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agentsmith".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agentsmith-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agentsmith-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agentsmith-dind-certs".to_string(),
             },
         });
         let state_dir = paths.data_dir.join(&manifest.container_base);
@@ -2147,7 +2201,7 @@ mod auth_set_tests {
 
         assert_eq!(
             resolved.as_deref(),
-            Some("jackin-workspace-agentsmith-k7p9m2xq")
+            Some("jk-k7p9m2xq-workspace-agentsmith")
         );
     }
 
@@ -2156,7 +2210,7 @@ mod auth_set_tests {
         let temp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         let mut manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
-            container_base: "jackin-workspace-agentsmith-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agentsmith",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -2166,12 +2220,12 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
-                role_container: "jackin-workspace-agentsmith-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agentsmith-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agentsmith-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agentsmith-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agentsmith".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agentsmith-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agentsmith-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agentsmith-dind-certs".to_string(),
             },
         });
         manifest.mark_status(instance::InstanceStatus::Purged);
@@ -2375,7 +2429,7 @@ mod auth_set_tests {
     fn ad_hoc_manifest_for_workdir(workdir: &std::path::Path) -> instance::InstanceManifest {
         let workdir = workdir.display().to_string();
         instance::InstanceManifest::new(instance::NewInstanceManifest {
-            container_base: "jackin-agentsmith-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-agentsmith",
             workspace_name: None,
             workspace_label: &workdir,
             workdir: &workdir,
@@ -2385,12 +2439,12 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
-                role_container: "jackin-agentsmith-k7p9m2xq".to_string(),
-                dind_container: "jackin-agentsmith-k7p9m2xq-dind".to_string(),
-                network: "jackin-agentsmith-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-agentsmith-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-agentsmith".to_string(),
+                dind_container: "jk-k7p9m2xq-agentsmith-dind".to_string(),
+                network: "jk-k7p9m2xq-agentsmith-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-agentsmith-dind-certs".to_string(),
             },
         })
     }
@@ -2399,7 +2453,7 @@ mod auth_set_tests {
     fn hardline_restore_candidate_marks_missing_manifest_available() {
         let temp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container = "jk-k7p9m2xq-workspace-agentsmith";
         let mut manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
             container_base: container,
             workspace_name: Some("workspace"),
@@ -2411,7 +2465,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -2443,7 +2497,7 @@ mod auth_set_tests {
     fn hardline_restore_candidate_errors_when_docker_unavailable() {
         let temp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container = "jk-k7p9m2xq-workspace-agentsmith";
         let mut manifest = instance::InstanceManifest::new(instance::NewInstanceManifest {
             container_base: container,
             workspace_name: Some("workspace"),
@@ -2455,7 +2509,7 @@ mod auth_set_tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: instance::DockerResources {
                 role_container: container.to_string(),
                 dind_container: format!("{container}-dind"),
@@ -2771,5 +2825,47 @@ mod auth_set_tests {
             msg.contains("op item delete I_UUID --vault V_UUID"),
             "must include copy-pasteable recovery command, got: {msg}"
         );
+    }
+}
+
+#[cfg(test)]
+mod resolve_role_tests {
+    use super::*;
+
+    #[test]
+    fn resolve_role_no_match_errors() {
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = runtime::FakeRunner::default();
+        runner.capture_queue.push_back(String::new());
+        let err = resolve_role_to_container(&selector, &mut runner).unwrap_err();
+        assert!(
+            err.to_string().contains("no managed container found"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn resolve_role_multiple_matches_errors_with_names() {
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = runtime::FakeRunner::default();
+        runner
+            .capture_queue
+            .push_back("jk-k7p9m2xq-agentsmith\njk-a1b2c3d4-agentsmith".to_string());
+        let err = resolve_role_to_container(&selector, &mut runner).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("multiple containers found"), "{msg}");
+        assert!(msg.contains("jk-k7p9m2xq-agentsmith"), "{msg}");
+        assert!(msg.contains("jk-a1b2c3d4-agentsmith"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_role_single_match_returns_name() {
+        let selector = RoleSelector::new(None, "agent-smith");
+        let mut runner = runtime::FakeRunner::default();
+        runner
+            .capture_queue
+            .push_back("jk-k7p9m2xq-agentsmith".to_string());
+        let name = resolve_role_to_container(&selector, &mut runner).unwrap();
+        assert_eq!(name, "jk-k7p9m2xq-agentsmith");
     }
 }

--- a/src/cli/cleanup.rs
+++ b/src/cli/cleanup.rs
@@ -18,7 +18,7 @@ Examples:
 pub struct EjectArgs {
     /// Role class selector, instance ID, or container name to stop
     pub selector: String,
-    /// Stop every instance of this role class, not just the default
+    /// Stop every matching instance (otherwise errors if multiple exist)
     #[arg(long)]
     pub all: bool,
     /// Also delete persisted state after stopping
@@ -41,7 +41,7 @@ Examples:
 pub struct PurgeArgs {
     /// Role class selector, instance ID, or container name
     pub selector: String,
-    /// Delete state for every instance, not just the default
+    /// Delete state for every matching instance (otherwise errors if multiple exist)
     #[arg(long)]
     pub all: bool,
 }

--- a/src/cli/cleanup.rs
+++ b/src/cli/cleanup.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use super::{BANNER, HELP_STYLES};
 
-/// Stop an role and clean up its container
+/// Stop a role and clean up its container
 #[derive(Debug, Args, PartialEq, Eq)]
 #[command(
     before_help = BANNER,
@@ -13,12 +13,12 @@ Examples:
   jackin eject agent-smith --all
   jackin eject agent-smith --purge
   jackin eject k7p9m2xq
-  jackin eject jackin-agent-smith-clone-1"
+  jackin eject jk-k7p9m2xq-agentsmith"
 )]
 pub struct EjectArgs {
     /// Role class selector, instance ID, or container name to stop
     pub selector: String,
-    /// Stop every running instance of this role class
+    /// Stop every instance of this role class, not just the default
     #[arg(long)]
     pub all: bool,
     /// Also delete persisted state after stopping
@@ -26,7 +26,7 @@ pub struct EjectArgs {
     pub purge: bool,
 }
 
-/// Delete persisted state for an role class
+/// Delete persisted state for a role class
 #[derive(Debug, Args, PartialEq, Eq)]
 #[command(
     before_help = BANNER,
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn eject_help_shows_examples() {
         let help = help_text(&["jackin", "eject", "--help"]);
-        assert!(help.contains("Stop an role and clean up its container"));
+        assert!(help.contains("Stop a role and clean up its container"));
         assert!(help.contains("jackin eject agent-smith --all"));
         assert!(help.contains("jackin eject agent-smith --purge"));
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -181,8 +181,8 @@ Examples:
 pub enum TrustCommand {
     /// Mark a third-party role source as trusted
     ///
-    /// Trust controls whether jackin' will build and run an role without
-    /// prompting.  Untrusted roles require interactive confirmation on
+    /// Trust controls whether jackin will build and run a role without
+    /// prompting. Untrusted roles require interactive confirmation on
     /// every load.
     #[command(
         before_help = BANNER,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,10 +33,12 @@ pub mod cleanup;
 pub mod config;
 pub mod dispatch;
 pub mod help;
+pub mod prune;
 pub mod role;
 pub mod workspace;
 
 pub use config::{AuthCommand, ConfigCommand, EnvCommand, MountCommand, TrustCommand};
+pub use prune::PruneCommand;
 pub use workspace::{WorkspaceClaudeTokenCommand, WorkspaceCommand, WorkspaceEnvCommand};
 
 /// Operator's CLI for orchestrating AI coding roles in isolated containers
@@ -98,6 +100,9 @@ pub enum Command {
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Exile,
     Purge(PurgeArgs),
+    /// Delete cached or stale jackin data
+    #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
+    Prune(PruneCommand),
     Console(ConsoleArgs),
     /// Validate, migrate, and scaffold role repositories
     #[command(subcommand, before_help = BANNER, styles = HELP_STYLES, disable_help_subcommand = true)]
@@ -183,6 +188,7 @@ mod tests {
             "eject",
             "exile",
             "purge",
+            "prune",
             "console",
             "role",
             "workspace",
@@ -261,6 +267,11 @@ mod tests {
             vec!["jackin", "eject", "--help"],
             vec!["jackin", "exile", "--help"],
             vec!["jackin", "purge", "--help"],
+            vec!["jackin", "prune", "roles", "--help"],
+            vec!["jackin", "prune", "cache", "--help"],
+            vec!["jackin", "prune", "images", "--help"],
+            vec!["jackin", "prune", "instances", "--help"],
+            vec!["jackin", "prune", "all", "--help"],
             vec!["jackin", "console", "--help"],
             vec!["jackin", "workspace", "create", "--help"],
             vec!["jackin", "workspace", "list", "--help"],

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -19,7 +19,7 @@ pub enum PruneCommand {
     Cache,
     /// Remove unused jackin-managed Docker images
     ///
-    /// Removes jk-* images that have no role containers (running or stopped).
+    /// Removes jk_* images that have no role containers (running or stopped).
     /// Images still used by a role container are skipped.
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Images,

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -93,6 +93,33 @@ mod tests {
     }
 
     #[test]
+    fn prune_cache_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "cache"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::Cache))
+        ));
+    }
+
+    #[test]
+    fn prune_images_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "images"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::Images))
+        ));
+    }
+
+    #[test]
+    fn prune_instances_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "instances"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::Instances))
+        ));
+    }
+
+    #[test]
     fn prune_all_defaults_yes_false() {
         let cli = Cli::try_parse_from(["jackin", "prune", "all"]).unwrap();
         assert!(matches!(

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -19,8 +19,8 @@ pub enum PruneCommand {
     Cache,
     /// Remove unused jackin-managed Docker images
     ///
-    /// Removes jk-* images that have no containers (running or stopped).
-    /// Images still used by any container are skipped.
+    /// Removes jk-* images that have no role containers (running or stopped).
+    /// Images still used by a role container are skipped.
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Images,
     /// Purge on-disk state for terminated instances

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -26,7 +26,7 @@ pub enum PruneCommand {
     /// Purge on-disk state for terminated instances
     ///
     /// Removes state directories and index entries for instances in terminal
-    /// statuses: clean_exited, superseded, failed_setup, and purged
+    /// statuses: `clean_exited`, `superseded`, `failed_setup`, and `purged`
     /// tombstones. Crashed, preserved, and recoverable instances are skipped
     /// — use `jackin eject <selector> --purge` for those.
     #[command(before_help = BANNER, styles = HELP_STYLES)]

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -1,0 +1,127 @@
+use clap::{Args, Subcommand};
+
+use super::{BANNER, HELP_STYLES};
+
+/// Delete cached or stale jackin data
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum PruneCommand {
+    /// Delete cached role repositories
+    ///
+    /// Removes the local role-repo cache. Role repos are re-cloned
+    /// automatically the next time a role is launched.
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Roles,
+    /// Delete shared caches
+    ///
+    /// Removes the shared cache directory. Includes the compiled terminfo
+    /// cache and version-check results. All caches regenerate automatically.
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Cache,
+    /// Remove unused jackin-managed Docker images
+    ///
+    /// Removes jk-* images that have no containers (running or stopped).
+    /// Images still used by any container are skipped.
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Images,
+    /// Purge on-disk state for terminated instances
+    ///
+    /// Removes state directories and index entries for instances in terminal
+    /// statuses: clean_exited, superseded, failed_setup, and purged
+    /// tombstones. Crashed, preserved, and recoverable instances are skipped
+    /// — use `jackin eject <selector> --purge` for those.
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    Instances,
+    /// Remove all prunable data
+    ///
+    /// Runs in order: prune instances, prune images, prune roles, prune cache.
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    All(PruneAllArgs),
+}
+
+/// Arguments for `jackin prune all`
+#[derive(Debug, Args, PartialEq, Eq)]
+#[command(before_help = BANNER, styles = HELP_STYLES)]
+pub struct PruneAllArgs {
+    /// Skip the confirmation prompt
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Cli;
+    use clap::Parser;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut result = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                for inner in chars.by_ref() {
+                    if inner.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+        result
+    }
+
+    fn help_text(args: &[&str]) -> String {
+        let err = Cli::try_parse_from(args).unwrap_err();
+        strip_ansi(&err.to_string())
+    }
+
+    #[test]
+    fn prune_help_lists_subcommands() {
+        let help = help_text(&["jackin", "prune", "--help"]);
+        for sub in ["roles", "cache", "images", "instances", "all"] {
+            assert!(help.contains(sub), "missing subcommand: {sub}");
+        }
+    }
+
+    #[test]
+    fn prune_roles_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "roles"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::Roles))
+        ));
+    }
+
+    #[test]
+    fn prune_all_defaults_yes_false() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "all"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::All(
+                PruneAllArgs { yes: false }
+            )))
+        ));
+    }
+
+    #[test]
+    fn prune_all_yes_flag_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "all", "--yes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::All(
+                PruneAllArgs { yes: true }
+            )))
+        ));
+    }
+
+    #[test]
+    fn prune_all_short_y_flag_parses() {
+        let cli = Cli::try_parse_from(["jackin", "prune", "all", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(crate::cli::Command::Prune(PruneCommand::All(
+                PruneAllArgs { yes: true }
+            )))
+        ));
+    }
+}

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -28,7 +28,7 @@ pub enum PruneCommand {
     /// Removes state directories and index entries for instances in terminal
     /// statuses: `clean_exited`, `superseded`, `failed_setup`, and `purged`
     /// tombstones. Crashed, preserved, and recoverable instances are skipped
-    /// — use `jackin eject <selector> --purge` for those.
+    /// — use `jackin hardline <selector>` to return or `jackin eject <selector> --purge` to discard.
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     Instances,
     /// Remove all prunable data

--- a/src/cli/role.rs
+++ b/src/cli/role.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use super::{BANNER, HELP_STYLES};
 
-/// Jack an role into an isolated container
+/// Jack a role into an isolated container
 ///
 /// TARGET can be a path (~/Projects/my-app), a path with container
 /// destination (~/Projects/my-app:/app), or a saved workspace name.
@@ -84,7 +84,7 @@ Examples:
   jackin hardline --inspect k7p9m2xq
   jackin hardline chainargos/the-architect
   jackin hardline k7p9m2xq
-  jackin hardline jackin-agent-smith-clone-1"
+  jackin hardline jk-k7p9m2xq-agentsmith"
 )]
 pub struct HardlineArgs {
     /// Role class selector, instance ID, or container name to reconnect to.
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn load_help_shows_description_and_examples() {
         let help = help_text(&["jackin", "load", "--help"]);
-        assert!(help.contains("Jack an role into an isolated container"));
+        assert!(help.contains("Jack a role into an isolated container"));
         assert!(help.contains("Examples:"));
         assert!(help.contains("jackin load agent-smith"));
         assert!(help.contains("jackin load agent-smith big-monorepo"));

--- a/src/config/roles.rs
+++ b/src/config/roles.rs
@@ -160,7 +160,7 @@ impl AppConfig {
         Ok((source, true))
     }
 
-    /// Mark an role source as trusted.  Returns `true` when the flag changed.
+    /// Mark a role source as trusted.  Returns `true` when the flag changed.
     // pub(crate): test-only affordance; production callers use ConfigEditor.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn trust_agent(&mut self, key: &str) -> bool {
@@ -173,7 +173,7 @@ impl AppConfig {
         false
     }
 
-    /// Revoke trust for an role source.  Returns `true` when the flag changed.
+    /// Revoke trust for a role source.  Returns `true` when the flag changed.
     /// Note: does not prevent revoking builtins — the caller should check
     /// [`is_builtin_agent`] first.
     // pub(crate): test-only affordance; production callers use ConfigEditor.

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -589,7 +589,9 @@ mod tests {
                 worktree_path: format!("/data/{container}/isolated{dst}"),
                 scratch_branch: format!("jackin/scratch/{container}"),
                 base_commit: "abc".into(),
-                selector_key: container.trim_start_matches("jackin-").into(),
+                selector_key: container
+                    .trim_start_matches(crate::instance::naming::CONTAINER_PREFIX_DASH)
+                    .into(),
                 container_name: container.into(),
                 cleanup_status: CleanupStatus::Active,
             }
@@ -619,13 +621,13 @@ mod tests {
         #[test]
         fn detect_drift_flags_running_containers() {
             let data = TempDir::new().unwrap();
-            let cdir = data.path().join("jackin-x");
+            let cdir = data.path().join("jk-a1b2c3d4-jackin");
             std::fs::create_dir_all(&cdir).unwrap();
             write_records(
                 &cdir,
                 std::slice::from_ref(&record_for(
                     "jackin",
-                    "jackin-x",
+                    "jk-a1b2c3d4-jackin",
                     "/workspace/jackin",
                     "/old/src",
                 )),
@@ -639,23 +641,28 @@ mod tests {
                 MountIsolation::Worktree,
             )];
             let mut runner = FakeRunner::default();
-            runner.capture_queue.push_back("jackin-x\n".into());
+            runner
+                .capture_queue
+                .push_back("jk-a1b2c3d4-jackin\n".into());
             runner.capture_queue.push_back(String::new());
             let det = detect_workspace_edit_drift(&paths, "jackin", &edited, &mut runner).unwrap();
-            assert_eq!(det.running_containers, vec!["jackin-x".to_string()]);
+            assert_eq!(
+                det.running_containers,
+                vec!["jk-a1b2c3d4-jackin".to_string()]
+            );
             assert!(det.stopped_records.is_empty());
         }
 
         #[test]
         fn detect_drift_flags_stopped_records_when_src_changes() {
             let data = TempDir::new().unwrap();
-            let cdir = data.path().join("jackin-x");
+            let cdir = data.path().join("jk-a1b2c3d4-jackin");
             std::fs::create_dir_all(&cdir).unwrap();
             write_records(
                 &cdir,
                 std::slice::from_ref(&record_for(
                     "jackin",
-                    "jackin-x",
+                    "jk-a1b2c3d4-jackin",
                     "/workspace/jackin",
                     "/old/src",
                 )),
@@ -674,19 +681,19 @@ mod tests {
             let det = detect_workspace_edit_drift(&paths, "jackin", &edited, &mut runner).unwrap();
             assert!(det.running_containers.is_empty());
             assert_eq!(det.stopped_records.len(), 1);
-            assert_eq!(det.stopped_records[0].container_name, "jackin-x");
+            assert_eq!(det.stopped_records[0].container_name, "jk-a1b2c3d4-jackin");
         }
 
         #[test]
         fn detect_drift_quiet_when_src_unchanged() {
             let data = TempDir::new().unwrap();
-            let cdir = data.path().join("jackin-x");
+            let cdir = data.path().join("jk-a1b2c3d4-jackin");
             std::fs::create_dir_all(&cdir).unwrap();
             write_records(
                 &cdir,
                 std::slice::from_ref(&record_for(
                     "jackin",
-                    "jackin-x",
+                    "jk-a1b2c3d4-jackin",
                     "/workspace/jackin",
                     "/same/src",
                 )),
@@ -718,13 +725,13 @@ mod tests {
         #[test]
         fn detect_drift_does_not_currently_flag_isolation_mode_flips() {
             let data = TempDir::new().unwrap();
-            let cdir = data.path().join("jackin-x");
+            let cdir = data.path().join("jk-a1b2c3d4-jackin");
             std::fs::create_dir_all(&cdir).unwrap();
             write_records(
                 &cdir,
                 std::slice::from_ref(&record_for(
                     "jackin",
-                    "jackin-x",
+                    "jk-a1b2c3d4-jackin",
                     "/workspace/jackin",
                     "/same/src",
                 )),
@@ -760,13 +767,13 @@ mod tests {
         #[test]
         fn detect_drift_flags_record_when_dst_removed_from_edit() {
             let data = TempDir::new().unwrap();
-            let cdir = data.path().join("jackin-x");
+            let cdir = data.path().join("jk-a1b2c3d4-jackin");
             std::fs::create_dir_all(&cdir).unwrap();
             write_records(
                 &cdir,
                 std::slice::from_ref(&record_for(
                     "jackin",
-                    "jackin-x",
+                    "jk-a1b2c3d4-jackin",
                     "/workspace/jackin",
                     "/old/src",
                 )),

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -2084,7 +2084,9 @@ mod tests {
             worktree_path: cdir.join("isolated").join(dst).display().to_string(),
             scratch_branch: format!("jackin/scratch/{container}"),
             base_commit: "deadbeef".into(),
-            selector_key: container.trim_start_matches("jackin-").into(),
+            selector_key: container
+                .trim_start_matches(crate::instance::naming::CONTAINER_PREFIX_DASH)
+                .into(),
             container_name: container.into(),
             cleanup_status: CleanupStatus::Active,
         };
@@ -2111,8 +2113,12 @@ mod tests {
 
     #[test]
     fn save_blocks_with_error_popup_when_running_container_has_drifted_state() {
-        let (tmp, paths, mut config, ws) =
-            setup_with_isolated_record("driftws", "/old/src", "/workspace/x", "jackin-driftws");
+        let (tmp, paths, mut config, ws) = setup_with_isolated_record(
+            "driftws",
+            "/old/src",
+            "/workspace/x",
+            "jk-a1b2c3d4-driftws",
+        );
         let cwd = tmp.path();
         let mut state = ManagerState::from_config(&config, cwd);
         let mut editor = EditorState::new_edit("driftws".into(), ws);
@@ -2141,7 +2147,7 @@ mod tests {
             e.modal = None;
         }
 
-        let mut runner = fake_runner_with_running(&["jackin-driftws"]);
+        let mut runner = fake_runner_with_running(&["jk-a1b2c3d4-driftws"]);
         super::commit_editor_save_with_runner(
             &mut state,
             &mut config,
@@ -2172,8 +2178,12 @@ mod tests {
 
     #[test]
     fn save_opens_confirm_modal_when_stopped_container_has_drifted_state() {
-        let (tmp, paths, mut config, ws) =
-            setup_with_isolated_record("driftws2", "/old/src", "/workspace/x", "jackin-driftws2");
+        let (tmp, paths, mut config, ws) = setup_with_isolated_record(
+            "driftws2",
+            "/old/src",
+            "/workspace/x",
+            "jk-b2c3d4e5-driftws2",
+        );
         let cwd = tmp.path();
         let mut state = ManagerState::from_config(&config, cwd);
         let mut editor = EditorState::new_edit("driftws2".into(), ws);
@@ -2226,7 +2236,7 @@ mod tests {
             }) => {
                 assert_eq!(
                     affected_containers,
-                    &vec!["jackin-driftws2".to_string()],
+                    &vec!["jk-b2c3d4e5-driftws2".to_string()],
                     "modal must carry the affected container names",
                 );
             }

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -1801,7 +1801,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/alpha.git",
                 role_source_ref: None,
-                image_tag: "jk-alpha",
+                image_tag: "jk_alpha",
                 docker: crate::instance::DockerResources {
                     role_container: "jk-k7p9m2xq-demo-alpha".into(),
                     dind_container: "jk-k7p9m2xq-demo-alpha-dind".into(),
@@ -1847,7 +1847,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/alpha.git",
                 role_source_ref: None,
-                image_tag: "jk-alpha",
+                image_tag: "jk_alpha",
                 docker: crate::instance::DockerResources {
                     role_container: "jk-k7p9m2xq-demo-alpha".into(),
                     dind_container: "jk-k7p9m2xq-demo-alpha-dind".into(),

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -1791,7 +1791,7 @@ mod tests {
         let paths = crate::paths::JackinPaths::for_tests(tmp.path());
         let mut manifest =
             crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
-                container_base: "jackin-demo-alpha-k7p9m2xq",
+                container_base: "jk-k7p9m2xq-demo-alpha",
                 workspace_name: Some("demo"),
                 workspace_label: "demo",
                 workdir: "/workspace/demo",
@@ -1801,17 +1801,17 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/alpha.git",
                 role_source_ref: None,
-                image_tag: "jackin-alpha",
+                image_tag: "jk-alpha",
                 docker: crate::instance::DockerResources {
-                    role_container: "jackin-demo-alpha-k7p9m2xq".into(),
-                    dind_container: "jackin-demo-alpha-k7p9m2xq-dind".into(),
-                    network: "jackin-demo-alpha-k7p9m2xq-net".into(),
-                    certs_volume: "jackin-demo-alpha-k7p9m2xq-dind-certs".into(),
+                    role_container: "jk-k7p9m2xq-demo-alpha".into(),
+                    dind_container: "jk-k7p9m2xq-demo-alpha-dind".into(),
+                    network: "jk-k7p9m2xq-demo-alpha-net".into(),
+                    certs_volume: "jk-k7p9m2xq-demo-alpha-dind-certs".into(),
                 },
             });
         manifest.mark_status(crate::instance::InstanceStatus::RestoreAvailable);
         manifest
-            .write(&paths.data_dir.join("jackin-demo-alpha-k7p9m2xq"))
+            .write(&paths.data_dir.join("jk-k7p9m2xq-demo-alpha"))
             .unwrap();
 
         let config = AppConfig::default();
@@ -1837,7 +1837,7 @@ mod tests {
         let paths = crate::paths::JackinPaths::for_tests(tmp.path());
         let mut manifest =
             crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
-                container_base: "jackin-demo-alpha-k7p9m2xq",
+                container_base: "jk-k7p9m2xq-demo-alpha",
                 workspace_name: Some("demo"),
                 workspace_label: "demo",
                 workdir: "/workspace/demo",
@@ -1847,17 +1847,17 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/alpha.git",
                 role_source_ref: None,
-                image_tag: "jackin-alpha",
+                image_tag: "jk-alpha",
                 docker: crate::instance::DockerResources {
-                    role_container: "jackin-demo-alpha-k7p9m2xq".into(),
-                    dind_container: "jackin-demo-alpha-k7p9m2xq-dind".into(),
-                    network: "jackin-demo-alpha-k7p9m2xq-net".into(),
-                    certs_volume: "jackin-demo-alpha-k7p9m2xq-dind-certs".into(),
+                    role_container: "jk-k7p9m2xq-demo-alpha".into(),
+                    dind_container: "jk-k7p9m2xq-demo-alpha-dind".into(),
+                    network: "jk-k7p9m2xq-demo-alpha-net".into(),
+                    certs_volume: "jk-k7p9m2xq-demo-alpha-dind-certs".into(),
                 },
             });
         manifest.mark_status(crate::instance::InstanceStatus::Active);
         manifest
-            .write(&paths.data_dir.join("jackin-demo-alpha-k7p9m2xq"))
+            .write(&paths.data_dir.join("jk-k7p9m2xq-demo-alpha"))
             .unwrap();
 
         let config = AppConfig::default();

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,13 +17,15 @@ pub fn is_missing_resource_error(message: &str) -> bool {
 }
 
 /// `True` when a Docker `rmi` error indicates an image is still referenced
-/// by a container. Match is case-insensitive.
+/// by a running container. Match is case-insensitive.
+///
+/// `"cannot be forced"` guards the running-container case. `"must be forced"`
+/// fires for multi-repo image references (not a container conflict) and is
+/// intentionally excluded — those images should be removable.
 #[must_use]
 pub fn is_image_in_use_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
-    lower.contains("image is being used by")
-        || lower.contains("cannot be forced")
-        || lower.contains("must be forced")
+    lower.contains("image is being used by") || lower.contains("cannot be forced")
 }
 
 /// Options that control how a command is executed.
@@ -409,7 +411,9 @@ mod tests {
         assert!(is_image_in_use_error(
             "conflict: unable to remove (cannot be forced)"
         ));
-        assert!(is_image_in_use_error(
+        // "must be forced" is the multi-repo case, NOT a container conflict —
+        // it should not match so those images can be removed.
+        assert!(!is_image_in_use_error(
             "conflict: unable to remove (must be forced)"
         ));
     }
@@ -427,6 +431,9 @@ mod tests {
         assert!(!is_image_in_use_error("permission denied"));
         assert!(!is_image_in_use_error(
             "Error response from daemon: no such image"
+        ));
+        assert!(!is_image_in_use_error(
+            "conflict: unable to remove (must be forced) - image is referenced in multiple repositories"
         ));
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,7 +17,7 @@ pub fn is_missing_resource_error(message: &str) -> bool {
 }
 
 /// `True` when a Docker `rmi` error indicates an image is still referenced
-/// by a running container. Match is case-insensitive.
+/// by a running or stopped container. Match is case-insensitive.
 ///
 /// `"cannot be forced"` guards the running-container case. `"must be forced"`
 /// fires for multi-repo image references (not a container conflict) and is

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 /// `True` when a Docker CLI error message reports an absent resource.
 ///
 /// Matches `inspect`'s `No such object`, or `rm`/`network rm`/`volume rm`'s
-/// `No such container`/`network`/`volume`. Match is case-insensitive
-/// because different daemon versions vary the casing.
+/// `No such container`/`network`/`volume`, and `rmi`'s `No such image`.
+/// Match is case-insensitive because different daemon versions vary the casing.
 #[must_use]
 pub fn is_missing_resource_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
@@ -13,6 +13,7 @@ pub fn is_missing_resource_error(message: &str) -> bool {
         || lower.contains("no such container")
         || lower.contains("no such network")
         || lower.contains("no such volume")
+        || lower.contains("no such image")
 }
 
 /// `True` when a Docker `rmi` error indicates an image is still referenced
@@ -427,5 +428,13 @@ mod tests {
         assert!(!is_image_in_use_error(
             "Error response from daemon: no such image"
         ));
+    }
+
+    #[test]
+    fn is_missing_resource_error_matches_no_such_image() {
+        assert!(is_missing_resource_error(
+            "Error response from daemon: No such image: jk-agent-smith:latest"
+        ));
+        assert!(is_missing_resource_error("no such image: jk-foo"));
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -15,6 +15,16 @@ pub fn is_missing_resource_error(message: &str) -> bool {
         || lower.contains("no such volume")
 }
 
+/// `True` when a Docker `rmi` error indicates an image is still referenced
+/// by a container. Match is case-insensitive.
+#[must_use]
+pub fn is_image_in_use_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("image is being used by")
+        || lower.contains("cannot be forced")
+        || lower.contains("must be forced")
+}
+
 /// Options that control how a command is executed.
 #[derive(Clone, Debug, Default)]
 pub struct RunOptions {
@@ -388,5 +398,34 @@ mod tests {
         let args = &["run", "-e"];
         let redacted = redact_env_args(args);
         assert_eq!(redacted, vec!["run", "-e"]);
+    }
+
+    #[test]
+    fn is_image_in_use_error_matches_all_three_patterns() {
+        assert!(is_image_in_use_error(
+            "image is being used by stopped container abc123"
+        ));
+        assert!(is_image_in_use_error(
+            "conflict: unable to remove (cannot be forced)"
+        ));
+        assert!(is_image_in_use_error(
+            "conflict: unable to remove (must be forced)"
+        ));
+    }
+
+    #[test]
+    fn is_image_in_use_error_is_case_insensitive() {
+        assert!(is_image_in_use_error(
+            "Image Is Being Used By running container"
+        ));
+        assert!(is_image_in_use_error("CANNOT BE FORCED"));
+    }
+
+    #[test]
+    fn is_image_in_use_error_does_not_match_real_errors() {
+        assert!(!is_image_in_use_error("permission denied"));
+        assert!(!is_image_in_use_error(
+            "Error response from daemon: no such image"
+        ));
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -19,7 +19,8 @@ pub fn is_missing_resource_error(message: &str) -> bool {
 /// `True` when a Docker `rmi` error indicates an image is still referenced
 /// by a running or stopped container. Match is case-insensitive.
 ///
-/// `"cannot be forced"` guards the running-container case. `"must be forced"`
+/// `"image is being used by"` covers stopped containers. `"cannot be forced"`
+/// covers running containers (Docker refuses `rmi --force`). `"must be forced"`
 /// fires for multi-repo image references (not a container conflict) and is
 /// intentionally excluded — those images should be removable.
 #[must_use]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -404,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn is_image_in_use_error_matches_all_three_patterns() {
+    fn is_image_in_use_error_matches_in_use_patterns() {
         assert!(is_image_in_use_error(
             "image is being used by stopped container abc123"
         ));

--- a/src/instance/auth.rs
+++ b/src/instance/auth.rs
@@ -970,7 +970,7 @@ plugins = []
 
         let (state, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -996,7 +996,7 @@ plugins = []
 
         let (state, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1026,7 +1026,7 @@ plugins = []
 
         let (state, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1053,7 +1053,7 @@ plugins = []
         seed_host_auth(&temp);
         let (state, outcome1) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1077,7 +1077,7 @@ plugins = []
         // Second run: should overwrite with host content
         let (state2, outcome2) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1105,7 +1105,7 @@ plugins = []
         // First run: sync mode writes credentials
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1118,7 +1118,7 @@ plugins = []
         // Operator switches to ignore — credentials must be wiped
         let (state2, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -1143,7 +1143,7 @@ plugins = []
 
         let (state, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::OAuthToken,
             &crate::instance::GithubAuthContext::default(),
@@ -1184,7 +1184,7 @@ plugins = []
         // get wiped under api_key.
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1199,7 +1199,7 @@ plugins = []
 
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::ApiKey,
             &crate::instance::GithubAuthContext::default(),
@@ -1230,7 +1230,7 @@ plugins = []
         // First run: sync mode writes credentials
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1245,7 +1245,7 @@ plugins = []
         // wizard and authenticates exclusively via CLAUDE_CODE_OAUTH_TOKEN.
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::OAuthToken,
             &crate::instance::GithubAuthContext::default(),
@@ -1271,7 +1271,7 @@ plugins = []
         // First run: token mode writes the onboarding skeleton
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::OAuthToken,
             &crate::instance::GithubAuthContext::default(),
@@ -1287,7 +1287,7 @@ plugins = []
         // Operator switches to sync — host auth must now be forwarded
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1317,7 +1317,7 @@ plugins = []
         // Token mode seeds an empty state
         let (_, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::OAuthToken,
             &crate::instance::GithubAuthContext::default(),
@@ -1329,7 +1329,7 @@ plugins = []
         // Switching to ignore must keep the empty shape (no .credentials.json)
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -1355,7 +1355,7 @@ plugins = []
         seed_host_auth(&temp);
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1375,7 +1375,7 @@ plugins = []
         // Second run: host auth missing — container auth must be preserved
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1402,7 +1402,7 @@ plugins = []
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1441,7 +1441,7 @@ plugins = []
         // First run: create the file with ignore mode (gets 0600)
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -1465,7 +1465,7 @@ plugins = []
         seed_host_auth(&temp);
         let (state2, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1497,7 +1497,7 @@ plugins = []
         seed_host_auth(&temp);
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1522,7 +1522,7 @@ plugins = []
         // Second run: host auth missing — files preserved but permissions repaired
         let (state2, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1563,7 +1563,7 @@ plugins = []
         // First run: create the state directory
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1581,7 +1581,7 @@ plugins = []
         // Sync should refuse to write through the symlink
         let err = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1609,7 +1609,7 @@ plugins = []
         // First run: create the state directory with credentials
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -1628,7 +1628,7 @@ plugins = []
         // Sync should refuse to write through the symlink
         let err = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),

--- a/src/instance/manifest.rs
+++ b/src/instance/manifest.rs
@@ -584,7 +584,7 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jk-org_agent",
+            image_tag: "jk_org_agent",
             docker: DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
@@ -608,7 +608,7 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jk-org_agent",
+            image_tag: "jk_org_agent",
             docker: DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
@@ -641,7 +641,7 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jk-org_agent",
+            image_tag: "jk_org_agent",
             docker: DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
@@ -685,7 +685,7 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jk-org_agent",
+            image_tag: "jk_org_agent",
             docker: DockerResources {
                 role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
                 dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),

--- a/src/instance/manifest.rs
+++ b/src/instance/manifest.rs
@@ -374,7 +374,7 @@ impl InstanceIndex {
         })
     }
 
-    /// Remove multiple entries from the index in a single lock pass.
+    /// Removes entries in a single lock pass.
     pub fn remove_many(data_dir: &Path, container_bases: &[&str]) -> anyhow::Result<()> {
         if container_bases.is_empty() {
             return Ok(());

--- a/src/instance/manifest.rs
+++ b/src/instance/manifest.rs
@@ -374,6 +374,20 @@ impl InstanceIndex {
         })
     }
 
+    /// Remove multiple entries from the index in a single lock pass.
+    pub fn remove_many(data_dir: &Path, container_bases: &[&str]) -> anyhow::Result<()> {
+        if container_bases.is_empty() {
+            return Ok(());
+        }
+        let set: std::collections::HashSet<&str> = container_bases.iter().copied().collect();
+        Self::with_lock(data_dir, |index| {
+            index
+                .instances
+                .retain(|entry| !set.contains(entry.container_base.as_str()));
+            Ok(())
+        })
+    }
+
     pub fn mark_purged(data_dir: &Path, container_base: &str) -> anyhow::Result<()> {
         Self::mark_many_purged(data_dir, &[container_base])
     }
@@ -560,7 +574,7 @@ mod tests {
 
     fn sample_manifest() -> InstanceManifest {
         InstanceManifest::new(NewInstanceManifest {
-            container_base: "jackin-workspace-agent-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agent",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -570,12 +584,12 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jackin-org__agent",
+            image_tag: "jk-org_agent",
             docker: DockerResources {
-                role_container: "jackin-workspace-agent-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agent-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agent-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agent-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agent-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agent-dind-certs".to_string(),
             },
         })
     }
@@ -584,7 +598,7 @@ mod tests {
     fn writes_manifest_under_jackin_state_dir() {
         let temp = tempdir().unwrap();
         let mut manifest = InstanceManifest::new(NewInstanceManifest {
-            container_base: "jackin-workspace-agent-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agent",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -594,12 +608,12 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jackin-org__agent",
+            image_tag: "jk-org_agent",
             docker: DockerResources {
-                role_container: "jackin-workspace-agent-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agent-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agent-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agent-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agent-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agent-dind-certs".to_string(),
             },
         });
         manifest.mark_status(InstanceStatus::Running);
@@ -617,7 +631,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let data_dir = temp.path();
         let manifest = InstanceManifest::new(NewInstanceManifest {
-            container_base: "jackin-workspace-agent-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agent",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -627,16 +641,16 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jackin-org__agent",
+            image_tag: "jk-org_agent",
             docker: DockerResources {
-                role_container: "jackin-workspace-agent-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agent-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agent-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agent-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agent-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agent-dind-certs".to_string(),
             },
         });
         manifest
-            .write(&data_dir.join("jackin-workspace-agent-k7p9m2xq"))
+            .write(&data_dir.join("jk-k7p9m2xq-workspace-agent"))
             .unwrap();
 
         let matches = InstanceIndex::matching_manifests(
@@ -652,7 +666,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].container_base, "jackin-workspace-agent-k7p9m2xq");
+        assert_eq!(matches[0].container_base, "jk-k7p9m2xq-workspace-agent");
         assert!(data_dir.join(INSTANCE_INDEX_FILE).exists());
     }
 
@@ -661,7 +675,7 @@ mod tests {
         let temp = tempdir().unwrap();
         let data_dir = temp.path();
         let mut manifest = InstanceManifest::new(NewInstanceManifest {
-            container_base: "jackin-workspace-agent-k7p9m2xq",
+            container_base: "jk-k7p9m2xq-workspace-agent",
             workspace_name: Some("workspace"),
             workspace_label: "workspace",
             workdir: "/workspace",
@@ -671,12 +685,12 @@ mod tests {
             agent_runtime: Agent::Claude,
             role_source_git: "https://example.invalid/role.git",
             role_source_ref: Some("main"),
-            image_tag: "jackin-org__agent",
+            image_tag: "jk-org_agent",
             docker: DockerResources {
-                role_container: "jackin-workspace-agent-k7p9m2xq".to_string(),
-                dind_container: "jackin-workspace-agent-k7p9m2xq-dind".to_string(),
-                network: "jackin-workspace-agent-k7p9m2xq-net".to_string(),
-                certs_volume: "jackin-workspace-agent-k7p9m2xq-dind-certs".to_string(),
+                role_container: "jk-k7p9m2xq-workspace-agent".to_string(),
+                dind_container: "jk-k7p9m2xq-workspace-agent-dind".to_string(),
+                network: "jk-k7p9m2xq-workspace-agent-net".to_string(),
+                certs_volume: "jk-k7p9m2xq-workspace-agent-dind-certs".to_string(),
             },
         });
 
@@ -708,7 +722,7 @@ mod tests {
 
         // Container B has a manifest on disk but no index entry —
         // simulates a manifest written before an index update.
-        let manifest_b_base = "jackin-workspace-agent-orphan01";
+        let manifest_b_base = "jk-orphan01-workspace-agent";
         let manifest_b = InstanceManifest {
             container_base: manifest_b_base.to_string(),
             ..manifest_a.clone()
@@ -751,6 +765,62 @@ mod tests {
         let index = InstanceIndex::read(data_dir.path()).unwrap();
         assert_eq!(index.instances.len(), 1);
         assert_eq!(index.instances[0].status, InstanceStatus::Purged);
+    }
+
+    #[test]
+    fn remove_many_empty_slice_is_noop() {
+        let data_dir = tempdir().unwrap();
+        InstanceIndex::remove_many(data_dir.path(), &[]).unwrap();
+        assert!(!data_dir.path().join("instances.json").exists());
+    }
+
+    #[test]
+    fn remove_many_deletes_only_named_entries() {
+        let data_dir = tempdir().unwrap();
+        let manifest = sample_manifest();
+        let other_base = "jk-a1b2c3d4-other-agent";
+        let mut other = manifest.clone();
+        other.container_base = other_base.to_string();
+        InstanceIndex::update_manifest(data_dir.path(), &manifest).unwrap();
+        InstanceIndex::update_manifest(data_dir.path(), &other).unwrap();
+
+        InstanceIndex::remove_many(data_dir.path(), &[manifest.container_base.as_str()]).unwrap();
+
+        let index = InstanceIndex::read_or_rebuild(data_dir.path()).unwrap();
+        assert_eq!(index.instances.len(), 1);
+        assert_eq!(index.instances[0].container_base, other_base);
+    }
+
+    #[test]
+    fn remove_many_with_absent_name_is_noop() {
+        let data_dir = tempdir().unwrap();
+        let manifest = sample_manifest();
+        InstanceIndex::update_manifest(data_dir.path(), &manifest).unwrap();
+
+        InstanceIndex::remove_many(data_dir.path(), &["jk-nothere-agent"]).unwrap();
+
+        let index = InstanceIndex::read_or_rebuild(data_dir.path()).unwrap();
+        assert_eq!(index.instances.len(), 1);
+        assert_eq!(index.instances[0].container_base, manifest.container_base);
+    }
+
+    #[test]
+    fn remove_many_with_duplicate_names_removes_once() {
+        let data_dir = tempdir().unwrap();
+        let manifest = sample_manifest();
+        InstanceIndex::update_manifest(data_dir.path(), &manifest).unwrap();
+
+        InstanceIndex::remove_many(
+            data_dir.path(),
+            &[
+                manifest.container_base.as_str(),
+                manifest.container_base.as_str(),
+            ],
+        )
+        .unwrap();
+
+        let index = InstanceIndex::read_or_rebuild(data_dir.path()).unwrap();
+        assert!(index.instances.is_empty());
     }
 
     #[test]

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -11,7 +11,7 @@ pub use manifest::{
     InstanceStatus, NewInstanceManifest,
 };
 pub use naming::{
-    class_family_matches, container_name_with_id, new_container_name, primary_container_name,
+    CONTAINER_PREFIX_DASH, class_family_matches, container_name_with_id, new_container_name,
     runtime_slug,
 };
 
@@ -551,7 +551,7 @@ plugins = []
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-k7p9m2xq-agentsmith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &GithubAuthContext::default(),
@@ -579,7 +579,7 @@ plugins = []
         // above, since they only look up paths through the enum. These
         // assertions verify the actual host paths under
         // `<container>/claude/`.
-        let container_root = paths.data_dir.join("jackin-agent-smith");
+        let container_root = paths.data_dir.join("jk-k7p9m2xq-agentsmith");
         assert_eq!(
             state.claude_account_json().unwrap(),
             container_root.join("claude").join("account.json"),
@@ -622,7 +622,7 @@ model = "gpt-5"
 
         let (state, outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-k7p9m2xq-agentsmith",
             &manifest,
             &|_| AuthForwardMode::Ignore,
             &GithubAuthContext::default(),
@@ -636,7 +636,7 @@ model = "gpt-5"
         assert!(
             !paths
                 .data_dir
-                .join("jackin-agent-smith")
+                .join("jk-k7p9m2xq-agentsmith")
                 .join("codex")
                 .join("config.toml")
                 .exists()
@@ -644,7 +644,7 @@ model = "gpt-5"
         assert!(
             paths
                 .data_dir
-                .join("jackin-agent-smith")
+                .join("jk-k7p9m2xq-agentsmith")
                 .join("home/.codex")
                 .is_dir()
         );
@@ -698,7 +698,7 @@ plugins = []
 
         let (state, selected_outcome) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-k7p9m2xq-agentsmith",
             &manifest,
             &auth_modes,
             &GithubAuthContext::default(),

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -10,10 +10,7 @@ pub use manifest::{
     DockerResources, InstanceIndex, InstanceIndexEntry, InstanceManifest, InstanceQuery,
     InstanceStatus, NewInstanceManifest,
 };
-pub use naming::{
-    CONTAINER_PREFIX_DASH, class_family_matches, container_name_with_id, new_container_name,
-    runtime_slug,
-};
+pub use naming::{class_family_matches, container_name_with_id, new_container_name, runtime_slug};
 
 /// Outcome of the `.claude.json` provisioning step, so callers can surface
 /// a one-time notice when host credentials are forwarded.

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -1,7 +1,7 @@
 use crate::selector::RoleSelector;
 use sha2::{Digest, Sha256};
 
-pub const CONTAINER_PREFIX: &str = "jk";
+pub(crate) const CONTAINER_PREFIX: &str = "jk";
 pub const CONTAINER_PREFIX_DASH: &str = "jk-";
 const INSTANCE_ID_LEN: usize = 8;
 const ROLE_BASE_DNS_BUDGET: usize = 58;

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -244,6 +244,20 @@ mod tests {
     }
 
     #[test]
+    fn class_family_matches_workspace_and_adhoc_for_same_selector() {
+        // A single role selector must match both a workspace-scoped container
+        // (jk-<id>-<ws>-<role>) and an ad-hoc container (jk-<id>-<role>).
+        // The rsplit_once fallback path handles the no-workspace case.
+        let selector = RoleSelector::new(None, "agent-smith");
+        assert!(class_family_matches(&selector, "jk-k7p9m2xq-agentsmith")); // ad-hoc
+        assert!(class_family_matches(
+            &selector,
+            "jk-k7p9m2xq-myproject-agentsmith" // workspace-scoped
+        ));
+        assert!(!class_family_matches(&selector, "jk-k7p9m2xq-agentbrown"));
+    }
+
+    #[test]
     fn no_workspace_long_role_fits_dns_budget() {
         let selector = RoleSelector::new(None, "role-name-with-a-very-long-human-friendly-label");
 

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -2,7 +2,7 @@ use crate::selector::RoleSelector;
 use sha2::{Digest, Sha256};
 
 pub(crate) const CONTAINER_PREFIX: &str = "jk";
-pub const CONTAINER_PREFIX_DASH: &str = "jk-";
+pub(crate) const CONTAINER_PREFIX_DASH: &str = "jk-";
 const INSTANCE_ID_LEN: usize = 8;
 const ROLE_BASE_DNS_BUDGET: usize = 58;
 

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -1,19 +1,16 @@
 use crate::selector::RoleSelector;
 use sha2::{Digest, Sha256};
 
-const CONTAINER_PREFIX: &str = "jackin";
+pub const CONTAINER_PREFIX: &str = "jk";
+pub const CONTAINER_PREFIX_DASH: &str = "jk-";
 const INSTANCE_ID_LEN: usize = 8;
 const ROLE_BASE_DNS_BUDGET: usize = 58;
 
 pub fn runtime_slug(selector: &RoleSelector) -> String {
     selector.namespace.as_ref().map_or_else(
         || selector.name.clone(),
-        |namespace| format!("{namespace}__{}", selector.name),
+        |namespace| format!("{namespace}_{}", selector.name),
     )
-}
-
-pub fn primary_container_name(selector: &RoleSelector) -> String {
-    format!("jackin-{}", runtime_slug(selector))
 }
 
 pub fn new_container_name(workspace_name: Option<&str>, selector: &RoleSelector) -> String {
@@ -31,20 +28,28 @@ pub fn container_name_with_id(
     let components = if let Some(workspace_name) = workspace_name {
         let workspace = compact_component(workspace_name, "workspace");
         let budget = ROLE_BASE_DNS_BUDGET - CONTAINER_PREFIX.len() - instance_id.len() - 3;
-        let workspace_budget = budget / 2;
-        let role_budget = budget - workspace_budget;
+        let (ws_part, role_part) = if workspace.len() + role.len() <= budget {
+            (workspace, role)
+        } else {
+            let workspace_budget = budget / 2;
+            let role_budget = budget - workspace_budget;
+            (
+                truncate_component(&workspace, workspace_budget),
+                truncate_component(&role, role_budget),
+            )
+        };
         vec![
             CONTAINER_PREFIX.to_string(),
-            truncate_component(&workspace, workspace_budget),
-            truncate_component(&role, role_budget),
             instance_id,
+            ws_part,
+            role_part,
         ]
     } else {
         let role_budget = ROLE_BASE_DNS_BUDGET - CONTAINER_PREFIX.len() - instance_id.len() - 2;
         vec![
             CONTAINER_PREFIX.to_string(),
-            truncate_component(&role, role_budget),
             instance_id,
+            truncate_component(&role, role_budget),
         ]
     };
 
@@ -54,18 +59,21 @@ pub fn container_name_with_id(
     name
 }
 
-/// Extract the trailing instance-ID component from a container name.
+/// Extract the instance-ID component from a container name.
 ///
-/// Returns `None` when the name has no `-` separator. Used by both
-/// manifest construction (the stored `instance_id` field) and operator
-/// display rendering — one parser owns the shape
-/// `jackin-[<workspace>-]<role>-<id>` produced by [`new_container_name`].
+/// Returns `None` when the name does not start with `jk-` or has no `-` after
+/// the id component. Used by both manifest construction (the stored
+/// `instance_id` field) and operator display rendering — one parser owns the
+/// shape `jk-<id>[-<workspace>]-<role>` produced by [`new_container_name`].
 #[must_use]
 pub fn instance_id_from_container_base(container_base: &str) -> Option<&str> {
-    container_base.rsplit_once('-').map(|(_, id)| id)
+    container_base
+        .strip_prefix(CONTAINER_PREFIX_DASH)?
+        .split_once('-')
+        .map(|(id, _)| id)
 }
 
-/// Recognize names of the shape `jackin-[<workspace>-]<role>-<id>`
+/// Recognize names of the shape `jk-<id>[-<workspace>]-<role>`
 /// produced by `new_container_name`. Scoping hook for `purge_class_data`.
 pub fn class_family_matches(selector: &RoleSelector, container_name: &str) -> bool {
     class_family_matches_with_slug(&compact_component(&selector.name, "role"), container_name)
@@ -73,24 +81,17 @@ pub fn class_family_matches(selector: &RoleSelector, container_name: &str) -> bo
 
 /// Loop-friendly variant of [`class_family_matches`].
 ///
-/// Callers iterating over many candidates (e.g. `purge_class_data`,
-/// `last_role` fallback in `app/context.rs`) precompute `role_slug`
-/// once via [`compact_component`] and pass it in — avoids one
-/// `String` allocation per comparison.
+/// Callers precompute `role_slug` once via [`compact_component`] and pass
+/// it in — avoids one `String` allocation per candidate.
 #[must_use]
 pub fn class_family_matches_with_slug(role_slug: &str, container_name: &str) -> bool {
-    let Some(rest) = container_name.strip_prefix("jackin-") else {
+    let Some(rest) = container_name.strip_prefix(CONTAINER_PREFIX_DASH) else {
         return false;
     };
-    let mut parts = rest.rsplitn(2, '-');
-    parts.next(); // discard the trailing instance id
-    let Some(prefix) = parts.next() else {
+    let Some((_, after_id)) = rest.split_once('-') else {
         return false;
     };
-    prefix
-        .rsplit_once('-')
-        .map_or(prefix, |(_, visible_role)| visible_role)
-        == role_slug
+    after_id.rsplit_once('-').map_or(after_id, |(_, role)| role) == role_slug
 }
 
 pub fn compact_component(input: &str, fallback: &str) -> String {
@@ -174,7 +175,7 @@ mod tests {
 
         let name = container_name_with_id(Some("chainargos-project"), &selector, "k7p9m2xq");
 
-        assert_eq!(name, "jackin-chainargosproject-agentbrown-k7p9m2xq");
+        assert_eq!(name, "jk-k7p9m2xq-chainargosproject-agentbrown");
         assert!(is_dns_label(&name));
         assert!(is_dns_label(&format!("{name}-dind")));
     }
@@ -185,7 +186,7 @@ mod tests {
 
         let name = container_name_with_id(None, &selector, "k7p9m2xq");
 
-        assert_eq!(name, "jackin-agentbrown-k7p9m2xq");
+        assert_eq!(name, "jk-k7p9m2xq-agentbrown");
         assert!(is_dns_label(&name));
     }
 
@@ -209,11 +210,11 @@ mod tests {
 
         assert!(class_family_matches(
             &selector,
-            "jackin-chainargosproject-agentbrown-k7p9m2xq"
+            "jk-k7p9m2xq-chainargosproject-agentbrown"
         ));
         assert!(!class_family_matches(
             &selector,
-            "jackin-chainargosproject-agentblue-k7p9m2xq"
+            "jk-k7p9m2xq-chainargosproject-agentblue"
         ));
     }
 
@@ -223,23 +224,33 @@ mod tests {
         // component is `agentbrown` (the longer name happens to end
         // in `brown`). Important for `purge_class_data` blast radius.
         let brown = RoleSelector::new(None, "brown");
-        assert!(!class_family_matches(&brown, "jackin-agentbrown-k7p9m2xq",));
+        assert!(!class_family_matches(&brown, "jk-k7p9m2xq-agentbrown",));
         let agentbrown = RoleSelector::new(None, "agentbrown");
-        assert!(!class_family_matches(&agentbrown, "jackin-brown-k7p9m2xq",));
-        assert!(class_family_matches(
-            &agentbrown,
-            "jackin-agentbrown-k7p9m2xq",
-        ));
+        assert!(!class_family_matches(&agentbrown, "jk-k7p9m2xq-brown",));
+        assert!(class_family_matches(&agentbrown, "jk-k7p9m2xq-agentbrown",));
     }
 
     #[test]
-    fn distinguishes_namespaced_and_flat_class_container_names() {
-        let namespaced = RoleSelector::new(Some("chainargos"), "the-architect");
-        let flat = RoleSelector::new(None, "chainargos-the-architect");
-
-        assert_ne!(
-            primary_container_name(&namespaced),
-            primary_container_name(&flat)
+    fn instance_id_from_container_base_extracts_second_component() {
+        assert_eq!(
+            instance_id_from_container_base("jk-k7p9m2xq-workspace-agentsmith"),
+            Some("k7p9m2xq")
         );
+        assert_eq!(
+            instance_id_from_container_base("jk-k7p9m2xq-agentsmith"),
+            Some("k7p9m2xq")
+        );
+        assert_eq!(instance_id_from_container_base("nojkprefix-k7p9m2xq"), None);
+        assert_eq!(instance_id_from_container_base("jk-noid"), None);
+    }
+
+    #[test]
+    fn no_workspace_long_role_fits_dns_budget() {
+        let selector = RoleSelector::new(None, "role-name-with-a-very-long-human-friendly-label");
+
+        let name = container_name_with_id(None, &selector, "k7p9m2xq");
+
+        assert!(name.len() <= 58, "{name}");
+        assert!(is_dns_label(&format!("{name}-dind")));
     }
 }

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -79,10 +79,8 @@ pub fn class_family_matches(selector: &RoleSelector, container_name: &str) -> bo
     class_family_matches_with_slug(&compact_component(&selector.name, "role"), container_name)
 }
 
-/// Loop-friendly variant of [`class_family_matches`].
-///
-/// Callers precompute `role_slug` once via [`compact_component`] and pass
-/// it in — avoids one `String` allocation per candidate.
+/// Loop-friendly variant of [`class_family_matches`] for callers that
+/// precompute the slug once across many candidates.
 #[must_use]
 pub fn class_family_matches_with_slug(role_slug: &str, container_name: &str) -> bool {
     let Some(rest) = container_name.strip_prefix(CONTAINER_PREFIX_DASH) else {

--- a/src/instance/naming.rs
+++ b/src/instance/naming.rs
@@ -80,7 +80,8 @@ pub fn class_family_matches(selector: &RoleSelector, container_name: &str) -> bo
 }
 
 /// Loop-friendly variant of [`class_family_matches`] for callers that
-/// precompute the slug once across many candidates.
+/// precompute the slug once across many candidates — avoids one
+/// [`compact_component`] allocation per comparison.
 #[must_use]
 pub fn class_family_matches_with_slug(role_slug: &str, container_name: &str) -> bool {
     let Some(rest) = container_name.strip_prefix(CONTAINER_PREFIX_DASH) else {

--- a/src/isolation/finalize.rs
+++ b/src/isolation/finalize.rs
@@ -196,7 +196,8 @@ fn finalize_clean_exit(
             eprintln!(
                 "[jackin] preserved isolated worktree for {container_name}:\n         {wt}\n         reason: {reason_str}\n         run `jackin hardline {short}` to return, inspect the path above directly, or `jackin purge {short}` to discard",
                 wt = rec.worktree_path,
-                short = container_name.trim_start_matches("jackin-"),
+                short = crate::instance::naming::instance_id_from_container_base(container_name)
+                    .unwrap_or(container_name),
             );
         }
         return Ok(FinalizeDecision::Preserved);
@@ -231,7 +232,10 @@ fn finalize_clean_exit(
                     eprintln!(
                         "[jackin] warning: force-delete of isolated worktree `{wt}` failed: {e}\n         record retained — re-run `jackin purge {short}` to retry after resolving the underlying issue",
                         wt = rec.worktree_path,
-                        short = container_name.trim_start_matches("jackin-"),
+                        short = crate::instance::naming::instance_id_from_container_base(
+                            container_name
+                        )
+                        .unwrap_or(container_name),
                     );
                     any_preserved_after_prompt = true;
                 }

--- a/src/isolation/state.rs
+++ b/src/isolation/state.rs
@@ -44,7 +44,6 @@ struct IsolationFile {
 }
 
 /// Path to `isolation.json` for a given container's state directory.
-/// `container_state_dir` is `<data_dir>/<container-name>` (e.g. `<data_dir>/jk-k7p9m2xq-agentsmith/`).
 pub fn isolation_file_path(container_state_dir: &Path) -> PathBuf {
     container_state_dir.join(STATE_DIR).join(ISOLATION_FILE)
 }

--- a/src/isolation/state.rs
+++ b/src/isolation/state.rs
@@ -44,7 +44,7 @@ struct IsolationFile {
 }
 
 /// Path to `isolation.json` for a given container's state directory.
-/// `container_state_dir` is `<data_dir>/jk-<container>`.
+/// `container_state_dir` is `<data_dir>/<container-name>` (e.g. `<data_dir>/jk-k7p9m2xq-agentsmith/`).
 pub fn isolation_file_path(container_state_dir: &Path) -> PathBuf {
     container_state_dir.join(STATE_DIR).join(ISOLATION_FILE)
 }

--- a/src/isolation/state.rs
+++ b/src/isolation/state.rs
@@ -44,7 +44,7 @@ struct IsolationFile {
 }
 
 /// Path to `isolation.json` for a given container's state directory.
-/// `container_state_dir` is `<data_dir>/jackin-<container>`.
+/// `container_state_dir` is `<data_dir>/jk-<container>`.
 pub fn isolation_file_path(container_state_dir: &Path) -> PathBuf {
     container_state_dir.join(STATE_DIR).join(ISOLATION_FILE)
 }
@@ -225,9 +225,7 @@ pub fn remove_record(container_state_dir: &Path, mount_dst: &str) -> anyhow::Res
     Ok(())
 }
 
-const CONTAINER_DIR_PREFIX: &str = "jackin-";
-
-/// Walk every `<data_dir>/jackin-*/` directory and collect records whose
+/// Walk every `<data_dir>/jk-*/` directory and collect records whose
 /// `workspace` matches the given name. Missing data dir → empty result.
 /// Per-container parse failures bubble up.
 pub fn list_records_for_workspace(
@@ -250,7 +248,7 @@ pub fn list_records_for_workspace(
         let Some(name_str) = name.to_str() else {
             continue;
         };
-        if !name_str.starts_with(CONTAINER_DIR_PREFIX) {
+        if !name_str.starts_with(crate::instance::naming::CONTAINER_PREFIX_DASH) {
             continue;
         }
         let records = read_records(&entry.path())?;
@@ -278,7 +276,7 @@ mod tests {
             scratch_branch: "jackin/scratch/the-architect".into(),
             base_commit: "deadbeef".into(),
             selector_key: "the-architect".into(),
-            container_name: "jackin-the-architect".into(),
+            container_name: "jk-a1b2c3d4-thearchitect".into(),
             cleanup_status: CleanupStatus::Active,
         }
     }
@@ -380,24 +378,24 @@ mod tests {
     fn list_records_for_workspace_walks_all_container_dirs() {
         let data = TempDir::new().unwrap();
         // Container A: workspace=jackin
-        let a = data.path().join("jackin-the-architect");
+        let a = data.path().join("jk-a1b2c3d4-thearchitect");
         std::fs::create_dir_all(&a).unwrap();
         let mut rec_a = sample_record();
-        rec_a.container_name = "jackin-the-architect".into();
+        rec_a.container_name = "jk-a1b2c3d4-thearchitect".into();
         write_records(&a, std::slice::from_ref(&rec_a)).unwrap();
         // Container B: workspace=jackin
-        let b = data.path().join("jackin-the-builder");
+        let b = data.path().join("jk-k7p9m2xq-thebuilder");
         std::fs::create_dir_all(&b).unwrap();
         let mut rec_b = sample_record();
-        rec_b.container_name = "jackin-the-builder".into();
+        rec_b.container_name = "jk-k7p9m2xq-thebuilder".into();
         rec_b.scratch_branch = "jackin/scratch/the-builder".into();
         write_records(&b, std::slice::from_ref(&rec_b)).unwrap();
         // Container C: workspace=docs (must be skipped when filtering by jackin)
-        let c = data.path().join("jackin-doc-writer");
+        let c = data.path().join("jk-b2c3d4e5-docwriter");
         std::fs::create_dir_all(&c).unwrap();
         let mut rec_c = sample_record();
         rec_c.workspace = "docs".into();
-        rec_c.container_name = "jackin-doc-writer".into();
+        rec_c.container_name = "jk-b2c3d4e5-docwriter".into();
         write_records(&c, &[rec_c]).unwrap();
 
         let mut found = list_records_for_workspace(data.path(), "jackin").unwrap();

--- a/src/runtime/attach.rs
+++ b/src/runtime/attach.rs
@@ -635,7 +635,7 @@ mod tests {
         let (_tmp, paths) = test_paths();
         let mut runner = FakeRunner::with_capture_queue(["true 0 false".to_string()]);
 
-        hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap();
+        hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap();
 
         // The attach command must appear; the trailing inspect for the
         // finalizer is appended after.
@@ -643,7 +643,7 @@ mod tests {
             runner
                 .recorded
                 .iter()
-                .any(|c| c == "docker attach --detach-keys= --sig-proxy=false jackin-agent-smith"),
+                .any(|c| c == "docker attach --detach-keys= --sig-proxy=false jk-agent-smith"),
             "expected docker attach in recorded commands"
         );
     }
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     fn hardline_new_session_execs_entrypoint_in_running_container() {
         let (_tmp, paths) = test_paths();
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = InstanceManifest::new(crate::instance::NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -663,7 +663,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: crate::instance::DockerResources {
                 role_container: container_name.to_string(),
                 dind_container: format!("{container_name}-dind"),
@@ -687,7 +687,7 @@ mod tests {
         .unwrap();
 
         assert!(runner.recorded.iter().any(|call| {
-            call == "docker exec -it -e JACKIN_AGENT=codex --workdir /workspace/project jackin-workspace-agentsmith-k7p9m2xq /jackin/runtime/entrypoint.sh"
+            call == "docker exec -it -e JACKIN_AGENT=codex --workdir /workspace/project jk-k7p9m2xq-workspace-agentsmith /jackin/runtime/entrypoint.sh"
         }));
     }
 
@@ -698,7 +698,7 @@ mod tests {
 
         let err = spawn_agent_session(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             None,
             crate::agent::Agent::Claude,
             &mut runner,
@@ -719,7 +719,7 @@ mod tests {
         let (_tmp, paths) = test_paths();
         let mut runner = FakeRunner::default();
 
-        let err = hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap_err();
+        let err = hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap_err();
 
         assert!(err.to_string().contains("not found"));
         assert!(
@@ -735,10 +735,10 @@ mod tests {
         let mut missing = FakeRunner::default();
         missing.fail_with.push((
             "docker inspect".to_string(),
-            "Error: No such object: jackin-agent-smith".to_string(),
+            "Error: No such object: jk-agent-smith".to_string(),
         ));
         assert_eq!(
-            inspect_container_state(&mut missing, "jackin-agent-smith"),
+            inspect_container_state(&mut missing, "jk-agent-smith"),
             ContainerState::NotFound
         );
 
@@ -748,7 +748,7 @@ mod tests {
             "Cannot connect to the Docker daemon at unix:///var/run/docker.sock".to_string(),
         ));
         assert!(matches!(
-            inspect_container_state(&mut unavailable, "jackin-agent-smith"),
+            inspect_container_state(&mut unavailable, "jk-agent-smith"),
             ContainerState::InspectUnavailable(reason)
                 if reason.contains("Cannot connect to the Docker daemon")
         ));
@@ -763,7 +763,7 @@ mod tests {
             "Cannot connect to the Docker daemon at unix:///var/run/docker.sock".to_string(),
         ));
 
-        let err = hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap_err();
+        let err = hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap_err();
 
         assert!(err.to_string().contains("Docker is unavailable"));
         assert!(
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn hardline_marks_missing_manifest_restore_available() {
         let (_tmp, paths) = test_paths();
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let mut manifest = InstanceManifest::new(crate::instance::NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -789,7 +789,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: crate::instance::DockerResources {
                 role_container: container_name.to_string(),
                 dind_container: format!("{container_name}-dind"),
@@ -815,7 +815,7 @@ mod tests {
     #[test]
     fn inspect_hardline_instance_reports_state_without_attaching() {
         let (_tmp, paths) = test_paths();
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let mut manifest = InstanceManifest::new(crate::instance::NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -827,7 +827,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Codex,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: Some("feature/role"),
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: crate::instance::DockerResources {
                 role_container: container_name.to_string(),
                 dind_container: format!("{container_name}-dind"),
@@ -859,13 +859,13 @@ mod tests {
             report.contains("Agent sessions: 101 /jackin/runtime/entrypoint.sh; 202 codex exec"),
             "{report}"
         );
-        assert!(report.contains("Role container: jackin-workspace-agentsmith-k7p9m2xq (running)"));
-        assert!(report.contains(
-            "DinD container: jackin-workspace-agentsmith-k7p9m2xq-dind (stopped exit:137)"
-        ));
+        assert!(report.contains("Role container: jk-k7p9m2xq-workspace-agentsmith (running)"));
         assert!(
-            report.contains("Docker network: jackin-workspace-agentsmith-k7p9m2xq-net (present)")
+            report.contains(
+                "DinD container: jk-k7p9m2xq-workspace-agentsmith-dind (stopped exit:137)"
+            )
         );
+        assert!(report.contains("Docker network: jk-k7p9m2xq-workspace-agentsmith-net (present)"));
         assert!(
             !runner
                 .recorded
@@ -882,7 +882,7 @@ mod tests {
         ]);
 
         let sessions =
-            inspect_agent_sessions(&mut runner, "jackin-agent-smith", &ContainerState::Running);
+            inspect_agent_sessions(&mut runner, "jk-agent-smith", &ContainerState::Running);
 
         let AgentSessionInventory::Sessions(sessions) = sessions else {
             panic!("expected sessions");
@@ -898,7 +898,7 @@ mod tests {
 
         let sessions = inspect_agent_sessions(
             &mut runner,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &ContainerState::Stopped {
                 exit_code: 137,
                 oom_killed: false,
@@ -912,7 +912,7 @@ mod tests {
     #[test]
     fn inspect_hardline_instance_still_reports_manifest_when_docker_unavailable() {
         let (_tmp, paths) = test_paths();
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = InstanceManifest::new(crate::instance::NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -924,7 +924,7 @@ mod tests {
             agent_runtime: crate::agent::Agent::Claude,
             role_source_git: "https://example.invalid/agent-smith.git",
             role_source_ref: None,
-            image_tag: "jackin-agent-smith",
+            image_tag: "jk-agent-smith",
             docker: crate::instance::DockerResources {
                 role_container: container_name.to_string(),
                 dind_container: format!("{container_name}-dind"),
@@ -948,12 +948,9 @@ mod tests {
         let report = inspect_hardline_instance(&paths, container_name, &mut runner).unwrap();
 
         assert!(report.contains("Workspace: workspace"), "{report}");
+        assert!(report.contains("Role container: jk-k7p9m2xq-workspace-agentsmith (unavailable:"));
         assert!(
-            report.contains("Role container: jackin-workspace-agentsmith-k7p9m2xq (unavailable:")
-        );
-        assert!(
-            report
-                .contains("Docker network: jackin-workspace-agentsmith-k7p9m2xq-net (unavailable:")
+            report.contains("Docker network: jk-k7p9m2xq-workspace-agentsmith-net (unavailable:")
         );
         assert!(
             !runner
@@ -968,7 +965,7 @@ mod tests {
         let (_tmp, paths) = test_paths();
         let mut runner = FakeRunner::with_capture_queue(["false 0 false".to_string()]);
 
-        let err = hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap_err();
+        let err = hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap_err();
 
         assert!(err.to_string().contains("exited cleanly"));
         assert!(
@@ -988,19 +985,19 @@ mod tests {
             "true 0 false".to_string(),
         ]);
 
-        hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap();
+        hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap();
 
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c == "docker start jackin-agent-smith"),
+                .any(|c| c == "docker start jk-agent-smith"),
             "expected docker start before attach"
         );
         let start_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker start jackin-agent-smith")
+            .position(|c| c == "docker start jk-agent-smith")
             .unwrap();
         let attach_idx = runner
             .recorded
@@ -1019,45 +1016,45 @@ mod tests {
             String::new(),
         ]);
         runner.fail_with.push((
-            "docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jackin-agent-smith-dind".to_string(),
-            "Error: No such object: jackin-agent-smith-dind".to_string(),
+            "docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-agent-smith-dind".to_string(),
+            "Error: No such object: jk-agent-smith-dind".to_string(),
         ));
         runner.fail_with.push((
-            "docker network inspect jackin-agent-smith-net".to_string(),
-            "Error: No such network: jackin-agent-smith-net".to_string(),
+            "docker network inspect jk-agent-smith-net".to_string(),
+            "Error: No such network: jk-agent-smith-net".to_string(),
         ));
 
-        hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap();
+        hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap();
 
         let network_create_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker network create --label jackin.managed=true --label jackin.role=jackin-agent-smith jackin-agent-smith-net")
+            .position(|c| c == "docker network create --label jackin.managed=true --label jackin.role=jk-agent-smith jk-agent-smith-net")
             .expect("expected missing network recreation");
         let network_connect_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker network connect jackin-agent-smith-net jackin-agent-smith")
+            .position(|c| c == "docker network connect jk-agent-smith-net jk-agent-smith")
             .expect("expected role container network reconnect");
         let dind_run_idx = runner
             .recorded
             .iter()
             .position(|c| {
-                c.contains("docker run -d --name jackin-agent-smith-dind")
-                    && c.contains("--network jackin-agent-smith-net")
-                    && c.contains("DOCKER_TLS_SAN=DNS:jackin-agent-smith-dind")
-                    && c.contains("jackin-agent-smith-dind-certs:/certs/client")
+                c.contains("docker run -d --name jk-agent-smith-dind")
+                    && c.contains("--network jk-agent-smith-net")
+                    && c.contains("DOCKER_TLS_SAN=DNS:jk-agent-smith-dind")
+                    && c.contains("jk-agent-smith-dind-certs:/certs/client")
             })
             .expect("expected missing DinD sidecar recreation");
         let dind_ready_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker exec jackin-agent-smith-dind docker info")
+            .position(|c| c == "docker exec jk-agent-smith-dind docker info")
             .expect("expected DinD readiness check");
         let role_start_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker start jackin-agent-smith")
+            .position(|c| c == "docker start jk-agent-smith")
             .expect("expected role restart");
         let attach_idx = runner
             .recorded
@@ -1076,11 +1073,11 @@ mod tests {
         let (_tmp, paths) = test_paths();
         let mut runner = FakeRunner::with_capture_queue(["false 137 false".to_string()]);
         runner.fail_with.push((
-            "docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jackin-agent-smith-dind".to_string(),
+            "docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-agent-smith-dind".to_string(),
             "Cannot connect to the Docker daemon at unix:///var/run/docker.sock".to_string(),
         ));
 
-        let err = hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap_err();
+        let err = hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap_err();
 
         assert!(err.to_string().contains("Docker is unavailable"));
         assert!(
@@ -1101,22 +1098,22 @@ mod tests {
             String::new(),
         ]);
 
-        hardline_agent(&paths, "jackin-agent-smith", &mut runner).unwrap();
+        hardline_agent(&paths, "jk-agent-smith", &mut runner).unwrap();
 
         let dind_start_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker start jackin-agent-smith-dind")
+            .position(|c| c == "docker start jk-agent-smith-dind")
             .expect("expected stopped DinD sidecar restart");
         let dind_ready_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker exec jackin-agent-smith-dind docker info")
+            .position(|c| c == "docker exec jk-agent-smith-dind docker info")
             .expect("expected DinD readiness check");
         let role_start_idx = runner
             .recorded
             .iter()
-            .position(|c| c == "docker start jackin-agent-smith")
+            .position(|c| c == "docker start jk-agent-smith")
             .expect("expected role restart");
         let attach_idx = runner
             .recorded

--- a/src/runtime/caffeinate.rs
+++ b/src/runtime/caffeinate.rs
@@ -398,9 +398,7 @@ mod tests {
     #[test]
     fn count_keep_awake_agents_counts_nonempty_lines() {
         let mut runner =
-            FakeRunner::with_capture_queue(
-                ["jackin-agent-smith\njackin-the-architect".to_string()],
-            );
+            FakeRunner::with_capture_queue(["jk-agent-smith\njk-the-architect".to_string()]);
         let count = count_keep_awake_agents(&mut runner).unwrap();
         assert_eq!(count, 2);
     }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -266,6 +266,9 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
 }
 
 /// Remove jk-* Docker images that have no jackin-managed role containers (running or stopped).
+///
+/// Best-effort: always returns `Ok(())`. Per-image failures are printed to stderr and
+/// counted in the summary but never propagate as errors.
 pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     let images_output = runner.capture(
         "docker",
@@ -342,7 +345,7 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
 
     if removed == 0 && failed == 0 {
         if skipped > 0 {
-            println!("All {skipped} image(s) are in use by containers; nothing removed.");
+            println!("No images removed ({skipped} skipped).");
         } else {
             println!("No unused jackin-managed images to remove.");
         }
@@ -996,6 +999,33 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         prune_images(&mut runner).unwrap();
 
         assert!(!runner.recorded.iter().any(|c| c.contains("docker rmi")));
+    }
+
+    #[test]
+    fn prune_images_counts_rmi_in_use_error_as_skipped_not_failed() {
+        // Image passes the pre-filter (not in the in_use set from docker ps)
+        // but docker rmi returns an in-use error at removal time. Should be
+        // skipped (Ok), not failed (error message + nonzero failed count).
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "docker rmi jk-agent-smith:latest".to_string(),
+                "conflict: unable to remove (cannot be forced) - image is being used by running container"
+                    .to_string(),
+            )],
+            capture_queue: std::collections::VecDeque::from(vec![
+                "jk-agent-smith:latest".to_string(), // docker images
+                String::new(),                        // docker ps -a: no containers in index
+            ]),
+            ..Default::default()
+        };
+
+        prune_images(&mut runner).unwrap();
+
+        // rmi was attempted (image was not in the pre-filter set)
+        assert!(runner
+            .recorded
+            .iter()
+            .any(|c| c.contains("docker rmi jk-agent-smith:latest")));
     }
 
     #[test]

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -173,7 +173,6 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
         let certs_volume = dind_certs_volume(&info.role);
         let network = format!("{}-net", info.role);
 
-        // Remove stopped role container, DinD sidecar, cert volume, and network.
         let _ = run_cleanup_command(runner, &["rm", "-f", &info.role]);
         let _ = run_cleanup_command(runner, &["rm", "-f", &info.name]);
         let _ = run_cleanup_command(runner, &["volume", "rm", &certs_volume]);
@@ -342,7 +341,11 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     }
 
     if removed == 0 && failed == 0 {
-        println!("No unused jackin-managed images to remove.");
+        if skipped > 0 {
+            println!("All {skipped} image(s) are in use by containers; nothing removed.");
+        } else {
+            println!("No unused jackin-managed images to remove.");
+        }
     } else if failed == 0 {
         println!("Removed {removed} image(s), skipped {skipped}.");
     } else {

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -5,7 +5,9 @@ use crate::selector::RoleSelector;
 use owo_colors::OwoColorize;
 
 use super::discovery::{list_managed_role_names, list_role_names};
-use super::naming::{FILTER_KIND_DIND, FILTER_KIND_ROLE, FILTER_MANAGED, dind_certs_volume};
+use super::naming::{
+    FILTER_IMAGES, FILTER_KIND_DIND, FILTER_KIND_ROLE, FILTER_MANAGED, dind_certs_volume,
+};
 
 pub fn purge_class_data(
     paths: &JackinPaths,
@@ -296,7 +298,7 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
         &[
             "images",
             "--filter",
-            "reference=jk-*",
+            FILTER_IMAGES,
             "--format",
             "{{.Repository}}:{{.Tag}}",
         ],

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -425,10 +425,6 @@ pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> 
         );
     }
 
-    if removed.is_empty() && skipped.is_empty() {
-        println!("No instances pruned.");
-    }
-
     Ok(())
 }
 

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -179,6 +179,18 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
             run_cleanup_command(runner, &["volume", "rm", &certs_volume]),
             run_cleanup_command(runner, &["network", "rm", &network]),
         ];
+        for (result, label) in results
+            .iter()
+            .zip(["role container", "dind sidecar", "certs volume", "network"])
+        {
+            if let Err(err) = result {
+                eprintln!(
+                    "  {} GC of {label} for {}: {err}",
+                    "warning:".yellow().bold(),
+                    info.role
+                );
+            }
+        }
         if results.iter().any(|r| r.is_ok()) {
             eprintln!(
                 "        {} orphaned resources for {}",
@@ -230,7 +242,12 @@ fn gc_orphaned_networks(runner: &mut impl CommandRunner) {
         if running.iter().any(|r| r == role) {
             continue;
         }
-        let _ = run_cleanup_command(runner, &["network", "rm", net_name]);
+        if let Err(err) = run_cleanup_command(runner, &["network", "rm", net_name]) {
+            eprintln!(
+                "  {} GC of network {net_name}: {err}",
+                "warning:".yellow().bold()
+            );
+        }
     }
 }
 
@@ -270,8 +287,8 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
 
 /// Remove jk-* Docker images that have no jackin-managed role containers (running or stopped).
 ///
-/// Best-effort: always returns `Ok(())`. Per-image failures are printed to stderr and
-/// counted in the summary but never propagate as errors.
+/// Per-image `rmi` failures are printed to stderr and counted in the summary but do not
+/// propagate. The initial `docker images` and `docker ps` enumeration calls do propagate.
 pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     let images_output = runner.capture(
         "docker",

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -179,9 +179,10 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
             run_cleanup_command(runner, &["volume", "rm", &certs_volume]),
             run_cleanup_command(runner, &["network", "rm", &network]),
         ];
-        for (result, label) in results
-            .iter()
-            .zip(["role container", "dind sidecar", "certs volume", "network"])
+        for (result, label) in
+            results
+                .iter()
+                .zip(["role container", "dind sidecar", "certs volume", "network"])
         {
             if let Err(err) = result {
                 eprintln!(
@@ -191,7 +192,7 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
                 );
             }
         }
-        if results.iter().any(|r| r.is_ok()) {
+        if results.iter().any(Result::is_ok) {
             eprintln!(
                 "        {} orphaned resources for {}",
                 "cleaned up".dimmed(),
@@ -1035,10 +1036,12 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         prune_images(&mut runner).unwrap();
 
         // rmi was attempted (image was not in the pre-filter set)
-        assert!(runner
-            .recorded
-            .iter()
-            .any(|c| c.contains("docker rmi jk-agent-smith:latest")));
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+        );
     }
 
     #[test]
@@ -1107,14 +1110,18 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         prune_images(&mut runner).unwrap();
 
         // Only jk-agent-smith:latest should have had rmi attempted.
-        assert!(runner
-            .recorded
-            .iter()
-            .any(|c| c.contains("docker rmi jk-agent-smith:latest")));
-        assert!(!runner
-            .recorded
-            .iter()
-            .any(|c| c.contains("docker rmi jk-neo:latest")));
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+        );
+        assert!(
+            !runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker rmi jk-neo:latest"))
+        );
     }
 
     #[test]

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -299,12 +299,10 @@ fn prune_dir(path: &std::path::Path, label: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Re-cloned on next launch.
 pub fn prune_roles(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.roles_dir, "role cache")
 }
 
-/// Terminfo and version-check caches regenerate on first use.
 pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.cache_dir, "shared cache")
 }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -545,7 +545,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jk-agent-smith",
+                image_tag: "jk_agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: primary.into(),
                     dind_container: format!("{primary}-dind"),
@@ -567,7 +567,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jk-agent-smith",
+                image_tag: "jk_agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: second.into(),
                     dind_container: format!("{second}-dind"),
@@ -987,7 +987,7 @@ jk-a1b2c3d4-myworkspace-agentsmith"
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jk-agent-smith",
+                image_tag: "jk_agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: container.to_string(),
                     dind_container: format!("{container}-dind"),
@@ -1064,8 +1064,8 @@ jk-a1b2c3d4-myworkspace-agentsmith"
     #[test]
     fn prune_images_skips_images_in_use_by_role_containers() {
         let mut runner = FakeRunner::with_capture_queue([
-            "jk-agent-smith:latest".to_string(), // docker images output
-            "jk-agent-smith".to_string(),        // docker ps -a output (no :tag)
+            "jk_agent-smith:latest".to_string(), // docker images output
+            "jk_agent-smith".to_string(),        // docker ps -a output (no :tag)
         ]);
 
         prune_images(&mut runner).unwrap();
@@ -1080,12 +1080,12 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         // skipped (Ok), not failed (error message + nonzero failed count).
         let mut runner = FakeRunner {
             fail_with: vec![(
-                "docker rmi jk-agent-smith:latest".to_string(),
+                "docker rmi jk_agent-smith:latest".to_string(),
                 "conflict: unable to remove (cannot be forced) - image is being used by running container"
                     .to_string(),
             )],
             capture_queue: std::collections::VecDeque::from(vec![
-                "jk-agent-smith:latest".to_string(), // docker images
+                "jk_agent-smith:latest".to_string(), // docker images
                 String::new(),                        // docker ps -a: no containers in index
             ]),
             ..Default::default()
@@ -1098,14 +1098,14 @@ jk-a1b2c3d4-myworkspace-agentsmith"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+                .any(|c| c.contains("docker rmi jk_agent-smith:latest"))
         );
     }
 
     #[test]
     fn prune_images_removes_images_not_in_use() {
         let mut runner = FakeRunner::with_capture_queue([
-            "jk-agent-smith:latest".to_string(), // docker images output
+            "jk_agent-smith:latest".to_string(), // docker images output
             String::new(),                       // docker ps -a: no containers
         ]);
 
@@ -1115,7 +1115,7 @@ jk-a1b2c3d4-myworkspace-agentsmith"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+                .any(|c| c.contains("docker rmi jk_agent-smith:latest"))
         );
     }
 
@@ -1139,11 +1139,11 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         // but prune_images still returns Ok — best-effort cleanup.
         let mut runner = FakeRunner {
             fail_with: vec![(
-                "docker rmi jk-agent-smith:latest".to_string(),
+                "docker rmi jk_agent-smith:latest".to_string(),
                 "Error response from daemon: permission denied".to_string(),
             )],
             capture_queue: std::collections::VecDeque::from(vec![
-                "jk-agent-smith:latest".to_string(), // docker images
+                "jk_agent-smith:latest".to_string(), // docker images
                 String::new(),                       // docker ps -a
             ]),
             ..Default::default()
@@ -1155,7 +1155,7 @@ jk-a1b2c3d4-myworkspace-agentsmith"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+                .any(|c| c.contains("docker rmi jk_agent-smith:latest"))
         );
     }
 
@@ -1163,24 +1163,24 @@ jk-a1b2c3d4-myworkspace-agentsmith"
     fn prune_images_mixed_removed_and_skipped() {
         // One image is in-use (pre-filtered), one is removed successfully.
         let mut runner = FakeRunner::with_capture_queue([
-            "jk-agent-smith:latest\njk-neo:latest".to_string(), // docker images: two images
-            "jk-neo".to_string(), // docker ps -a: jk-neo in use (no :tag → normalised to jk-neo:latest)
+            "jk_agent-smith:latest\njk_neo:latest".to_string(), // docker images: two images
+            "jk_neo".to_string(), // docker ps -a: jk-neo in use (no :tag → normalised to jk_neo:latest)
         ]);
 
         prune_images(&mut runner).unwrap();
 
-        // Only jk-agent-smith:latest should have had rmi attempted.
+        // Only jk_agent-smith:latest should have had rmi attempted.
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+                .any(|c| c.contains("docker rmi jk_agent-smith:latest"))
         );
         assert!(
             !runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rmi jk-neo:latest"))
+                .any(|c| c.contains("docker rmi jk_neo:latest"))
         );
     }
 
@@ -1189,11 +1189,11 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         // TOCTOU: image listed but already gone by rmi time — should be skipped, not failed.
         let mut runner = FakeRunner {
             fail_with: vec![(
-                "docker rmi jk-agent-smith:latest".to_string(),
-                "Error response from daemon: No such image: jk-agent-smith:latest".to_string(),
+                "docker rmi jk_agent-smith:latest".to_string(),
+                "Error response from daemon: No such image: jk_agent-smith:latest".to_string(),
             )],
             capture_queue: std::collections::VecDeque::from(vec![
-                "jk-agent-smith:latest".to_string(),
+                "jk_agent-smith:latest".to_string(),
                 String::new(),
             ]),
             ..Default::default()
@@ -1262,7 +1262,7 @@ jk-a1b2c3d4-myworkspace-agentsmith"
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jk-agent-smith",
+                image_tag: "jk_agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: container.to_string(),
                     dind_container: format!("{container}-dind"),

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -343,8 +343,10 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
 
     if removed == 0 && failed == 0 {
         println!("No unused jackin-managed images to remove.");
-    } else {
+    } else if failed == 0 {
         println!("Removed {removed} image(s), skipped {skipped}.");
+    } else {
+        println!("Removed {removed} image(s), skipped {skipped}, failed {failed}.");
     }
     Ok(())
 }
@@ -1088,12 +1090,12 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         let mut runner = FakeRunner::default();
         prune_instances(&paths, &mut runner).unwrap();
 
+        let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
         for name in [clean, superseded, failed, purged] {
             assert!(
                 !paths.data_dir.join(name).exists(),
                 "{name} should be pruned"
             );
-            let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
             assert!(
                 index.instances.iter().all(|e| e.container_base != name),
                 "{name} should be absent from index"

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -398,11 +398,9 @@ pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> 
     }
 
     if !removed.is_empty() {
+        // Stale index entries with no state dir are harmless — purge_container_filesystem
+        // tolerates NotFound, so the next prune run retries unless the index is corrupt.
         let refs: Vec<&str> = removed.iter().map(String::as_str).collect();
-        // State dirs are already gone; index update is best-effort. A stale
-        // entry with no state dir on disk is harmless — purge_container_filesystem
-        // tolerates NotFound, so the next prune run re-removes successfully unless
-        // the index file itself is permanently corrupt.
         if let Err(err) = InstanceIndex::remove_many(&paths.data_dir, &refs) {
             eprintln!(
                 "{} instance index could not be updated: {err:#}; run `jackin prune instances` again to retry",
@@ -901,7 +899,7 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         container: &str,
         status: crate::instance::InstanceStatus,
     ) {
-        let manifest =
+        let mut manifest =
             crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
                 container_base: container,
                 workspace_name: Some("ws"),
@@ -921,7 +919,6 @@ jk-a1b2c3d4-myworkspace-agentsmith"
                     certs_volume: format!("{container}-dind-certs"),
                 },
             });
-        let mut manifest = manifest;
         manifest.mark_status(status);
         let state_dir = paths.data_dir.join(container);
         std::fs::create_dir_all(&state_dir).unwrap();

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -307,7 +307,7 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.cache_dir, "shared cache")
 }
 
-/// Remove jk-* Docker images that have no jackin-managed role containers (running or stopped).
+/// Remove jk_* Docker images that have no jackin-managed role containers (running or stopped).
 ///
 /// Per-image `rmi` failures are printed to stderr and counted in the summary but do not
 /// propagate. The initial `docker images` and `docker ps` enumeration calls do propagate.
@@ -444,13 +444,24 @@ pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> 
         // Stale index entries with no state dir are harmless — purge_container_filesystem
         // tolerates NotFound, so the next prune run retries unless the index is corrupt.
         let refs: Vec<&str> = removed.iter().map(String::as_str).collect();
-        if let Err(err) = InstanceIndex::remove_many(&paths.data_dir, &refs) {
-            eprintln!(
-                "{} instance index could not be updated: {err:#}; run `jackin prune instances` again to retry",
-                "warning:".yellow().bold()
+        let index_updated = match InstanceIndex::remove_many(&paths.data_dir, &refs) {
+            Ok(()) => true,
+            Err(err) => {
+                eprintln!(
+                    "{} instance index could not be updated: {err:#}; run `jackin prune instances` again to retry",
+                    "warning:".yellow().bold()
+                );
+                false
+            }
+        };
+        if index_updated {
+            println!("Pruned {} instance(s):", removed.len());
+        } else {
+            println!(
+                "Removed state for {} instance(s) (index not updated):",
+                removed.len()
             );
         }
-        println!("Pruned {} instance(s):", removed.len());
         for name in &removed {
             println!("  {name}");
         }
@@ -944,6 +955,32 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         };
 
         gc_orphaned_resources(&mut runner); // must not panic
+    }
+
+    #[test]
+    fn gc_does_not_panic_when_list_role_names_fails_in_orphaned_networks() {
+        // Network ls succeeds (non-empty), but the docker ps to list running roles fails.
+        // gc_orphaned_networks must emit a warning and return without calling network rm.
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "label=jackin.kind=role".to_string(),
+                "Error response from daemon: socket timeout".to_string(),
+            )],
+            capture_queue: std::collections::VecDeque::from(vec![
+                String::new(),                                    // collect_orphaned_dind: no DinD
+                "jk-agent-smith-net\tjk-agent-smith".to_string(), // gc_orphaned_networks: network ls
+            ]),
+            ..Default::default()
+        };
+
+        gc_orphaned_resources(&mut runner); // must not panic
+
+        assert!(
+            !runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker network rm"))
+        );
     }
 
     // ── prune_dir ────────────────────────────────────────────────────────────

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -173,16 +173,19 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
         let certs_volume = dind_certs_volume(&info.role);
         let network = format!("{}-net", info.role);
 
-        let _ = run_cleanup_command(runner, &["rm", "-f", &info.role]);
-        let _ = run_cleanup_command(runner, &["rm", "-f", &info.name]);
-        let _ = run_cleanup_command(runner, &["volume", "rm", &certs_volume]);
-        let _ = run_cleanup_command(runner, &["network", "rm", &network]);
-
-        eprintln!(
-            "        {} orphaned resources for {}",
-            "cleaned up".dimmed(),
-            info.role
-        );
+        let results = [
+            run_cleanup_command(runner, &["rm", "-f", &info.role]),
+            run_cleanup_command(runner, &["rm", "-f", &info.name]),
+            run_cleanup_command(runner, &["volume", "rm", &certs_volume]),
+            run_cleanup_command(runner, &["network", "rm", &network]),
+        ];
+        if results.iter().any(|r| r.is_ok()) {
+            eprintln!(
+                "        {} orphaned resources for {}",
+                "cleaned up".dimmed(),
+                info.role
+            );
+        }
     }
 
     // Clean up any orphaned networks that survived without a DinD container
@@ -402,7 +405,7 @@ pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> 
         // the index file itself is permanently corrupt.
         if let Err(err) = InstanceIndex::remove_many(&paths.data_dir, &refs) {
             eprintln!(
-                "{} instance index could not be updated: {err}; run `jackin prune instances` again to retry",
+                "{} instance index could not be updated: {err:#}; run `jackin prune instances` again to retry",
                 "warning:".yellow().bold()
             );
         }
@@ -1077,6 +1080,27 @@ jk-a1b2c3d4-myworkspace-agentsmith"
                 .iter()
                 .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
         );
+    }
+
+    #[test]
+    fn prune_images_mixed_removed_and_skipped() {
+        // One image is in-use (pre-filtered), one is removed successfully.
+        let mut runner = FakeRunner::with_capture_queue([
+            "jk-agent-smith:latest\njk-neo:latest".to_string(), // docker images: two images
+            "jk-neo".to_string(), // docker ps -a: jk-neo in use (no :tag → normalised to jk-neo:latest)
+        ]);
+
+        prune_images(&mut runner).unwrap();
+
+        // Only jk-agent-smith:latest should have had rmi attempted.
+        assert!(runner
+            .recorded
+            .iter()
+            .any(|c| c.contains("docker rmi jk-agent-smith:latest")));
+        assert!(!runner
+            .recorded
+            .iter()
+            .any(|c| c.contains("docker rmi jk-neo:latest")));
     }
 
     #[test]

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -201,7 +201,7 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
                 );
             }
         }
-        if results.iter().any(Result::is_ok) {
+        if results.iter().all(Result::is_ok) {
             eprintln!(
                 "        {} orphaned resources for {}",
                 "cleaned up".dimmed(),
@@ -378,7 +378,10 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
                 {
                     skipped += 1;
                 } else {
-                    eprintln!("  could not remove {image}: {error}");
+                    eprintln!(
+                        "  {} could not remove {image}: {error}",
+                        "error:".red().bold()
+                    );
                     failed += 1;
                 }
             }
@@ -908,6 +911,39 @@ jk-a1b2c3d4-myworkspace-agentsmith"
                 .iter()
                 .any(|c| c.contains("docker network rm jk-neo-net"))
         );
+    }
+
+    #[test]
+    fn gc_does_not_panic_when_collect_orphaned_dind_fails() {
+        // Docker daemon unreachable — the DinD ps call fails. gc_orphaned_resources
+        // must emit a warning and return without panicking.
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "label=jackin.kind=dind".to_string(),
+                "Error response from daemon: socket timeout".to_string(),
+            )],
+            ..Default::default()
+        };
+
+        gc_orphaned_resources(&mut runner); // must not panic
+    }
+
+    #[test]
+    fn gc_does_not_panic_when_network_ls_fails() {
+        // DinD list succeeds (no orphans), but docker network ls fails.
+        // gc_orphaned_networks must emit a warning and return without panicking.
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "network ls".to_string(),
+                "Error response from daemon: socket timeout".to_string(),
+            )],
+            capture_queue: std::collections::VecDeque::from(vec![
+                String::new(), // collect_orphaned_dind: no DinD sidecars
+            ]),
+            ..Default::default()
+        };
+
+        gc_orphaned_resources(&mut runner); // must not panic
     }
 
     // ── prune_dir ────────────────────────────────────────────────────────────

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -167,8 +167,15 @@ fn collect_orphaned_dind(runner: &mut impl CommandRunner) -> anyhow::Result<Vec<
 /// volumes, and networks.  Errors are logged but do not abort the launch — GC
 /// is best-effort.
 pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
-    let Ok(orphaned) = collect_orphaned_dind(runner) else {
-        return;
+    let orphaned = match collect_orphaned_dind(runner) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!(
+                "  {} GC: could not list orphaned DinD containers: {err}",
+                "warning:".yellow().bold()
+            );
+            return;
+        }
     };
 
     for info in &orphaned {
@@ -211,7 +218,7 @@ pub(super) fn gc_orphaned_resources(runner: &mut impl CommandRunner) {
 /// Remove jackin-managed Docker networks whose owning role container no
 /// longer exists.
 fn gc_orphaned_networks(runner: &mut impl CommandRunner) {
-    let Ok(net_output) = runner.capture(
+    let net_output = match runner.capture(
         "docker",
         &[
             "network",
@@ -222,8 +229,15 @@ fn gc_orphaned_networks(runner: &mut impl CommandRunner) {
             "{{.Name}}\t{{.Label \"jackin.role\"}}",
         ],
         None,
-    ) else {
-        return;
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!(
+                "  {} GC: could not list orphaned networks: {err}",
+                "warning:".yellow().bold()
+            );
+            return;
+        }
     };
 
     let networks: Vec<(&str, &str)> = net_output
@@ -237,8 +251,15 @@ fn gc_orphaned_networks(runner: &mut impl CommandRunner) {
         return;
     }
 
-    let Ok(running) = list_role_names(runner, false) else {
-        return;
+    let running = match list_role_names(runner, false) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!(
+                "  {} GC: could not list running role containers: {err}",
+                "warning:".yellow().bold()
+            );
+            return;
+        }
     };
 
     for (net_name, role) in networks {
@@ -383,8 +404,9 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
 /// Purge on-disk state for terminated instances and clear their index entries.
 ///
 /// Targets `clean_exited`, `superseded`, `failed_setup`, and `purged`
-/// tombstones. Any instance whose Docker resources are still present is
-/// skipped; use `jackin eject <selector> --purge` for those.
+/// tombstones. Any instance whose filesystem teardown fails — typically because
+/// Docker resources are still present — is skipped; use
+/// `jackin eject <selector> --purge` for those.
 pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
 
@@ -1071,7 +1093,9 @@ jk-a1b2c3d4-myworkspace-agentsmith"
 
         assert_eq!(
             runner.recorded,
-            vec!["docker images --filter reference=jk-* --format {{.Repository}}:{{.Tag}}"]
+            vec![format!(
+                "docker images --filter {FILTER_IMAGES} --format {{{{.Repository}}}}:{{{{.Tag}}}}"
+            )]
         );
     }
 
@@ -1180,6 +1204,52 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         assert!(
             paths.data_dir.join(crashed).exists(),
             "crashed should be kept"
+        );
+    }
+
+    #[test]
+    fn prune_instances_prunes_purged_tombstone_with_no_state_directory() {
+        // Purged tombstones are index-only entries — the state dir is already gone.
+        // purge_container_filesystem must tolerate NotFound so the tombstone is
+        // removed from the index without error.
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let container = "jk-k7p9m2xq-agentsmith";
+        // Register in the index but do NOT create the state directory.
+        let manifest =
+            crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
+                container_base: container,
+                workspace_name: Some("ws"),
+                workspace_label: "ws",
+                workdir: "/ws",
+                host_workdir_fingerprint: "sha256:test",
+                role_key: "agent-smith",
+                role_display_name: "Agent Smith",
+                agent_runtime: crate::agent::Agent::Claude,
+                role_source_git: "https://example.invalid/agent-smith.git",
+                role_source_ref: None,
+                image_tag: "jk-agent-smith",
+                docker: crate::instance::DockerResources {
+                    role_container: container.to_string(),
+                    dind_container: format!("{container}-dind"),
+                    network: format!("{container}-net"),
+                    certs_volume: format!("{container}-dind-certs"),
+                },
+            });
+        let mut manifest = manifest;
+        manifest.mark_status(crate::instance::InstanceStatus::Purged);
+        crate::instance::InstanceIndex::update_manifest(&paths.data_dir, &manifest).unwrap();
+
+        let mut runner = FakeRunner::default();
+        prune_instances(&paths, &mut runner).unwrap();
+
+        let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
+        assert!(
+            index
+                .instances
+                .iter()
+                .all(|e| e.container_base != container),
+            "tombstone should be cleared from the index"
         );
     }
 

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -1,11 +1,11 @@
 use crate::docker::CommandRunner;
-use crate::instance::InstanceIndex;
+use crate::instance::{InstanceIndex, InstanceStatus};
 use crate::paths::JackinPaths;
 use crate::selector::RoleSelector;
 use owo_colors::OwoColorize;
 
 use super::discovery::{list_managed_role_names, list_role_names};
-use super::naming::{FILTER_KIND_DIND, FILTER_MANAGED, dind_certs_volume};
+use super::naming::{FILTER_KIND_DIND, FILTER_KIND_ROLE, FILTER_MANAGED, dind_certs_volume};
 
 pub fn purge_class_data(
     paths: &JackinPaths,
@@ -240,6 +240,190 @@ pub fn exile_all(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ── Prune ────────────────────────────────────────────────────────────────────
+
+fn prune_dir(path: &std::path::Path, label: &str) -> anyhow::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => println!("Removed {label} ({}).", path.display()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            println!("{label} already empty.");
+        }
+        Err(error) => {
+            return Err(anyhow::Error::from(error)
+                .context(format!("failed to remove {label} at {}", path.display())));
+        }
+    }
+    Ok(())
+}
+
+/// Re-cloned on next launch.
+pub fn prune_roles(paths: &JackinPaths) -> anyhow::Result<()> {
+    prune_dir(&paths.roles_dir, "role cache")
+}
+
+/// Terminfo and version-check caches regenerate on first use.
+pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
+    prune_dir(&paths.cache_dir, "shared cache")
+}
+
+/// Remove jk-* Docker images that have no jackin-managed role containers (running or stopped).
+pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
+    let images_output = runner.capture(
+        "docker",
+        &[
+            "images",
+            "--filter",
+            "reference=jk-*",
+            "--format",
+            "{{.Repository}}:{{.Tag}}",
+        ],
+        None,
+    )?;
+
+    let all_images: Vec<String> = images_output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if all_images.is_empty() {
+        println!("No jackin-managed images found.");
+        return Ok(());
+    }
+
+    let in_use_output = runner.capture(
+        "docker",
+        &[
+            "ps",
+            "-a",
+            "--filter",
+            FILTER_KIND_ROLE,
+            "--format",
+            "{{.Image}}",
+        ],
+        None,
+    )?;
+
+    let in_use: std::collections::HashSet<String> = in_use_output
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|img| {
+            if img.contains(':') {
+                img.to_string()
+            } else {
+                format!("{img}:latest")
+            }
+        })
+        .collect();
+
+    let mut removed = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+
+    for image in &all_images {
+        if in_use.contains(image) {
+            skipped += 1;
+            continue;
+        }
+        match runner.capture("docker", &["rmi", image], None) {
+            Ok(_) => removed += 1,
+            Err(error) => {
+                let msg = error.to_string();
+                if crate::docker::is_image_in_use_error(&msg)
+                    || crate::docker::is_missing_resource_error(&msg)
+                {
+                    skipped += 1;
+                } else {
+                    eprintln!("  could not remove {image}: {error}");
+                    failed += 1;
+                }
+            }
+        }
+    }
+
+    if removed == 0 && failed == 0 {
+        println!("No unused jackin-managed images to remove.");
+    } else {
+        println!("Removed {removed} image(s), skipped {skipped}.");
+    }
+    Ok(())
+}
+
+/// Purge on-disk state for terminated instances and clear their index entries.
+///
+/// Targets `clean_exited`, `superseded`, `failed_setup`, and `purged`
+/// tombstones. Any instance whose Docker resources are still present is
+/// skipped; use `jackin eject <selector> --purge` for those.
+pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> anyhow::Result<()> {
+    let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
+
+    let prunable = [
+        InstanceStatus::CleanExited,
+        InstanceStatus::Superseded,
+        InstanceStatus::FailedSetup,
+        InstanceStatus::Purged,
+    ];
+
+    let candidates: Vec<String> = index
+        .instances
+        .iter()
+        .filter(|e| prunable.contains(&e.status))
+        .map(|e| e.container_base.clone())
+        .collect();
+
+    if candidates.is_empty() {
+        println!("No instances to prune.");
+        return Ok(());
+    }
+
+    let mut removed: Vec<String> = Vec::new();
+    let mut skipped: Vec<(String, anyhow::Error)> = Vec::new();
+
+    for container_base in candidates {
+        match purge_container_filesystem(paths, &container_base, runner) {
+            Ok(()) => removed.push(container_base),
+            Err(error) => skipped.push((container_base, error)),
+        }
+    }
+
+    if !removed.is_empty() {
+        let refs: Vec<&str> = removed.iter().map(String::as_str).collect();
+        // State dirs are already gone; index update is best-effort. A stale
+        // entry with no state dir on disk is harmless — purge_container_filesystem
+        // tolerates NotFound, so the next prune run re-removes successfully unless
+        // the index file itself is permanently corrupt.
+        if let Err(err) = InstanceIndex::remove_many(&paths.data_dir, &refs) {
+            eprintln!(
+                "{} instance index could not be updated: {err}; run `jackin prune instances` again to retry",
+                "warning:".yellow().bold()
+            );
+        }
+        println!("Pruned {} instance(s):", removed.len());
+        for name in &removed {
+            println!("  {name}");
+        }
+    }
+
+    if !skipped.is_empty() {
+        eprintln!(
+            "Skipped {} instance(s) — Docker resources still present:",
+            skipped.len()
+        );
+        for (name, error) in &skipped {
+            eprintln!("  {name}: {error}");
+        }
+        eprintln!(
+            "Use `jackin eject <selector> --purge` to remove Docker resources and state together."
+        );
+    }
+
+    if removed.is_empty() && skipped.is_empty() {
+        println!("No instances pruned.");
+    }
+
+    Ok(())
+}
+
 fn ensure_role_resources_absent_for_purge(
     runner: &mut impl CommandRunner,
     container_name: &str,
@@ -282,19 +466,16 @@ mod tests {
     fn eject_all_targets_only_requested_class_family() {
         let selector = RoleSelector::new(None, "agent-smith");
         let names = vec![
-            "jackin-agentsmith-k7p9m2xq".to_string(),
-            "jackin-myproject-agentsmith-a1b2c3d4".to_string(),
-            "jackin-chainargos-thearchitect-w9x8y7z6".to_string(),
+            "jk-k7p9m2xq-agentsmith".to_string(),
+            "jk-a1b2c3d4-myproject-agentsmith".to_string(),
+            "jk-w9x8y7z6-chainargos-thearchitect".to_string(),
         ];
 
         let matched = matching_family(&selector, &names);
 
         assert_eq!(
             matched,
-            vec![
-                "jackin-agentsmith-k7p9m2xq",
-                "jackin-myproject-agentsmith-a1b2c3d4",
-            ]
+            vec!["jk-k7p9m2xq-agentsmith", "jk-a1b2c3d4-myproject-agentsmith",]
         );
     }
 
@@ -302,8 +483,8 @@ mod tests {
     fn purge_all_removes_matching_state_directories() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let primary = "jackin-agentsmith-k7p9m2xq";
-        let second = "jackin-workspace-agentsmith-a1b2c3d4";
+        let primary = "jk-k7p9m2xq-agentsmith";
+        let second = "jk-a1b2c3d4-workspace-agentsmith";
         let manifest =
             crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
                 container_base: primary,
@@ -316,7 +497,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jackin-agent-smith",
+                image_tag: "jk-agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: primary.into(),
                     dind_container: format!("{primary}-dind"),
@@ -338,7 +519,7 @@ mod tests {
                 agent_runtime: crate::agent::Agent::Claude,
                 role_source_git: "https://example.invalid/agent-smith.git",
                 role_source_ref: None,
-                image_tag: "jackin-agent-smith",
+                image_tag: "jk-agent-smith",
                 docker: crate::instance::DockerResources {
                     role_container: second.into(),
                     dind_container: format!("{second}-dind"),
@@ -348,7 +529,7 @@ mod tests {
             });
         second_manifest.write(&paths.data_dir.join(second)).unwrap();
         crate::instance::InstanceIndex::update_manifest(&paths.data_dir, &second_manifest).unwrap();
-        let unrelated = "jackin-chainargos-thearchitect-w9x8y7z6";
+        let unrelated = "jk-w9x8y7z6-chainargos-thearchitect";
         std::fs::create_dir_all(paths.data_dir.join(unrelated)).unwrap();
         let selector = RoleSelector::new(None, "agent-smith");
 
@@ -373,7 +554,7 @@ mod tests {
     fn purge_container_state_refuses_when_role_container_exists() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container = "jackin-agent-smith";
+        let container = "jk-agent-smith";
         std::fs::create_dir_all(paths.data_dir.join(container)).unwrap();
         let mut runner = FakeRunner::with_capture_queue(["false 0 false".to_string()]);
 
@@ -391,7 +572,7 @@ mod tests {
     fn purge_container_state_refuses_when_dind_sidecar_exists() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container = "jackin-agent-smith";
+        let container = "jk-agent-smith";
         std::fs::create_dir_all(paths.data_dir.join(container)).unwrap();
         let mut runner =
             FakeRunner::with_capture_queue([String::new(), "true 0 false".to_string()]);
@@ -410,15 +591,15 @@ mod tests {
     fn eject_agent_removes_container_dind_and_network() {
         let mut runner = FakeRunner::default();
 
-        eject_role("jackin-agent-smith", &mut runner).unwrap();
+        eject_role("jk-agent-smith", &mut runner).unwrap();
 
         assert_eq!(
             runner.recorded,
             vec![
-                "docker rm -f jackin-agent-smith",
-                "docker rm -f jackin-agent-smith-dind",
-                "docker volume rm jackin-agent-smith-dind-certs",
-                "docker network rm jackin-agent-smith-net",
+                "docker rm -f jk-agent-smith",
+                "docker rm -f jk-agent-smith-dind",
+                "docker volume rm jk-agent-smith-dind-certs",
+                "docker network rm jk-agent-smith-net",
             ]
         );
     }
@@ -428,45 +609,44 @@ mod tests {
         let mut runner = FakeRunner {
             fail_with: vec![
                 (
-                    "docker rm -f jackin-agent-smith".to_string(),
-                    "Error response from daemon: No such container: jackin-agent-smith".to_string(),
+                    "docker rm -f jk-agent-smith".to_string(),
+                    "Error response from daemon: No such container: jk-agent-smith".to_string(),
                 ),
                 (
-                    "docker rm -f jackin-agent-smith-dind".to_string(),
-                    "Error response from daemon: No such container: jackin-agent-smith-dind"
+                    "docker rm -f jk-agent-smith-dind".to_string(),
+                    "Error response from daemon: No such container: jk-agent-smith-dind"
                         .to_string(),
                 ),
                 (
-                    "docker volume rm jackin-agent-smith-dind-certs".to_string(),
-                    "Error response from daemon: No such volume: jackin-agent-smith-dind-certs"
+                    "docker volume rm jk-agent-smith-dind-certs".to_string(),
+                    "Error response from daemon: No such volume: jk-agent-smith-dind-certs"
                         .to_string(),
                 ),
                 (
-                    "docker network rm jackin-agent-smith-net".to_string(),
-                    "Error response from daemon: No such network: jackin-agent-smith-net"
-                        .to_string(),
+                    "docker network rm jk-agent-smith-net".to_string(),
+                    "Error response from daemon: No such network: jk-agent-smith-net".to_string(),
                 ),
             ],
             ..Default::default()
         };
 
-        eject_role("jackin-agent-smith", &mut runner).unwrap();
+        eject_role("jk-agent-smith", &mut runner).unwrap();
 
         assert_eq!(
             runner.recorded,
             vec![
-                "docker rm -f jackin-agent-smith",
-                "docker rm -f jackin-agent-smith-dind",
-                "docker volume rm jackin-agent-smith-dind-certs",
-                "docker network rm jackin-agent-smith-net",
+                "docker rm -f jk-agent-smith",
+                "docker rm -f jk-agent-smith-dind",
+                "docker volume rm jk-agent-smith-dind-certs",
+                "docker network rm jk-agent-smith-net",
             ]
         );
     }
 
     #[test]
     fn exile_all_ejects_all_managed_agents() {
-        let mut runner = FakeRunner::with_capture_queue([r"jackin-agentsmith-k7p9m2xq
-jackin-myworkspace-agentsmith-a1b2c3d4"
+        let mut runner = FakeRunner::with_capture_queue([r"jk-k7p9m2xq-agentsmith
+jk-a1b2c3d4-myworkspace-agentsmith"
             .to_string()]);
 
         exile_all(&mut runner).unwrap();
@@ -475,14 +655,14 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             runner.recorded,
             vec![
                 "docker ps -a --filter label=jackin.kind=role --format {{.Names}}",
-                "docker rm -f jackin-agentsmith-k7p9m2xq",
-                "docker rm -f jackin-agentsmith-k7p9m2xq-dind",
-                "docker volume rm jackin-agentsmith-k7p9m2xq-dind-certs",
-                "docker network rm jackin-agentsmith-k7p9m2xq-net",
-                "docker rm -f jackin-myworkspace-agentsmith-a1b2c3d4",
-                "docker rm -f jackin-myworkspace-agentsmith-a1b2c3d4-dind",
-                "docker volume rm jackin-myworkspace-agentsmith-a1b2c3d4-dind-certs",
-                "docker network rm jackin-myworkspace-agentsmith-a1b2c3d4-net",
+                "docker rm -f jk-k7p9m2xq-agentsmith",
+                "docker rm -f jk-k7p9m2xq-agentsmith-dind",
+                "docker volume rm jk-k7p9m2xq-agentsmith-dind-certs",
+                "docker network rm jk-k7p9m2xq-agentsmith-net",
+                "docker rm -f jk-a1b2c3d4-myworkspace-agentsmith",
+                "docker rm -f jk-a1b2c3d4-myworkspace-agentsmith-dind",
+                "docker volume rm jk-a1b2c3d4-myworkspace-agentsmith-dind-certs",
+                "docker network rm jk-a1b2c3d4-myworkspace-agentsmith-net",
             ]
         );
     }
@@ -492,19 +672,19 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
         let mut runner = FakeRunner {
             fail_with: vec![
                 (
-                    "docker rm -f jackin-agentsmith-k7p9m2xq".to_string(),
-                    "Error response from daemon: No such container: jackin-agentsmith-k7p9m2xq"
+                    "docker rm -f jk-k7p9m2xq-agentsmith".to_string(),
+                    "Error response from daemon: No such container: jk-k7p9m2xq-agentsmith"
                         .to_string(),
                 ),
                 (
-                    "docker network rm jackin-agentsmith-k7p9m2xq-net".to_string(),
-                    "Error response from daemon: No such network: jackin-agentsmith-k7p9m2xq-net"
+                    "docker network rm jk-k7p9m2xq-agentsmith-net".to_string(),
+                    "Error response from daemon: No such network: jk-k7p9m2xq-agentsmith-net"
                         .to_string(),
                 ),
             ],
             capture_queue: VecDeque::from(vec![
-                r"jackin-agentsmith-k7p9m2xq
-jackin-myworkspace-agentsmith-a1b2c3d4"
+                r"jk-k7p9m2xq-agentsmith
+jk-a1b2c3d4-myworkspace-agentsmith"
                     .to_string(),
             ]),
             ..Default::default()
@@ -516,14 +696,14 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             runner.recorded,
             vec![
                 "docker ps -a --filter label=jackin.kind=role --format {{.Names}}",
-                "docker rm -f jackin-agentsmith-k7p9m2xq",
-                "docker rm -f jackin-agentsmith-k7p9m2xq-dind",
-                "docker volume rm jackin-agentsmith-k7p9m2xq-dind-certs",
-                "docker network rm jackin-agentsmith-k7p9m2xq-net",
-                "docker rm -f jackin-myworkspace-agentsmith-a1b2c3d4",
-                "docker rm -f jackin-myworkspace-agentsmith-a1b2c3d4-dind",
-                "docker volume rm jackin-myworkspace-agentsmith-a1b2c3d4-dind-certs",
-                "docker network rm jackin-myworkspace-agentsmith-a1b2c3d4-net",
+                "docker rm -f jk-k7p9m2xq-agentsmith",
+                "docker rm -f jk-k7p9m2xq-agentsmith-dind",
+                "docker volume rm jk-k7p9m2xq-agentsmith-dind-certs",
+                "docker network rm jk-k7p9m2xq-agentsmith-net",
+                "docker rm -f jk-a1b2c3d4-myworkspace-agentsmith",
+                "docker rm -f jk-a1b2c3d4-myworkspace-agentsmith-dind",
+                "docker volume rm jk-a1b2c3d4-myworkspace-agentsmith-dind-certs",
+                "docker network rm jk-a1b2c3d4-myworkspace-agentsmith-net",
             ]
         );
     }
@@ -531,12 +711,12 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
     #[test]
     fn is_missing_cleanup_error_tolerates_all_resource_types() {
         let container_err =
-            anyhow::anyhow!("Error response from daemon: No such container: jackin-agent-smith");
+            anyhow::anyhow!("Error response from daemon: No such container: jk-agent-smith");
         let volume_err = anyhow::anyhow!(
-            "Error response from daemon: No such volume: jackin-agent-smith-dind-certs"
+            "Error response from daemon: No such volume: jk-agent-smith-dind-certs"
         );
         let network_err =
-            anyhow::anyhow!("Error response from daemon: No such network: jackin-agent-smith-net");
+            anyhow::anyhow!("Error response from daemon: No such network: jk-agent-smith-net");
         let real_err = anyhow::anyhow!("Error response from daemon: permission denied");
 
         assert!(is_missing_cleanup_error(&container_err));
@@ -549,7 +729,7 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
     fn gc_removes_orphaned_dind_and_network() {
         let mut runner = FakeRunner::with_capture_queue([
             // collect_orphaned_dind: docker ps -a --filter label=jackin.kind=dind
-            "jackin-agent-smith-dind\tjackin-agent-smith".to_string(),
+            "jk-agent-smith-dind\tjk-agent-smith".to_string(),
             // collect_orphaned_dind: list_role_names (running)
             String::new(),
             // gc_orphaned_networks: docker network ls
@@ -562,25 +742,25 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rm -f jackin-agent-smith-dind"))
+                .any(|c| c.contains("docker rm -f jk-agent-smith-dind"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rm -f jackin-agent-smith"))
+                .any(|c| c.contains("docker rm -f jk-agent-smith"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker volume rm jackin-agent-smith-dind-certs"))
+                .any(|c| c.contains("docker volume rm jk-agent-smith-dind-certs"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker network rm jackin-agent-smith-net"))
+                .any(|c| c.contains("docker network rm jk-agent-smith-net"))
         );
     }
 
@@ -588,9 +768,9 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
     fn gc_skips_dind_when_agent_is_running() {
         let mut runner = FakeRunner::with_capture_queue([
             // collect_orphaned_dind: docker ps -a --filter label=jackin.kind=dind
-            "jackin-agent-smith-dind\tjackin-agent-smith".to_string(),
+            "jk-agent-smith-dind\tjk-agent-smith".to_string(),
             // collect_orphaned_dind: running agent-labeled roles — role IS running
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
             // gc_orphaned_networks: docker network ls
             String::new(),
         ]);
@@ -601,7 +781,7 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             !runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rm -f jackin-agent-smith-dind"))
+                .any(|c| c.contains("docker rm -f jk-agent-smith-dind"))
         );
     }
 
@@ -625,7 +805,7 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             // collect_orphaned_dind: no DinD sidecars
             String::new(),
             // gc_orphaned_networks: docker network ls — has a network
-            "jackin-agent-smith-net\tjackin-agent-smith".to_string(),
+            "jk-agent-smith-net\tjk-agent-smith".to_string(),
             // gc_orphaned_networks: list_role_names (running) — role not running
             String::new(),
         ]);
@@ -636,7 +816,7 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker network rm jackin-agent-smith-net"))
+                .any(|c| c.contains("docker network rm jk-agent-smith-net"))
         );
     }
 
@@ -644,7 +824,7 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
     fn gc_cleans_multiple_orphans() {
         let mut runner = FakeRunner::with_capture_queue([
             // collect_orphaned_dind: two orphaned DinD sidecars
-            "jackin-agent-smith-dind\tjackin-agent-smith\njackin-neo-dind\tjackin-neo".to_string(),
+            "jk-agent-smith-dind\tjk-agent-smith\njk-neo-dind\tjk-neo".to_string(),
             // collect_orphaned_dind: list_role_names (running)
             String::new(),
             // gc_orphaned_networks: no additional networks
@@ -657,31 +837,288 @@ jackin-myworkspace-agentsmith-a1b2c3d4"
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rm -f jackin-agent-smith-dind"))
+                .any(|c| c.contains("docker rm -f jk-agent-smith-dind"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker volume rm jackin-agent-smith-dind-certs"))
+                .any(|c| c.contains("docker volume rm jk-agent-smith-dind-certs"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker rm -f jackin-neo-dind"))
+                .any(|c| c.contains("docker rm -f jk-neo-dind"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker volume rm jackin-neo-dind-certs"))
+                .any(|c| c.contains("docker volume rm jk-neo-dind-certs"))
         );
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker network rm jackin-neo-net"))
+                .any(|c| c.contains("docker network rm jk-neo-net"))
         );
+    }
+
+    // ── prune_dir ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_dir_removes_existing_directory() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().join("cache");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("file.txt"), b"data").unwrap();
+
+        prune_dir(&target, "cache").unwrap();
+
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn prune_dir_is_ok_when_directory_absent() {
+        let temp = tempdir().unwrap();
+        let target = temp.path().join("cache");
+
+        prune_dir(&target, "cache").unwrap();
+    }
+
+    // ── prune_instances ──────────────────────────────────────────────────────
+
+    fn make_instance_at(
+        paths: &JackinPaths,
+        container: &str,
+        status: crate::instance::InstanceStatus,
+    ) {
+        let manifest =
+            crate::instance::InstanceManifest::new(crate::instance::NewInstanceManifest {
+                container_base: container,
+                workspace_name: Some("ws"),
+                workspace_label: "ws",
+                workdir: "/ws",
+                host_workdir_fingerprint: "sha256:test",
+                role_key: "agent-smith",
+                role_display_name: "Agent Smith",
+                agent_runtime: crate::agent::Agent::Claude,
+                role_source_git: "https://example.invalid/agent-smith.git",
+                role_source_ref: None,
+                image_tag: "jk-agent-smith",
+                docker: crate::instance::DockerResources {
+                    role_container: container.to_string(),
+                    dind_container: format!("{container}-dind"),
+                    network: format!("{container}-net"),
+                    certs_volume: format!("{container}-dind-certs"),
+                },
+            });
+        let mut manifest = manifest;
+        manifest.mark_status(status);
+        let state_dir = paths.data_dir.join(container);
+        std::fs::create_dir_all(&state_dir).unwrap();
+        manifest.write(&state_dir).unwrap();
+        crate::instance::InstanceIndex::update_manifest(&paths.data_dir, &manifest).unwrap();
+    }
+
+    #[test]
+    fn prune_instances_removes_terminal_statuses_only() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let prunable = "jk-k7p9m2xq-agentsmith";
+        let kept = "jk-a1b2c3d4-agentsmith";
+        make_instance_at(
+            &paths,
+            prunable,
+            crate::instance::InstanceStatus::CleanExited,
+        );
+        make_instance_at(&paths, kept, crate::instance::InstanceStatus::Crashed);
+
+        let mut runner = FakeRunner::default();
+        prune_instances(&paths, &mut runner).unwrap();
+
+        assert!(!paths.data_dir.join(prunable).exists());
+        assert!(paths.data_dir.join(kept).exists());
+        let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
+        assert!(index.instances.iter().all(|e| e.container_base != prunable));
+        assert!(index.instances.iter().any(|e| e.container_base == kept));
+    }
+
+    #[test]
+    fn prune_instances_skips_when_docker_resources_present() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let container = "jk-k7p9m2xq-agentsmith";
+        make_instance_at(
+            &paths,
+            container,
+            crate::instance::InstanceStatus::CleanExited,
+        );
+
+        // Fake runner returns non-empty inspect → container still exists.
+        let mut runner = FakeRunner::with_capture_queue(["false 0 false".to_string()]);
+        prune_instances(&paths, &mut runner).unwrap();
+
+        assert!(paths.data_dir.join(container).exists());
+        let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
+        assert!(
+            index
+                .instances
+                .iter()
+                .any(|e| e.container_base == container)
+        );
+    }
+
+    #[test]
+    fn prune_instances_is_ok_when_data_dir_absent() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+
+        let mut runner = FakeRunner::default();
+        prune_instances(&paths, &mut runner).unwrap();
+    }
+
+    // ── prune_images ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_images_skips_images_in_use_by_role_containers() {
+        let mut runner = FakeRunner::with_capture_queue([
+            "jk-agent-smith:latest".to_string(), // docker images output
+            "jk-agent-smith".to_string(),        // docker ps -a output (no :tag)
+        ]);
+
+        prune_images(&mut runner).unwrap();
+
+        assert!(!runner.recorded.iter().any(|c| c.contains("docker rmi")));
+    }
+
+    #[test]
+    fn prune_images_removes_images_not_in_use() {
+        let mut runner = FakeRunner::with_capture_queue([
+            "jk-agent-smith:latest".to_string(), // docker images output
+            String::new(),                       // docker ps -a: no containers
+        ]);
+
+        prune_images(&mut runner).unwrap();
+
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+        );
+    }
+
+    #[test]
+    fn prune_images_is_ok_when_no_images_found() {
+        let mut runner = FakeRunner::with_capture_queue([String::new()]);
+
+        prune_images(&mut runner).unwrap();
+
+        assert_eq!(
+            runner.recorded,
+            vec!["docker images --filter reference=jk-* --format {{.Repository}}:{{.Tag}}"]
+        );
+    }
+
+    #[test]
+    fn prune_images_is_ok_when_rmi_fails_with_real_error() {
+        // A real Docker error (not in-use, not missing) is printed to stderr
+        // but prune_images still returns Ok — best-effort cleanup.
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "docker rmi jk-agent-smith:latest".to_string(),
+                "Error response from daemon: permission denied".to_string(),
+            )],
+            capture_queue: std::collections::VecDeque::from(vec![
+                "jk-agent-smith:latest".to_string(), // docker images
+                String::new(),                       // docker ps -a
+            ]),
+            ..Default::default()
+        };
+
+        prune_images(&mut runner).unwrap();
+
+        assert!(
+            runner
+                .recorded
+                .iter()
+                .any(|c| c.contains("docker rmi jk-agent-smith:latest"))
+        );
+    }
+
+    #[test]
+    fn prune_images_skips_when_image_disappears_between_list_and_rmi() {
+        // TOCTOU: image listed but already gone by rmi time — should be skipped, not failed.
+        let mut runner = FakeRunner {
+            fail_with: vec![(
+                "docker rmi jk-agent-smith:latest".to_string(),
+                "Error response from daemon: No such image: jk-agent-smith:latest".to_string(),
+            )],
+            capture_queue: std::collections::VecDeque::from(vec![
+                "jk-agent-smith:latest".to_string(),
+                String::new(),
+            ]),
+            ..Default::default()
+        };
+
+        prune_images(&mut runner).unwrap();
+    }
+
+    #[test]
+    fn prune_instances_removes_all_four_prunable_statuses() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        let clean = "jk-a1b2c3d4-agentsmith";
+        let superseded = "jk-b2c3d4e5-agentsmith";
+        let failed = "jk-c3d4e5f6-agentsmith";
+        let purged = "jk-d4e5f6a7-agentsmith";
+        let crashed = "jk-e5f6a7b8-agentsmith";
+        make_instance_at(&paths, clean, crate::instance::InstanceStatus::CleanExited);
+        make_instance_at(
+            &paths,
+            superseded,
+            crate::instance::InstanceStatus::Superseded,
+        );
+        make_instance_at(&paths, failed, crate::instance::InstanceStatus::FailedSetup);
+        make_instance_at(&paths, purged, crate::instance::InstanceStatus::Purged);
+        make_instance_at(&paths, crashed, crate::instance::InstanceStatus::Crashed);
+
+        let mut runner = FakeRunner::default();
+        prune_instances(&paths, &mut runner).unwrap();
+
+        for name in [clean, superseded, failed, purged] {
+            assert!(
+                !paths.data_dir.join(name).exists(),
+                "{name} should be pruned"
+            );
+            let index = crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir).unwrap();
+            assert!(
+                index.instances.iter().all(|e| e.container_base != name),
+                "{name} should be absent from index"
+            );
+        }
+        assert!(
+            paths.data_dir.join(crashed).exists(),
+            "crashed should be kept"
+        );
+    }
+
+    #[test]
+    fn prune_dir_returns_err_with_path_context_on_failure() {
+        // Create a file at the path so remove_dir_all fails (ENOTDIR on the
+        // path's parent, or similar — exact error is platform-dependent but
+        // it will not be NotFound).
+        let temp = tempdir().unwrap();
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, b"").unwrap();
+        let target = blocker.join("child"); // child of a file — cannot exist
+
+        let err = prune_dir(&target, "test label").unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("failed to remove test label"), "got: {msg}");
+        assert!(msg.contains("child"), "got: {msg}");
     }
 }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -397,7 +397,7 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     } else if failed == 0 {
         println!("Removed {removed} image(s), skipped {skipped}.");
     } else {
-        println!("Removed {removed} image(s), skipped {skipped}, failed {failed}.");
+        eprintln!("Removed {removed} image(s), skipped {skipped}, failed {failed}.");
     }
     Ok(())
 }
@@ -407,7 +407,7 @@ pub fn prune_images(runner: &mut impl CommandRunner) -> anyhow::Result<()> {
 /// Targets `clean_exited`, `superseded`, `failed_setup`, and `purged`
 /// tombstones. Any instance whose filesystem teardown fails — typically because
 /// Docker resources are still present — is skipped; use
-/// `jackin eject <selector> --purge` for those.
+/// `jackin hardline <selector>` to return or `jackin eject <selector> --purge` to discard.
 pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> anyhow::Result<()> {
     let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
 

--- a/src/runtime/discovery.rs
+++ b/src/runtime/discovery.rs
@@ -84,11 +84,11 @@ mod tests {
 
     #[test]
     fn list_managed_agent_names_excludes_dind_sidecars() {
-        let mut runner = FakeRunner::with_capture_queue(["jackin-agent-smith".to_string()]);
+        let mut runner = FakeRunner::with_capture_queue(["jk-agent-smith".to_string()]);
 
         let names = list_managed_role_names(&mut runner).unwrap();
 
-        assert_eq!(names, vec!["jackin-agent-smith"]);
+        assert_eq!(names, vec!["jk-agent-smith"]);
         assert!(runner.recorded.iter().any(|call| {
             call == "docker ps -a --filter label=jackin.kind=role --format {{.Names}}"
         }));
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn list_running_agent_display_names_excludes_dind_sidecars() {
         let mut runner =
-            FakeRunner::with_capture_queue(["jackin-agentsmith-k7p9m2xq\tAgent Smith".to_string()]);
+            FakeRunner::with_capture_queue(["jk-k7p9m2xq-agentsmith\tAgent Smith".to_string()]);
 
         let names = list_running_agent_display_names(&mut runner).unwrap();
 

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -3210,7 +3210,7 @@ mod tests {
         agent: crate::agent::Agent,
     ) -> InstanceManifest {
         let role_source_git = format!("https://example.invalid/{role_key}.git");
-        let image_tag = format!("jackin-{role_key}");
+        let image_tag = format!("{}-{role_key}", crate::instance::naming::CONTAINER_PREFIX);
         InstanceManifest::new(NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -3414,7 +3414,7 @@ mod tests {
         // proceeds. The function must NOT consume the logs queue entry in
         // this case.
         let mut runner = FakeRunner::with_capture_queue(["true 0 false".to_string()]);
-        let result = super::diagnose_premature_exit(&mut runner, "jackin-the-architect");
+        let result = super::diagnose_premature_exit(&mut runner, "jk-the-architect");
         assert!(
             result.is_none(),
             "running container must not be diagnosed as a failure"
@@ -3429,7 +3429,7 @@ mod tests {
             "false 127 false".to_string(),
             "/jackin/runtime/entrypoint.sh: line 85: exec: codex: not found".to_string(),
         ]);
-        let err = super::diagnose_premature_exit(&mut runner, "jackin-the-architect")
+        let err = super::diagnose_premature_exit(&mut runner, "jk-the-architect")
             .expect("stopped container must produce a diagnostic error");
         let msg = err.to_string();
         assert!(
@@ -3444,7 +3444,7 @@ mod tests {
             runner
                 .recorded
                 .iter()
-                .any(|c| c.contains("docker logs --tail 40 jackin-the-architect")),
+                .any(|c| c.contains("docker logs --tail 40 jk-the-architect")),
             "must shell out to `docker logs` to capture the entrypoint output"
         );
     }
@@ -3507,7 +3507,7 @@ plugins = []
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -3581,7 +3581,7 @@ plugins = []
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -3637,7 +3637,7 @@ plugins = []
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::OAuthToken,
             &crate::instance::GithubAuthContext::default(),
@@ -3689,7 +3689,7 @@ agents = ["codex"]
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -3749,7 +3749,7 @@ agents = ["codex"]
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -3798,7 +3798,7 @@ agents = ["codex"]
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-agent-smith",
+            "jk-agent-smith",
             &manifest,
             &|_| crate::config::AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -3853,7 +3853,7 @@ agents = ["amp"]
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-the-architect",
+            "jk-the-architect",
             &manifest,
             &|_| crate::config::AuthForwardMode::Sync,
             &crate::instance::GithubAuthContext::default(),
@@ -3904,7 +3904,7 @@ agents = ["amp"]
 
         let (state, _) = RoleState::prepare(
             &paths,
-            "jackin-the-architect",
+            "jk-the-architect",
             &manifest,
             &|_| crate::config::AuthForwardMode::Ignore,
             &crate::instance::GithubAuthContext::default(),
@@ -3942,7 +3942,7 @@ agents = ["amp"]
             workdir: "/workspace/jackin".into(),
             mounts: vec![MaterializedMount {
                 bind_src:
-                    "/data/jackin-the-architect/git/worktree/repo/Users/donbeave/Projects/jackin-project/jackin/jackin-the-architect"
+                    "/data/jk-the-architect/git/worktree/repo/Users/donbeave/Projects/jackin-project/jackin/jk-the-architect"
                         .into(),
                 dst: "/Users/donbeave/Projects/jackin-project/jackin".into(),
                 readonly: false,
@@ -3952,14 +3952,14 @@ agents = ["amp"]
                     host_git_target:
                         "/jackin/host/Users/donbeave/Projects/jackin-project/jackin/.git".into(),
                     git_file_override:
-                        "/data/jackin-the-architect/git/overrides/Users/donbeave/Projects/jackin-project/jackin/.git"
+                        "/data/jk-the-architect/git/overrides/Users/donbeave/Projects/jackin-project/jackin/.git"
                             .into(),
                     git_file_target: "/Users/donbeave/Projects/jackin-project/jackin/.git".into(),
                     gitdir_back_override:
-                        "/data/jackin-the-architect/git/overrides/Users/donbeave/Projects/jackin-project/jackin/gitdir"
+                        "/data/jk-the-architect/git/overrides/Users/donbeave/Projects/jackin-project/jackin/gitdir"
                             .into(),
                     gitdir_back_target:
-                        "/jackin/host/Users/donbeave/Projects/jackin-project/jackin/.git/worktrees/jackin-the-architect/gitdir"
+                        "/jackin/host/Users/donbeave/Projects/jackin-project/jackin/.git/worktrees/jk-the-architect/gitdir"
                             .into(),
                 }),
             }],
@@ -3972,7 +3972,7 @@ agents = ["amp"]
         // 1: worktree at <dst>, no :ro (writable).
         assert_eq!(
             strings[0],
-            "/data/jackin-the-architect/git/worktree/repo/Users/donbeave/Projects/jackin-project/jackin/jackin-the-architect:/Users/donbeave/Projects/jackin-project/jackin"
+            "/data/jk-the-architect/git/worktree/repo/Users/donbeave/Projects/jackin-project/jackin/jk-the-architect:/Users/donbeave/Projects/jackin-project/jackin"
         );
         assert!(!strings[0].ends_with(":ro"));
 
@@ -4014,7 +4014,7 @@ agents = ["amp"]
         );
         assert!(
             strings[3].contains(
-                ":/jackin/host/Users/donbeave/Projects/jackin-project/jackin/.git/worktrees/jackin-the-architect/gitdir:ro"
+                ":/jackin/host/Users/donbeave/Projects/jackin-project/jackin/.git/worktrees/jk-the-architect/gitdir:ro"
             )
         );
     }
@@ -4483,15 +4483,18 @@ plugins = ["code-review@claude-plugins-official"]
                 .any(|call| call.contains("git -C") || call.contains("git clone"))
         );
         assert!(runner.recorded.iter().any(|call| {
-            call.contains("docker build ") && call.contains("-t jackin-chainargos__the-architect")
+            call.contains("docker build ") && call.contains("-t jk-chainargos_the-architect")
         }));
         assert!(runner.recorded.iter().any(|call| {
-            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jackin-thearchitect-")
+            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-")
+                && call.contains("thearchitect")
         }));
         let run_cmd = runner
             .recorded
             .iter()
-            .find(|call| call.contains("docker run -d -it --name jackin-thearchitect-"))
+            .find(|call| {
+                call.contains("docker run -d -it --name jk-") && call.contains("thearchitect")
+            })
             .unwrap();
         assert!(run_cmd.contains(" --model sonnet"));
         let container_name = launched_role_container_name(&runner);
@@ -4694,9 +4697,10 @@ plugins = ["code-review@claude-plugins-official"]
         .unwrap();
 
         assert!(
-            runner.recorded.iter().any(
-                |call| call.contains("docker build ") && call.contains("-t jackin-agent-smith")
-            )
+            runner
+                .recorded
+                .iter()
+                .any(|call| call.contains("docker build ") && call.contains("-t jk-agent-smith"))
         );
         assert!(
             runner
@@ -4705,14 +4709,12 @@ plugins = ["code-review@claude-plugins-official"]
                 .any(|call| call.contains("docker build "))
         );
         assert!(runner.recorded.iter().any(|call| {
-            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jackin-agentsmith-")
+            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-")
+                && call.contains("agentsmith")
         }));
-        assert!(
-            runner
-                .recorded
-                .iter()
-                .any(|call| call.contains("docker run -d -it --name jackin-agentsmith-"))
-        );
+        assert!(runner.recorded.iter().any(
+            |call| call.contains("docker run -d -it --name jk-") && call.contains("agentsmith")
+        ));
         assert!(
             !runner
                 .recorded
@@ -4809,7 +4811,7 @@ model = "gpt-5"
         assert!(
             !paths
                 .data_dir
-                .join("jackin-agent-smith")
+                .join("jk-agent-smith")
                 .join("codex")
                 .join("config.toml")
                 .exists()
@@ -4885,7 +4887,7 @@ agents = ["codex"]
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -4957,7 +4959,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5007,7 +5009,7 @@ plugins = []
         let build_call = runner
             .recorded
             .iter()
-            .find(|call| call.contains("docker build ") && call.contains("-t jackin-agent-smith"))
+            .find(|call| call.contains("docker build ") && call.contains("-t jk-agent-smith"))
             .unwrap();
         assert!(build_call.contains("--build-arg JACKIN_HOST_UID="));
         assert!(build_call.contains("--build-arg JACKIN_HOST_GID="));
@@ -5223,7 +5225,7 @@ plugins = []
         let mut config = AppConfig::load_or_init(&paths).unwrap();
         let selector = RoleSelector::new(None, "agent-smith");
         let mut runner = FakeRunner {
-            fail_on: vec!["docker run -d -it --name jackin-agentsmith-".to_string()],
+            fail_on: vec!["docker run -d -it --name jk-".to_string()],
             capture_queue: VecDeque::from(vec![
                 String::new(),
                 String::new(),
@@ -5263,11 +5265,7 @@ plugins = ["code-review@claude-plugins-official"]
         )
         .unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("docker run -d -it --name jackin-agentsmith-")
-        );
+        assert!(error.to_string().contains("docker run -d -it --name jk-"));
         let container_name = launched_role_container_name(&runner);
         let dind = format!("{container_name}-dind");
         let certs_volume = format!("{container_name}-dind-certs");
@@ -5309,7 +5307,7 @@ plugins = ["code-review@claude-plugins-official"]
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5380,7 +5378,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5492,7 +5490,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5602,7 +5600,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5646,15 +5644,12 @@ plugins = []
     #[test]
     fn append_no_proxy_host_is_idempotent() {
         assert_eq!(
-            append_no_proxy_host(
-                "localhost,jackin-agent-smith-dind",
-                "jackin-agent-smith-dind"
-            ),
-            "localhost,jackin-agent-smith-dind"
+            append_no_proxy_host("localhost,jk-agent-smith-dind", "jk-agent-smith-dind"),
+            "localhost,jk-agent-smith-dind"
         );
         assert_eq!(
-            append_no_proxy_host("", "jackin-agent-smith-dind"),
-            "jackin-agent-smith-dind"
+            append_no_proxy_host("", "jk-agent-smith-dind"),
+            "jk-agent-smith-dind"
         );
     }
 
@@ -5669,7 +5664,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5723,7 +5718,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5783,7 +5778,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5842,7 +5837,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -5957,7 +5952,7 @@ plugins = []
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6061,7 +6056,7 @@ trusted = true
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6133,7 +6128,7 @@ dst = "/workspace"
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6236,7 +6231,7 @@ trusted = true
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6316,7 +6311,7 @@ trusted = true
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6413,7 +6408,7 @@ trusted = true
             String::new(),
             String::new(),
             String::new(),
-            "jackin-agent-smith".to_string(),
+            "jk-agent-smith".to_string(),
         ]);
 
         let repo_dir = crate::repo::CachedRepo::new(&paths, &selector).repo_dir;
@@ -6482,7 +6477,8 @@ plugins = []
 
         let (name, _lock) = claim_container_name(&paths, None, &selector, &mut runner).unwrap();
 
-        assert!(name.starts_with("jackin-agentsmith-"), "{name}");
+        assert!(name.starts_with("jk-"), "{name}");
+        assert!(name.contains("agentsmith"), "{name}");
         assert!(!name.contains("clone"), "{name}");
         assert!(crate::instance::naming::is_dns_label(&name), "{name}");
         assert!(
@@ -6490,7 +6486,8 @@ plugins = []
             "{name}"
         );
         assert!(runner.recorded.iter().any(|call| {
-            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jackin-agentsmith-")
+            call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-")
+                && call.contains("agentsmith")
         }));
         assert!(
             !runner
@@ -6528,7 +6525,8 @@ plugins = []
 
         let (name, _lock) = claim_container_name(&paths, None, &selector, &mut runner).unwrap();
 
-        assert!(name.starts_with("jackin-agentsmith-"), "{name}");
+        assert!(name.starts_with("jk-"), "{name}");
+        assert!(name.ends_with("-agentsmith"), "{name}");
         assert!(!name.contains("clone"), "{name}");
         assert_eq!(
             runner
@@ -6556,12 +6554,13 @@ plugins = []
 
         let (name, _lock) = claim_container_name(&paths, None, &selector, &mut runner).unwrap();
 
-        assert!(name.starts_with("jackin-agentsmith-"), "{name}");
+        assert!(name.starts_with("jk-"), "{name}");
+        assert!(name.ends_with("-agentsmith"), "{name}");
         assert!(
             runner
                 .recorded
                 .iter()
-                .any(|call| call.starts_with("docker rm jackin-agentsmith-"))
+                .any(|call| call.starts_with("docker rm jk-") && call.contains("agentsmith"))
         );
     }
 
@@ -6576,7 +6575,8 @@ plugins = []
 
         let (name, _lock) = claim_container_name(&paths, None, &selector, &mut runner).unwrap();
 
-        assert!(name.starts_with("jackin-agentsmith-"), "{name}");
+        assert!(name.starts_with("jk-"), "{name}");
+        assert!(name.ends_with("-agentsmith"), "{name}");
         assert!(!name.contains("clone"), "{name}");
         assert!(
             !runner
@@ -6596,7 +6596,11 @@ plugins = []
         let (name, _lock) =
             claim_container_name(&paths, Some("my-workspace"), &selector, &mut runner).unwrap();
 
-        assert!(name.starts_with("jackin-myworkspace-agentsmith-"), "{name}");
+        assert!(name.starts_with("jk-"), "{name}");
+        assert!(
+            name.contains("myworkspace") && name.ends_with("-agentsmith"),
+            "{name}"
+        );
         assert!(name.len() <= 58, "{name}");
     }
 
@@ -6604,7 +6608,7 @@ plugins = []
     fn restore_candidate_blocks_noninteractive_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = workspace_manifest(
             container_name,
             "agent-smith",
@@ -6626,7 +6630,7 @@ plugins = []
     fn running_matching_instance_does_not_block_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = workspace_manifest(
             container_name,
             "agent-smith",
@@ -6645,7 +6649,7 @@ plugins = []
     fn stopped_matching_instance_does_not_block_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = workspace_manifest(
             container_name,
             "agent-smith",
@@ -6664,7 +6668,7 @@ plugins = []
     fn related_restore_candidate_blocks_noninteractive_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let manifest = workspace_manifest(
             container_name,
             "the-architect",
@@ -6688,7 +6692,7 @@ plugins = []
     fn running_related_instance_does_not_block_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let manifest = workspace_manifest(
             container_name,
             "the-architect",
@@ -6707,7 +6711,7 @@ plugins = []
     fn stopped_related_instance_does_not_block_fresh_load() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let manifest = workspace_manifest(
             container_name,
             "the-architect",
@@ -6726,7 +6730,7 @@ plugins = []
     fn related_restore_candidates_ignore_finished_instances() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let mut manifest = workspace_manifest(
             container_name,
             "the-architect",
@@ -6745,7 +6749,7 @@ plugins = []
 
     #[test]
     fn related_restore_candidate_with_container_recovers_in_place() {
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let candidate = RelatedRestoreCandidate {
             manifest: workspace_manifest(
                 container_name,
@@ -6767,7 +6771,7 @@ plugins = []
 
     #[test]
     fn missing_related_restore_candidate_rebuilds_in_place() {
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let candidate = RelatedRestoreCandidate {
             manifest: workspace_manifest(
                 container_name,
@@ -6790,7 +6794,7 @@ plugins = []
 
     #[test]
     fn related_restore_load_options_use_manifest_source_ref_and_agent() {
-        let container_name = "jackin-workspace-thearchitect-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-thearchitect";
         let mut manifest = workspace_manifest(
             container_name,
             "the-architect",
@@ -6825,7 +6829,7 @@ plugins = []
     fn supersede_restore_candidates_updates_manifest_and_index() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = workspace_manifest(
             container_name,
             "agent-smith",
@@ -6846,7 +6850,7 @@ plugins = []
     fn restore_candidate_label_includes_manifest_and_mount_state() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let mut manifest = workspace_manifest(
             container_name,
             "agent-smith",
@@ -6887,7 +6891,7 @@ plugins = []
     fn record_instance_attach_outcome_updates_manifest() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
-        let container_name = "jackin-workspace-agentsmith-k7p9m2xq";
+        let container_name = "jk-k7p9m2xq-workspace-agentsmith";
         let manifest = workspace_manifest(
             container_name,
             "agent-smith",

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -3210,7 +3210,7 @@ mod tests {
         agent: crate::agent::Agent,
     ) -> InstanceManifest {
         let role_source_git = format!("https://example.invalid/{role_key}.git");
-        let image_tag = format!("{}-{role_key}", crate::instance::naming::CONTAINER_PREFIX);
+        let image_tag = format!("{}{role_key}", crate::runtime::naming::IMAGE_PREFIX);
         InstanceManifest::new(NewInstanceManifest {
             container_base: container_name,
             workspace_name: Some("workspace"),
@@ -4483,7 +4483,7 @@ plugins = ["code-review@claude-plugins-official"]
                 .any(|call| call.contains("git -C") || call.contains("git clone"))
         );
         assert!(runner.recorded.iter().any(|call| {
-            call.contains("docker build ") && call.contains("-t jk-chainargos_the-architect")
+            call.contains("docker build ") && call.contains("-t jk_chainargos_the-architect")
         }));
         assert!(runner.recorded.iter().any(|call| {
             call.contains("docker inspect --format {{.State.Running}} {{.State.ExitCode}} {{.State.OOMKilled}} jk-")
@@ -4700,7 +4700,7 @@ plugins = ["code-review@claude-plugins-official"]
             runner
                 .recorded
                 .iter()
-                .any(|call| call.contains("docker build ") && call.contains("-t jk-agent-smith"))
+                .any(|call| call.contains("docker build ") && call.contains("-t jk_agent-smith"))
         );
         assert!(
             runner
@@ -5009,7 +5009,7 @@ plugins = []
         let build_call = runner
             .recorded
             .iter()
-            .find(|call| call.contains("docker build ") && call.contains("-t jk-agent-smith"))
+            .find(|call| call.contains("docker build ") && call.contains("-t jk_agent-smith"))
             .unwrap();
         assert!(build_call.contains("--build-arg JACKIN_HOST_UID="));
         assert!(build_call.contains("--build-arg JACKIN_HOST_GID="));

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -21,7 +21,10 @@ pub use self::attach::{
     spawn_agent_session,
 };
 pub use self::caffeinate::reconcile as reconcile_keep_awake;
-pub use self::cleanup::{eject_role, exile_all, purge_class_data, purge_container_state};
+pub use self::cleanup::{
+    eject_role, exile_all, prune_cache, prune_images, prune_instances, prune_roles,
+    purge_class_data, purge_container_state,
+};
 pub(crate) use self::discovery::list_role_names;
 pub use self::discovery::{
     list_managed_role_names, list_running_agent_display_names, list_running_agent_names,

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -5,9 +5,8 @@ use crate::selector::RoleSelector;
 
 /// Prefix for jackin-managed Docker image names.
 ///
-/// Uses `_` as the separator (vs `jk-` for container names) so the image-name
-/// boundary is visually distinct from the container-name boundary and all
-/// structural separators in an image name are `_`.
+/// Uses `_` as the separator so all structural boundaries in an image name
+/// are `_`, visually distinct from container names which use `jk-{id}-…`.
 pub(super) const IMAGE_PREFIX: &str = "jk_";
 
 // ── Docker label keys ─────────────────────────────────────────────────────
@@ -70,8 +69,8 @@ pub(super) fn image_name(selector: &RoleSelector) -> String {
 /// Image tag for a branch-specific local build. Branch slashes become dashes
 /// so the tag is a valid Docker name and does not overwrite the stable image
 /// (e.g. `jk_the-architect_feat-my-pr`). All structural separators in image
-/// names are `_` — unambiguous because role names and branch slugs contain
-/// only `[a-z0-9-]`.
+/// names are `_`. Role names and branch slugs contain only `[a-z0-9-]`, so
+/// `_` marks every boundary.
 pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
     let slug = branch.replace('/', "-").to_ascii_lowercase();
     format!("{IMAGE_PREFIX}{}_{slug}", runtime_slug(selector))

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -1,5 +1,7 @@
 //! Naming conventions, Docker label/filter constants, and lightweight identifier helpers.
 
+use crate::instance::naming::CONTAINER_PREFIX_DASH;
+use crate::instance::runtime_slug;
 use crate::selector::RoleSelector;
 
 // ── Docker label keys ─────────────────────────────────────────────────────
@@ -12,6 +14,8 @@ pub(super) const LABEL_MANAGED: &str = "jackin.managed=true";
 pub(super) const LABEL_KIND_ROLE: &str = "jackin.kind=role";
 /// `DinD` sidecars only — distinguishes them from role containers.
 pub(super) const LABEL_KIND_DIND: &str = "jackin.kind=dind";
+/// Filter expression for `docker images --filter` to list jackin-managed role images.
+pub(super) const FILTER_IMAGES: &str = "reference=jk-*";
 /// Filter expression for `docker ps --filter` to find managed containers.
 pub(super) const FILTER_MANAGED: &str = "label=jackin.managed=true";
 /// Filter expression for `docker ps --filter` to find role containers.
@@ -54,11 +58,7 @@ pub fn matching_family(selector: &RoleSelector, names: &[String]) -> Vec<String>
 }
 
 pub(super) fn image_name(selector: &RoleSelector) -> String {
-    format!(
-        "{}{}",
-        crate::instance::naming::CONTAINER_PREFIX_DASH,
-        crate::instance::runtime_slug(selector)
-    )
+    format!("{CONTAINER_PREFIX_DASH}{}", runtime_slug(selector))
 }
 
 /// Image tag for a branch-specific local build. Branch slashes become dashes
@@ -66,11 +66,7 @@ pub(super) fn image_name(selector: &RoleSelector) -> String {
 /// (e.g. `jk-the-architect-feat-my-pr`).
 pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
     let slug = branch.replace('/', "-").to_ascii_lowercase();
-    format!(
-        "{}{}-{slug}",
-        crate::instance::naming::CONTAINER_PREFIX_DASH,
-        crate::instance::runtime_slug(selector)
-    )
+    format!("{CONTAINER_PREFIX_DASH}{}-{slug}", runtime_slug(selector))
 }
 
 /// Docker volume name for the TLS client certificates shared between the

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -110,6 +110,20 @@ mod tests {
     }
 
     #[test]
+    fn image_name_for_branch_lowercases_uppercase_branch() {
+        let namespaced = crate::selector::RoleSelector::new(Some("chainargos"), "agent-brown");
+        let flat = crate::selector::RoleSelector::new(None, "the-architect");
+        assert_eq!(
+            image_name_for_branch(&namespaced, "Feat/MY-PR"),
+            "jk-chainargos_agent-brown_feat-my-pr"
+        );
+        assert_eq!(
+            image_name_for_branch(&flat, "RELEASE/1.0"),
+            "jk-the-architect_release-1.0"
+        );
+    }
+
+    #[test]
     fn dind_certs_volume_derives_from_container_name() {
         assert_eq!(
             dind_certs_volume("jk-agent-smith"),

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -89,6 +89,26 @@ mod tests {
     }
 
     #[test]
+    fn image_name_for_branch_substitutes_slashes_and_keeps_prefix() {
+        let namespaced = crate::selector::RoleSelector::new(Some("chainargos"), "agent-brown");
+        let flat = crate::selector::RoleSelector::new(None, "the-architect");
+
+        assert_eq!(
+            image_name_for_branch(&namespaced, "feat/my-pr"),
+            "jk-chainargos_agent-brown-feat-my-pr"
+        );
+        assert_eq!(
+            image_name_for_branch(&flat, "main"),
+            "jk-the-architect-main"
+        );
+        // Branch with multiple slashes — all become dashes.
+        assert_eq!(
+            image_name_for_branch(&flat, "feat/scope/detail"),
+            "jk-the-architect-feat-scope-detail"
+        );
+    }
+
+    #[test]
     fn dind_certs_volume_derives_from_container_name() {
         assert_eq!(
             dind_certs_volume("jk-agent-smith"),

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -96,6 +96,12 @@ mod tests {
     }
 
     #[test]
+    fn image_name_flat_role_uses_jk_underscore_prefix() {
+        let flat = crate::selector::RoleSelector::new(None, "agent-smith");
+        assert_eq!(image_name(&flat), "jk_agent-smith");
+    }
+
+    #[test]
     fn image_name_for_branch_substitutes_slashes_and_keeps_prefix() {
         let namespaced = crate::selector::RoleSelector::new(Some("chainargos"), "agent-brown");
         let flat = crate::selector::RoleSelector::new(None, "the-architect");

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -29,8 +29,8 @@ pub(super) const LABEL_KEEP_AWAKE: &str = "jackin.keep_awake=true";
 /// Format a human-friendly role name from a container name and its display label.
 ///
 /// Examples:
-///   - `("jackin-thearchitect-k7p9m2xq", "The Architect")` → `"The Architect (k7p9m2xq)"`
-///   - `("jackin-thearchitect-k7p9m2xq", "")` → `"jackin-thearchitect-k7p9m2xq"`
+///   - `("jk-k7p9m2xq-thearchitect", "The Architect")` → `"The Architect (k7p9m2xq)"`
+///   - `("jk-k7p9m2xq-thearchitect", "")` → `"jk-k7p9m2xq-thearchitect"`
 ///
 /// The instance-ID suffix is appended so two concurrent sessions of the
 /// same role render as distinct rows in operator output.
@@ -54,15 +54,23 @@ pub fn matching_family(selector: &RoleSelector, names: &[String]) -> Vec<String>
 }
 
 pub(super) fn image_name(selector: &RoleSelector) -> String {
-    format!("jackin-{}", crate::instance::runtime_slug(selector))
+    format!(
+        "{}{}",
+        crate::instance::naming::CONTAINER_PREFIX_DASH,
+        crate::instance::runtime_slug(selector)
+    )
 }
 
 /// Image tag for a branch-specific local build. Branch slashes become dashes
 /// so the tag is a valid Docker name and does not overwrite the stable image
-/// (e.g. `jackin-the-architect-feat-my-pr`).
+/// (e.g. `jk-the-architect-feat-my-pr`).
 pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
     let slug = branch.replace('/', "-").to_ascii_lowercase();
-    format!("jackin-{}-{slug}", crate::instance::runtime_slug(selector))
+    format!(
+        "{}{}-{slug}",
+        crate::instance::naming::CONTAINER_PREFIX_DASH,
+        crate::instance::runtime_slug(selector)
+    )
 }
 
 /// Docker volume name for the TLS client certificates shared between the
@@ -76,29 +84,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dind_certs_volume_derives_from_container_name() {
-        assert_eq!(
-            dind_certs_volume("jackin-agent-smith"),
-            "jackin-agent-smith-dind-certs"
-        );
-        assert_eq!(
-            dind_certs_volume("jackin-chainargos__the-architect-clone-2"),
-            "jackin-chainargos__the-architect-clone-2-dind-certs"
-        );
+    fn image_name_distinguishes_namespaced_and_flat_classes() {
+        let namespaced = crate::selector::RoleSelector::new(Some("chainargos"), "agent-brown");
+        let flat = crate::selector::RoleSelector::new(None, "chainargos-agent-brown");
+        assert_ne!(image_name(&namespaced), image_name(&flat));
+        assert_eq!(image_name(&namespaced), "jk-chainargos_agent-brown");
+        assert_eq!(image_name(&flat), "jk-chainargos-agent-brown");
     }
 
     #[test]
-    fn image_name_distinguishes_namespaced_and_flat_classes() {
-        let namespaced = RoleSelector::new(Some("chainargos"), "the-architect");
-        let flat = RoleSelector::new(None, "chainargos-the-architect");
-
-        assert_ne!(image_name(&namespaced), image_name(&flat));
+    fn dind_certs_volume_derives_from_container_name() {
+        assert_eq!(
+            dind_certs_volume("jk-agent-smith"),
+            "jk-agent-smith-dind-certs"
+        );
+        assert_eq!(
+            dind_certs_volume("jk-k7p9m2xq-chainargos-thearchitect"),
+            "jk-k7p9m2xq-chainargos-thearchitect-dind-certs"
+        );
     }
 
     #[test]
     fn format_agent_display_appends_instance_id() {
         assert_eq!(
-            format_role_display("jackin-thearchitect-k7p9m2xq", "The Architect"),
+            format_role_display("jk-k7p9m2xq-thearchitect", "The Architect"),
             "The Architect (k7p9m2xq)"
         );
     }
@@ -106,8 +115,8 @@ mod tests {
     #[test]
     fn format_agent_display_falls_back_to_container_name() {
         assert_eq!(
-            format_role_display("jackin-thearchitect-k7p9m2xq", ""),
-            "jackin-thearchitect-k7p9m2xq"
+            format_role_display("jk-k7p9m2xq-thearchitect", ""),
+            "jk-k7p9m2xq-thearchitect"
         );
     }
 }

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -63,10 +63,11 @@ pub(super) fn image_name(selector: &RoleSelector) -> String {
 
 /// Image tag for a branch-specific local build. Branch slashes become dashes
 /// so the tag is a valid Docker name and does not overwrite the stable image
-/// (e.g. `jk-the-architect-feat-my-pr`).
+/// (e.g. `jk-the-architect_feat-my-pr`). The `_` between role slug and branch
+/// slug mirrors the namespace separator so the boundary is unambiguous.
 pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
     let slug = branch.replace('/', "-").to_ascii_lowercase();
-    format!("{CONTAINER_PREFIX_DASH}{}-{slug}", runtime_slug(selector))
+    format!("{CONTAINER_PREFIX_DASH}{}_{slug}", runtime_slug(selector))
 }
 
 /// Docker volume name for the TLS client certificates shared between the
@@ -95,16 +96,16 @@ mod tests {
 
         assert_eq!(
             image_name_for_branch(&namespaced, "feat/my-pr"),
-            "jk-chainargos_agent-brown-feat-my-pr"
+            "jk-chainargos_agent-brown_feat-my-pr"
         );
         assert_eq!(
             image_name_for_branch(&flat, "main"),
-            "jk-the-architect-main"
+            "jk-the-architect_main"
         );
         // Branch with multiple slashes — all become dashes.
         assert_eq!(
             image_name_for_branch(&flat, "feat/scope/detail"),
-            "jk-the-architect-feat-scope-detail"
+            "jk-the-architect_feat-scope-detail"
         );
     }
 

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -1,8 +1,14 @@
 //! Naming conventions, Docker label/filter constants, and lightweight identifier helpers.
 
-use crate::instance::naming::CONTAINER_PREFIX_DASH;
 use crate::instance::runtime_slug;
 use crate::selector::RoleSelector;
+
+/// Prefix for jackin-managed Docker image names.
+///
+/// Uses `_` as the separator (vs `jk-` for container names) so the image-name
+/// boundary is visually distinct from the container-name boundary and all
+/// structural separators in an image name are `_`.
+pub(super) const IMAGE_PREFIX: &str = "jk_";
 
 // ── Docker label keys ─────────────────────────────────────────────────────
 //
@@ -15,7 +21,7 @@ pub(super) const LABEL_KIND_ROLE: &str = "jackin.kind=role";
 /// `DinD` sidecars only — distinguishes them from role containers.
 pub(super) const LABEL_KIND_DIND: &str = "jackin.kind=dind";
 /// Filter expression for `docker images --filter` to list jackin-managed role images.
-pub(super) const FILTER_IMAGES: &str = "reference=jk-*";
+pub(super) const FILTER_IMAGES: &str = "reference=jk_*";
 /// Filter expression for `docker ps --filter` to find managed containers.
 pub(super) const FILTER_MANAGED: &str = "label=jackin.managed=true";
 /// Filter expression for `docker ps --filter` to find role containers.
@@ -58,16 +64,17 @@ pub fn matching_family(selector: &RoleSelector, names: &[String]) -> Vec<String>
 }
 
 pub(super) fn image_name(selector: &RoleSelector) -> String {
-    format!("{CONTAINER_PREFIX_DASH}{}", runtime_slug(selector))
+    format!("{IMAGE_PREFIX}{}", runtime_slug(selector))
 }
 
 /// Image tag for a branch-specific local build. Branch slashes become dashes
 /// so the tag is a valid Docker name and does not overwrite the stable image
-/// (e.g. `jk-the-architect_feat-my-pr`). The `_` between role slug and branch
-/// slug mirrors the namespace separator so the boundary is unambiguous.
+/// (e.g. `jk_the-architect_feat-my-pr`). All structural separators in image
+/// names are `_` — unambiguous because role names and branch slugs contain
+/// only `[a-z0-9-]`.
 pub(super) fn image_name_for_branch(selector: &RoleSelector, branch: &str) -> String {
     let slug = branch.replace('/', "-").to_ascii_lowercase();
-    format!("{CONTAINER_PREFIX_DASH}{}_{slug}", runtime_slug(selector))
+    format!("{IMAGE_PREFIX}{}_{slug}", runtime_slug(selector))
 }
 
 /// Docker volume name for the TLS client certificates shared between the
@@ -85,8 +92,8 @@ mod tests {
         let namespaced = crate::selector::RoleSelector::new(Some("chainargos"), "agent-brown");
         let flat = crate::selector::RoleSelector::new(None, "chainargos-agent-brown");
         assert_ne!(image_name(&namespaced), image_name(&flat));
-        assert_eq!(image_name(&namespaced), "jk-chainargos_agent-brown");
-        assert_eq!(image_name(&flat), "jk-chainargos-agent-brown");
+        assert_eq!(image_name(&namespaced), "jk_chainargos_agent-brown");
+        assert_eq!(image_name(&flat), "jk_chainargos-agent-brown");
     }
 
     #[test]
@@ -96,16 +103,16 @@ mod tests {
 
         assert_eq!(
             image_name_for_branch(&namespaced, "feat/my-pr"),
-            "jk-chainargos_agent-brown_feat-my-pr"
+            "jk_chainargos_agent-brown_feat-my-pr"
         );
         assert_eq!(
             image_name_for_branch(&flat, "main"),
-            "jk-the-architect_main"
+            "jk_the-architect_main"
         );
         // Branch with multiple slashes — all become dashes.
         assert_eq!(
             image_name_for_branch(&flat, "feat/scope/detail"),
-            "jk-the-architect_feat-scope-detail"
+            "jk_the-architect_feat-scope-detail"
         );
     }
 
@@ -115,11 +122,11 @@ mod tests {
         let flat = crate::selector::RoleSelector::new(None, "the-architect");
         assert_eq!(
             image_name_for_branch(&namespaced, "Feat/MY-PR"),
-            "jk-chainargos_agent-brown_feat-my-pr"
+            "jk_chainargos_agent-brown_feat-my-pr"
         );
         assert_eq!(
             image_name_for_branch(&flat, "RELEASE/1.0"),
-            "jk-the-architect_release-1.0"
+            "jk_the-architect_release-1.0"
         );
     }
 

--- a/src/runtime/repo_cache.rs
+++ b/src/runtime/repo_cache.rs
@@ -1,5 +1,5 @@
 use crate::docker::{CommandRunner, RunOptions};
-use crate::instance::primary_container_name;
+use crate::instance::runtime_slug;
 use crate::paths::JackinPaths;
 use crate::repo::{CachedRepo, validate_role_repo};
 use crate::selector::RoleSelector;
@@ -265,7 +265,7 @@ pub(super) fn register_agent_repo(
 
     let lock_path = paths
         .data_dir
-        .join(format!("{}.repo.lock", primary_container_name(selector)));
+        .join(format!("{}.repo.lock", runtime_slug(selector)));
     let lock_file = std::fs::File::create(&lock_path)?;
     lock_file
         .lock_exclusive()
@@ -392,7 +392,7 @@ pub(super) fn resolve_agent_repo_with(
         };
         paths
             .data_dir
-            .join(format!("{}.locks", primary_container_name(selector)))
+            .join(format!("{}.locks", runtime_slug(selector)))
             .join(file_name)
     };
     std::fs::create_dir_all(lock_path.parent().unwrap_or(&paths.data_dir))?;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -98,14 +98,6 @@ impl Selector {
             return Ok(Self::Container(input.to_string()));
         }
 
-        if !input.contains('/')
-            && let Some((base, suffix)) = input.rsplit_once("-clone-")
-            && is_valid_role_segment(base)
-            && suffix.chars().all(|ch| ch.is_ascii_digit())
-        {
-            return Ok(Self::Container(format!("jackin-{input}")));
-        }
-
         Ok(Self::Role(RoleSelector::parse(input)?))
     }
 }
@@ -128,19 +120,18 @@ fn is_valid_role_segment(value: &str) -> bool {
 }
 
 fn is_valid_container_name(value: &str) -> bool {
-    value.strip_prefix("jackin-").is_some_and(|suffix| {
-        !suffix.is_empty()
-            && suffix
-                .chars()
-                .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
-    })
+    value
+        .strip_prefix(crate::instance::naming::CONTAINER_PREFIX_DASH)
+        .is_some_and(|suffix| {
+            !suffix.is_empty()
+                && suffix.chars().all(|ch| {
+                    ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_'
+                })
+        })
 }
 
 fn is_reserved_builtin_role_name(value: &str) -> bool {
-    value.starts_with("jackin-")
-        || value.rsplit_once("-clone-").is_some_and(|(base, suffix)| {
-            is_valid_role_segment(base) && suffix.chars().all(|ch| ch.is_ascii_digit())
-        })
+    value.starts_with(crate::instance::naming::CONTAINER_PREFIX_DASH)
 }
 
 #[cfg(test)]
@@ -159,11 +150,7 @@ mod tests {
     #[test]
     fn class_parser_rejects_reserved_builtin_names() {
         assert!(matches!(
-            RoleSelector::parse("jackin-agent-smith"),
-            Err(SelectorError::Invalid(_))
-        ));
-        assert!(matches!(
-            RoleSelector::parse("agent-smith-clone-1"),
+            RoleSelector::parse("jk-agent-smith"),
             Err(SelectorError::Invalid(_))
         ));
     }
@@ -179,28 +166,19 @@ mod tests {
 
     #[test]
     fn parses_container_selector() {
-        let selector = Selector::parse("jackin-chainargos-the-architect-clone-1").unwrap();
+        let selector = Selector::parse("jk-k7p9m2xq-chainargos-thearchitect").unwrap();
         assert_eq!(
             selector,
-            Selector::Container("jackin-chainargos-the-architect-clone-1".to_string())
+            Selector::Container("jk-k7p9m2xq-chainargos-thearchitect".to_string())
         );
     }
 
     #[test]
-    fn parses_container_selector_with_namespace_separator() {
-        let selector = Selector::parse("jackin-chainargos__the-architect").unwrap();
+    fn parses_container_selector_no_workspace() {
+        let selector = Selector::parse("jk-k7p9m2xq-agentsmith").unwrap();
         assert_eq!(
             selector,
-            Selector::Container("jackin-chainargos__the-architect".to_string())
-        );
-    }
-
-    #[test]
-    fn parses_clone_shorthand_selector() {
-        let selector = Selector::parse("agent-smith-clone-1").unwrap();
-        assert_eq!(
-            selector,
-            Selector::Container("jackin-agent-smith-clone-1".to_string())
+            Selector::Container("jk-k7p9m2xq-agentsmith".to_string())
         );
     }
 

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -227,10 +227,10 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jk-agent-smith", "2.1.91");
+        store_image_version(&paths, "jk_agent-smith", "2.1.91");
 
         assert_eq!(
-            stored_image_version(&paths, "jk-agent-smith"),
+            stored_image_version(&paths, "jk_agent-smith"),
             Some("2.1.91".to_string())
         );
     }
@@ -241,13 +241,13 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jk-agent-smith", "2.1.91");
+        store_image_version(&paths, "jk_agent-smith", "2.1.91");
         // Seed the npm cache with a newer version
         let cache = npm_cache_path(&paths);
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(needs_claude_update(&paths, "jk-agent-smith", &mut runner));
+        assert!(needs_claude_update(&paths, "jk_agent-smith", &mut runner));
     }
 
     #[test]
@@ -256,12 +256,12 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jk-agent-smith", "2.1.92");
+        store_image_version(&paths, "jk_agent-smith", "2.1.92");
         let cache = npm_cache_path(&paths);
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(!needs_claude_update(&paths, "jk-agent-smith", &mut runner));
+        assert!(!needs_claude_update(&paths, "jk_agent-smith", &mut runner));
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
 
         let mut runner = StubRunner("2.1.92".to_string());
         // No stored version yet → should not force rebuild
-        assert!(!needs_claude_update(&paths, "jk-agent-smith", &mut runner));
+        assert!(!needs_claude_update(&paths, "jk_agent-smith", &mut runner));
     }
 
     #[test]
@@ -328,10 +328,10 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jk-the-architect", "1.14.48");
+        store_opencode_version(&paths, "jk_the-architect", "1.14.48");
 
         assert_eq!(
-            stored_opencode_version(&paths, "jk-the-architect"),
+            stored_opencode_version(&paths, "jk_the-architect"),
             Some("1.14.48".to_string())
         );
     }
@@ -342,14 +342,14 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jk-the-architect", "1.14.47");
+        store_opencode_version(&paths, "jk_the-architect", "1.14.47");
         let cache = opencode_npm_cache_path(&paths);
         let _ = write_cached(&cache, "1.14.48");
 
         let mut runner = StubRunner("1.14.48".to_string());
         assert!(needs_opencode_update(
             &paths,
-            "jk-the-architect",
+            "jk_the-architect",
             &mut runner
         ));
     }
@@ -360,14 +360,14 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jk-the-architect", "1.14.48");
+        store_opencode_version(&paths, "jk_the-architect", "1.14.48");
         let cache = opencode_npm_cache_path(&paths);
         let _ = write_cached(&cache, "1.14.48");
 
         let mut runner = StubRunner("1.14.48".to_string());
         assert!(!needs_opencode_update(
             &paths,
-            "jk-the-architect",
+            "jk_the-architect",
             &mut runner
         ));
     }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -227,10 +227,10 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jackin-agent-smith", "2.1.91");
+        store_image_version(&paths, "jk-agent-smith", "2.1.91");
 
         assert_eq!(
-            stored_image_version(&paths, "jackin-agent-smith"),
+            stored_image_version(&paths, "jk-agent-smith"),
             Some("2.1.91".to_string())
         );
     }
@@ -241,17 +241,13 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jackin-agent-smith", "2.1.91");
+        store_image_version(&paths, "jk-agent-smith", "2.1.91");
         // Seed the npm cache with a newer version
         let cache = npm_cache_path(&paths);
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(needs_claude_update(
-            &paths,
-            "jackin-agent-smith",
-            &mut runner
-        ));
+        assert!(needs_claude_update(&paths, "jk-agent-smith", &mut runner));
     }
 
     #[test]
@@ -260,16 +256,12 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_image_version(&paths, "jackin-agent-smith", "2.1.92");
+        store_image_version(&paths, "jk-agent-smith", "2.1.92");
         let cache = npm_cache_path(&paths);
         let _ = write_cached(&cache, "2.1.92");
 
         let mut runner = StubRunner("2.1.92".to_string());
-        assert!(!needs_claude_update(
-            &paths,
-            "jackin-agent-smith",
-            &mut runner
-        ));
+        assert!(!needs_claude_update(&paths, "jk-agent-smith", &mut runner));
     }
 
     #[test]
@@ -280,11 +272,7 @@ mod tests {
 
         let mut runner = StubRunner("2.1.92".to_string());
         // No stored version yet → should not force rebuild
-        assert!(!needs_claude_update(
-            &paths,
-            "jackin-agent-smith",
-            &mut runner
-        ));
+        assert!(!needs_claude_update(&paths, "jk-agent-smith", &mut runner));
     }
 
     #[test]
@@ -340,10 +328,10 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jackin-the-architect", "1.14.48");
+        store_opencode_version(&paths, "jk-the-architect", "1.14.48");
 
         assert_eq!(
-            stored_opencode_version(&paths, "jackin-the-architect"),
+            stored_opencode_version(&paths, "jk-the-architect"),
             Some("1.14.48".to_string())
         );
     }
@@ -354,14 +342,14 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jackin-the-architect", "1.14.47");
+        store_opencode_version(&paths, "jk-the-architect", "1.14.47");
         let cache = opencode_npm_cache_path(&paths);
         let _ = write_cached(&cache, "1.14.48");
 
         let mut runner = StubRunner("1.14.48".to_string());
         assert!(needs_opencode_update(
             &paths,
-            "jackin-the-architect",
+            "jk-the-architect",
             &mut runner
         ));
     }
@@ -372,14 +360,14 @@ mod tests {
         let paths = JackinPaths::for_tests(temp.path());
         paths.ensure_base_dirs().unwrap();
 
-        store_opencode_version(&paths, "jackin-the-architect", "1.14.48");
+        store_opencode_version(&paths, "jk-the-architect", "1.14.48");
         let cache = opencode_npm_cache_path(&paths);
         let _ = write_cached(&cache, "1.14.48");
 
         let mut runner = StubRunner("1.14.48".to_string());
         assert!(!needs_opencode_update(
             &paths,
-            "jackin-the-architect",
+            "jk-the-architect",
             &mut runner
         ));
     }


### PR DESCRIPTION
## Summary

Renames all jackin-managed Docker resources from `jackin-{workspace}-{role}-{id}` to `jk-{id}-{workspace?}-{role}`. The shorter `jk-` prefix saves 5 characters per name; putting the instance ID second means all Docker resources from the same session share a common visible prefix in `docker ps` output. Concurrent launches of the same role are now easier to distinguish at a glance. Adds `jackin prune` with five subcommands (`roles`, `cache`, `images`, `instances`, `all`) so operators can clean up jackin's host-side cached data without resorting to `rm -rf ~/.jackin`. Also fixes several CLI consistency issues: `--all` flag help text, stale container name examples, grammar (`an role` → `a role`), and operator output that leaked internal TOML field names (`keep_awake`, `git_pull_on_entry`).

## What's deferred (follow-up PRs)

- `DockerResources::from_container_name` extraction (tracked in Codebase Readability roadmap) — 44+ `format!("{name}-dind")` derivations still inline; this PR does not worsen the count.
- `class_family_matches` / `runtime_slug` deduplication across `app/mod.rs` call sites.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jackin-jackin-thearchitect-9vr9jhvf:refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-9vr9jhvf
git checkout -B jackin/scratch/jackin-jackin-thearchitect-9vr9jhvf refs/remotes/origin/jackin/scratch/jackin-jackin-thearchitect-9vr9jhvf
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-naming"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-naming"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib
```

### Tests

```sh
cargo test --lib
```

Covers 1872 tests including new unit tests for `prune_dir`, `prune_instances` (all four prunable statuses, Docker-present skip), `prune_images` (in-use skip, remove success, real-error best-effort, TOCTOU disappear), `remove_many` (empty slice, absent name, duplicate names, one-of-two removed), and `is_image_in_use_error` (all three match strings, case-insensitivity, false-positive guard).

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Verify any existing instance rows show container names in `jk-{id}-{role}` or `jk-{id}-{workspace}-{role}` format. Then exercise the new prune command:

```sh
cargo run --bin jackin -- prune instances --debug
cargo run --bin jackin -- prune roles --debug
cargo run --bin jackin -- prune images --debug
```

Each subcommand should print "No instances to prune." / "role cache already empty." / "No jackin-managed images found." on a fresh install with no cached state.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/commands/prune/**  
NEW page. Should appear in the Commands sidebar group between `purge` and `workspace`. Walk the subcommand table and the status table under `prune instances`.

**http://localhost:4321/reference/instance-resource-naming/**  
NEW page. Should appear in the Behind jackin' — Internals sidebar group. Verify the container name budget math, the `_` separator for namespaced image names, and the CLI selector examples.

**http://localhost:4321/reference/runtime-instance-model/**  
UPDATED naming format section: `jk-{id}-{workspace?}-{role}`, with link to Instance and Resource Naming.

**http://localhost:4321/reference/architecture/**  
UPDATED roles directory tree (no `github.com/` nesting) and `isolation.json` path prefix (`jk-` not `jackin-`).

## Migration notes

None. Pre-release: existing `jackin-*` state directories under `~/.jackin/data/` will not be recognised by the new naming code. Stale data fails with the standard lookup error, which is expected per the pre-release breaking-change rule.