### PR TITLE
fix(construct): bump VERSION to 0.2-trixie

### DIFF
--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.1-trixie
+0.2-trixie


### PR DESCRIPTION
## Summary

- `construct:0.1-trixie` already exists in registry; CI publish step fails with "tag already exists"
- Dockerfile changed in #376 (added `procps`) so new image must be published under a new version
- Bumps `docker/construct/VERSION` from `0.1-trixie` → `0.2-trixie`

## Test plan

- [ ] CI `publish manifest` job passes
- [ ] `construct-required` gate passes
- [ ] `projectjackin/construct:0.2-trixie` visible on Docker Hub after merge