### PR TITLE
fix(launch): show real container name in summary

### DIFF
--- a/docs/src/content/docs/reference/roadmap/behavioral-spec-runtime-launch.mdx
+++ b/docs/src/content/docs/reference/roadmap/behavioral-spec-runtime-launch.mdx
@@ -16,8 +16,8 @@ The file has grown significantly due to: instance identity support, Kimi agent r
 | INV | Description | Verify by |
 |---|---|---|
 | INV-1 | Trust confirmation still happens before the image build — an untrusted third-party agent may be cloned/resolved, but not built or launched until confirmed | `confirm_agent_trust` closure runs before `build_agent_image` in `load_agent_with` |
-| INV-2 | Token mode still fails fast before runtime startup work — missing `CLAUDE_CODE_OAUTH_TOKEN` aborts before DinD/network launch | `verify_token_env_present` runs before `AgentState::prepare` / `launch_agent_runtime` |
-| INV-3 | Container slot claim still happens after image build and before runtime launch | `claim_container_name` stays between `build_agent_image` and `launch_agent_runtime` |
+| INV-2 | Token mode still fails fast before auth state preparation and runtime startup — missing `CLAUDE_CODE_OAUTH_TOKEN` aborts before DinD/network launch | `verify_token_env_present` runs before `AgentState::prepare` / `launch_agent_runtime` |
+| INV-3 | Container slot claim happens before the launch summary is printed so the operator-visible container name is the final locked name | `claim_container_name` runs before `build_config_rows` and the claimed name flows through `launch_agent_runtime` |
 | INV-4 | Foreground attach finalization still runs before teardown classification — isolated worktrees are finalized before deciding whether to preserve or clean the container | `finalize_foreground_session` happens before the `inspect_container_state(...)` cleanup match |
 | INV-5 | Cleanup classification still preserves restartable sessions and tears down clean exits | `Running` / crash paths disarm cleanup; clean exit runs cleanup |
 | INV-6 | `render_exit` still runs on both success and error exits from `load_agent_with` | both `Ok(_)` and `Err(error)` arms call `render_exit` |
@@ -27,9 +27,9 @@ The file has grown significantly due to: instance identity support, Kimi agent r
 `load_agent` (public API) → `load_agent_with` (current pipeline):
 
 1. **Resolve source + trust** — resolve repo state, then confirm untrusted agents
-2. **Resolve launch inputs** — manifest env, operator env, auth mode, and diagnostics
-3. **Build + claim slot** — build the image, then claim the container name/slot
-4. **Prepare state + materialize workspace** — auth state, isolated mounts, cache/state dirs
+2. **Resolve/claim instance** — resolve restore candidates, then claim the final container name/slot
+3. **Resolve launch inputs** — print the launch summary with the claimed name, then resolve manifest env, operator env, auth mode, and diagnostics
+4. **Build + prepare state** — build the image, prepare auth state, isolated mounts, cache/state dirs
 5. **Launch + finalize** — start runtime, attach, finalize worktrees, classify teardown/preservation
 
 ## Steps

--- a/src/runtime/launch.rs
+++ b/src/runtime/launch.rs
@@ -1418,17 +1418,75 @@ fn load_role_with(
         .find(|(_, w)| w.workdir == workspace.workdir)
         .map(|(name, _)| name.clone());
 
-    // Show a preliminary config summary. The real launch ID is generated
-    // after the image build, but the preview follows the same DNS-safe shape.
+    let role_key = selector.key();
+    let restore_container = if let Some(container) = opts.restore_container_base.as_ref() {
+        Some(container.clone())
+    } else {
+        match resolve_restore_candidate(
+            paths,
+            workspace_name.as_deref(),
+            workspace.label.as_str(),
+            &workspace.workdir,
+            &role_key,
+            agent,
+            runner,
+        )? {
+            RestoreResolution::StartFresh => None,
+            RestoreResolution::RestoreCurrentRole(container) => Some(container),
+            RestoreResolution::RecoverRelatedRole(container) => {
+                let load_result = hardline_agent(paths, &container, runner).map(|()| container);
+                let agent_display_name = match &load_result {
+                    Ok(container_name) => format_role_display(container_name, &agent_display_name),
+                    Err(_) => agent_display_name,
+                };
+                match load_result {
+                    Ok(_) => {
+                        render_exit(&agent_display_name, runner, opts);
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        render_exit(&agent_display_name, runner, opts);
+                        return Err(error);
+                    }
+                }
+            }
+            RestoreResolution::RebuildRelatedRole(manifest) => {
+                let selector = RoleSelector::parse(&manifest.role_key)?;
+                let related_opts = related_restore_load_options(opts, &manifest)?;
+                let load_result =
+                    load_role(paths, config, &selector, workspace, runner, &related_opts)
+                        .map(|()| manifest.container_base);
+                let agent_display_name = match &load_result {
+                    Ok(container_name) => format_role_display(container_name, &agent_display_name),
+                    Err(_) => agent_display_name,
+                };
+                match load_result {
+                    Ok(_) => {
+                        render_exit(&agent_display_name, runner, opts);
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        render_exit(&agent_display_name, runner, opts);
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    };
+    let restoring = restore_container.is_some();
+    let (container_name, _name_lock) = if let Some(container_name) = restore_container {
+        claim_known_container_name(paths, &container_name, runner)?
+    } else {
+        claim_container_name(paths, workspace_name.as_deref(), selector, runner)?
+    };
+
     let image_tag = opts.role_branch.as_deref().map_or_else(
         || image_name(selector),
         |b| image_name_for_branch(selector, b),
     );
-    let preliminary_name =
-        crate::instance::container_name_with_id(workspace_name.as_deref(), selector, "preview");
     let config_rows = build_config_rows(
         &agent_display_name,
-        &preliminary_name,
+        &container_name,
         workspace,
         &git,
         &image_tag,
@@ -1520,34 +1578,6 @@ fn load_role_with(
     }
 
     let load_result = (|| -> anyhow::Result<String> {
-        let role_key = selector.key();
-        let restore_container = if let Some(container) = opts.restore_container_base.as_ref() {
-            Some(container.clone())
-        } else {
-            match resolve_restore_candidate(
-                paths,
-                workspace_name.as_deref(),
-                workspace.label.as_str(),
-                &workspace.workdir,
-                &role_key,
-                agent,
-                runner,
-            )? {
-                RestoreResolution::StartFresh => None,
-                RestoreResolution::RestoreCurrentRole(container) => Some(container),
-                RestoreResolution::RecoverRelatedRole(container) => {
-                    hardline_agent(paths, &container, runner)?;
-                    return Ok(container);
-                }
-                RestoreResolution::RebuildRelatedRole(manifest) => {
-                    let selector = RoleSelector::parse(&manifest.role_key)?;
-                    let opts = related_restore_load_options(opts, &manifest)?;
-                    load_role(paths, config, &selector, workspace, runner, &opts)?;
-                    return Ok(manifest.container_base);
-                }
-            }
-        };
-
         // Step 2: Build Docker image
         let rebuild = opts.rebuild;
         let agent_update = !rebuild && {
@@ -1587,12 +1617,6 @@ fn load_role_with(
             repo_lock,
         )?;
 
-        let restoring = restore_container.is_some();
-        let (container_name, _name_lock) = if let Some(container_name) = restore_container {
-            claim_known_container_name(paths, &container_name, runner)?
-        } else {
-            claim_container_name(paths, workspace_name.as_deref(), selector, runner)?
-        };
         let container_state = paths.data_dir.join(&container_name);
         let network = format!("{container_name}-net");
         let dind = format!("{container_name}-dind");


### PR DESCRIPTION
## Summary

Fixes the launch summary so the `container` row shows the actual claimed container name that will be used for Docker resources, instead of a synthetic `jk-preview-...` placeholder. Restore resolution and name claiming now happen before the summary table is rendered, and the runtime launch behavioral spec now pins that ordering.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/launch-summary-real-container:refs/remotes/origin/fix/launch-summary-real-container
git checkout -B fix/launch-summary-real-container refs/remotes/origin/fix/launch-summary-real-container
```

### Static Checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --all-targets
```

### Tests

```sh
cargo nextest run --all-features
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run build
bun run check:repo-links
bunx tsc --noEmit
bun test
```

**http://localhost:4321/reference/roadmap/behavioral-spec-runtime-launch/**  
Updated contributor-facing runtime launch spec. Check that the pipeline now says jackin claims the final container name before rendering the launch summary.

### User Smoke

```sh
cargo run --bin jackin -- load the-architect . --debug
```

Confirm the launch summary's `container` row uses a real `jk-<id>-...` container name, not `jk-preview-...`, and that the debug `docker run --name ...` command uses the same base name.

## Migration notes

None. This changes launch ordering and operator-visible summary output only; no schema or on-disk state shape changes.
