### PR TITLE
refactor: centralize TUI scroll widgets

### DIFF
--- a/docs/src/content/docs/reference/tui-design-decisions.mdx
+++ b/docs/src/content/docs/reference/tui-design-decisions.mdx
@@ -135,11 +135,11 @@ The workspace mounts formula uses `.max(1)` because an empty mount list renders 
 - Scrollbar thumbs are proportional to visible content in both axes, so small overflow produces a long thumb and large overflow produces a short thumb, while a block scrolled to its maximum offset still shows the thumb at the visible end of the track.
 - Horizontal scrolling preserves matching trailing padding for each row's leading padding, so two-space-indented tables do not pin their final visible character against the right border or scrollbar column at maximum horizontal offset.
 
-Input hit-testing, focusability, scrollbar dragging, wheel/key max-offset math, right-padding content width, and Ratatui scrollbar state construction must use the shared scroll helpers in <RepoFile path="src/console/widgets/scrollable.rs" /> (`viewport_width`, `viewport_height`, `is_scrollable`, `max_offset`, `effective_offset`, and `scrollbar_position_for_offset`). Do not reimplement `area.width - 2`, `area.height - 2`, `content - viewport`, proportional thumb sizing, trailing scroll padding, or Ratatui scrollbar-position formulas in input handlers or widget renderers; drift between input geometry and renderer geometry is a scroll bug.
+Input hit-testing, focusability, scrollbar dragging, wheel/key max-offset math, right-padding content width, and Ratatui scrollbar state construction must use the shared scroll helpers in <RepoFile path="src/console/widgets/scrollable.rs" /> (`viewport_width`, `viewport_height`, `is_scrollable`, `max_offset`, `effective_offset`, `scrollbar_position_for_offset`, and the private `scrollbar_content_length` via the existing `render_*_scrollbar` helpers). Do not reimplement `area.width - 2`, `area.height - 2`, `content - viewport`, proportional thumb sizing, trailing scroll padding, or Ratatui scrollbar-position formulas in input handlers or widget renderers; drift between input geometry and renderer geometry is a scroll bug. In particular, do not pass raw `content_length` to `ScrollbarState::new()` — the correct argument is `content_length - viewport + 1` (the number of distinct scroll positions), which `scrollbar_content_length` computes; passing the raw length produces a thumb that is too small for moderate overflows.
 
 Signature:
 ```rust
-pub(super) fn render_scrollable_block(
+pub(crate) fn render_scrollable_block(
     frame: &mut Frame,
     area: Rect,
     lines: Vec<Line<'_>>,
@@ -177,7 +177,7 @@ In `scroll_active_panel`, dispatch order for the list stage:
 1. If `list_names_focused` → scroll `list_names_scroll_x` (left pane).
 2. Otherwise → compute `list_scroll_areas`, route to the block under the pointer.
 
-The left pane scroll uses `apply_horizontal_scroll_unbounded` (no clamping to content width) because `render_scrollable_block` clamps on every frame anyway.
+The left pane scroll uses `apply_scroll_delta` (no clamping to content width) because `render_scrollable_block` clamps on every frame anyway.
 
 ---
 

--- a/docs/src/content/docs/reference/tui-design-decisions.mdx
+++ b/docs/src/content/docs/reference/tui-design-decisions.mdx
@@ -115,7 +115,7 @@ These are the exact formulas that match what each render function passes to `ren
 | Block | `content_height` |
 |---|---|
 | Workspace mounts | `1 + max(data_rows, 1)` where `data_rows = sum of 1-or-2 per mount (1 if src==dst, 2 otherwise)` |
-| Global mounts / Role global mounts | `1 + n*2 + 1` where n = mount count (assumes src≠dst; +1 for header) |
+| Global mounts / Role global mounts | `1 + data_rows` where `data_rows = sum of 1-or-2 per mount (1 if src==dst, 2 otherwise)`; empty sections render one placeholder row |
 | Roles | `2 + agent_count` (1 "Default …" row + 1 blank row + agent rows) |
 | Left sidebar (workspace names) | no vertical scroll — use `clamp_list_scroll_for_area` horizontal-only path |
 
@@ -132,6 +132,10 @@ The workspace mounts formula uses `.max(1)` because an empty mount list renders 
 - Horizontal scrollbar rendered only when content overflows horizontally.
 - Vertical scrollbar rendered only when content overflows vertically.
 - `*scroll_x` and `*scroll_y` clamped to valid range in-place every frame (eliminates stale overshoot).
+- Scrollbar thumbs are proportional to visible content in both axes, so small overflow produces a long thumb and large overflow produces a short thumb, while a block scrolled to its maximum offset still shows the thumb at the visible end of the track.
+- Horizontal scrolling preserves matching trailing padding for each row's leading padding, so two-space-indented tables do not pin their final visible character against the right border or scrollbar column at maximum horizontal offset.
+
+Input hit-testing, focusability, scrollbar dragging, wheel/key max-offset math, right-padding content width, and Ratatui scrollbar state construction must use the shared scroll helpers in <RepoFile path="src/console/widgets/scrollable.rs" /> (`viewport_width`, `viewport_height`, `is_scrollable`, `max_offset`, `effective_offset`, and `scrollbar_position_for_offset`). Do not reimplement `area.width - 2`, `area.height - 2`, `content - viewport`, proportional thumb sizing, trailing scroll padding, or Ratatui scrollbar-position formulas in input handlers or widget renderers; drift between input geometry and renderer geometry is a scroll bug.
 
 Signature:
 ```rust

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -663,6 +663,7 @@ fn scroll_active_panel(
 /// Dispatch a vertical scroll event to whichever content block the mouse is over.
 /// Horizontal-only blocks (List view mounts) are silently ignored here —
 /// their scroll is only driven by left/right events via `scroll_active_panel`.
+#[allow(clippy::missing_const_for_fn)]
 fn scroll_active_panel_vertical(
     state: &mut ManagerState<'_>,
     mouse: MouseEvent,

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -7,7 +7,8 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use super::super::super::widgets::file_browser::FileBrowserState;
 use super::super::render::global_mounts::trust_content_width;
 use super::super::render::list::{
-    global_mounts_content_width, mount_block_height, workspace_mounts_content_width,
+    global_mounts_block_height, global_mounts_content_height, global_mounts_content_width,
+    mount_block_height, workspace_mounts_content_height, workspace_mounts_content_width,
 };
 use super::super::render::{
     is_scrollable, max_scroll_offset, scroll_viewport_height, scroll_viewport_width,
@@ -587,7 +588,7 @@ fn scroll_active_panel(
         ManagerStage::List => {
             update_scroll_focus(state, mouse, term_size, config);
             if state.list_names_focused {
-                apply_horizontal_scroll_unbounded(&mut state.list_names_scroll_x, delta);
+                apply_scroll_delta(&mut state.list_names_scroll_x, delta);
                 return;
             }
             let Some(areas) = list_scroll_areas(state, term_size, config) else {
@@ -676,13 +677,13 @@ fn scroll_active_panel_vertical(
             }
             match settings.active_tab {
                 SettingsTab::Mounts => {
-                    apply_vertical_scroll(&mut settings.mounts.scroll_y, delta);
+                    apply_scroll_delta(&mut settings.mounts.scroll_y, delta);
                 }
                 SettingsTab::Environments => {
-                    apply_vertical_scroll(&mut settings.env.scroll_y, delta);
+                    apply_scroll_delta(&mut settings.env.scroll_y, delta);
                 }
                 SettingsTab::Trust => {
-                    apply_vertical_scroll(&mut settings.trust.scroll_y, delta);
+                    apply_scroll_delta(&mut settings.trust.scroll_y, delta);
                 }
                 // Auth has too few rows to overflow — ignore vertical scroll.
                 SettingsTab::Auth => {}
@@ -694,7 +695,7 @@ fn scroll_active_panel_vertical(
                 EditorTab::General => {}
                 // Mounts, Roles, Secrets, Auth all use tab_scroll_y.
                 EditorTab::Mounts | EditorTab::Roles | EditorTab::Secrets | EditorTab::Auth => {
-                    apply_vertical_scroll(&mut editor.tab_scroll_y, delta);
+                    apply_scroll_delta(&mut editor.tab_scroll_y, delta);
                 }
             }
         }
@@ -702,16 +703,16 @@ fn scroll_active_panel_vertical(
             // Scroll the focused block vertically.
             match state.list_scroll_focus {
                 Some(MountScrollFocus::Workspace) => {
-                    apply_vertical_scroll(&mut state.list_mounts_scroll_y, delta);
+                    apply_scroll_delta(&mut state.list_mounts_scroll_y, delta);
                 }
                 Some(MountScrollFocus::Global) => {
-                    apply_vertical_scroll(&mut state.list_global_mounts_scroll_y, delta);
+                    apply_scroll_delta(&mut state.list_global_mounts_scroll_y, delta);
                 }
                 Some(MountScrollFocus::RoleGlobal) => {
-                    apply_vertical_scroll(&mut state.list_role_global_mounts_scroll_y, delta);
+                    apply_scroll_delta(&mut state.list_role_global_mounts_scroll_y, delta);
                 }
                 Some(MountScrollFocus::Roles) => {
-                    apply_vertical_scroll(&mut state.list_roles_scroll_y, delta);
+                    apply_scroll_delta(&mut state.list_roles_scroll_y, delta);
                 }
                 None => {}
             }
@@ -720,19 +721,8 @@ fn scroll_active_panel_vertical(
     }
 }
 
-#[allow(clippy::missing_const_for_fn)]
-fn apply_vertical_scroll(value: &mut u16, delta: i16) {
-    *value = if delta.is_negative() {
-        value.saturating_sub(delta.unsigned_abs())
-    } else {
-        value.saturating_add(delta as u16)
-    };
-}
-
-/// Apply a horizontal scroll delta without clamping to content width.
-/// The render frame (`render_scrollable_block`) clamps the stored value each
-/// time it draws, so no separate max is needed here.
-const fn apply_horizontal_scroll_unbounded(value: &mut u16, delta: i16) {
+/// The render frame clamps stored values each draw, so no max is needed here.
+const fn apply_scroll_delta(value: &mut u16, delta: i16) {
     *value = if delta.is_negative() {
         value.saturating_sub(delta.unsigned_abs())
     } else {
@@ -795,28 +785,21 @@ fn list_scroll_areas(
     let global_h = if global_mounts.is_empty() {
         0
     } else {
-        super::super::render::list::global_mounts_block_height(global_mounts.as_slice())
+        global_mounts_block_height(global_mounts.as_slice())
     };
     let role_global_h = if role_global_mounts.is_empty() {
         0
     } else {
-        super::super::render::list::global_mounts_block_height(role_global_mounts.as_slice())
+        global_mounts_block_height(role_global_mounts.as_slice())
     };
     let agent_count = super::super::render::list::agents_block_agent_count(Some(workspace), config);
     let roles_h = super::super::render::list::agents_block_height(agent_count);
     let roles_y = body_y + 3 + mounts_h + global_h + role_global_h;
     let roles_content_w =
         super::super::render::list::agents_block_content_width(Some(workspace), config);
-    let workspace_mounts_content_h = 1 + workspace
-        .mounts
-        .iter()
-        .map(|m| if m.src == m.dst { 1 } else { 2 })
-        .sum::<usize>()
-        .max(1);
-    let global_content_h =
-        super::super::render::list::global_mounts_content_height(global_mounts.as_slice());
-    let role_global_content_h =
-        super::super::render::list::global_mounts_content_height(role_global_mounts.as_slice());
+    let workspace_mounts_content_h = workspace_mounts_content_height(workspace.mounts.as_slice());
+    let global_content_h = global_mounts_content_height(global_mounts.as_slice());
+    let role_global_content_h = global_mounts_content_height(role_global_mounts.as_slice());
     let roles_content_h = 2 + agent_count;
     Some(ListScrollAreas {
         workspace: ScrollArea {
@@ -875,11 +858,7 @@ fn current_dir_scroll_areas(
     let roles_h = super::super::render::list::agents_block_height(agent_count);
     let roles_y = body_y + 3 + mounts_h;
     let roles_content_w = super::super::render::list::agents_block_content_width(None, config);
-    let workspace_content_h = 1 + mounts
-        .iter()
-        .map(|m| if m.src == m.dst { 1 } else { 2 })
-        .sum::<usize>()
-        .max(1);
+    let workspace_content_h = workspace_mounts_content_height(&mounts);
     let roles_content_h = 2 + agent_count;
     ListScrollAreas {
         workspace: ScrollArea {
@@ -2026,5 +2005,22 @@ mod mouse_drag_tests {
         };
         assert!(matches!(editor.active_field, FieldFocus::Row(0)));
         assert!(!editor.workspace_mounts_scroll_focused);
+    }
+
+    #[test]
+    fn scroll_up_decrements_vertical_scroll_offset() {
+        let config = config_with_scrollable_workspace_and_global_mounts();
+        let mut state = selected_demo_state(&config);
+        state.list_scroll_focus = Some(MountScrollFocus::Global);
+        state.list_global_mounts_scroll_y = 3;
+
+        handle_mouse_with_config(
+            &mut state,
+            mouse_kind_at(MouseEventKind::ScrollUp, 31, 12),
+            term(100),
+            Some(&config),
+        );
+
+        assert_eq!(state.list_global_mounts_scroll_y, 2);
     }
 }

--- a/src/console/manager/input/mouse.rs
+++ b/src/console/manager/input/mouse.rs
@@ -9,6 +9,9 @@ use super::super::render::global_mounts::trust_content_width;
 use super::super::render::list::{
     global_mounts_content_width, mount_block_height, workspace_mounts_content_width,
 };
+use super::super::render::{
+    is_scrollable, max_scroll_offset, scroll_viewport_height, scroll_viewport_width,
+};
 use super::super::state::{
     DragState, EditorTab, FieldFocus, ManagerListRow, ManagerStage, ManagerState, Modal,
     MountScrollFocus, SettingsTab, clamp_split,
@@ -315,7 +318,8 @@ fn try_select_editor_mount_row(
         return false;
     };
     editor.active_field = FieldFocus::Row(index);
-    editor.workspace_mounts_scroll_focused = is_scrollable(area, area_info.content_width);
+    editor.workspace_mounts_scroll_focused =
+        is_scrollable(area_info.content_width, scroll_viewport_width(area));
     true
 }
 
@@ -459,26 +463,35 @@ fn update_scroll_focus(
                 return;
             };
             state.list_scroll_focus = if point_in(mouse, areas.workspace.area)
-                && (is_scrollable(areas.workspace.area, areas.workspace.content_width)
-                    || is_scrollable_v(areas.workspace.area, areas.workspace.content_height))
-            {
+                && (is_scrollable(
+                    areas.workspace.content_width,
+                    scroll_viewport_width(areas.workspace.area),
+                ) || is_scrollable(
+                    areas.workspace.content_height,
+                    scroll_viewport_height(areas.workspace.area),
+                )) {
                 Some(MountScrollFocus::Workspace)
             } else if point_in(mouse, areas.global.area)
                 && areas.global.area.height > 0
-                && (is_scrollable(areas.global.area, areas.global.content_width)
-                    || is_scrollable_v(areas.global.area, areas.global.content_height))
+                && (is_scrollable(
+                    areas.global.content_width,
+                    scroll_viewport_width(areas.global.area),
+                ) || is_scrollable(
+                    areas.global.content_height,
+                    scroll_viewport_height(areas.global.area),
+                ))
             {
                 Some(MountScrollFocus::Global)
             } else if areas.role_global.is_some_and(|r| {
                 point_in(mouse, r.area)
-                    && (is_scrollable(r.area, r.content_width)
-                        || is_scrollable_v(r.area, r.content_height))
+                    && (is_scrollable(r.content_width, scroll_viewport_width(r.area))
+                        || is_scrollable(r.content_height, scroll_viewport_height(r.area)))
             }) {
                 Some(MountScrollFocus::RoleGlobal)
             } else if areas.roles.is_some_and(|r| {
                 point_in(mouse, r.area)
-                    && (is_scrollable(r.area, r.content_width)
-                        || is_scrollable_v(r.area, r.content_height))
+                    && (is_scrollable(r.content_width, scroll_viewport_width(r.area))
+                        || is_scrollable(r.content_height, scroll_viewport_height(r.area)))
             }) {
                 Some(MountScrollFocus::Roles)
             } else {
@@ -491,8 +504,8 @@ fn update_scroll_focus(
                     editor.workspace_mounts_scroll_focused = false;
                 } else {
                     let area = editor_scroll_area(editor, term_size);
-                    editor.workspace_mounts_scroll_focused =
-                        point_in(mouse, area.area) && is_scrollable(area.area, area.content_width);
+                    editor.workspace_mounts_scroll_focused = point_in(mouse, area.area)
+                        && is_scrollable(area.content_width, scroll_viewport_width(area.area));
                 }
                 editor.tab_content_scroll_focused = false;
             } else {
@@ -502,9 +515,9 @@ fn update_scroll_focus(
                 } else {
                     let content_area = settings_content_area(term_size);
                     let in_content = point_in(mouse, content_area);
-                    let viewport_h = content_area.height.saturating_sub(2) as usize;
+                    let viewport_h = scroll_viewport_height(content_area);
                     editor.tab_content_scroll_focused =
-                        in_content && editor.tab_content_height > viewport_h;
+                        in_content && is_scrollable(editor.tab_content_height, viewport_h);
                 }
             }
         }
@@ -538,16 +551,6 @@ const fn point_in(mouse: MouseEvent, area: Rect) -> bool {
         && mouse.row < area.y.saturating_add(area.height)
 }
 
-const fn is_scrollable(area: Rect, content_width: usize) -> bool {
-    let viewport = area.width.saturating_sub(2) as usize;
-    viewport > 0 && content_width > viewport
-}
-
-const fn is_scrollable_v(area: Rect, content_height: usize) -> bool {
-    let viewport = area.height.saturating_sub(2) as usize;
-    viewport > 0 && content_height > viewport
-}
-
 #[derive(Clone, Copy)]
 struct ScrollArea {
     area: Rect,
@@ -556,8 +559,8 @@ struct ScrollArea {
 }
 
 fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width: usize) -> bool {
-    let viewport = area.width.saturating_sub(2) as usize;
-    if viewport == 0 || content_width <= viewport {
+    let viewport = scroll_viewport_width(area);
+    if !is_scrollable(content_width, viewport) {
         return false;
     }
     let scrollbar_y = area.y + area.height.saturating_sub(1);
@@ -566,7 +569,7 @@ fn drag_scrollbar(value: &mut u16, mouse: MouseEvent, area: Rect, content_width:
     if mouse.row != scrollbar_y || mouse.column < start_x || mouse.column > end_x {
         return false;
     }
-    let max_position = content_width.saturating_sub(viewport);
+    let max_position = usize::from(max_scroll_offset(content_width, viewport));
     let track = usize::from(end_x.saturating_sub(start_x)).max(1);
     let rel = usize::from(mouse.column.saturating_sub(start_x));
     *value = ((max_position * rel) / track).min(usize::from(u16::MAX)) as u16;
@@ -616,7 +619,9 @@ fn scroll_active_panel(
                 return;
             }
             let area = editor_scroll_area(editor, term_size);
-            if point_in(mouse, area.area) && is_scrollable(area.area, area.content_width) {
+            if point_in(mouse, area.area)
+                && is_scrollable(area.content_width, scroll_viewport_width(area.area))
+            {
                 editor.workspace_mounts_scroll_focused = true;
                 apply_horizontal_scroll(
                     &mut editor.workspace_mounts_scroll_x,
@@ -736,7 +741,7 @@ const fn apply_horizontal_scroll_unbounded(value: &mut u16, delta: i16) {
 }
 
 fn apply_horizontal_scroll(value: &mut u16, delta: i16, area: Rect, content_width: usize) {
-    let max = max_scroll_offset(area, content_width);
+    let max = max_scroll_offset(content_width, scroll_viewport_width(area));
     let current = (*value).min(max);
     let next = if delta.is_negative() {
         current.saturating_sub(delta.unsigned_abs())
@@ -744,17 +749,6 @@ fn apply_horizontal_scroll(value: &mut u16, delta: i16, area: Rect, content_widt
         current.saturating_add(delta as u16)
     };
     *value = next.min(max);
-}
-
-fn max_scroll_offset(area: Rect, content_width: usize) -> u16 {
-    let viewport = area.width.saturating_sub(2) as usize;
-    if viewport == 0 || content_width <= viewport {
-        0
-    } else {
-        content_width
-            .saturating_sub(viewport)
-            .min(usize::from(u16::MAX)) as u16
-    }
 }
 
 struct ListScrollAreas {
@@ -801,12 +795,12 @@ fn list_scroll_areas(
     let global_h = if global_mounts.is_empty() {
         0
     } else {
-        mount_block_height(global_mounts.as_slice())
+        super::super::render::list::global_mounts_block_height(global_mounts.as_slice())
     };
     let role_global_h = if role_global_mounts.is_empty() {
         0
     } else {
-        mount_block_height(role_global_mounts.as_slice())
+        super::super::render::list::global_mounts_block_height(role_global_mounts.as_slice())
     };
     let agent_count = super::super::render::list::agents_block_agent_count(Some(workspace), config);
     let roles_h = super::super::render::list::agents_block_height(agent_count);
@@ -819,8 +813,10 @@ fn list_scroll_areas(
         .map(|m| if m.src == m.dst { 1 } else { 2 })
         .sum::<usize>()
         .max(1);
-    let global_content_h = global_mounts.len() * 2 + 1;
-    let role_global_content_h = role_global_mounts.len() * 2 + 1;
+    let global_content_h =
+        super::super::render::list::global_mounts_content_height(global_mounts.as_slice());
+    let role_global_content_h =
+        super::super::render::list::global_mounts_content_height(role_global_mounts.as_slice());
     let roles_content_h = 2 + agent_count;
     Some(ListScrollAreas {
         workspace: ScrollArea {
@@ -1817,8 +1813,8 @@ mod mouse_drag_tests {
             height: 5,
         };
         let expected_max = super::max_scroll_offset(
-            global_area,
             super::global_mounts_content_width(global_mounts.as_slice()),
+            super::scroll_viewport_width(global_area),
         );
         assert_eq!(state.list_global_mounts_scroll_x, expected_max);
 
@@ -1859,14 +1855,15 @@ mod mouse_drag_tests {
         }
 
         let workspace = config.workspaces.get("demo").unwrap();
+        let workspace_area = Rect {
+            x: 30,
+            y: 6,
+            width: 70,
+            height: 4,
+        };
         let expected_max = super::max_scroll_offset(
-            Rect {
-                x: 30,
-                y: 6,
-                width: 70,
-                height: 4,
-            },
             super::workspace_mounts_content_width(workspace.mounts.as_slice()),
+            super::scroll_viewport_width(workspace_area),
         );
 
         assert_eq!(
@@ -1894,8 +1891,8 @@ mod mouse_drag_tests {
             height: 5,
         };
         let expected_max = super::max_scroll_offset(
-            global_area,
             super::global_mounts_content_width(global_mounts.as_slice()),
+            super::scroll_viewport_width(global_area),
         );
 
         handle_mouse_with_config(

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -565,17 +565,43 @@ fn global_mount_block_height(rows: &[crate::config::GlobalMountRow]) -> u16 {
     let (global, scoped) = split_global_mount_rows(rows);
     let mut h = 0;
     if !global.is_empty() || scoped.is_empty() {
-        h += global_mount_rows_height(global.len());
+        h += global_mount_rows_height(&global);
     }
     if !scoped.is_empty() {
-        h += global_mount_rows_height(scoped.len());
+        h += global_mount_rows_height(&scoped);
     }
     h
 }
 
-fn global_mount_rows_height(count: usize) -> u16 {
-    let rows = if count == 0 { 1 } else { count * 2 };
-    (rows + 3).min(12) as u16
+fn global_mount_rows_height(rows: &[&crate::config::GlobalMountRow]) -> u16 {
+    let content_height = if rows.is_empty() {
+        1
+    } else {
+        1 + rows
+            .iter()
+            .map(|row| if row.mount.src == row.mount.dst { 1 } else { 2 })
+            .sum::<usize>()
+    };
+    (content_height + 2).min(12) as u16
+}
+
+pub(in crate::console::manager) fn global_mounts_content_height(
+    mounts: &[crate::workspace::MountConfig],
+) -> usize {
+    if mounts.is_empty() {
+        1
+    } else {
+        1 + mounts
+            .iter()
+            .map(|mount| if mount.src == mount.dst { 1 } else { 2 })
+            .sum::<usize>()
+    }
+}
+
+pub(in crate::console::manager) fn global_mounts_block_height(
+    mounts: &[crate::workspace::MountConfig],
+) -> u16 {
+    (global_mounts_content_height(mounts) + 2).min(12) as u16
 }
 
 fn split_global_mount_rows(
@@ -982,10 +1008,10 @@ fn render_global_mounts_subpanel(
         let constraints: Vec<Constraint> = {
             let mut c = Vec::new();
             if !global.is_empty() || scoped.is_empty() {
-                c.push(Constraint::Length(global_mount_rows_height(global.len())));
+                c.push(Constraint::Length(global_mount_rows_height(&global)));
             }
             if !scoped.is_empty() {
-                c.push(Constraint::Length(global_mount_rows_height(scoped.len())));
+                c.push(Constraint::Length(global_mount_rows_height(&scoped)));
             }
             c
         };
@@ -1484,7 +1510,7 @@ mod mount_block_height_tests {
     //! against the "phantom empty row" regression where a fixed
     //! `Constraint::Length(5)` over-allocated by 1 for a single-mount
     //! current-directory workspace.
-    use super::mount_block_height;
+    use super::{global_mounts_block_height, global_mounts_content_height, mount_block_height};
     use crate::workspace::MountConfig;
 
     fn mount(path: &str) -> MountConfig {
@@ -1523,6 +1549,21 @@ mod mount_block_height_tests {
     fn many_mounts_clamp_to_twelve() {
         let mounts: Vec<MountConfig> = (0..20).map(|i| mount(&format!("/m/{i}"))).collect();
         assert_eq!(mount_block_height(&mounts), 12);
+    }
+
+    #[test]
+    fn global_mount_heights_match_rendered_line_count() {
+        let same_path = mount("/cache/shared");
+        let split_path = MountConfig {
+            src: "/host/cache".into(),
+            dst: "/container/cache".into(),
+            readonly: false,
+            isolation: crate::isolation::MountIsolation::Shared,
+        };
+
+        assert_eq!(global_mounts_content_height(&[same_path]), 2);
+        assert_eq!(global_mounts_content_height(&[split_path]), 3);
+        assert_eq!(global_mounts_block_height(&[]), 3);
     }
 }
 

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -406,6 +406,16 @@ pub(in crate::console::manager) fn workspace_mounts_content_width(
     super::max_line_width(&lines)
 }
 
+pub(in crate::console::manager) fn workspace_mounts_content_height(
+    mounts: &[crate::workspace::MountConfig],
+) -> usize {
+    1 + mounts
+        .iter()
+        .map(|m| if m.src == m.dst { 1 } else { 2 })
+        .sum::<usize>()
+        .max(1)
+}
+
 pub(in crate::console::manager) fn global_mounts_content_width(
     mounts: &[crate::workspace::MountConfig],
 ) -> usize {

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -16,11 +16,11 @@ pub(super) mod global_mounts;
 pub(super) mod list;
 pub(super) mod modal;
 
-// Re-export the shared modal geometry helper so `manager::input::mouse` can
-// reach it via `super::super::render::modal_outer_rect`.
+// input::mouse has no path into the modal submodule — re-exported here so it
+// can reach modal_outer_rect via super::super::render.
 pub(super) use modal::modal_outer_rect;
-// Re-export the editor entry point so input handlers can redraw the editor
-// while a modal is being dismissed (see `input::mod`).
+// Modal dismissal sequencing requires a render call across a module boundary;
+// re-exported here so input handlers can reach render_editor directly.
 pub use editor::render_editor;
 
 pub(in crate::console::manager) use crate::console::widgets::scrollable::{
@@ -262,20 +262,12 @@ mod footer_wrap_tests {
     }
 }
 
-pub(super) const fn effective_scroll_x(
-    content_width: usize,
-    viewport: usize,
-    scroll_x: u16,
-) -> u16 {
-    effective_scroll(content_width, viewport, scroll_x)
-}
-
 pub(super) const fn clamp_scroll_x(
     content_width: usize,
     viewport: usize,
     scroll_x: &mut u16,
 ) -> u16 {
-    let effective = effective_scroll_x(content_width, viewport, *scroll_x);
+    let effective = effective_scroll(content_width, viewport, *scroll_x);
     *scroll_x = effective;
     effective
 }
@@ -305,10 +297,9 @@ pub(super) fn follow_cursor_y(
 /// Adjust `scroll_y` so `cursor` stays in the editor/settings content viewport.
 ///
 /// The chrome constant 9 = header 3 + tab strip 2 + footer 2 + block borders 2.
-/// `usize::MAX` is passed as `content_height` because the rendered line count is
-/// not known at input-dispatch time; it is large enough that `follow_cursor_y`'s
-/// upper clamp (`raw.min(max_scroll)`) never fires — the `as u16` truncation in
-/// the caller means the effective ceiling is 65 535, well above any real viewport.
+/// `usize::MAX` is passed as `content_height` so `follow_cursor_y`'s upper clamp
+/// (`raw.min(max_scroll as u16)`) never fires: `max_scroll` overflows on the `as
+/// u16` cast to ≈ 65 535 − viewport_h, which is unreachable for any real cursor row.
 pub(super) fn cursor_scroll_for_panel(
     cursor: usize,
     scroll_y: u16,
@@ -689,11 +680,7 @@ fn workspace_mounts_scrollable(
     viewport_w: usize,
 ) -> bool {
     let w = list::workspace_mounts_content_width(mounts);
-    let data_rows: usize = mounts
-        .iter()
-        .map(|m| if m.src == m.dst { 1 } else { 2 })
-        .sum();
-    let content_h = 1 + data_rows.max(1);
+    let content_h = list::workspace_mounts_content_height(mounts);
     let viewport_h = scroll_viewport_height(Rect {
         x: 0,
         y: 0,
@@ -991,6 +978,32 @@ mod horizontal_scrollbar_tests {
 
         assert_eq!(scroll_x, 6);
         assert_eq!(visible, "efgh  ");
+    }
+
+    #[test]
+    fn scrollable_block_clamps_scroll_y_in_place() {
+        let backend = TestBackend::new(12, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut scroll_x = 0;
+        let mut scroll_y = 99;
+        let lines: Vec<Line<'static>> = (0..8).map(|idx| Line::from(format!("{idx:02}"))).collect();
+
+        terminal
+            .draw(|frame| {
+                render_scrollable_block(
+                    frame,
+                    Rect::new(0, 0, 12, 6),
+                    lines,
+                    &mut scroll_x,
+                    &mut scroll_y,
+                    false,
+                    None,
+                );
+            })
+            .unwrap();
+
+        // viewport_h = 4, content = 8, max_y = 4
+        assert_eq!(scroll_y, 4);
     }
 }
 

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -299,7 +299,7 @@ pub(super) fn follow_cursor_y(
 /// The chrome constant 9 = header 3 + tab strip 2 + footer 2 + block borders 2.
 /// `usize::MAX` is passed as `content_height` so `follow_cursor_y`'s upper clamp
 /// (`raw.min(max_scroll as u16)`) never fires: `max_scroll` overflows on the `as
-/// u16` cast to ≈ 65 535 − viewport_h, which is unreachable for any real cursor row.
+/// u16` cast to ≈ 65 535 − `viewport_h`, which is unreachable for any real cursor row.
 pub(super) fn cursor_scroll_for_panel(
     cursor: usize,
     scroll_y: u16,

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::Paragraph,
 };
 
 use super::state::{ManagerListRow, ManagerStage, ManagerState};
@@ -23,6 +23,13 @@ pub(super) use modal::modal_outer_rect;
 // while a modal is being dismissed (see `input::mod`).
 pub use editor::render_editor;
 
+pub(in crate::console::manager) use crate::console::widgets::scrollable::{
+    effective_offset as effective_scroll, is_scrollable, max_offset as max_scroll_offset,
+    viewport_height as scroll_viewport_height, viewport_width as scroll_viewport_width,
+};
+pub(super) use crate::console::widgets::scrollable::{
+    line_width, max_line_width, render_scrollable_block,
+};
 pub(super) use crate::console::widgets::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 
 // ── Footer item model ──────────────────────────────────────────────
@@ -174,13 +181,6 @@ fn footer_lines(items: &[FooterItem], width: u16) -> Vec<Line<'static>> {
     lines
 }
 
-pub(super) fn line_width(line: &Line<'_>) -> usize {
-    line.spans
-        .iter()
-        .map(|span| span.content.chars().count())
-        .sum()
-}
-
 #[cfg(test)]
 mod footer_wrap_tests {
     use super::*;
@@ -262,64 +262,19 @@ mod footer_wrap_tests {
     }
 }
 
-pub(super) fn max_line_width(lines: &[Line<'_>]) -> usize {
-    lines.iter().map(line_width).max().unwrap_or(0)
-}
-
-pub(super) fn render_horizontal_scrollbar(
-    frame: &mut Frame,
-    block_area: Rect,
+pub(super) const fn effective_scroll_x(
     content_width: usize,
+    viewport: usize,
     scroll_x: u16,
-) {
-    let viewport = block_area.width.saturating_sub(2) as usize;
-    if viewport == 0 || content_width <= viewport {
-        return;
-    }
-    let mut state = ScrollbarState::new(content_width)
-        .position(usize::from(scroll_x))
-        .viewport_content_length(viewport);
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
-        .begin_symbol(None)
-        .end_symbol(None)
-        .track_symbol(Some("·"))
-        .thumb_symbol("━")
-        .track_style(Style::default().fg(PHOSPHOR_DARK))
-        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
-    let area = Rect {
-        x: block_area.x + 1,
-        y: block_area.y + block_area.height.saturating_sub(1),
-        width: block_area.width.saturating_sub(2),
-        height: 1,
-    };
-    frame.render_stateful_widget(scrollbar, area, &mut state);
+) -> u16 {
+    effective_scroll(content_width, viewport, scroll_x)
 }
 
-pub(super) fn effective_scroll_x(content_width: usize, viewport: usize, scroll_x: u16) -> u16 {
-    if viewport == 0 || content_width <= viewport {
-        0
-    } else {
-        scroll_x.min(
-            content_width
-                .saturating_sub(viewport)
-                .min(usize::from(u16::MAX)) as u16,
-        )
-    }
-}
-
-pub(super) fn effective_scroll_y(content_height: usize, viewport_h: usize, scroll_y: u16) -> u16 {
-    if viewport_h == 0 || content_height <= viewport_h {
-        0
-    } else {
-        scroll_y.min(
-            content_height
-                .saturating_sub(viewport_h)
-                .min(usize::from(u16::MAX)) as u16,
-        )
-    }
-}
-
-pub(super) fn clamp_scroll_x(content_width: usize, viewport: usize, scroll_x: &mut u16) -> u16 {
+pub(super) const fn clamp_scroll_x(
+    content_width: usize,
+    viewport: usize,
+    scroll_x: &mut u16,
+) -> u16 {
     let effective = effective_scroll_x(content_width, viewport, *scroll_x);
     *scroll_x = effective;
     effective
@@ -361,83 +316,6 @@ pub(super) fn cursor_scroll_for_panel(
 ) -> u16 {
     let viewport_h = (term.height.saturating_sub(9) as usize).max(1);
     follow_cursor_y(cursor, usize::MAX, viewport_h, scroll_y)
-}
-
-pub(super) fn render_vertical_scrollbar(
-    frame: &mut Frame,
-    block_area: Rect,
-    content_height: usize,
-    scroll_y: u16,
-) {
-    let viewport = block_area.height.saturating_sub(2) as usize;
-    if viewport == 0 || content_height <= viewport {
-        return;
-    }
-    let mut state = ScrollbarState::new(content_height)
-        .position(usize::from(scroll_y))
-        .viewport_content_length(viewport);
-    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-        .begin_symbol(None)
-        .end_symbol(None)
-        .track_symbol(Some("·"))
-        .thumb_symbol("█")
-        .track_style(Style::default().fg(PHOSPHOR_DARK))
-        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
-    let area = Rect {
-        x: block_area.x + block_area.width.saturating_sub(1),
-        y: block_area.y + 1,
-        width: 1,
-        height: block_area.height.saturating_sub(2),
-    };
-    frame.render_stateful_widget(scrollbar, area, &mut state);
-}
-
-/// Render lines inside a bordered scrollable block.
-///
-/// Border is `PHOSPHOR_GREEN` when `focused`, `PHOSPHOR_DARK` otherwise.
-/// Optional `title` renders `WHITE + BOLD` in the top border.
-/// Clamps `*scroll_x` and `*scroll_y` to their effective maximums in-place
-/// so callers never accumulate stale overshoot from past scroll events.
-pub(super) fn render_scrollable_block(
-    frame: &mut Frame,
-    area: Rect,
-    lines: Vec<Line<'_>>,
-    scroll_x: &mut u16,
-    scroll_y: &mut u16,
-    focused: bool,
-    title: Option<&str>,
-) {
-    let border_color = if focused {
-        PHOSPHOR_GREEN
-    } else {
-        PHOSPHOR_DARK
-    };
-    let mut block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(border_color));
-    if let Some(t) = title {
-        block = block.title(Span::styled(
-            t,
-            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
-        ));
-    }
-    let content_width = max_line_width(&lines);
-    let content_height = lines.len();
-    let viewport_w = area.width.saturating_sub(2) as usize;
-    let viewport_h = area.height.saturating_sub(2) as usize;
-    let eff_x = effective_scroll_x(content_width, viewport_w, *scroll_x);
-    let eff_y = effective_scroll_y(content_height, viewport_h, *scroll_y);
-    *scroll_x = eff_x;
-    *scroll_y = eff_y;
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(block)
-            .style(Style::default().fg(PHOSPHOR_GREEN))
-            .scroll((eff_y, eff_x)),
-        area,
-    );
-    render_horizontal_scrollbar(frame, area, content_width, eff_x);
-    render_vertical_scrollbar(frame, area, content_height, eff_y);
 }
 
 #[allow(clippy::too_many_lines)]
@@ -658,7 +536,7 @@ fn clamp_editor_scroll_for_frame(area: Rect, editor: &mut super::state::EditorSt
         .split(area);
     clamp_scroll_x(
         list::workspace_mounts_content_width(&editor.pending.mounts),
-        chunks[2].width.saturating_sub(2) as usize,
+        scroll_viewport_width(chunks[2]),
         &mut editor.workspace_mounts_scroll_x,
     );
 }
@@ -678,7 +556,7 @@ fn clamp_global_mounts_scroll_for_frame(
         .split(area);
     clamp_scroll_x(
         global_mounts::global_mounts_content_width(&global.pending),
-        chunks[2].width.saturating_sub(2) as usize,
+        scroll_viewport_width(chunks[2]),
         &mut global.scroll_x,
     );
 }
@@ -698,7 +576,7 @@ fn clamp_list_scroll_for_area(
             Constraint::Percentage(right_pct),
         ])
         .split(area);
-    let viewport = columns[1].width.saturating_sub(2) as usize;
+    let viewport = scroll_viewport_width(columns[1]);
 
     match state.selected_row() {
         ManagerListRow::CurrentDirectory => {
@@ -729,12 +607,21 @@ fn clamp_list_scroll_for_area(
                 viewport,
                 &mut state.list_mounts_scroll_x,
             );
-            let picker_role = state.inline_role_picker.as_ref().and_then(|picker| {
-                picker
-                    .list_state
-                    .selected
-                    .and_then(|idx| picker.filtered.get(idx).cloned())
-            });
+            let picker_role = state
+                .inline_role_picker
+                .as_ref()
+                .and_then(|picker| {
+                    picker
+                        .list_state
+                        .selected
+                        .and_then(|idx| picker.filtered.get(idx).cloned())
+                })
+                .or_else(|| {
+                    state
+                        .inline_agent_picker
+                        .as_ref()
+                        .map(|(role, _)| role.clone())
+                });
             let global_rows = global_rows_for(config, picker_role.as_ref());
             let (global, scoped) = partition_mounts_by_scope(&global_rows);
             clamp_scroll_x(
@@ -766,19 +653,19 @@ fn clamp_list_scroll_for_area(
     }
 
     // Clamp left-pane name scroll to valid range.
-    let left_viewport_w = columns[0].width.saturating_sub(2) as usize;
+    let left_viewport_w = scroll_viewport_width(columns[0]);
     if left_viewport_w == 0 {
         state.list_names_scroll_x = 0;
     } else {
         let name_content_w = list_names_content_width(state);
-        if name_content_w <= left_viewport_w {
-            state.list_names_scroll_x = 0;
-            state.list_names_focused = false;
-        } else {
-            let max = (name_content_w - left_viewport_w) as u16;
+        if is_scrollable(name_content_w, left_viewport_w) {
+            let max = max_scroll_offset(name_content_w, left_viewport_w);
             if state.list_names_scroll_x > max {
                 state.list_names_scroll_x = max;
             }
+        } else {
+            state.list_names_scroll_x = 0;
+            state.list_names_focused = false;
         }
     }
 }
@@ -807,8 +694,13 @@ fn workspace_mounts_scrollable(
         .map(|m| if m.src == m.dst { 1 } else { 2 })
         .sum();
     let content_h = 1 + data_rows.max(1);
-    let viewport_h = list::mount_block_height(mounts) as usize - 2;
-    w > viewport_w || content_h > viewport_h
+    let viewport_h = scroll_viewport_height(Rect {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: list::mount_block_height(mounts),
+    });
+    is_scrollable(w, viewport_w) || is_scrollable(content_h, viewport_h)
 }
 
 /// Returns `true` when the focused block still overflows the right pane
@@ -823,7 +715,7 @@ fn focused_block_still_scrollable(
     cwd: &std::path::Path,
 ) -> bool {
     use super::state::{ManagerListRow, MountScrollFocus};
-    let viewport_w = right_pane.width.saturating_sub(2) as usize;
+    let viewport_w = scroll_viewport_width(right_pane);
 
     match focus {
         MountScrollFocus::Workspace => match state.selected_row() {
@@ -849,9 +741,50 @@ fn focused_block_still_scrollable(
             ManagerListRow::NewWorkspace => false,
         },
         MountScrollFocus::Global | MountScrollFocus::RoleGlobal => {
-            // Global mounts change rarely; treat as always scrollable when focused
-            // to avoid computing the full mount list width here.
-            true
+            let ManagerListRow::SavedWorkspace(i) = state.selected_row() else {
+                return false;
+            };
+            let Some(summary) = state.workspaces.get(i) else {
+                return false;
+            };
+            if !config.workspaces.contains_key(&summary.name) {
+                return false;
+            }
+            let picker_role = state
+                .inline_role_picker
+                .as_ref()
+                .and_then(|picker| {
+                    picker
+                        .list_state
+                        .selected
+                        .and_then(|idx| picker.filtered.get(idx).cloned())
+                })
+                .or_else(|| {
+                    state
+                        .inline_agent_picker
+                        .as_ref()
+                        .map(|(role, _)| role.clone())
+                });
+            let global_rows = global_rows_for(config, picker_role.as_ref());
+            let (global, scoped) = partition_mounts_by_scope(&global_rows);
+            let mounts = match focus {
+                MountScrollFocus::Global => global,
+                MountScrollFocus::RoleGlobal => scoped,
+                MountScrollFocus::Workspace | MountScrollFocus::Roles => unreachable!(),
+            };
+            if mounts.is_empty() {
+                return false;
+            }
+            let global_w = list::global_mounts_content_width(mounts.as_slice());
+            let global_h = list::global_mounts_content_height(mounts.as_slice());
+            let block_h = list::global_mounts_block_height(mounts.as_slice()) as usize;
+            let viewport_h = scroll_viewport_height(Rect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: block_h as u16,
+            });
+            is_scrollable(global_w, viewport_w) || is_scrollable(global_h, viewport_h)
         }
         MountScrollFocus::Roles => {
             let ws_config = match state.selected_row() {
@@ -865,8 +798,13 @@ fn focused_block_still_scrollable(
             let roles_w = list::agents_block_content_width(ws_config, config);
             let roles_h = 2 + agent_count;
             let block_h = list::agents_block_height(agent_count) as usize;
-            let viewport_h = block_h.saturating_sub(2);
-            roles_w > viewport_w || roles_h > viewport_h
+            let viewport_h = scroll_viewport_height(Rect {
+                x: 0,
+                y: 0,
+                width: 0,
+                height: block_h as u16,
+            });
+            is_scrollable(roles_w, viewport_w) || is_scrollable(roles_h, viewport_h)
         }
     }
 }
@@ -934,7 +872,12 @@ pub(super) fn centered_rect_fixed(outer: Rect, pct_w: u16, rows: u16) -> Rect {
 
 #[cfg(test)]
 mod horizontal_scrollbar_tests {
-    use super::clamp_scroll_x;
+    use super::{clamp_scroll_x, render_scrollable_block};
+    use crate::console::widgets::scrollable::scrollbar_position_for_offset;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::text::Line;
 
     #[test]
     fn stored_scroll_offset_clamps_to_visible_end() {
@@ -947,6 +890,107 @@ mod horizontal_scrollbar_tests {
 
         scroll_x = scroll_x.saturating_sub(8);
         assert_eq!(scroll_x, 32);
+    }
+
+    #[test]
+    fn scrollbar_position_maps_visible_end_to_track_end() {
+        assert_eq!(scrollbar_position_for_offset(13, 10, 0), 0);
+        assert_eq!(scrollbar_position_for_offset(13, 10, 3), 3);
+    }
+
+    #[test]
+    fn scrollbar_position_clamps_overscroll() {
+        assert_eq!(scrollbar_position_for_offset(13, 10, 99), 3);
+    }
+
+    #[test]
+    fn scrollable_block_scrollbar_thumbs_reach_visible_ends() {
+        let backend = TestBackend::new(12, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut scroll_x = 10;
+        let mut scroll_y = 4;
+        let lines: Vec<Line<'static>> = (0..8)
+            .map(|idx| Line::from(format!("{idx:02}-abcdefghijklmnopq")))
+            .collect();
+
+        terminal
+            .draw(|frame| {
+                render_scrollable_block(
+                    frame,
+                    Rect::new(0, 0, 12, 6),
+                    lines,
+                    &mut scroll_x,
+                    &mut scroll_y,
+                    true,
+                    Some(" Test "),
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(10, 5)].symbol(), "━");
+        assert_eq!(buffer[(11, 4)].symbol(), "█");
+    }
+
+    #[test]
+    fn scrollable_block_scrollbar_thumbs_are_proportional_to_viewport() {
+        let backend = TestBackend::new(12, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut scroll_x = 0;
+        let mut scroll_y = 0;
+        let lines: Vec<Line<'static>> = (0..5)
+            .map(|idx| Line::from(format!("{idx:02}-abcdefgh")))
+            .collect();
+
+        terminal
+            .draw(|frame| {
+                render_scrollable_block(
+                    frame,
+                    Rect::new(0, 0, 12, 6),
+                    lines,
+                    &mut scroll_x,
+                    &mut scroll_y,
+                    true,
+                    Some(" Test "),
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let horizontal_thumb_len = (1..=10).filter(|x| buffer[(*x, 5)].symbol() == "━").count();
+        let vertical_thumb_len = (1..=4).filter(|y| buffer[(11, *y)].symbol() == "█").count();
+
+        assert_eq!(horizontal_thumb_len, 9);
+        assert_eq!(vertical_thumb_len, 3);
+    }
+
+    #[test]
+    fn scrollable_block_preserves_matching_right_padding_at_horizontal_end() {
+        let backend = TestBackend::new(8, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut scroll_x = 99;
+        let mut scroll_y = 0;
+        let lines = vec![Line::from("  abcdefgh")];
+
+        terminal
+            .draw(|frame| {
+                render_scrollable_block(
+                    frame,
+                    Rect::new(0, 0, 8, 4),
+                    lines,
+                    &mut scroll_x,
+                    &mut scroll_y,
+                    true,
+                    Some(" Test "),
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let visible: String = (1..=6).map(|x| buffer[(x, 1)].symbol()).collect();
+
+        assert_eq!(scroll_x, 6);
+        assert_eq!(visible, "efgh  ");
     }
 }
 

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -28,6 +28,7 @@ pub mod panel_rain;
 pub mod role_picker;
 pub mod save_discard;
 pub mod scope_picker;
+pub mod scrollable;
 pub mod source_picker;
 pub mod text_input;
 pub mod workdir_pick;

--- a/src/console/widgets/op_picker/render.rs
+++ b/src/console/widgets/op_picker/render.rs
@@ -5,11 +5,12 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Paragraph},
 };
 
 use crate::operator_env::OpField;
 
+use super::super::scrollable::{is_scrollable, render_vertical_scrollbar_in_area};
 use super::super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
 use super::{OpLoadState, OpPickerError, OpPickerFatalState, OpPickerStage, OpPickerState};
 
@@ -189,29 +190,15 @@ fn render_pane(frame: &mut Frame, area: Rect, state: &OpPickerState) {
 
     // Vertical scrollbar on the right edge of the list area.
     if let Some((total, position, viewport)) = scroll_info
-        && total > viewport
+        && is_scrollable(total, viewport)
     {
-        let scrolled = position
-            .saturating_mul(total.saturating_sub(1))
-            .checked_div(total.saturating_sub(viewport))
-            .unwrap_or(0);
-        let mut sb_state = ScrollbarState::new(total)
-            .position(scrolled)
-            .viewport_content_length(viewport);
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .begin_symbol(None)
-            .end_symbol(None)
-            .track_symbol(Some("·"))
-            .thumb_symbol("█")
-            .track_style(Style::default().fg(PHOSPHOR_DARK))
-            .thumb_style(Style::default().fg(PHOSPHOR_DIM));
         let sb_area = Rect {
             x: rows[3].x + rows[3].width.saturating_sub(1),
             y: rows[3].y,
             width: 1,
             height: rows[3].height,
         };
-        frame.render_stateful_widget(scrollbar, sb_area, &mut sb_state);
+        render_vertical_scrollbar_in_area(frame, sb_area, total, viewport, position as u16);
     }
 }
 

--- a/src/console/widgets/op_picker/render.rs
+++ b/src/console/widgets/op_picker/render.rs
@@ -198,7 +198,13 @@ fn render_pane(frame: &mut Frame, area: Rect, state: &OpPickerState) {
             width: 1,
             height: rows[3].height,
         };
-        render_vertical_scrollbar_in_area(frame, sb_area, total, viewport, position as u16);
+        render_vertical_scrollbar_in_area(
+            frame,
+            sb_area,
+            total,
+            viewport,
+            position.min(usize::from(u16::MAX)) as u16,
+        );
     }
 }
 

--- a/src/console/widgets/scrollable.rs
+++ b/src/console/widgets/scrollable.rs
@@ -1,0 +1,214 @@
+//! Shared scroll geometry and scrollbar rendering for console widgets.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+
+use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
+
+pub(crate) const fn viewport_width(area: Rect) -> usize {
+    area.width.saturating_sub(2) as usize
+}
+
+pub(crate) const fn viewport_height(area: Rect) -> usize {
+    area.height.saturating_sub(2) as usize
+}
+
+pub(crate) const fn max_offset(content_len: usize, viewport: usize) -> u16 {
+    if viewport == 0 || content_len <= viewport {
+        0
+    } else {
+        let max = content_len.saturating_sub(viewport);
+        if max > u16::MAX as usize {
+            u16::MAX
+        } else {
+            max as u16
+        }
+    }
+}
+
+pub(crate) const fn is_scrollable(content_len: usize, viewport: usize) -> bool {
+    viewport > 0 && content_len > viewport
+}
+
+pub(crate) const fn effective_offset(content_len: usize, viewport: usize, offset: u16) -> u16 {
+    let max = max_offset(content_len, viewport);
+    if offset > max { max } else { offset }
+}
+
+pub(crate) fn scrollbar_position_for_offset(
+    content_length: usize,
+    viewport: usize,
+    offset: usize,
+) -> usize {
+    if is_scrollable(content_length, viewport) {
+        offset.min(content_length.saturating_sub(viewport))
+    } else {
+        0
+    }
+}
+
+const fn scrollbar_content_length(content_length: usize, viewport: usize) -> usize {
+    if is_scrollable(content_length, viewport) {
+        content_length.saturating_sub(viewport).saturating_add(1)
+    } else {
+        0
+    }
+}
+
+pub(crate) fn line_width(line: &Line<'_>) -> usize {
+    line.spans
+        .iter()
+        .map(|span| span.content.chars().count())
+        .sum()
+}
+
+fn leading_space_count(line: &Line<'_>) -> usize {
+    let mut count = 0;
+    for span in &line.spans {
+        for ch in span.content.chars() {
+            if ch != ' ' {
+                return count;
+            }
+            count += 1;
+        }
+    }
+    count
+}
+
+fn scroll_line_width(line: &Line<'_>) -> usize {
+    line_width(line).saturating_add(leading_space_count(line))
+}
+
+pub(crate) fn max_line_width(lines: &[Line<'_>]) -> usize {
+    lines.iter().map(scroll_line_width).max().unwrap_or(0)
+}
+
+fn add_trailing_padding(mut lines: Vec<Line<'_>>) -> Vec<Line<'_>> {
+    for line in &mut lines {
+        let padding = leading_space_count(line);
+        if padding > 0 {
+            line.spans.push(Span::raw(" ".repeat(padding)));
+        }
+    }
+    lines
+}
+
+pub(crate) fn render_horizontal_scrollbar(
+    frame: &mut Frame,
+    block_area: Rect,
+    content_width: usize,
+    scroll_x: u16,
+) {
+    let viewport = viewport_width(block_area);
+    if !is_scrollable(content_width, viewport) {
+        return;
+    }
+    let position = scrollbar_position_for_offset(content_width, viewport, usize::from(scroll_x));
+    let mut state = ScrollbarState::new(scrollbar_content_length(content_width, viewport))
+        .position(position)
+        .viewport_content_length(viewport);
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .track_symbol(Some("·"))
+        .thumb_symbol("━")
+        .track_style(Style::default().fg(PHOSPHOR_DARK))
+        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
+    let area = Rect {
+        x: block_area.x + 1,
+        y: block_area.y + block_area.height.saturating_sub(1),
+        width: block_area.width.saturating_sub(2),
+        height: 1,
+    };
+    frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+pub(crate) fn render_vertical_scrollbar(
+    frame: &mut Frame,
+    block_area: Rect,
+    content_height: usize,
+    scroll_y: u16,
+) {
+    let viewport = viewport_height(block_area);
+    if !is_scrollable(content_height, viewport) {
+        return;
+    }
+    let area = Rect {
+        x: block_area.x + block_area.width.saturating_sub(1),
+        y: block_area.y + 1,
+        width: 1,
+        height: block_area.height.saturating_sub(2),
+    };
+    render_vertical_scrollbar_in_area(frame, area, content_height, viewport, scroll_y);
+}
+
+pub(crate) fn render_vertical_scrollbar_in_area(
+    frame: &mut Frame,
+    area: Rect,
+    content_height: usize,
+    viewport: usize,
+    scroll_y: u16,
+) {
+    if !is_scrollable(content_height, viewport) || area.height == 0 {
+        return;
+    }
+    let position = scrollbar_position_for_offset(content_height, viewport, usize::from(scroll_y));
+    let mut state = ScrollbarState::new(scrollbar_content_length(content_height, viewport))
+        .position(position)
+        .viewport_content_length(viewport);
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .begin_symbol(None)
+        .end_symbol(None)
+        .track_symbol(Some("·"))
+        .thumb_symbol("█")
+        .track_style(Style::default().fg(PHOSPHOR_DARK))
+        .thumb_style(Style::default().fg(PHOSPHOR_DIM));
+    frame.render_stateful_widget(scrollbar, area, &mut state);
+}
+
+pub(crate) fn render_scrollable_block(
+    frame: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'_>>,
+    scroll_x: &mut u16,
+    scroll_y: &mut u16,
+    focused: bool,
+    title: Option<&str>,
+) {
+    let border_color = if focused {
+        PHOSPHOR_GREEN
+    } else {
+        PHOSPHOR_DARK
+    };
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    if let Some(t) = title {
+        block = block.title(Span::styled(
+            t,
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
+        ));
+    }
+    let content_width = max_line_width(&lines);
+    let content_height = lines.len();
+    let viewport_w = viewport_width(area);
+    let viewport_h = viewport_height(area);
+    let eff_x = effective_offset(content_width, viewport_w, *scroll_x);
+    let eff_y = effective_offset(content_height, viewport_h, *scroll_y);
+    *scroll_x = eff_x;
+    *scroll_y = eff_y;
+    frame.render_widget(
+        Paragraph::new(add_trailing_padding(lines))
+            .block(block)
+            .style(Style::default().fg(PHOSPHOR_GREEN))
+            .scroll((eff_y, eff_x)),
+        area,
+    );
+    render_horizontal_scrollbar(frame, area, content_width, eff_x);
+    render_vertical_scrollbar(frame, area, content_height, eff_y);
+}

--- a/src/console/widgets/scrollable.rs
+++ b/src/console/widgets/scrollable.rs
@@ -23,6 +23,12 @@ pub(crate) const fn max_offset(content_len: usize, viewport: usize) -> u16 {
         0
     } else {
         let max = content_len.saturating_sub(viewport);
+        // Silent truncation: an overflow greater than u16::MAX cannot be fully
+        // addressed by a u16 scroll offset. Debug builds surface this.
+        debug_assert!(
+            max <= u16::MAX as usize,
+            "scroll overflow (content_len - viewport) exceeds u16::MAX — scrollbar position truncated"
+        );
         if max > u16::MAX as usize {
             u16::MAX
         } else {
@@ -53,6 +59,9 @@ pub(crate) fn scrollbar_position_for_offset(
 }
 
 const fn scrollbar_content_length(content_length: usize, viewport: usize) -> usize {
+    // Ratatui sizes the thumb as viewport / scrollbar_content_length. Passing raw
+    // content_length produces a thumb that is too small for moderate overflows.
+    // The correct value is the number of distinct scroll positions: overflow + 1.
     if is_scrollable(content_length, viewport) {
         content_length.saturating_sub(viewport).saturating_add(1)
     } else {
@@ -67,6 +76,8 @@ pub(crate) fn line_width(line: &Line<'_>) -> usize {
         .sum()
 }
 
+// Trailing padding mirrors leading spaces so indented content scrolls
+// symmetrically — without it the rightmost indent column is unreachable.
 fn leading_space_count(line: &Line<'_>) -> usize {
     let mut count = 0;
     for span in &line.spans {
@@ -80,12 +91,15 @@ fn leading_space_count(line: &Line<'_>) -> usize {
     count
 }
 
-fn scroll_line_width(line: &Line<'_>) -> usize {
-    line_width(line).saturating_add(leading_space_count(line))
-}
-
 pub(crate) fn max_line_width(lines: &[Line<'_>]) -> usize {
-    lines.iter().map(scroll_line_width).max().unwrap_or(0)
+    // Adds leading_space_count a second time to account for the matching trailing
+    // padding that add_trailing_padding appends; the padded line is genuinely that
+    // wide, so content_width must reflect it to keep the scrollbar range correct.
+    lines
+        .iter()
+        .map(|l| line_width(l).saturating_add(leading_space_count(l)))
+        .max()
+        .unwrap_or(0)
 }
 
 fn add_trailing_padding(mut lines: Vec<Line<'_>>) -> Vec<Line<'_>> {


### PR DESCRIPTION
## Summary

Centralizes console scroll geometry and scrollbar rendering into `src/console/widgets/scrollable.rs` so all scrollable TUI panels — workspace detail Mounts, Global mounts, Roles, Settings, and the 1Password picker — share the same viewport, max-offset, scrollability, proportional thumb sizing, horizontal trailing-padding, and thumb-position logic. Operators see consistent horizontal and vertical scroll behavior across every block: long thumbs for small overflows, shorter thumbs for larger overflows, matching left/right padding at maximum horizontal scroll.

## Hard rule: Shared scrollable widget

Scroll viewport sizing, scrollability, max-offset clamping, effective offsets, Ratatui scrollbar state construction, proportional thumb sizing, trailing scroll padding, and thumb positioning now belong in `src/console/widgets/scrollable.rs`; renderers and input handlers must call those helpers rather than reimplementing the math. Specifically, callers must not pass raw `content_length` to `ScrollbarState::new()` — the correct argument is `content_length - viewport + 1` (the number of distinct scroll positions), which the private `scrollbar_content_length` helper computes; passing the raw length produces a thumb that is too small for moderate overflows. The full rule and the mandatory helper API live in the TUI design decisions reference.

## What's deferred

- Direct unit tests for `max_offset` edge cases (viewport == 0, content_len == viewport, overflow past u16::MAX) — the `debug_assert!` in `max_offset` surfaces the boundary in debug builds; a future test PR can pin these contracts explicitly.
- `workspace_mounts_content_height` dedicated unit test — covered indirectly via `list_scroll_areas` integration paths in `mouse_drag_tests`.
- Op-picker scrollbar pixel regression test — the new `scrollbar_position_for_offset`-based formula is provably more correct than the removed inline formula; a render-buffer assertion is a nice-to-have follow-up.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin codex/shared-scrollable-widget:refs/remotes/origin/codex/shared-scrollable-widget
git checkout -B codex/shared-scrollable-widget refs/remotes/origin/codex/shared-scrollable-widget
```

### Static checks

```sh
cargo fmt --check
cargo clippy --lib
```

### Tests

```sh
cargo test horizontal_scrollbar_tests --lib
cargo test op_picker --lib
cargo test mouse_drag_tests --lib
cargo test mount_block_height_tests --lib
```

These cover: shared scrollbar thumb positioning and proportional sizing, right-padding preservation at maximum horizontal scroll, Y-axis in-place clamp assertion, scroll-up (negative-delta) decrement, picker scrollbar reuse, mouse/wheel/drag scroll geometry, and the global-mount block height used by vertical scrolling.

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Open a workspace with horizontally overflowing Mounts and Global mounts, focus each scrollable block (click or Tab), then scroll right/down to the maximum and back with the keyboard or mouse wheel. The content should keep moving until the real end, the scrollbar thumb should reach the visible end of its track, Mounts/Global mounts/Roles/picker lists should follow the same behavior, and two-space-indented rows should keep matching right-side padding at the maximum horizontal offset.

### Documentation

```sh
cd docs
bun run build
bun run check:repo-links
bunx tsc --noEmit
bun test
bun run dev
```

Astro serves at `http://localhost:4321/`. Page to walk:

**http://localhost:4321/reference/tui-design-decisions/**
UPDATED Internals reference. Confirm the scrollable block section names the shared helper module, requires proportional thumb sizing and trailing scroll padding, documents `scrollbar_content_length` as the required `ScrollbarState::new()` argument source, and the Global mounts height formula matches the rendered one-or-two-row-per-mount behavior.

## Migration notes

None.
