### PR TITLE
fix(ci): replace lychee --no-cache with --cache=false

### DIFF
--- a/.github/actions/check-deployed-docs/action.yml
+++ b/.github/actions/check-deployed-docs/action.yml
@@ -76,7 +76,7 @@ runs:
         lycheeVersion: ${{ inputs.lychee-version }}
         args: >-
           --config docs/lychee.toml
-          --no-cache
+          --cache=false
           --include-fragments
           --remap
           "${{ inputs.edit-url }}/(.*) file://${{ github.workspace }}/\$1"


### PR DESCRIPTION
## Summary

lychee v0.24.x removed the `--no-cache` flag; the replacement is `--cache=false`. The `check-deployed-docs` composite action was still passing the old flag, which caused the `deploy` job to exit immediately with an argument error after deploying to GitHub Pages. This is a pre-existing latent bug that was first triggered by the push-to-main from merging #369.

## Migration notes

None.