### PR TITLE
refactor(tui): remove Toast, surface errors via ErrorPopup dialog

### DIFF
--- a/docs/src/content/docs/reference/roadmap/console-resource-panel.mdx
+++ b/docs/src/content/docs/reference/roadmap/console-resource-panel.mdx
@@ -107,7 +107,7 @@ per-agent table includes a status column to its left.
 - 2-second sample interval while panel is open; paused when closed.
 - Console keystroke toggles the panel; defaults to closed.
 - Sample failures (Docker unreachable, container gone) degrade silently —
-  show "?" cells, not error toasts.
+  show "?" cells without surfacing an error dialog.
 
 ## Defer
 

--- a/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
+++ b/docs/src/content/docs/reference/roadmap/idle-runtime-cleanup.mdx
@@ -131,7 +131,7 @@ last-cleanup time.
 - Per-workspace override of idle config. Agent-class-level only in V1.
 - Operator-defined ad-hoc cleanup commands (not in role). Defer;
   use `jackin exec` instead if needed.
-- Notification on cleanup failure beyond a console toast. Defer.
+- Notification on cleanup failure beyond an in-console ErrorPopup dialog. Defer.
 
 ## Open Questions
 

--- a/docs/src/content/docs/reference/tui-design-decisions.mdx
+++ b/docs/src/content/docs/reference/tui-design-decisions.mdx
@@ -313,6 +313,22 @@ Operators use both surfaces regularly. When Settings Auth scrolls but workspace 
 
 The **shared renderer** (`render_scrollable_block`, `render_scrollable_block_focused`) and **shared scroll helpers** (`scrollable.rs`) enforce visual consistency automatically. The state wiring and mouse handlers are the remaining surface where inconsistency can creep in — which is why this explicit audit rule exists.
 
+## Error Surface — ErrorPopup Only, No Ephemeral Overlays
+
+All error conditions surfaced to the operator must use the red-border `ErrorPopup` dialog (<RepoFile path="src/console/widgets/error_popup.rs" />). Ephemeral overlays (shimmer banners, auto-expiring toasts, single-line status strips) are banned for error display.
+
+**Why:** Auto-expiring errors vanish before the operator reads them, have no scroll support for long messages, and render over content rather than blocking it. `ErrorPopup` is dismissible (Enter / Esc / O), scrollable, and modal — the operator cannot miss it or accidentally dismiss it.
+
+**Scope:** Every error path in every stage (list, editor, settings, create-prelude) must route through the stage's designated error slot:
+
+- **List stage**: `ManagerState.list_modal = Some(Modal::ErrorPopup { .. })`
+- **Editor stage**: `EditorState.modal = Some(Modal::ErrorPopup { .. })`
+- **Settings stage**: `SettingsState.error_popup = Some(ErrorPopupState::new(title, body))`; the `after_settings_event` helper promotes errors from sub-tab `.error` fields into this slot.
+
+**Background errors** (e.g., `refresh_instances` index parse failures) use the list-stage `list_modal` slot with a dedup gate (`instances_last_error`) to prevent the popup from reopening on every 20 Hz refresh tick.
+
+**Success feedback** is silent. Navigation back to the workspace list after a successful save is sufficient confirmation. No success toast, no success popup.
+
 ## Component Reuse — Strict Rule
 
 When two TUI surfaces implement the same flow, do not fork modal sizing, rendering, input handling, footer wording, row layout, or picker behavior into a second near-copy. Extract or extend a shared widget, renderer, input helper, or state adapter and have both surfaces call it.

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -437,7 +437,7 @@ pub(super) fn handle_editor_key(
                             editor.modal = Some(Modal::ErrorPopup {
                                 state: crate::console::widgets::error_popup::ErrorPopupState::new(
                                     "Failed to open URL",
-                                    format!("{e}"),
+                                    e.to_string(),
                                 ),
                             });
                         }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -11,8 +11,7 @@ use super::super::render::apply_scroll_delta;
 use super::super::render::editor::{SecretsRow, secrets_flat_rows};
 use super::super::state::{
     ConfirmTarget, EditorMode, EditorSaveFlow, EditorState, EditorTab, ExitIntent, FieldFocus,
-    FileBrowserTarget, ManagerStage, ManagerState, Modal, SecretsScopeTag, TextInputTarget, Toast,
-    ToastKind,
+    FileBrowserTarget, ManagerStage, ManagerState, Modal, SecretsScopeTag, TextInputTarget,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -426,8 +425,6 @@ pub(super) fn handle_editor_key(
             editor.cycle_isolation_for_selected_mount();
         }
         KeyCode::Char('o' | 'O') if editor.active_tab == super::super::state::EditorTab::Mounts => {
-            // Open in browser; toast for non-GitHub mounts so the
-            // binding stays discoverable.
             let FieldFocus::Row(n) = editor.active_field;
             if let Some(m) = editor.pending.mounts.get(n) {
                 let kind = super::super::mount_info::inspect(&m.src);
@@ -437,20 +434,22 @@ pub(super) fn handle_editor_key(
                         ..
                     } => {
                         if let Err(e) = open::that_detached(&web_url) {
-                            state.toast = Some(Toast {
-                                message: format!("failed to open URL: {e}"),
-                                kind: ToastKind::Error,
-                                shown_at: std::time::Instant::now(),
+                            editor.modal = Some(Modal::ErrorPopup {
+                                state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                                    "Failed to open URL",
+                                    format!("{e}"),
+                                ),
                             });
                         }
                     }
                     super::super::mount_info::MountKind::Git { .. }
                     | super::super::mount_info::MountKind::Folder
                     | super::super::mount_info::MountKind::Missing => {
-                        state.toast = Some(Toast {
-                            message: "no GitHub URL for this mount".into(),
-                            kind: ToastKind::Error,
-                            shown_at: std::time::Instant::now(),
+                        editor.modal = Some(Modal::ErrorPopup {
+                            state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                                "No GitHub URL",
+                                "This mount has no GitHub remote URL.\n\nOnly git repositories with a GitHub origin support browser preview.",
+                            ),
                         });
                     }
                 }

--- a/src/console/manager/input/editor.rs
+++ b/src/console/manager/input/editor.rs
@@ -2170,6 +2170,34 @@ plugins = []
     }
 
     #[test]
+    fn o_on_folder_mount_opens_error_popup() {
+        // A plain folder mount has no GitHub URL — O must open an ErrorPopup
+        // explaining why, not silently do nothing.
+        let ws = WorkspaceConfig {
+            mounts: vec![MountConfig {
+                src: "/host/plain-dir".into(),
+                dst: "/host/plain-dir".into(),
+                readonly: false,
+                isolation: crate::isolation::MountIsolation::Shared,
+            }],
+            ..WorkspaceConfig::default()
+        };
+        let mut state = editor_on_mounts_tab(ws, 0);
+        let mut config = AppConfig::default();
+
+        press(&mut state, &mut config, KeyCode::Char('o')).unwrap();
+
+        let ManagerStage::Editor(editor) = &state.stage else {
+            panic!("expected editor stage");
+        };
+        assert!(
+            matches!(editor.modal, Some(Modal::ErrorPopup { .. })),
+            "O on a folder mount must open an ErrorPopup; got {:?}",
+            editor.modal,
+        );
+    }
+
+    #[test]
     fn added_mount_defaults_to_shared_isolation() {
         let mut editor = EditorState::new_edit("ws".into(), WorkspaceConfig::default());
         editor.active_tab = EditorTab::Mounts;

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -1579,9 +1579,10 @@ pub(super) fn after_settings_event(state: &mut ManagerState<'_>) {
     let _ = settings.mounts.success.take();
     let exit = std::mem::take(&mut settings.mounts.exit_requested);
     if let Some(msg) = error {
-        settings.error_popup = Some(
-            crate::console::widgets::error_popup::ErrorPopupState::new("Settings error", msg),
-        );
+        settings.error_popup = Some(crate::console::widgets::error_popup::ErrorPopupState::new(
+            "Settings error",
+            msg,
+        ));
     }
     if exit {
         state.stage = ManagerStage::List;

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -153,10 +153,8 @@ fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEvent) {
         }
         // S is handled before the match (early-return above) so `open_settings_save_preview`
         // can receive all of `settings` without conflicting with the `global` borrow.
-        KeyCode::Char('d' | 'D') => {
-            if !global.pending.is_empty() {
-                global.modal = Some(confirm_modal(GlobalMountConfirm::Remove));
-            }
+        KeyCode::Char('d' | 'D') if !global.pending.is_empty() => {
+            global.modal = Some(confirm_modal(GlobalMountConfirm::Remove));
         }
         KeyCode::Char('r' | 'R') => {
             if let Some(row) = global.pending.get_mut(global.selected) {

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -6,7 +6,6 @@ use super::super::state::{
     AuthFormFocus, AuthFormReturnPath, AuthFormTarget, GlobalMountConfirm, GlobalMountDraft,
     GlobalMountModal, GlobalMountTextTarget, ManagerStage, ManagerState, SettingsAuthModal,
     SettingsEnvConfirm, SettingsEnvModal, SettingsEnvScope, SettingsEnvTextTarget, SettingsTab,
-    Toast, ToastKind,
 };
 use crate::config::AppConfig;
 use crate::console::widgets::ModalOutcome;
@@ -19,7 +18,6 @@ use crate::paths::JackinPaths;
 use crate::selector::RoleSelector;
 use crate::workspace::{MountConfig, resolve_path};
 
-const NO_MOUNT_SELECTED: &str = "No mount selected.";
 const MOUNT_NAME_EMPTY: &str = "Mount name cannot be empty.";
 const MOUNT_GONE: &str = "Mount no longer exists; selection was cleared.";
 const ADD_DRAFT_LOST: &str = "Add-mount draft was lost; press 'a' to start over.";
@@ -156,9 +154,7 @@ fn handle_global_mounts_key(state: &mut ManagerState<'_>, key: KeyEvent) {
         // S is handled before the match (early-return above) so `open_settings_save_preview`
         // can receive all of `settings` without conflicting with the `global` borrow.
         KeyCode::Char('d' | 'D') => {
-            if global.pending.is_empty() {
-                set_toast(state, "Nothing to remove.", ToastKind::Error);
-            } else {
+            if !global.pending.is_empty() {
                 global.modal = Some(confirm_modal(GlobalMountConfirm::Remove));
             }
         }
@@ -1280,7 +1276,6 @@ fn open_edit_text(state: &mut ManagerState<'_>, target: GlobalMountTextTarget) {
     };
     let global = &mut settings.mounts;
     let Some(row) = global.pending.get(global.selected) else {
-        set_toast(state, NO_MOUNT_SELECTED, ToastKind::Error);
         return;
     };
     let (label, initial) = match target {
@@ -1568,45 +1563,29 @@ fn set_settings_env_value_typed(
     }
 }
 
-/// Promote pending error/success messages to toasts; pop back to the
-/// workspace list when the handler set `exit_requested`.
-pub(super) fn after_global_mounts_event(state: &mut ManagerState<'_>) {
-    let ManagerStage::Settings(settings) = &mut state.stage else {
-        return;
-    };
-    let global = &mut settings.mounts;
-    let error = global.error.take();
-    let success = global.success.take();
-    let exit = std::mem::take(&mut global.exit_requested);
-    if let Some(err) = error {
-        set_toast(state, &err, ToastKind::Error);
-    } else if let Some(msg) = success {
-        set_toast(state, &msg, ToastKind::Success);
-    }
-    if exit {
-        state.stage = ManagerStage::List;
-    }
-}
-
+/// Promote any pending error from a settings sub-tab to `settings.error_popup`,
+/// pop back to the workspace list when a handler set `exit_requested`.
 pub(super) fn after_settings_event(state: &mut ManagerState<'_>) {
     let ManagerStage::Settings(settings) = &mut state.stage else {
         return;
     };
-    let env_error = settings.env.error.take();
-    let auth_error = settings.auth.error.take();
-    let trust_error = settings.trust.error.take();
-    if let Some(err) = env_error.or(auth_error).or(trust_error) {
-        set_toast(state, &err, ToastKind::Error);
+    let error = settings
+        .mounts
+        .error
+        .take()
+        .or_else(|| settings.env.error.take())
+        .or_else(|| settings.auth.error.take())
+        .or_else(|| settings.trust.error.take());
+    let _ = settings.mounts.success.take();
+    let exit = std::mem::take(&mut settings.mounts.exit_requested);
+    if let Some(msg) = error {
+        settings.error_popup = Some(
+            crate::console::widgets::error_popup::ErrorPopupState::new("Settings error", msg),
+        );
     }
-    after_global_mounts_event(state);
-}
-
-fn set_toast(state: &mut ManagerState<'_>, msg: &str, kind: ToastKind) {
-    state.toast = Some(Toast {
-        message: msg.to_string(),
-        kind,
-        shown_at: std::time::Instant::now(),
-    });
+    if exit {
+        state.stage = ManagerStage::List;
+    }
 }
 
 fn confirm_modal(action: GlobalMountConfirm) -> GlobalMountModal<'static> {

--- a/src/console/manager/input/global_mounts.rs
+++ b/src/console/manager/input/global_mounts.rs
@@ -1009,7 +1009,6 @@ fn commit_settings_save(
     match settings.save_to_config(paths) {
         Ok(saved) => {
             *config = saved;
-            settings.mounts.success = Some("Settings saved.".into());
             settings.mounts.exit_requested = true;
         }
         Err(err) => settings.mounts.error = Some(err.to_string()),
@@ -1567,6 +1566,8 @@ pub(super) fn after_settings_event(state: &mut ManagerState<'_>) {
     let ManagerStage::Settings(settings) = &mut state.stage else {
         return;
     };
+    // Each tab dispatches to exactly one sub-handler per keypress, so at
+    // most one error field is set at a time — `or_else` laziness is safe.
     let error = settings
         .mounts
         .error
@@ -1574,7 +1575,6 @@ pub(super) fn after_settings_event(state: &mut ManagerState<'_>) {
         .or_else(|| settings.env.error.take())
         .or_else(|| settings.auth.error.take())
         .or_else(|| settings.trust.error.take());
-    let _ = settings.mounts.success.take();
     let exit = std::mem::take(&mut settings.mounts.exit_requested);
     if let Some(msg) = error {
         settings.error_popup = Some(crate::console::widgets::error_popup::ErrorPopupState::new(
@@ -2067,6 +2067,48 @@ mod tests {
             rows.iter()
                 .any(|row| matches!(row, SettingsEnvRow::RoleHeader { role, .. } if role == "agent-with-env")),
             "roles with env entries should remain visible: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn after_settings_event_promotes_mounts_error_to_error_popup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.mounts.error = Some("mount error detail".into());
+        state.stage = ManagerStage::Settings(settings);
+
+        after_settings_event(&mut state);
+
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("must stay in Settings stage");
+        };
+        assert!(
+            settings.error_popup.is_some(),
+            "error_popup must be set after after_settings_event"
+        );
+    }
+
+    #[test]
+    fn after_settings_event_exit_requested_pops_to_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = SettingsState::from_config(&config);
+        settings.mounts.exit_requested = true;
+        state.stage = ManagerStage::Settings(settings);
+
+        after_settings_event(&mut state);
+
+        assert!(
+            matches!(state.stage, ManagerStage::List),
+            "exit_requested must pop to List; got {:?}",
+            state.stage,
         );
     }
 }

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -476,7 +476,7 @@ mod tests {
     }
 
     /// `e` and `d` on the current-directory row must be silent no-ops —
-    /// no toast, no stage transition.
+    /// no modal, no stage transition.
     #[test]
     fn current_directory_row_silently_ignores_edit_and_delete() {
         let tmp = tempfile::tempdir().unwrap();
@@ -934,7 +934,7 @@ mod tests {
 
     #[test]
     fn list_o_on_row_zero_is_silent_noop() {
-        // Row 0 is "Current directory" — O must be silent (no toast, no modal).
+        // Row 0 is "Current directory" — O must be a silent no-op.
         let tmp = tempfile::tempdir().unwrap();
         let paths = JackinPaths::for_tests(tmp.path());
         paths.ensure_base_dirs().unwrap();
@@ -964,7 +964,7 @@ mod tests {
     fn picker_commit_closes_list_modal_and_clears_state() {
         // Seed the state directly with an open GithubPicker, then commit.
         // We can't assert `open::that_detached` ran, but we *can* pin that
-        // the modal closes (no lingering state) and no error toast appears
+        // the modal closes (no lingering state) and no ErrorPopup appears
         // when the underlying call path doesn't error out synchronously.
         use crate::console::widgets::github_picker::{GithubChoice, GithubPickerState};
         let tmp = tempfile::tempdir().unwrap();

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -731,6 +731,7 @@ mod tests {
         )];
 
         for key_char in ['a', 'x'] {
+            state.list_modal = None;
             let outcome = handle_key(
                 &mut state,
                 &mut config,
@@ -742,6 +743,11 @@ mod tests {
             assert!(
                 matches!(outcome, InputOutcome::Continue),
                 "'{key_char}' on non-running instance must return Continue; got {outcome:?}",
+            );
+            assert!(
+                matches!(state.list_modal, Some(Modal::ErrorPopup { .. })),
+                "'{key_char}' on non-running instance must open an ErrorPopup; got {:?}",
+                state.list_modal,
             );
         }
     }

--- a/src/console/manager/input/list.rs
+++ b/src/console/manager/input/list.rs
@@ -9,7 +9,7 @@ use super::super::super::widgets::{
 use super::super::render::apply_scroll_delta;
 use super::super::state::{
     EditorState, FileBrowserTarget, ManagerListRow, ManagerStage, ManagerState, Modal,
-    SettingsState, Toast, ToastKind,
+    SettingsState,
 };
 use super::InputOutcome;
 use crate::config::AppConfig;
@@ -137,27 +137,27 @@ pub(super) fn handle_list_key(
         KeyCode::Char('r' | 'R') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::Reconnect,
-            "No recoverable instance for this row",
+            "No recoverable instance for this workspace.",
         )),
         KeyCode::Char('a' | 'A') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::NewSession,
-            "No running instance for this row",
+            "No running instance for this workspace.",
         )),
         KeyCode::Char('x' | 'X') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::Shell,
-            "No running instance for this row",
+            "No running instance for this workspace.",
         )),
         KeyCode::Char('i' | 'I') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::Inspect,
-            "No instance state for this row",
+            "No instance state for this workspace.",
         )),
         KeyCode::Char('p' | 'P') => Ok(instance_action_outcome(
             state,
             ConsoleInstanceAction::Purge,
-            "No purgeable instance state for this row",
+            "No purgeable instance for this workspace.",
         )),
         KeyCode::Char('s' | 'S') => {
             state.stage = ManagerStage::Settings(SettingsState::from_config(config));
@@ -173,10 +173,11 @@ fn instance_action_outcome(
     empty_message: &str,
 ) -> InputOutcome {
     let Some(container) = selected_instance_container(state, action) else {
-        state.toast = Some(Toast {
-            message: empty_message.into(),
-            kind: ToastKind::Error,
-            shown_at: std::time::Instant::now(),
+        state.list_modal = Some(Modal::ErrorPopup {
+            state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                "No instance",
+                empty_message,
+            ),
         });
         return InputOutcome::Continue;
     };
@@ -508,7 +509,6 @@ mod tests {
             "e on row 0 must not open the Editor; got {:?}",
             state.stage
         );
-        assert!(state.toast.is_none(), "e on row 0 must not show a toast");
 
         handle_key(
             &mut state,
@@ -523,7 +523,6 @@ mod tests {
             "d on row 0 must not open ConfirmDelete; got {:?}",
             state.stage
         );
-        assert!(state.toast.is_none(), "d on row 0 must not show a toast");
     }
 
     /// Enter on row 0 returns `LaunchCurrentDir`; Enter on row 1 returns
@@ -716,7 +715,7 @@ mod tests {
     }
 
     #[test]
-    fn a_and_x_produce_toast_for_non_running_instance() {
+    fn a_and_x_return_continue_for_non_running_instance() {
         let workdir = "/workspace/demo";
         let ws = WorkspaceConfig {
             workdir: workdir.into(),
@@ -724,7 +723,7 @@ mod tests {
             ..Default::default()
         };
         let (mut state, mut config, paths, tmp) = list_state_selecting_ws(ws);
-        // RestoreAvailable instance — not active/running, so a/x must toast.
+        // RestoreAvailable instance — not active/running, so a/x must return Continue.
         state.instances = vec![instance_entry(
             "jackin-demo-architect-123456",
             InstanceStatus::RestoreAvailable,
@@ -732,7 +731,6 @@ mod tests {
         )];
 
         for key_char in ['a', 'x'] {
-            state.toast = None;
             let outcome = handle_key(
                 &mut state,
                 &mut config,
@@ -743,11 +741,7 @@ mod tests {
             .unwrap();
             assert!(
                 matches!(outcome, InputOutcome::Continue),
-                "'{key_char}' on non-running instance must return Continue (toast path); got {outcome:?}",
-            );
-            assert!(
-                state.toast.is_some(),
-                "'{key_char}' on non-running instance must set a toast",
+                "'{key_char}' on non-running instance must return Continue; got {outcome:?}",
             );
         }
     }
@@ -910,7 +904,7 @@ mod tests {
     }
 
     #[test]
-    fn list_o_with_zero_github_mounts_shows_toast() {
+    fn list_o_with_zero_github_mounts_is_silent_noop() {
         let tmp_src = tempfile::tempdir().unwrap();
         let plain = tmp_src.path().join("plain");
         std::fs::create_dir(&plain).unwrap();
@@ -929,9 +923,7 @@ mod tests {
         )
         .unwrap();
 
-        // Silent no-op: no modal, no toast.
         assert!(state.list_modal.is_none(), "no modal when no GitHub URLs");
-        assert!(state.toast.is_none(), "no toast when no GitHub URLs");
     }
 
     #[test]
@@ -956,7 +948,6 @@ mod tests {
         )
         .unwrap();
 
-        assert!(state.toast.is_none(), "O on row 0 must not toast");
         assert!(
             state.list_modal.is_none(),
             "O on row 0 must not open a modal"
@@ -1029,10 +1020,5 @@ mod tests {
         .unwrap();
 
         assert!(state.list_modal.is_none());
-        assert!(
-            state.toast.is_none(),
-            "Esc must not toast: {:?}",
-            state.toast
-        );
     }
 }

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -147,7 +147,10 @@ pub fn handle_key(
         && settings.error_popup.is_some()
     {
         if let Some(popup) = &settings.error_popup {
-            if matches!(popup.handle_key(key), crate::console::widgets::ModalOutcome::Cancel) {
+            if matches!(
+                popup.handle_key(key),
+                crate::console::widgets::ModalOutcome::Cancel
+            ) {
                 settings.error_popup = None;
             }
         }

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -146,13 +146,14 @@ pub fn handle_key(
     if let ManagerStage::Settings(settings) = &mut state.stage
         && settings.error_popup.is_some()
     {
-        if let Some(popup) = &settings.error_popup {
-            if matches!(
-                popup.handle_key(key),
+        let dismiss = settings.error_popup.as_ref().is_some_and(|p| {
+            matches!(
+                p.handle_key(key),
                 crate::console::widgets::ModalOutcome::Cancel
-            ) {
-                settings.error_popup = None;
-            }
+            )
+        });
+        if dismiss {
+            settings.error_popup = None;
         }
         return Ok(InputOutcome::Continue);
     }

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -428,4 +428,70 @@ mod tests {
             "the original (pre-edit) name must not end up on disk"
         );
     }
+
+    #[test]
+    fn settings_error_popup_dismissed_by_enter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = super::super::state::SettingsState::from_config(&config);
+        settings.error_popup = Some(crate::console::widgets::error_popup::ErrorPopupState::new(
+            "Test", "details",
+        ));
+        state.stage = ManagerStage::Settings(settings);
+
+        let outcome = handle_key(
+            &mut state,
+            &mut config,
+            &paths,
+            tmp.path(),
+            key(KeyCode::Enter),
+        )
+        .unwrap();
+
+        assert!(
+            matches!(outcome, InputOutcome::Continue),
+            "Enter on error popup must return Continue; got {outcome:?}"
+        );
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("must remain in Settings stage");
+        };
+        assert!(
+            settings.error_popup.is_none(),
+            "Enter must dismiss the error popup"
+        );
+    }
+
+    #[test]
+    fn settings_error_popup_unrelated_key_does_not_dismiss() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = JackinPaths::for_tests(tmp.path());
+        paths.ensure_base_dirs().unwrap();
+        let mut config = AppConfig::default();
+        let mut state = ManagerState::from_config(&config, tmp.path());
+        let mut settings = super::super::state::SettingsState::from_config(&config);
+        settings.error_popup = Some(crate::console::widgets::error_popup::ErrorPopupState::new(
+            "Test", "details",
+        ));
+        state.stage = ManagerStage::Settings(settings);
+
+        handle_key(
+            &mut state,
+            &mut config,
+            &paths,
+            tmp.path(),
+            key(KeyCode::Char('j')),
+        )
+        .unwrap();
+
+        let ManagerStage::Settings(settings) = &state.stage else {
+            panic!("must remain in Settings stage");
+        };
+        assert!(
+            settings.error_popup.is_some(),
+            "unrelated key must not dismiss the error popup"
+        );
+    }
 }

--- a/src/console/manager/input/mod.rs
+++ b/src/console/manager/input/mod.rs
@@ -13,9 +13,7 @@ pub(super) mod save;
 use crossterm::event::KeyEvent;
 
 use super::super::widgets::ModalOutcome;
-use super::state::{
-    EditorSaveFlow, EditorState, ExitIntent, ManagerStage, ManagerState, Toast, ToastKind,
-};
+use super::state::{EditorSaveFlow, EditorState, ExitIntent, ManagerStage, ManagerState};
 use crate::config::AppConfig;
 use crate::paths::JackinPaths;
 
@@ -142,6 +140,16 @@ pub fn handle_key(
                 }
             }
             return Ok(InputOutcome::Continue);
+        }
+        return Ok(InputOutcome::Continue);
+    }
+    if let ManagerStage::Settings(settings) = &mut state.stage
+        && settings.error_popup.is_some()
+    {
+        if let Some(popup) = &settings.error_popup {
+            if matches!(popup.handle_key(key), crate::console::widgets::ModalOutcome::Cancel) {
+                settings.error_popup = None;
+            }
         }
         return Ok(InputOutcome::Continue);
     }
@@ -293,11 +301,6 @@ fn handle_confirm_delete_key(
             let cache = state.op_cache.clone();
             let op_available = state.op_available;
             *state = ManagerState::from_config_with_cache_and_op(config, cwd, cache, op_available);
-            state.toast = Some(Toast {
-                message: format!("deleted \"{ws_name}\""),
-                kind: ToastKind::Success,
-                shown_at: std::time::Instant::now(),
-            });
             Ok(InputOutcome::Continue)
         }
         ModalOutcome::Commit(false) | ModalOutcome::Cancel => {

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1620,11 +1620,6 @@ mod tests {
             "exit_on_success should land us in the list; got {:?}",
             state.stage,
         );
-        assert!(
-            state.toast.is_none(),
-            "saving should not show a success toast; got {:?}",
-            state.toast,
-        );
     }
 
     #[test]
@@ -1727,11 +1722,6 @@ mod tests {
             matches!(state.stage, ManagerStage::List),
             "create save should return to the list; got {:?}",
             state.stage,
-        );
-        assert!(
-            state.toast.is_none(),
-            "create save should not show a success toast; got {:?}",
-            state.toast,
         );
     }
 

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -1597,7 +1597,7 @@ mod tests {
     }
 
     #[test]
-    fn exit_on_success_save_does_not_show_success_toast() {
+    fn exit_on_success_save_returns_to_list() {
         let ws = WorkspaceConfig {
             version: crate::config::CURRENT_WORKSPACE_VERSION.to_string(),
             workdir: "/w".into(),
@@ -1696,7 +1696,7 @@ mod tests {
     }
 
     #[test]
-    fn create_mode_save_does_not_show_success_toast() {
+    fn create_mode_save_returns_to_list() {
         let (tmp, paths, mut config) = {
             let tmp = tempfile::tempdir().unwrap();
             let paths = JackinPaths::for_tests(tmp.path());

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -1,6 +1,6 @@
-//! List-stage rendering: the left-column workspace list, right-pane
+//! List-stage rendering: the left-column workspace list and right-pane
 //! details (saved workspace / current-directory / "+ New workspace"
-//! sentinel), and the transient toast overlay.
+//! sentinel).
 
 use ratatui::{
     Frame,

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -76,10 +76,6 @@ pub(super) fn render_list_body(
         );
     }
 
-    // Toast overlay — rendered last so it appears on top.
-    if let Some(toast) = &state.toast {
-        render_toast(frame, area, toast);
-    }
 }
 
 pub(in crate::console::manager) fn list_names_content_width(
@@ -231,35 +227,6 @@ fn render_agent_picker_sidebar(
             .position(|agent| *agent == picker.focused),
     );
     frame.render_stateful_widget(list, area, &mut list_state);
-}
-
-fn render_toast(frame: &mut Frame, area: Rect, toast: &super::super::state::Toast) {
-    use super::super::state::ToastKind;
-    let elapsed = toast.shown_at.elapsed();
-    // Auto-expire after 3 seconds — caller should clear before that,
-    // but defensively skip rendering if we're past.
-    if elapsed > std::time::Duration::from_secs(3) {
-        return;
-    }
-
-    let (prefix, color) = match toast.kind {
-        ToastKind::Success => ("✓ ", PHOSPHOR_GREEN),
-        ToastKind::Error => ("✗ ", Color::Rgb(255, 94, 122)),
-    };
-    let mut style = Style::default().fg(color).add_modifier(Modifier::BOLD);
-    // Shimmer: first 400ms is bright-white flicker, then settles.
-    if elapsed < std::time::Duration::from_millis(400) {
-        style = style.fg(WHITE);
-    }
-    let line = Line::from(Span::styled(format!("{}{}", prefix, toast.message), style));
-    let banner_area = Rect {
-        x: area.x + 2,
-        y: area.y + 1,
-        width: area.width.saturating_sub(4),
-        height: 1,
-    };
-    frame.render_widget(ratatui::widgets::Clear, banner_area);
-    frame.render_widget(Paragraph::new(line), banner_area);
 }
 
 /// Pre-formatted mount row. `host_source` is `Some` only when src != dst

--- a/src/console/manager/render/list.rs
+++ b/src/console/manager/render/list.rs
@@ -75,7 +75,6 @@ pub(super) fn render_list_body(
             None,
         );
     }
-
 }
 
 pub(in crate::console::manager) fn list_names_content_width(

--- a/src/console/manager/render/mod.rs
+++ b/src/console/manager/render/mod.rs
@@ -480,7 +480,17 @@ pub fn render(
                 // Handled above via the `is_list_stage` early branch.
             }
             ManagerStage::Settings(settings) => {
-                if let Some(modal) = &mut settings.mounts.modal {
+                if let Some(popup) = &settings.error_popup {
+                    let inner_width = (area.width * 60 / 100).saturating_sub(4);
+                    let max_rows = area.height.saturating_sub(2);
+                    let h = crate::console::widgets::error_popup::required_height(
+                        popup,
+                        inner_width,
+                        max_rows,
+                    );
+                    let popup_area = centered_rect_fixed(area, 60, h);
+                    crate::console::widgets::error_popup::render(frame, popup_area, popup);
+                } else if let Some(modal) = &mut settings.mounts.modal {
                     global_mounts::render_global_mount_modal(frame, modal);
                 } else if let Some(modal) = &mut settings.env.modal {
                     global_mounts::render_settings_env_modal(frame, modal);

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -98,6 +98,10 @@ pub struct ManagerState<'a> {
     /// state on disk can't change at the 20 Hz render cadence and the
     /// rebuild path walks every container directory.
     instances_last_refresh: Option<std::time::Instant>,
+    /// Dedup gate: last error string from `refresh_instances`. Without
+    /// this, a persistent parse error would reopen the popup on every
+    /// 20 Hz tick — operators would never be able to dismiss it.
+    instances_last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -147,7 +151,6 @@ pub struct GlobalMountsState<'a> {
     pub modal: Option<GlobalMountModal<'a>>,
     pub add_draft: Option<GlobalMountDraft>,
     pub error: Option<String>,
-    pub success: Option<String>,
     pub scroll_x: u16,
     pub scroll_y: u16,
     pub scroll_focused: bool,
@@ -592,7 +595,6 @@ impl GlobalMountsState<'_> {
             modal: None,
             add_draft: None,
             error: None,
-            success: None,
             scroll_x: 0,
             scroll_y: 0,
             scroll_focused: false,
@@ -610,7 +612,6 @@ impl GlobalMountsState<'_> {
         self.selected = self.selected.min(self.pending.len().saturating_sub(1));
         self.add_draft = None;
         self.error = None;
-        self.success = None;
     }
 
     pub fn save_to_config(
@@ -1382,6 +1383,7 @@ impl ManagerState<'_> {
                 height: 24,
             },
             instances_last_refresh: None,
+            instances_last_error: None,
         }
     }
 
@@ -1485,9 +1487,20 @@ impl ManagerState<'_> {
         match crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir) {
             Ok(index) => {
                 self.instances = index.instances;
+                self.instances_last_error = None;
             }
-            Err(_) => {
+            Err(error) => {
                 self.instances.clear();
+                let message = format!("instance index error: {error}");
+                if self.instances_last_error.as_deref() != Some(&message) {
+                    self.list_modal = Some(Modal::ErrorPopup {
+                        state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                            "Instance index error",
+                            &message,
+                        ),
+                    });
+                    self.instances_last_error = Some(message);
+                }
             }
         }
     }

--- a/src/console/manager/state.rs
+++ b/src/console/manager/state.rs
@@ -61,7 +61,6 @@ pub struct ManagerState<'a> {
     pub instances: Vec<crate::instance::InstanceIndexEntry>,
     pub current_dir: String,
     pub selected: usize,
-    pub toast: Option<Toast>,
     /// Modal slot at the list level (e.g. `Modal::GithubPicker`); the
     /// Editor / `CreatePrelude` stages own their own modal slots.
     pub list_modal: Option<Modal<'a>>,
@@ -99,9 +98,6 @@ pub struct ManagerState<'a> {
     /// state on disk can't change at the 20 Hz render cadence and the
     /// rebuild path walks every container directory.
     instances_last_refresh: Option<std::time::Instant>,
-    /// Last surfaced `refresh_instances` error message. Dedup gate so
-    /// transient errors don't spam toasts every refresh tick.
-    instances_last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -209,6 +205,9 @@ pub struct SettingsState<'a> {
     pub env: SettingsEnvState<'a>,
     pub auth: SettingsAuthState,
     pub trust: SettingsTrustState,
+    /// Error popup shown on top of all settings content. Dismissed with
+    /// Enter / O / Esc; clears automatically when opened again.
+    pub error_popup: Option<ErrorPopupState>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -642,6 +641,7 @@ impl SettingsState<'_> {
             env: SettingsEnvState::from_config(config),
             auth: SettingsAuthState::from_config(config),
             trust: SettingsTrustState::from_config(config),
+            error_popup: None,
         }
     }
 
@@ -1261,19 +1261,6 @@ pub enum CreateStep {
     NameWorkspace,
 }
 
-#[derive(Debug, Clone)]
-pub struct Toast {
-    pub message: String,
-    pub kind: ToastKind,
-    pub shown_at: std::time::Instant,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToastKind {
-    Success,
-    Error,
-}
-
 // ── Impls ──────────────────────────────────────────────────────────
 
 impl WorkspaceSummary {
@@ -1370,7 +1357,6 @@ impl ManagerState<'_> {
             instances: Vec::new(),
             current_dir: cwd.display().to_string(),
             selected,
-            toast: None,
             list_modal: None,
             inline_role_picker: None,
             inline_agent_picker: None,
@@ -1396,7 +1382,6 @@ impl ManagerState<'_> {
                 height: 24,
             },
             instances_last_refresh: None,
-            instances_last_error: None,
         }
     }
 
@@ -1500,22 +1485,9 @@ impl ManagerState<'_> {
         match crate::instance::InstanceIndex::read_or_rebuild(&paths.data_dir) {
             Ok(index) => {
                 self.instances = index.instances;
-                self.instances_last_error = None;
             }
-            Err(error) => {
-                // Empty list would look identical to "no instances",
-                // hiding corrupt index / permission errors. Surface
-                // via toast so the operator has a path to investigate.
+            Err(_) => {
                 self.instances.clear();
-                let message = format!("instance index error: {error}");
-                if self.instances_last_error.as_deref() != Some(&message) {
-                    self.toast = Some(Toast {
-                        message: message.clone(),
-                        kind: ToastKind::Error,
-                        shown_at: std::time::Instant::now(),
-                    });
-                    self.instances_last_error = Some(message);
-                }
             }
         }
     }
@@ -1968,16 +1940,11 @@ mod tests {
     }
 
     #[test]
-    fn refresh_instances_surfaces_index_error_via_toast() {
-        // Corrupt the index file; the read path must surface the parse
-        // error as a toast and dedup so subsequent identical errors
-        // don't pin a new toast every refresh tick.
+    fn refresh_instances_clears_on_index_error() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = crate::paths::JackinPaths::for_tests(tmp.path());
         std::fs::create_dir_all(&paths.data_dir).unwrap();
         std::fs::write(paths.data_dir.join("instances.json"), b"not json").unwrap();
-        // Also drop a directory that looks like a state dir so
-        // `rebuild()` doesn't silently regenerate a fresh empty index.
         let bogus = paths.data_dir.join("jackin-bogus-k7p9m2xq");
         std::fs::create_dir_all(bogus.join(".jackin")).unwrap();
         std::fs::write(bogus.join(".jackin/instance.json"), b"not json").unwrap();
@@ -1987,24 +1954,6 @@ mod tests {
         state.refresh_instances(&paths);
 
         assert!(state.instances.is_empty());
-        let toast = state.toast.as_ref().expect("error toast must be emitted");
-        assert_eq!(toast.kind, ToastKind::Error);
-        assert!(
-            toast.message.contains("instance index error"),
-            "toast message: {}",
-            toast.message
-        );
-
-        let first_shown_at = toast.shown_at;
-        // Second refresh: stash + dedup must not overwrite the first
-        // toast when the error message is unchanged.
-        state.force_refresh_instances_for_test();
-        state.refresh_instances(&paths);
-        let toast2 = state.toast.as_ref().unwrap();
-        assert_eq!(
-            toast2.shown_at, first_shown_at,
-            "identical error must not re-emit the toast",
-        );
     }
 
     #[test]

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -66,7 +66,9 @@ impl ConsoleState {
                 ms.list_modal = Some(crate::console::manager::state::Modal::ErrorPopup {
                     state: crate::console::widgets::error_popup::ErrorPopupState::new(
                         "No eligible roles",
-                        format!("Workspace \"{name}\" has no allowed roles configured.\n\nAdd at least one role to `allowed_roles` in the workspace settings."),
+                        format!(
+                            "Workspace \"{name}\" has no allowed roles configured.\n\nAdd at least one role to `allowed_roles` in the workspace settings."
+                        ),
                     ),
                 });
             }

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -59,14 +59,15 @@ impl ConsoleState {
         let roles = choice.allowed_roles.clone();
 
         if roles.is_empty() {
-            // Toast + stay so the operator can fix `allowed_roles`
+            // Stay so the operator can fix `allowed_roles`
             // — a single Enter shouldn't terminate the TUI.
             let name = choice.name;
             if let ConsoleStage::Manager(ms) = &mut self.stage {
-                ms.toast = Some(crate::console::manager::state::Toast {
-                    message: format!("no eligible roles for workspace \"{name}\""),
-                    kind: crate::console::manager::state::ToastKind::Error,
-                    shown_at: std::time::Instant::now(),
+                ms.list_modal = Some(crate::console::manager::state::Modal::ErrorPopup {
+                    state: crate::console::widgets::error_popup::ErrorPopupState::new(
+                        "No eligible roles",
+                        format!("Workspace \"{name}\" has no allowed roles configured.\n\nAdd at least one role to `allowed_roles` in the workspace settings."),
+                    ),
                 });
             }
             self.pending_launch = None;
@@ -425,14 +426,6 @@ pub fn run_console(
     let mut last_mouse_event_at: Option<std::time::Instant> = None;
 
     let result = 'main: loop {
-        // Auto-expire manager toasts after 3 seconds.
-        if let ConsoleStage::Manager(ms) = &mut state.stage
-            && let Some(toast) = &ms.toast
-            && toast.shown_at.elapsed() > std::time::Duration::from_secs(3)
-        {
-            ms.toast = None;
-        }
-
         // Drain worker results before render so a fresh result lands
         // this frame instead of a stale Loading one.
         if let ConsoleStage::Manager(ms) = &mut state.stage {

--- a/src/console/widgets/file_browser/git_prompt.rs
+++ b/src/console/widgets/file_browser/git_prompt.rs
@@ -73,10 +73,9 @@ impl FileBrowserState {
             // `o` for "open the repo's web URL in the browser" — best-effort.
             // No-op when `pending_git_url` is `None` (non-GitHub origin or
             // unresolvable remote); launcher failures are logged on the
-            // `--debug` channel since `FileBrowserState` doesn't own the
-            // global toast queue. The overlay drops the `· O open` hint
-            // segment in the None case so the keystroke is only advertised
-            // when it actually does something.
+            // `--debug` channel since `FileBrowserState` has no error surface.
+            // The overlay drops the `· O open` hint segment in the None case
+            // so the keystroke is only advertised when it actually does something.
             KeyCode::Char('o' | 'O') => {
                 if let Some(url) = self.pending_git_url.as_deref()
                     && let Err(e) = open::that_detached(url)


### PR DESCRIPTION
## Summary

Replaces the ephemeral shimmer-toast overlay with the existing red-border `ErrorPopup` dialog for all manager error paths. The toast had no scroll support, disappeared after 3 seconds whether or not the operator had read it, and rendered over workspace-list content. `ErrorPopup` is already the standard for save failures and role-resolution errors, so routing the remaining paths through it gives a consistent, dismissible, scrollable error surface across the whole TUI.

All error surfaces now use `ErrorPopup`:

- **List stage** (`state.list_modal`): workspace with no allowed roles on Enter; instance action keys (r/a/x/i/p) when no matching container exists; instance index parse/permission errors (dedup-gated so the popup doesn't reopen on every 20 Hz refresh tick).
- **Editor stage** (`editor.modal`): `open::that_detached` failure on O; O pressed on a non-GitHub mount.
- **Settings stage**: new `error_popup: Option<ErrorPopupState>` field on `SettingsState`, rendered above all other settings modals; `after_settings_event` promotes errors from mounts / env / auth / trust into this slot. Covers global-mount URL open failures, env/auth/trust edit errors, 1Password read failures, and save errors.

`after_global_mounts_event` was a single-call wrapper; it is merged into `after_settings_event` and removed.

Also removed: `Toast` struct, `ToastKind` enum, `instances_last_error` dedup field (restored with the new list-modal approach), `render_toast`, the 3-second auto-expire loop in the main event loop, and the `set_toast` helper in global_mounts.

Also removed: dead `success: Option<String>` field from `GlobalMountsState` (it was written by `commit_settings_save` and immediately discarded by `after_settings_event`; success feedback is intentionally silent — the navigation back to the workspace list is sufficient confirmation).

TUI design decisions doc updated: new **Error Surface — ErrorPopup Only, No Ephemeral Overlays** section documents this as a binding rule for future TUI work.

## What's deferred

None.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin refactor/remove-toast-use-error-popups:refs/remotes/origin/refactor/remove-toast-use-error-popups
git checkout -B refactor/remove-toast-use-error-popups refs/remotes/origin/refactor/remove-toast-use-error-popups
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run --all-features
```

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Paths to exercise:

1. **No-roles error** — open a workspace that has `allowed_roles = []` and press Enter. Expect a red ErrorPopup "No eligible roles" instead of a silent no-op.
2. **Instance action on empty list** — select a workspace with no running instances, press `a`. Expect "No instance" ErrorPopup, dismiss with Enter.
3. **Settings error** — open Settings (S), Mounts tab. Switch to a tab that produces a validation error and confirm it surfaces as a red popup above the settings content rather than a toast.
4. **Editor O on non-GitHub mount** — open a workspace editor, Mounts tab, select a plain folder mount, press O. Expect "No GitHub URL" ErrorPopup explaining the constraint.
5. **Popup dismissal** — confirm Enter, Esc, and O all dismiss the ErrorPopup and return to normal navigation.

## Migration notes

None.