### PR TITLE
feat(build): pass GitHub token as BuildKit secret to docker build

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -39,6 +39,9 @@ pub struct RunOptions {
     /// When `true`, both stdout and stderr are sent to `/dev/null`.
     /// Useful for suppressing noisy output (e.g. git fetch) in non-debug mode.
     pub quiet: bool,
+    /// Additional environment variables injected into the child process,
+    /// additive over the inherited parent environment.
+    pub extra_env: Vec<(String, String)>,
 }
 
 pub trait CommandRunner {
@@ -129,7 +132,11 @@ impl CommandRunner for ShellRunner {
         self.log_command(program, args, cwd);
 
         if opts.quiet {
-            let mut child = Self::build_command(program, args, cwd)
+            let mut cmd = Self::build_command(program, args, cwd);
+            if !opts.extra_env.is_empty() {
+                cmd.envs(opts.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+            }
+            let mut child = cmd
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn()?;
@@ -141,9 +148,11 @@ impl CommandRunner for ShellRunner {
                 args.join(" ")
             );
         } else if opts.capture_stderr {
-            let mut child = Self::build_command(program, args, cwd)
-                .stderr(std::process::Stdio::piped())
-                .spawn()?;
+            let mut cmd = Self::build_command(program, args, cwd);
+            if !opts.extra_env.is_empty() {
+                cmd.envs(opts.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+            }
+            let mut child = cmd.stderr(std::process::Stdio::piped()).spawn()?;
             let stderr = child.stderr.take().ok_or_else(|| {
                 anyhow::anyhow!(
                     "failed to capture stderr for {} {}",
@@ -181,7 +190,11 @@ impl CommandRunner for ShellRunner {
                 );
             }
         } else {
-            let mut child = Self::build_command(program, args, cwd).spawn()?;
+            let mut cmd = Self::build_command(program, args, cwd);
+            if !opts.extra_env.is_empty() {
+                cmd.envs(opts.extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+            }
+            let mut child = cmd.spawn()?;
             let status = child.wait()?;
             anyhow::ensure!(
                 status.success(),

--- a/src/runtime/image.rs
+++ b/src/runtime/image.rs
@@ -10,7 +10,11 @@ use super::identity::HostIdentity;
 use super::naming::{LABEL_IMAGE_CONSTRUCT, LABEL_IMAGE_CONSTRUCT_VERSION, image_name};
 
 /// Build the Docker image for the role. Returns the image name.
-#[allow(clippy::similar_names, clippy::too_many_arguments)]
+#[allow(
+    clippy::similar_names,
+    clippy::too_many_arguments,
+    clippy::too_many_lines
+)]
 pub(super) fn build_agent_image(
     paths: &JackinPaths,
     selector: &RoleSelector,
@@ -166,12 +170,29 @@ pub(super) fn build_agent_image(
     build_args.extend(["--label", &construct_label]);
     build_args.extend(["-t", &image, "-f", &dockerfile_path, &context_dir]);
 
+    let github_token = resolve_github_token(runner);
+    let secret_file: Option<tempfile::NamedTempFile> = github_token.as_ref().and_then(|token| {
+        let mut f = tempfile::NamedTempFile::new().ok()?;
+        std::io::Write::write_all(&mut f, token.as_bytes()).ok()?;
+        Some(f)
+    });
+    let secret_arg = secret_file
+        .as_ref()
+        .map(|f| format!("id=github_token,src={}", f.path().display()));
+    if let Some(ref s) = secret_arg {
+        build_args.extend(["--secret", s.as_str()]);
+    }
+
     runner.run(
         "docker",
         &build_args,
         None,
         &RunOptions {
             capture_stderr: true,
+            extra_env: github_token
+                .as_ref()
+                .map(|_| vec![("DOCKER_BUILDKIT".to_string(), "1".to_string())])
+                .unwrap_or_default(),
             ..RunOptions::default()
         },
     )?;
@@ -306,4 +327,24 @@ fn extract_agent_version(
         }
         _ => {}
     }
+}
+
+/// Resolves a GitHub token for authenticating mise's GitHub API calls during
+/// Docker image builds. Checks `GITHUB_TOKEN` and `GH_TOKEN` env vars first
+/// (set in CI and by operators), then falls back to `gh auth token` for local
+/// development where the user is already logged in via the gh CLI.
+///
+/// Returns `None` when no token is available; callers must degrade gracefully
+/// (build still works, mise falls back to unauthenticated GitHub API access).
+fn resolve_github_token(runner: &mut impl CommandRunner) -> Option<String> {
+    for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Some(t) = std::env::var(var).ok().filter(|t| !t.trim().is_empty()) {
+            return Some(t.trim().to_string());
+        }
+    }
+    runner
+        .capture("gh", &["auth", "token"], None)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }


### PR DESCRIPTION
## Related pull requests

- https://github.com/jackin-project/jackin-role-action/pull/11
- https://github.com/jackin-project/jackin-the-architect/pull/59
- https://github.com/jackin-project/jackin-agent-smith/pull/32

## Summary

Adds a GitHub token to `docker build` via a BuildKit `--secret` mount so `mise` can authenticate GitHub API calls when downloading tool releases (e.g. `just`, `opentofu`, `protoc`, `cargo-binstall`). Without authentication, unauthenticated GitHub API requests hit the 60 req/hour rate limit and fail with 403, breaking both CI builds and local `jackin` image builds. The token is resolved from `GITHUB_TOKEN`/`GH_TOKEN` env vars first, then falls back to `gh auth token` for local development where the operator is already logged in via the gh CLI. The secret is written to a `NamedTempFile` and mounted at `/run/secrets/github_token`; it is never baked into any image layer and the temp file is deleted immediately after `docker build` returns. `DOCKER_BUILDKIT=1` is set in the child process environment to ensure secrets work on Docker < 23 where BuildKit is not yet the default.

Two code changes: `RunOptions` in `docker.rs` gains an `extra_env` field (defaulting to empty) so callers can inject env vars into the child process without touching the global process environment, and `build_agent_image()` in `image.rs` gains `resolve_github_token()` and the secret-file plumbing.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feat/github-token-secret-mount:refs/remotes/origin/feat/github-token-secret-mount
git checkout -B feat/github-token-secret-mount refs/remotes/origin/feat/github-token-secret-mount
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run --all-features
```

### User smoke

```sh
cargo run --bin jackin -- --debug
```

Launch any role that has `mise install` steps (e.g. the-architect). Observe that docker build succeeds without GitHub API 403 errors. Verify `DOCKER_BUILDKIT=1` appears in `[jackin debug cmd]` output and that `--secret id=github_token,src=...` is present in the docker build invocation.