### PR TITLE
fix: update validate-agent-action → jackin-role-action references

### DIFF
--- a/docs/src/content/docs/reference/roadmap/docs-separate-repository.mdx
+++ b/docs/src/content/docs/reference/roadmap/docs-separate-repository.mdx
@@ -18,7 +18,7 @@ repositories**:
 - `jackin-project/jackin-the-architect` — Rust development role
 - `jackin-project/homebrew-tap` — install channel
 - `jackin-project/jackin-marketplace` — Claude plugin marketplace
-- `jackin-project/validate-agent-action` — role manifest validator
+- `jackin-project/jackin-role-action` — role manifest validator
 - `jackin-project/jackin-dev`, `jackin-project/jackin-github-terraform`
   — supporting infrastructure
 

--- a/src/bin/role.rs
+++ b/src/bin/role.rs
@@ -6,7 +6,7 @@ use jackin::role_authoring;
 
 /// Validate, migrate, and inspect jackin role repositories.
 ///
-/// Used by CI (validate-agent-action) and role authors to validate the role
+/// Used by CI (jackin-role-action) and role authors to validate the role
 /// contract, migrate manifests, and extract metadata from role repositories.
 #[derive(Parser)]
 #[command(name = "jackin-role", version)]

--- a/src/role_authoring.rs
+++ b/src/role_authoring.rs
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jackin-project/validate-agent-action@main
+      - uses: jackin-project/jackin-role-action@main
 "
 }
 

--- a/src/runtime/naming.rs
+++ b/src/runtime/naming.rs
@@ -46,7 +46,7 @@ pub(super) const LABEL_IMAGE_CONSTRUCT: &str = "jackin.construct_image";
 /// role image. Role CI calls `jackin-role construct-version` to obtain the tag,
 /// passes it as `--build-arg CONSTRUCT_VERSION=<ver>` to `docker build`, and
 /// the Dockerfile's `LABEL jackin.construct_version=${CONSTRUCT_VERSION}`
-/// instruction writes the image label (see validate-agent-action). Checked at
+/// instruction writes the image label (see jackin-role-action). Checked at
 /// launch time: a mismatch against the Dockerfile's pinned version means the
 /// published image pre-dates a Renovate bump; jackin falls back to workspace
 /// mode so the role's workspace Dockerfile — carrying the new pin — is used.


### PR DESCRIPTION
## Summary

Repo `jackin-project/validate-agent-action` was renamed to `jackin-project/jackin-role-action`. Updates all references in the jackin codebase: the role scaffold workflow template, two code comments, and one docs page.

## Migration notes

None — GitHub redirects the old repo name, but explicit references are cleaner.