### PR TITLE
fix: move git-hooks dir to /jackin/state and add procps to construct

### DIFF
--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     git-lfs \
     jq \
     openssh-client \
+    procps \
     ripgrep \
     sudo \
     tmux \

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -92,9 +92,9 @@ fi
 # overwrite this path; per-repo .git/hooks/ hooks are bypassed while
 # either flag is enabled.
 if [ "${JACKIN_GIT_COAUTHOR_TRAILER:-0}" = "1" ] || [ "${JACKIN_GIT_DCO:-0}" = "1" ]; then
-    _hooks_dir="/jackin/runtime/git-hooks"
+    _hooks_dir="/jackin/state/git-hooks"
     mkdir -p "$_hooks_dir" || {
-        echo "[entrypoint] ERROR: failed to create git-hooks dir $_hooks_dir (is /jackin mounted read-only?)" >&2
+        echo "[entrypoint] ERROR: failed to create git-hooks dir $_hooks_dir (is /jackin/state unwritable?)" >&2
         exit 1
     }
     cat > "$_hooks_dir/prepare-commit-msg" <<'HOOK_EOF' || { echo "[entrypoint] ERROR: failed to write prepare-commit-msg hook" >&2; exit 1; }


### PR DESCRIPTION
## Summary

Fixes a crash where entering an agent container would immediately show `[exited]` with no error visible to the operator. When `JACKIN_GIT_COAUTHOR_TRAILER=1` or `JACKIN_GIT_DCO=1` is set, `entrypoint.sh` tried to `mkdir /jackin/runtime/git-hooks` to install the git prepare-commit-msg hook. `/jackin/runtime/` is owned by root; the `agent` user gets `Permission denied`, `set -e` exits the entrypoint, and the tmux session dies silently. The fix moves `_hooks_dir` to `/jackin/state/git-hooks`, which is the bind-mounted per-instance state directory already writable by the agent user. Also adds `procps` to the construct image so `ps` is available inside containers for debugging.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/entrypoint-git-hooks-dir-procps:refs/remotes/origin/fix/entrypoint-git-hooks-dir-procps
git checkout -B fix/entrypoint-git-hooks-dir-procps refs/remotes/origin/fix/entrypoint-git-hooks-dir-procps
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-376"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-376"
```

Build and use the local construct image:

```sh
just construct-build-local
export JACKIN_CONSTRUCT_IMAGE="jackin-local/construct:trixie"
```

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Select a role with `JACKIN_GIT_COAUTHOR_TRAILER=1` or `JACKIN_GIT_DCO=1` set in its env config. The agent session should open and stay open instead of immediately showing `[exited]`. Inside the container, `ps aux` should now work.
