### PR TITLE
fix(prune): prune system --all removes all managed state including jackin home

### DIFF
--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -81,6 +81,8 @@ jackin prune system [--yes] [--all]
 
 Runs all four subcommands in order: `instances` → `images` → `roles` → `cache`. Prompts for confirmation before proceeding unless `--yes` is passed. By default skips running instances; pass `--all` to stop and remove them too.
 
+When `--all` is passed and all steps succeed, jackin also removes its runtime home directory if it is empty after cleanup, leaving no managed state on disk.
+
 ### Options
 
 | Option | Description |
@@ -118,6 +120,7 @@ jackin prune system --all
 - **Running instances (without `--all`)** — without the `--all` flag, containers that are currently attached or running are never stopped or purged by `prune`. Pass `--all` to include them.
 - **Stopped instances with recovery state (without `--all`)** — instances with status `restore_available`, `crashed`, `preserved_dirty`, or `preserved_unpushed` are skipped unless `--all` is passed. Use `jackin hardline` to reconnect or `jackin eject <selector> --purge` to explicitly remove them.
 - **Operator config** — `~/.config/jackin/config.toml` and saved workspaces are never modified by `prune`.
+- **Runtime home when non-empty** — `prune system --all` removes the runtime home directory only when it is empty after all steps succeed. Any content that could not be cleaned (for example, an instance state directory that failed to purge) causes the runtime home to be left in place.
 
 ## Relationship to `jackin purge`
 

--- a/docs/src/content/docs/commands/prune.mdx
+++ b/docs/src/content/docs/commands/prune.mdx
@@ -81,7 +81,7 @@ jackin prune system [--yes] [--all]
 
 Runs all four subcommands in order: `instances` → `images` → `roles` → `cache`. Prompts for confirmation before proceeding unless `--yes` is passed. By default skips running instances; pass `--all` to stop and remove them too.
 
-When `--all` is passed and all steps succeed, jackin also removes its runtime home directory if it is empty after cleanup, leaving no managed state on disk.
+When `--all` is passed and all steps succeed, jackin removes its runtime home directory entirely, leaving no managed state on disk.
 
 ### Options
 
@@ -120,7 +120,6 @@ jackin prune system --all
 - **Running instances (without `--all`)** — without the `--all` flag, containers that are currently attached or running are never stopped or purged by `prune`. Pass `--all` to include them.
 - **Stopped instances with recovery state (without `--all`)** — instances with status `restore_available`, `crashed`, `preserved_dirty`, or `preserved_unpushed` are skipped unless `--all` is passed. Use `jackin hardline` to reconnect or `jackin eject <selector> --purge` to explicitly remove them.
 - **Operator config** — `~/.config/jackin/config.toml` and saved workspaces are never modified by `prune`.
-- **Runtime home when non-empty** — `prune system --all` removes the runtime home directory only when it is empty after all steps succeed. Any content that could not be cleaned (for example, an instance state directory that failed to purge) causes the runtime home to be left in place.
 
 ## Relationship to `jackin purge`
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1256,6 +1256,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 let errors: Vec<anyhow::Error> =
                     results.into_iter().filter_map(Result::err).collect();
                 if errors.is_empty() {
+                    runtime::prune_jackin_home(&paths);
                     Ok(())
                 } else {
                     for err in &errors {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1256,7 +1256,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 let errors: Vec<anyhow::Error> =
                     results.into_iter().filter_map(Result::err).collect();
                 if errors.is_empty() {
-                    runtime::prune_jackin_home(&paths);
+                    if args.all {
+                        runtime::prune_jackin_home(&paths);
+                    }
                     Ok(())
                 } else {
                     for err in &errors {

--- a/src/config/workspaces.rs
+++ b/src/config/workspaces.rs
@@ -601,6 +601,7 @@ mod tests {
         fn paths_for(data: &std::path::Path) -> JackinPaths {
             JackinPaths {
                 home_dir: data.into(),
+                jackin_home: data.into(),
                 config_dir: data.into(),
                 config_file: data.join("config.toml"),
                 workspaces_dir: data.join("workspaces"),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct JackinPaths {
     pub home_dir: PathBuf,
+    pub jackin_home: PathBuf,
     pub config_dir: PathBuf,
     pub config_file: PathBuf,
     pub workspaces_dir: PathBuf,
@@ -45,20 +46,23 @@ impl JackinPaths {
             cache_dir: jackin_home.join("cache"),
             home_dir: home_dir.to_path_buf(),
             config_dir,
+            jackin_home,
         }
     }
 
     pub fn for_tests(root: &Path) -> Self {
         let home_dir = root.join("home");
         let config_dir = root.join("config");
+        let jackin_home = home_dir.join(".jackin");
         Self {
             config_file: config_dir.join("config.toml"),
             workspaces_dir: config_dir.join("workspaces"),
-            roles_dir: home_dir.join(".jackin/roles"),
-            data_dir: home_dir.join(".jackin/data"),
-            cache_dir: home_dir.join(".jackin/cache"),
+            roles_dir: jackin_home.join("roles"),
+            data_dir: jackin_home.join("data"),
+            cache_dir: jackin_home.join("cache"),
             home_dir,
             config_dir,
+            jackin_home,
         }
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -94,6 +94,7 @@ mod env_override_tests {
             None,
         );
 
+        assert_eq!(paths.jackin_home, jackin_root.path());
         assert_eq!(paths.data_dir, jackin_root.path().join("data"));
         assert_eq!(paths.roles_dir, jackin_root.path().join("roles"));
         assert_eq!(paths.cache_dir, jackin_root.path().join("cache"));

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -493,9 +493,15 @@ pub fn prune_all_instances(
 ) -> anyhow::Result<()> {
     exile_all(runner)?;
 
+    // With all containers gone, reconcile will stop caffeinate and remove its
+    // PID file. Must run before sweep_stale_artifacts so we SIGTERM the live
+    // process before deleting the only handle to it.
+    super::caffeinate::reconcile(paths, runner);
+
     let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
     if index.instances.is_empty() {
         println!("No instances to prune.");
+        sweep_stale_artifacts(&paths.data_dir);
         return Ok(());
     }
 
@@ -542,7 +548,33 @@ pub fn prune_all_instances(
         );
     }
 
+    sweep_stale_artifacts(&paths.data_dir);
     Ok(())
+}
+
+/// Remove all artifacts left behind after all instances are gone, then remove
+/// data_dir itself if empty. Best-effort: individual failures are silently
+/// ignored because this is housekeeping, not load-bearing state management.
+fn sweep_stale_artifacts(data_dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(data_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_file() {
+            if name.ends_with(".lock") || name.ends_with(".pid") || name == "instances.json" {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        } else if ft.is_dir() && name.ends_with(".locks") {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+    // Remove the directory itself if it is now empty. `remove_dir` (not
+    // `remove_dir_all`) is intentional: if any entry was skipped above
+    // (e.g. a failed-purge state dir), the directory is not empty and
+    // `remove_dir` fails silently, leaving the partial state intact.
+    let _ = std::fs::remove_dir(data_dir);
 }
 
 fn ensure_role_resources_absent_for_purge(
@@ -1401,5 +1433,85 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         let msg = err.to_string();
         assert!(msg.contains("failed to remove test label"), "got: {msg}");
         assert!(msg.contains("child"), "got: {msg}");
+    }
+
+    // ── sweep_stale_artifacts ────────────────────────────────────────────────
+
+    #[test]
+    fn prune_all_instances_sweeps_orphaned_lock_files_and_locks_dirs() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        std::fs::create_dir_all(&paths.data_dir).unwrap();
+
+        // Plant the kinds of stale artifacts that accumulate in data_dir.
+        std::fs::write(paths.data_dir.join("jk-abc123-thearchitect.lock"), b"").unwrap();
+        std::fs::write(paths.data_dir.join("caffeinate.lock"), b"").unwrap();
+        std::fs::write(paths.data_dir.join("caffeinate.pid"), b"99999").unwrap();
+        std::fs::write(paths.data_dir.join("instances.json.lock"), b"").unwrap();
+        std::fs::create_dir_all(paths.data_dir.join("the-architect.locks")).unwrap();
+        std::fs::write(
+            paths.data_dir.join("the-architect.locks").join("default.repo.lock"),
+            b"",
+        )
+        .unwrap();
+
+        // FakeRunner: exile_all calls docker ps -a to list managed containers
+        // (returns empty), then caffeinate reconcile calls docker ps (returns
+        // empty — no keep-awake agents). No instances in index.
+        let mut runner = FakeRunner::with_capture_queue([
+            String::new(), // exile_all: docker ps -a (no managed containers)
+            String::new(), // caffeinate reconcile: docker ps keep-awake check
+        ]);
+        prune_all_instances(&paths, &mut runner).unwrap();
+
+        assert!(
+            !paths.data_dir.join("jk-abc123-thearchitect.lock").exists(),
+            "instance launch lock should be removed"
+        );
+        assert!(
+            !paths.data_dir.join("caffeinate.lock").exists(),
+            "caffeinate mutex lock should be removed"
+        );
+        assert!(
+            !paths.data_dir.join("caffeinate.pid").exists(),
+            "caffeinate pid file should be removed"
+        );
+        assert!(
+            !paths.data_dir.join("instances.json.lock").exists(),
+            "instances.json.lock should be removed"
+        );
+        assert!(
+            !paths.data_dir.join("the-architect.locks").exists(),
+            "repo locks dir should be removed"
+        );
+        assert!(
+            !paths.data_dir.exists(),
+            "data_dir itself should be removed when empty"
+        );
+    }
+
+    #[test]
+    fn prune_all_instances_sweeps_even_when_index_empty() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        std::fs::create_dir_all(&paths.data_dir).unwrap();
+        std::fs::write(paths.data_dir.join("jk-stale.lock"), b"").unwrap();
+
+        // No instances in index; exile_all and caffeinate reconcile each make
+        // one docker ps call.
+        let mut runner = FakeRunner::with_capture_queue([
+            String::new(), // exile_all
+            String::new(), // caffeinate reconcile
+        ]);
+        prune_all_instances(&paths, &mut runner).unwrap();
+
+        assert!(
+            !paths.data_dir.join("jk-stale.lock").exists(),
+            "stale lock swept even with empty index"
+        );
+        assert!(
+            !paths.data_dir.exists(),
+            "data_dir removed when only stale locks present"
+        );
     }
 }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -1469,7 +1469,10 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         std::fs::write(paths.data_dir.join("instances.json.lock"), b"").unwrap();
         std::fs::create_dir_all(paths.data_dir.join("the-architect.locks")).unwrap();
         std::fs::write(
-            paths.data_dir.join("the-architect.locks").join("default.repo.lock"),
+            paths
+                .data_dir
+                .join("the-architect.locks")
+                .join("default.repo.lock"),
             b"",
         )
         .unwrap();

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -307,18 +307,10 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.cache_dir, "shared cache")
 }
 
-/// Uses `remove_dir` (not `remove_dir_all`) so surviving content prevents
-/// removal rather than being silently deleted.
 pub fn prune_jackin_home(paths: &JackinPaths) {
-    match std::fs::remove_dir(&paths.jackin_home) {
+    match std::fs::remove_dir_all(&paths.jackin_home) {
         Ok(()) => println!("Removed jackin home ({}).", paths.jackin_home.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {
-            println!(
-                "jackin home ({}) not empty, leaving in place.",
-                paths.jackin_home.display()
-            );
-        }
         Err(err) => {
             eprintln!(
                 "  {} could not remove {}: {err}",
@@ -508,134 +500,52 @@ pub fn prune_instances(paths: &JackinPaths, runner: &mut impl CommandRunner) -> 
 
 /// Force-eject all managed Docker resources then purge every instance's
 /// state directory and index entry, regardless of status.
-/// Used by `jackin prune all`.
+/// Used by `jackin prune instances --all` and `jackin prune system --all`.
 pub fn prune_all_instances(
     paths: &JackinPaths,
     runner: &mut impl CommandRunner,
 ) -> anyhow::Result<()> {
     exile_all(runner)?;
 
-    // reconcile must run before sweep_stale_artifacts: with all containers
-    // gone, reconcile will attempt to stop any live caffeinate process and
-    // remove its PID file. sweep_stale_artifacts unconditionally deletes
-    // *.pid files, so running it first would remove the PID file while
-    // caffeinate is still alive, leaving an orphaned process with no
-    // recoverable handle.
+    // reconcile must run before data_dir removal: with all containers gone,
+    // reconcile will attempt to stop any live caffeinate process and remove
+    // its PID file. Removing data_dir first would delete the PID file before
+    // reconcile can read it to stop the live process, orphaning it.
     super::caffeinate::reconcile(paths, runner);
 
     let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
     if index.instances.is_empty() {
         println!("No instances to prune.");
-        sweep_stale_artifacts(&paths.data_dir);
-        return Ok(());
-    }
+    } else {
+        let containers: Vec<String> = index
+            .instances
+            .iter()
+            .map(|e| e.container_base.clone())
+            .collect();
 
-    let containers: Vec<String> = index
-        .instances
-        .iter()
-        .map(|e| e.container_base.clone())
-        .collect();
-
-    let mut removed: Vec<String> = Vec::new();
-    let mut skipped: Vec<(String, anyhow::Error)> = Vec::new();
-
-    for container_base in containers {
-        match purge_container_filesystem(paths, &container_base, runner) {
-            Ok(()) => removed.push(container_base),
-            Err(error) => skipped.push((container_base, error)),
+        println!("Pruned {} instance(s):", containers.len());
+        for name in &containers {
+            println!("  {name}");
         }
-    }
-
-    if !removed.is_empty() {
-        let refs: Vec<&str> = removed.iter().map(String::as_str).collect();
-        match InstanceIndex::remove_many(&paths.data_dir, &refs) {
-            Ok(()) => println!("Pruned {} instance(s):", removed.len()),
-            Err(err) => {
+        for container_base in &containers {
+            if let Err(err) = purge_container_filesystem(paths, container_base, runner) {
                 eprintln!(
-                    "{} instance index could not be updated: {err:#}; run `jackin prune instances` again to retry",
+                    "  {} isolation cleanup for {container_base} failed: {err}",
                     "warning:".yellow().bold()
-                );
-                println!(
-                    "Removed state for {} instance(s) (index not updated):",
-                    removed.len()
                 );
             }
         }
-        for name in &removed {
-            println!("  {name}");
-        }
     }
 
-    for (name, error) in &skipped {
-        eprintln!(
-            "{} failed to purge state for {name}: {error}",
-            "warning:".yellow().bold()
-        );
-    }
-
-    if skipped.is_empty() {
-        sweep_stale_artifacts(&paths.data_dir);
+    if let Err(err) = std::fs::remove_dir_all(&paths.data_dir)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(anyhow::Error::from(err).context(format!(
+            "failed to remove instance data at {}",
+            paths.data_dir.display()
+        )));
     }
     Ok(())
-}
-
-fn sweep_stale_artifacts(data_dir: &std::path::Path) {
-    let entries = match std::fs::read_dir(data_dir) {
-        Ok(e) => e,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
-        Err(err) => {
-            eprintln!(
-                "  {} could not read {}: {err}",
-                "warning:".yellow().bold(),
-                data_dir.display()
-            );
-            return;
-        }
-    };
-    for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let name = file_name.to_string_lossy();
-        let Ok(ft) = entry.file_type() else { continue };
-        let ext = std::path::Path::new(name.as_ref())
-            .extension()
-            .and_then(std::ffi::OsStr::to_str)
-            .unwrap_or("");
-        let path = entry.path();
-        if ft.is_file()
-            && (ext == "lock" || ext == "pid" || name == "instances.json")
-            && let Err(err) = std::fs::remove_file(&path)
-            && err.kind() != std::io::ErrorKind::NotFound
-        {
-            eprintln!(
-                "  {} could not remove {}: {err}",
-                "warning:".yellow().bold(),
-                path.display()
-            );
-        } else if ft.is_dir()
-            && ext == "locks"
-            && let Err(err) = std::fs::remove_dir_all(&path)
-            && err.kind() != std::io::ErrorKind::NotFound
-        {
-            eprintln!(
-                "  {} could not remove {}: {err}",
-                "warning:".yellow().bold(),
-                path.display()
-            );
-        }
-    }
-    // `remove_dir` (not `remove_dir_all`): if any entry was skipped above
-    // (e.g. a failed-purge state dir), the directory is not empty and
-    // `remove_dir` fails silently, leaving the partial state intact.
-    if let Err(err) = std::fs::remove_dir(data_dir)
-        && err.kind() != std::io::ErrorKind::NotFound
-        && err.kind() != std::io::ErrorKind::DirectoryNotEmpty
-    {
-        eprintln!(
-            "  {} could not remove {}: {err}",
-            "warning:".yellow().bold(),
-            data_dir.display()
-        );
-    }
 }
 
 fn ensure_role_resources_absent_for_purge(
@@ -1497,16 +1407,13 @@ jk-a1b2c3d4-myworkspace-agentsmith"
     }
 
     #[test]
-    fn prune_all_instances_sweeps_orphaned_lock_files_and_locks_dirs() {
+    fn prune_all_instances_removes_data_dir_entirely() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         std::fs::create_dir_all(&paths.data_dir).unwrap();
         std::fs::write(paths.data_dir.join("jk-abc123-thearchitect.lock"), b"").unwrap();
         std::fs::write(paths.data_dir.join("caffeinate.lock"), b"").unwrap();
         std::fs::write(paths.data_dir.join("caffeinate.pid"), b"99999").unwrap();
-        std::fs::write(paths.data_dir.join("instances.json.lock"), b"").unwrap();
-        // instances.json is NOT pre-planted; read_or_rebuild will create it,
-        // then sweep_stale_artifacts must remove it.
         std::fs::create_dir_all(paths.data_dir.join("the-architect.locks")).unwrap();
         std::fs::write(
             paths
@@ -1524,37 +1431,13 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         prune_all_instances(&paths, &mut runner).unwrap();
 
         assert!(
-            !paths.data_dir.join("jk-abc123-thearchitect.lock").exists(),
-            "instance launch lock should be removed"
-        );
-        assert!(
-            !paths.data_dir.join("caffeinate.lock").exists(),
-            "caffeinate mutex lock should be removed"
-        );
-        assert!(
-            !paths.data_dir.join("caffeinate.pid").exists(),
-            "caffeinate pid file should be removed"
-        );
-        assert!(
-            !paths.data_dir.join("instances.json.lock").exists(),
-            "instances.json.lock should be removed"
-        );
-        assert!(
-            !paths.data_dir.join("instances.json").exists(),
-            "instances.json should be removed"
-        );
-        assert!(
-            !paths.data_dir.join("the-architect.locks").exists(),
-            "repo locks dir should be removed"
-        );
-        assert!(
             !paths.data_dir.exists(),
-            "data_dir itself should be removed when empty"
+            "data_dir should be completely removed"
         );
     }
 
     #[test]
-    fn prune_all_instances_sweeps_even_when_index_empty() {
+    fn prune_all_instances_removes_data_dir_when_index_empty() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         std::fs::create_dir_all(&paths.data_dir).unwrap();
@@ -1566,44 +1449,20 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         ]);
         prune_all_instances(&paths, &mut runner).unwrap();
 
-        assert!(
-            !paths.data_dir.join("jk-stale.lock").exists(),
-            "stale lock swept even with empty index"
-        );
-        assert!(
-            !paths.data_dir.exists(),
-            "data_dir removed when only stale locks present"
-        );
+        assert!(!paths.data_dir.exists(), "data_dir removed");
     }
 
     // ── prune_jackin_home ────────────────────────────────────────────────────
 
     #[test]
-    fn prune_jackin_home_removes_empty_dir() {
-        let temp = tempdir().unwrap();
-        let paths = JackinPaths::for_tests(temp.path());
-        std::fs::create_dir_all(&paths.jackin_home).unwrap();
-
-        prune_jackin_home(&paths);
-
-        assert!(
-            !paths.jackin_home.exists(),
-            "empty jackin_home should be removed"
-        );
-    }
-
-    #[test]
-    fn prune_jackin_home_does_not_remove_non_empty_dir() {
+    fn prune_jackin_home_removes_home() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         std::fs::create_dir_all(paths.jackin_home.join("leftover")).unwrap();
 
         prune_jackin_home(&paths);
 
-        assert!(
-            paths.jackin_home.exists(),
-            "jackin_home with remaining content must survive"
-        );
+        assert!(!paths.jackin_home.exists(), "jackin_home should be removed");
     }
 
     #[test]

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -593,32 +593,36 @@ fn sweep_stale_artifacts(data_dir: &std::path::Path) {
         }
     };
     for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().into_owned();
+        let raw_name = entry.file_name();
+        let name = raw_name.to_string_lossy();
         let Ok(ft) = entry.file_type() else { continue };
-        let has_ext = |s: &str| {
-            std::path::Path::new(&name)
-                .extension()
-                .is_some_and(|e| e.eq_ignore_ascii_case(s))
-        };
+        let ext = std::path::Path::new(name.as_ref())
+            .extension()
+            .map(std::ffi::OsStr::to_ascii_lowercase);
+        let ext_str = ext
+            .as_deref()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or("");
+        let path = entry.path();
         if ft.is_file()
-            && (has_ext("lock") || has_ext("pid") || name == "instances.json")
-            && let Err(err) = std::fs::remove_file(entry.path())
+            && (ext_str == "lock" || ext_str == "pid" || name == "instances.json")
+            && let Err(err) = std::fs::remove_file(&path)
             && err.kind() != std::io::ErrorKind::NotFound
         {
             eprintln!(
                 "  {} could not remove {}: {err}",
                 "warning:".yellow().bold(),
-                entry.path().display()
+                path.display()
             );
         } else if ft.is_dir()
-            && has_ext("locks")
-            && let Err(err) = std::fs::remove_dir_all(entry.path())
+            && ext_str == "locks"
+            && let Err(err) = std::fs::remove_dir_all(&path)
             && err.kind() != std::io::ErrorKind::NotFound
         {
             eprintln!(
                 "  {} could not remove {}: {err}",
                 "warning:".yellow().bold(),
-                entry.path().display()
+                path.display()
             );
         }
     }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -593,19 +593,16 @@ fn sweep_stale_artifacts(data_dir: &std::path::Path) {
         }
     };
     for entry in entries.flatten() {
-        let raw_name = entry.file_name();
-        let name = raw_name.to_string_lossy();
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
         let Ok(ft) = entry.file_type() else { continue };
         let ext = std::path::Path::new(name.as_ref())
             .extension()
-            .map(std::ffi::OsStr::to_ascii_lowercase);
-        let ext_str = ext
-            .as_deref()
             .and_then(std::ffi::OsStr::to_str)
             .unwrap_or("");
         let path = entry.path();
         if ft.is_file()
-            && (ext_str == "lock" || ext_str == "pid" || name == "instances.json")
+            && (ext == "lock" || ext == "pid" || name == "instances.json")
             && let Err(err) = std::fs::remove_file(&path)
             && err.kind() != std::io::ErrorKind::NotFound
         {
@@ -615,7 +612,7 @@ fn sweep_stale_artifacts(data_dir: &std::path::Path) {
                 path.display()
             );
         } else if ft.is_dir()
-            && ext_str == "locks"
+            && ext == "locks"
             && let Err(err) = std::fs::remove_dir_all(&path)
             && err.kind() != std::io::ErrorKind::NotFound
         {

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -307,6 +307,25 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.cache_dir, "shared cache")
 }
 
+/// Remove the jackin home directory if it is empty. Called as the last step of
+/// `prune system --all` after instances, images, roles, and cache are removed.
+/// Uses `remove_dir` (not `remove_dir_all`) so any surviving content prevents
+/// removal rather than being silently deleted.
+pub fn prune_jackin_home(paths: &JackinPaths) {
+    match std::fs::remove_dir(&paths.jackin_home) {
+        Ok(()) => println!("Removed jackin home ({}).", paths.jackin_home.display()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+        Err(err) => {
+            eprintln!(
+                "  {} could not remove {}: {err}",
+                "warning:".yellow().bold(),
+                paths.jackin_home.display()
+            );
+        }
+    }
+}
+
 /// Remove jk_* Docker images that have no jackin-managed role containers (running or stopped).
 ///
 /// Per-image `rmi` failures are printed to stderr and counted in the summary but do not

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -307,15 +307,18 @@ pub fn prune_cache(paths: &JackinPaths) -> anyhow::Result<()> {
     prune_dir(&paths.cache_dir, "shared cache")
 }
 
-/// Remove the jackin home directory if it is empty. Called as the last step of
-/// `prune system --all` after instances, images, roles, and cache are removed.
-/// Uses `remove_dir` (not `remove_dir_all`) so any surviving content prevents
+/// Uses `remove_dir` (not `remove_dir_all`) so surviving content prevents
 /// removal rather than being silently deleted.
 pub fn prune_jackin_home(paths: &JackinPaths) {
     match std::fs::remove_dir(&paths.jackin_home) {
         Ok(()) => println!("Removed jackin home ({}).", paths.jackin_home.display()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+        Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {
+            println!(
+                "jackin home ({}) not empty, leaving in place.",
+                paths.jackin_home.display()
+            );
+        }
         Err(err) => {
             eprintln!(
                 "  {} could not remove {}: {err}",
@@ -512,9 +515,12 @@ pub fn prune_all_instances(
 ) -> anyhow::Result<()> {
     exile_all(runner)?;
 
-    // With all containers gone, reconcile will stop caffeinate and remove its
-    // PID file. Must run before sweep_stale_artifacts so we SIGTERM the live
-    // process before deleting the only handle to it.
+    // reconcile must run before sweep_stale_artifacts: with all containers
+    // gone, reconcile will attempt to stop any live caffeinate process and
+    // remove its PID file. sweep_stale_artifacts unconditionally deletes
+    // *.pid files, so running it first would remove the PID file while
+    // caffeinate is still alive, leaving an orphaned process with no
+    // recoverable handle.
     super::caffeinate::reconcile(paths, runner);
 
     let index = InstanceIndex::read_or_rebuild(&paths.data_dir)?;
@@ -567,33 +573,66 @@ pub fn prune_all_instances(
         );
     }
 
-    sweep_stale_artifacts(&paths.data_dir);
+    if skipped.is_empty() {
+        sweep_stale_artifacts(&paths.data_dir);
+    }
     Ok(())
 }
 
-/// Remove all artifacts left behind after all instances are gone, then remove
-/// data_dir itself if empty. Best-effort: individual failures are silently
-/// ignored because this is housekeeping, not load-bearing state management.
 fn sweep_stale_artifacts(data_dir: &std::path::Path) {
-    let Ok(entries) = std::fs::read_dir(data_dir) else {
-        return;
+    let entries = match std::fs::read_dir(data_dir) {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+        Err(err) => {
+            eprintln!(
+                "  {} could not read {}: {err}",
+                "warning:".yellow().bold(),
+                data_dir.display()
+            );
+            return;
+        }
     };
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().into_owned();
         let Ok(ft) = entry.file_type() else { continue };
         if ft.is_file() {
             if name.ends_with(".lock") || name.ends_with(".pid") || name == "instances.json" {
-                let _ = std::fs::remove_file(entry.path());
+                if let Err(err) = std::fs::remove_file(entry.path()) {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        eprintln!(
+                            "  {} could not remove {}: {err}",
+                            "warning:".yellow().bold(),
+                            entry.path().display()
+                        );
+                    }
+                }
             }
         } else if ft.is_dir() && name.ends_with(".locks") {
-            let _ = std::fs::remove_dir_all(entry.path());
+            if let Err(err) = std::fs::remove_dir_all(entry.path()) {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    eprintln!(
+                        "  {} could not remove {}: {err}",
+                        "warning:".yellow().bold(),
+                        entry.path().display()
+                    );
+                }
+            }
         }
     }
-    // Remove the directory itself if it is now empty. `remove_dir` (not
-    // `remove_dir_all`) is intentional: if any entry was skipped above
+    // `remove_dir` (not `remove_dir_all`): if any entry was skipped above
     // (e.g. a failed-purge state dir), the directory is not empty and
     // `remove_dir` fails silently, leaving the partial state intact.
-    let _ = std::fs::remove_dir(data_dir);
+    if let Err(err) = std::fs::remove_dir(data_dir) {
+        if err.kind() != std::io::ErrorKind::NotFound
+            && err.kind() != std::io::ErrorKind::DirectoryNotEmpty
+        {
+            eprintln!(
+                "  {} could not remove {}: {err}",
+                "warning:".yellow().bold(),
+                data_dir.display()
+            );
+        }
+    }
 }
 
 fn ensure_role_resources_absent_for_purge(
@@ -1454,19 +1493,17 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         assert!(msg.contains("child"), "got: {msg}");
     }
 
-    // ── sweep_stale_artifacts ────────────────────────────────────────────────
-
     #[test]
     fn prune_all_instances_sweeps_orphaned_lock_files_and_locks_dirs() {
         let temp = tempdir().unwrap();
         let paths = JackinPaths::for_tests(temp.path());
         std::fs::create_dir_all(&paths.data_dir).unwrap();
-
-        // Plant the kinds of stale artifacts that accumulate in data_dir.
         std::fs::write(paths.data_dir.join("jk-abc123-thearchitect.lock"), b"").unwrap();
         std::fs::write(paths.data_dir.join("caffeinate.lock"), b"").unwrap();
         std::fs::write(paths.data_dir.join("caffeinate.pid"), b"99999").unwrap();
         std::fs::write(paths.data_dir.join("instances.json.lock"), b"").unwrap();
+        // instances.json is NOT pre-planted; read_or_rebuild will create it,
+        // then sweep_stale_artifacts must remove it.
         std::fs::create_dir_all(paths.data_dir.join("the-architect.locks")).unwrap();
         std::fs::write(
             paths
@@ -1477,9 +1514,6 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         )
         .unwrap();
 
-        // FakeRunner: exile_all calls docker ps -a to list managed containers
-        // (returns empty), then caffeinate reconcile calls docker ps (returns
-        // empty — no keep-awake agents). No instances in index.
         let mut runner = FakeRunner::with_capture_queue([
             String::new(), // exile_all: docker ps -a (no managed containers)
             String::new(), // caffeinate reconcile: docker ps keep-awake check
@@ -1503,6 +1537,10 @@ jk-a1b2c3d4-myworkspace-agentsmith"
             "instances.json.lock should be removed"
         );
         assert!(
+            !paths.data_dir.join("instances.json").exists(),
+            "instances.json should be removed"
+        );
+        assert!(
             !paths.data_dir.join("the-architect.locks").exists(),
             "repo locks dir should be removed"
         );
@@ -1519,8 +1557,6 @@ jk-a1b2c3d4-myworkspace-agentsmith"
         std::fs::create_dir_all(&paths.data_dir).unwrap();
         std::fs::write(paths.data_dir.join("jk-stale.lock"), b"").unwrap();
 
-        // No instances in index; exile_all and caffeinate reconcile each make
-        // one docker ps call.
         let mut runner = FakeRunner::with_capture_queue([
             String::new(), // exile_all
             String::new(), // caffeinate reconcile
@@ -1535,5 +1571,43 @@ jk-a1b2c3d4-myworkspace-agentsmith"
             !paths.data_dir.exists(),
             "data_dir removed when only stale locks present"
         );
+    }
+
+    // ── prune_jackin_home ────────────────────────────────────────────────────
+
+    #[test]
+    fn prune_jackin_home_removes_empty_dir() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        std::fs::create_dir_all(&paths.jackin_home).unwrap();
+
+        prune_jackin_home(&paths);
+
+        assert!(
+            !paths.jackin_home.exists(),
+            "empty jackin_home should be removed"
+        );
+    }
+
+    #[test]
+    fn prune_jackin_home_does_not_remove_non_empty_dir() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        std::fs::create_dir_all(paths.jackin_home.join("leftover")).unwrap();
+
+        prune_jackin_home(&paths);
+
+        assert!(
+            paths.jackin_home.exists(),
+            "jackin_home with remaining content must survive"
+        );
+    }
+
+    #[test]
+    fn prune_jackin_home_is_ok_when_absent() {
+        let temp = tempdir().unwrap();
+        let paths = JackinPaths::for_tests(temp.path());
+        // jackin_home never created — must not panic
+        prune_jackin_home(&paths);
     }
 }

--- a/src/runtime/cleanup.rs
+++ b/src/runtime/cleanup.rs
@@ -595,43 +595,45 @@ fn sweep_stale_artifacts(data_dir: &std::path::Path) {
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().into_owned();
         let Ok(ft) = entry.file_type() else { continue };
-        if ft.is_file() {
-            if name.ends_with(".lock") || name.ends_with(".pid") || name == "instances.json" {
-                if let Err(err) = std::fs::remove_file(entry.path()) {
-                    if err.kind() != std::io::ErrorKind::NotFound {
-                        eprintln!(
-                            "  {} could not remove {}: {err}",
-                            "warning:".yellow().bold(),
-                            entry.path().display()
-                        );
-                    }
-                }
-            }
-        } else if ft.is_dir() && name.ends_with(".locks") {
-            if let Err(err) = std::fs::remove_dir_all(entry.path()) {
-                if err.kind() != std::io::ErrorKind::NotFound {
-                    eprintln!(
-                        "  {} could not remove {}: {err}",
-                        "warning:".yellow().bold(),
-                        entry.path().display()
-                    );
-                }
-            }
+        let has_ext = |s: &str| {
+            std::path::Path::new(&name)
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case(s))
+        };
+        if ft.is_file()
+            && (has_ext("lock") || has_ext("pid") || name == "instances.json")
+            && let Err(err) = std::fs::remove_file(entry.path())
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "  {} could not remove {}: {err}",
+                "warning:".yellow().bold(),
+                entry.path().display()
+            );
+        } else if ft.is_dir()
+            && has_ext("locks")
+            && let Err(err) = std::fs::remove_dir_all(entry.path())
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "  {} could not remove {}: {err}",
+                "warning:".yellow().bold(),
+                entry.path().display()
+            );
         }
     }
     // `remove_dir` (not `remove_dir_all`): if any entry was skipped above
     // (e.g. a failed-purge state dir), the directory is not empty and
     // `remove_dir` fails silently, leaving the partial state intact.
-    if let Err(err) = std::fs::remove_dir(data_dir) {
-        if err.kind() != std::io::ErrorKind::NotFound
-            && err.kind() != std::io::ErrorKind::DirectoryNotEmpty
-        {
-            eprintln!(
-                "  {} could not remove {}: {err}",
-                "warning:".yellow().bold(),
-                data_dir.display()
-            );
-        }
+    if let Err(err) = std::fs::remove_dir(data_dir)
+        && err.kind() != std::io::ErrorKind::NotFound
+        && err.kind() != std::io::ErrorKind::DirectoryNotEmpty
+    {
+        eprintln!(
+            "  {} could not remove {}: {err}",
+            "warning:".yellow().bold(),
+            data_dir.display()
+        );
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,7 +23,7 @@ pub use self::attach::{
 pub use self::caffeinate::reconcile as reconcile_keep_awake;
 pub use self::cleanup::{
     eject_role, exile_all, prune_all_instances, prune_cache, prune_images, prune_instances,
-    prune_roles, purge_class_data, purge_container_state,
+    prune_jackin_home, prune_roles, purge_class_data, purge_container_state,
 };
 pub(crate) use self::discovery::list_role_names;
 pub use self::discovery::{


### PR DESCRIPTION
## Summary

- `prune system --all` and `prune instances --all` now remove all managed state completely: after ejecting all Docker containers and stopping caffeinate, each instance's isolation state is cleaned up, then `data_dir` is removed entirely via `remove_dir_all`
- `prune system --all` additionally removes the jackin home directory itself after all steps succeed — nothing is left on disk
- `prune_jackin_home` is guarded behind `--all`; `prune system` (without `--all`) leaves the home directory in place
- Added `jackin_home: PathBuf` field to `JackinPaths`, correctly derived from the same `JACKIN_HOME_DIR` override as `data_dir`/`roles_dir`/`cache_dir`
- Updated `docs/commands/prune.mdx` to document that `--all` removes the runtime home directory entirely

**Hard-rule callout:** All cleanup is scoped to paths under `jackin_home` (`~/.jackin`). Config at `~/.config/jackin/` is never touched. `caffeinate::reconcile` is macOS-only and only SIGTERMs a process jackin itself spawned.

**What's deferred:** `prune instances` (without `--all`) does not remove `data_dir` — there may be running instances with live lock files. Only the `--all` path, which first ejects every container, is safe to nuke `data_dir`.

## Verify locally

```bash
# export TIRITH=0
cargo run --bin jackin -- console --debug
# launch a role, then:
cargo run --bin jackin -- prune system --all --yes --debug
ls -la ~/.jackin/
# ~/.jackin/ directory should be gone entirely
```

## Migration notes

No schema changes.