### PR TITLE
fix(runtime): configure container tmux for agent keyboard and terminal compatibility

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -336,9 +336,8 @@ printf '\033[2J\033[H'
 # adds no value and clutters the agent's full-screen UI.
 tmux set-option -g status off 2>/dev/null || true
 
-# `always` instead of `on`: none of the supported agents (claude, codex, amp,
-# kimi, opencode) emit the per-app activation escape, so `on` would have no
-# effect — Shift+Enter would still collapse to plain Enter.
+# `always` not `on`: agents don't emit the per-app activation escape, so `on`
+# silently fails to forward Shift+Enter.
 tmux set-option -s extended-keys always
 # Paired with extended-keys: advertises extkeys to xterm*-TERM panes so their
 # terminfo queries confirm support.

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -336,31 +336,19 @@ printf '\033[2J\033[H'
 # adds no value and clutters the agent's full-screen UI.
 tmux set-option -g status off 2>/dev/null || true
 
-# Agent-friendly tmux settings. All are set unconditionally and all failures are
-# suppressed — an older tmux that doesn't know a flag stays functional, it just
-# lacks that capability.
+# `|| true` keeps startup working on tmux versions that don't recognise a flag.
 #
-# extended-keys always: forward Shift+Enter, Ctrl+Space, and other modified-key
-# sequences (CSI-u / xterm modifyOtherKeys format) to the agent without waiting
-# for the agent to opt in via an activation escape. Without this, the container
-# tmux collapses Shift+Enter to plain Enter before the agent sees it.
+# `always` instead of `on`: agents don't emit the per-app activation escape, so
+# `on` would have no effect — Shift+Enter would still collapse to plain Enter.
 tmux set-option -s extended-keys always 2>/dev/null || true
-# Advertise extkeys capability to panes whose TERM matches xterm* so the
-# agent's terminfo query confirms support.
+# Paired with extended-keys: advertises extkeys to xterm*-TERM panes so their
+# terminfo queries confirm support.
 tmux set-option -as terminal-features 'xterm*:extkeys' 2>/dev/null || true
-# focus-events: emit FocusIn/FocusOut escape sequences to panes so editors
-# (Neovim, Helix, etc.) running alongside an agent can autoread files the
-# agent modified while the editor pane was in the background.
 tmux set-option -g focus-events on 2>/dev/null || true
-# allow-passthrough: let OSC/DCS sequences wrapped in the DCS passthrough
-# envelope reach the outer terminal — covers desktop notifications, progress
-# bars, OSC 52 clipboard writes, and iTerm2/Ghostty inline images from inside
-# the container session.
+# Container panes cannot reach the outer terminal's OSC surface without this;
+# agent desktop notifications and progress bars are silently dropped otherwise.
 tmux set-option -g allow-passthrough on 2>/dev/null || true
-# escape-time 0: eliminate the 500 ms ambiguity window tmux uses to decide
-# whether a bare Escape is a prefix or a standalone key. Agents send Escape
-# frequently (vi-mode, TUI navigation); the default delay makes the UI feel
-# sluggish and can cause misfired key sequences.
+# Default 500 ms Escape disambiguation misfires in agent TUI vi-mode navigation.
 tmux set-option -sg escape-time 0 2>/dev/null || true
 
 exec "${LAUNCH[@]}"

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -336,4 +336,31 @@ printf '\033[2J\033[H'
 # adds no value and clutters the agent's full-screen UI.
 tmux set-option -g status off 2>/dev/null || true
 
+# Agent-friendly tmux settings. All are set unconditionally and all failures are
+# suppressed — an older tmux that doesn't know a flag stays functional, it just
+# lacks that capability.
+#
+# extended-keys always: forward Shift+Enter, Ctrl+Space, and other modified-key
+# sequences (CSI-u / xterm modifyOtherKeys format) to the agent without waiting
+# for the agent to opt in via an activation escape. Without this, the container
+# tmux collapses Shift+Enter to plain Enter before the agent sees it.
+tmux set-option -s extended-keys always 2>/dev/null || true
+# Advertise extkeys capability to panes whose TERM matches xterm* so the
+# agent's terminfo query confirms support.
+tmux set-option -as terminal-features 'xterm*:extkeys' 2>/dev/null || true
+# focus-events: emit FocusIn/FocusOut escape sequences to panes so editors
+# (Neovim, Helix, etc.) running alongside an agent can autoread files the
+# agent modified while the editor pane was in the background.
+tmux set-option -g focus-events on 2>/dev/null || true
+# allow-passthrough: let OSC/DCS sequences wrapped in the DCS passthrough
+# envelope reach the outer terminal — covers desktop notifications, progress
+# bars, OSC 52 clipboard writes, and iTerm2/Ghostty inline images from inside
+# the container session.
+tmux set-option -g allow-passthrough on 2>/dev/null || true
+# escape-time 0: eliminate the 500 ms ambiguity window tmux uses to decide
+# whether a bare Escape is a prefix or a standalone key. Agents send Escape
+# frequently (vi-mode, TUI navigation); the default delay makes the UI feel
+# sluggish and can cause misfired key sequences.
+tmux set-option -sg escape-time 0 2>/dev/null || true
+
 exec "${LAUNCH[@]}"

--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -336,19 +336,19 @@ printf '\033[2J\033[H'
 # adds no value and clutters the agent's full-screen UI.
 tmux set-option -g status off 2>/dev/null || true
 
-# `|| true` keeps startup working on tmux versions that don't recognise a flag.
-#
-# `always` instead of `on`: agents don't emit the per-app activation escape, so
-# `on` would have no effect — Shift+Enter would still collapse to plain Enter.
-tmux set-option -s extended-keys always 2>/dev/null || true
+# `always` instead of `on`: none of the supported agents (claude, codex, amp,
+# kimi, opencode) emit the per-app activation escape, so `on` would have no
+# effect — Shift+Enter would still collapse to plain Enter.
+tmux set-option -s extended-keys always
 # Paired with extended-keys: advertises extkeys to xterm*-TERM panes so their
 # terminfo queries confirm support.
-tmux set-option -as terminal-features 'xterm*:extkeys' 2>/dev/null || true
-tmux set-option -g focus-events on 2>/dev/null || true
+tmux set-option -as terminal-features 'xterm*:extkeys'
+tmux set-option -g focus-events on
 # Container panes cannot reach the outer terminal's OSC surface without this;
 # agent desktop notifications and progress bars are silently dropped otherwise.
-tmux set-option -g allow-passthrough on 2>/dev/null || true
-# Default 500 ms Escape disambiguation misfires in agent TUI vi-mode navigation.
-tmux set-option -sg escape-time 0 2>/dev/null || true
+tmux set-option -g allow-passthrough on
+# Escape disambiguation delay causes misfired key sequences in agent TUI
+# vi-mode navigation.
+tmux set-option -sg escape-time 0
 
 exec "${LAUNCH[@]}"

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
                 { label: 'GitHub CLI Authentication', slug: 'guides/authentication/github-cli' },
               ],
             },
+            { label: 'Running inside tmux', slug: 'guides/tmux' },
             { label: 'Security Model', slug: 'guides/security-model' },
             { label: 'Comparison', slug: 'guides/comparison' },
           ],

--- a/docs/src/content/docs/commands/console.mdx
+++ b/docs/src/content/docs/commands/console.mdx
@@ -60,3 +60,7 @@ The console intentionally stays narrower. **New niche flags and detail-level opt
 | **Where new niche flags land** | Rarely | First, and sometimes exclusively |
 
 For a deeper operator workflow around fresh instances versus multiple agent sessions inside one running instance, see [Parallel Agents](/guides/parallel-agents/).
+
+## Running inside tmux
+
+If you run `jackin console` from within a tmux session, your host tmux needs a small amount of configuration for agents to receive the correct keyboard and terminal experience — specifically `extended-keys always` so that Shift+Enter is not collapsed to plain Enter before it reaches the agent. See [Running inside tmux](/guides/tmux/) for the required settings and an explanation of each one.

--- a/docs/src/content/docs/guides/tmux.mdx
+++ b/docs/src/content/docs/guides/tmux.mdx
@@ -15,7 +15,7 @@ These settings apply to the **host tmux** — the session you start `jackin cons
 Add the following lines to your `~/.tmux.conf`:
 
 ```sh
-# Pass Shift+Enter and other modified keys through to the agent (tmux 3.2+)
+# Pass Shift+Enter and other modified keys through to the agent (tmux 3.2a+)
 set -s extended-keys always
 set -as terminal-features 'xterm*:extkeys'
 
@@ -43,9 +43,9 @@ If you also want mouse scrollback and pane interaction, add `set -g mouse on`. T
 
 tmux by default collapses modifier+key combinations before forwarding them to the inner pane. Shift+Enter arrives at the agent as plain Enter, which submits the prompt instead of inserting a newline.
 
-`set -s extended-keys always` forwards extended key sequences (xterm CSI-u / `modifyOtherKeys` format) unconditionally, without waiting for the inner app to opt in via an activation escape. `set -as terminal-features 'xterm*:extkeys'` advertises that capability to inner panes so their terminfo queries confirm support.
+`set -s extended-keys always` forwards extended key sequences (`modifyOtherKeys` format) unconditionally, without waiting for the inner app to opt in via an activation escape. `set -as terminal-features 'xterm*:extkeys'` advertises that capability to inner panes so their terminfo queries confirm support.
 
-**Requires tmux 3.2 or later.**
+**Requires tmux 3.2a or later.**
 
 ### `focus-events` — editor file reloads
 
@@ -53,7 +53,7 @@ When enabled, tmux emits `FocusIn` and `FocusOut` escape sequences to the active
 
 ### `allow-passthrough on` — desktop notifications and progress bars
 
-Agents emit OSC escape sequences for desktop notifications, progress bars, and clipboard updates. tmux intercepts and drops these by default. With `allow-passthrough on`, tmux forwards DCS-wrapped passthrough sequences to the outer terminal so they reach iTerm2, Ghostty, Kitty, etc.
+tmux-aware tools (Claude Code, iTerm2 inline images, etc.) wrap their OSC sequences in a DCS passthrough escape when they detect `$TMUX`. With `allow-passthrough on`, tmux forwards those DCS-wrapped sequences to the outer terminal so desktop notifications, progress bars, and clipboard writes reach iTerm2, Ghostty, Kitty, etc. Tools that emit raw OSC without DCS wrapping require `allow-passthrough all` (tmux 3.4+) instead.
 
 **Requires tmux 3.3 or later.**
 

--- a/docs/src/content/docs/guides/tmux.mdx
+++ b/docs/src/content/docs/guides/tmux.mdx
@@ -1,13 +1,13 @@
 ---
 title: Running inside tmux
-description: Host tmux settings required for Shift+Enter, focus events, and mouse support when running jackin' inside a tmux session
+description: Host tmux settings required for Shift+Enter, focus events, and mouse support when running jackin inside a tmux session
 ---
-import { Aside, Steps } from '@astrojs/starlight/components'
+import { Aside } from '@astrojs/starlight/components'
 
 If you run `jackin console` inside a tmux session, a few host-side tmux settings are required for agents to receive the full keyboard and terminal experience they expect. Without them, Shift+Enter collapses to plain Enter, focus events are lost, and desktop notifications never reach your terminal.
 
 <Aside type="note">
-These settings apply to the **host tmux** — the session you start `jackin console` inside. The container's internal tmux is configured automatically by jackin'; you do not need to touch it.
+These settings apply to the **host tmux** — the session you start `jackin console` inside. The container's internal tmux is configured automatically by jackin; you do not need to touch it.
 </Aside>
 
 ## Required configuration
@@ -16,14 +16,11 @@ Add the following lines to your `~/.tmux.conf`:
 
 ```sh
 # Pass Shift+Enter and other modified keys through to the agent (tmux 3.2+)
-set -s extended-keys on
+set -s extended-keys always
 set -as terminal-features 'xterm*:extkeys'
 
 # Let editors know when their pane gains or loses focus
 set -g focus-events on
-
-# Mouse: scrollback scrolling, pane click and resize
-set -g mouse on
 
 # Pass OSC sequences through to the outer terminal (desktop notifications, progress bars)
 set -g allow-passthrough on
@@ -38,40 +35,39 @@ Reload without restarting tmux:
 tmux source-file ~/.tmux.conf
 ```
 
+If you also want mouse scrollback and pane interaction, add `set -g mouse on`. This is a personal preference — some operators prefer scroll events to reach the terminal emulator directly.
+
 ## What each setting does
 
 ### `extended-keys` — fixes Shift+Enter
 
 tmux by default collapses modifier+key combinations before forwarding them to the inner pane. Shift+Enter arrives at the agent as plain Enter, which submits the prompt instead of inserting a newline.
 
-`set -s extended-keys on` tells tmux to recognise and re-emit extended key sequences (the xterm CSI-u / `modifyOtherKeys` format). `set -as terminal-features 'xterm*:extkeys'` advertises that capability to inner panes so their terminfo queries confirm support.
+`set -s extended-keys always` forwards extended key sequences (xterm CSI-u / `modifyOtherKeys` format) unconditionally, without waiting for the inner app to opt in via an activation escape. `set -as terminal-features 'xterm*:extkeys'` advertises that capability to inner panes so their terminfo queries confirm support.
 
-**Requires tmux 3.2 or later.** If Shift+Enter still misfires after reloading, switch to `extended-keys always` — that variant forwards extended keys unconditionally without waiting for the inner app to opt in.
+**Requires tmux 3.2 or later.**
 
 ### `focus-events` — editor file reloads
 
 When enabled, tmux emits `FocusIn` and `FocusOut` escape sequences to the active pane when the tmux window gains or loses OS focus. Editors running alongside an agent (Neovim, Helix, etc.) use these events to re-read files that the agent modified while the editor was in the background, keeping the display current without a manual reload.
 
-### `mouse on` — scrollback and pane interaction
-
-Enables scroll-wheel scrollback through tmux's buffer, pane selection by click, and pane-border resizing by drag. Without it, scroll events pass through to the inner application as raw characters, which either does nothing or inserts garbage in a shell pane.
-
 ### `allow-passthrough on` — desktop notifications and progress bars
 
-Agents write desktop notifications, progress bars, and clipboard updates as OSC escape sequences wrapped in the DCS passthrough envelope. tmux silently drops these by default. With `allow-passthrough on`, they reach your outer terminal (iTerm2, Ghostty, Kitty, etc.) and behave as expected.
+Agents emit OSC escape sequences for desktop notifications, progress bars, and clipboard updates. tmux intercepts and drops these by default. With `allow-passthrough on`, tmux forwards DCS-wrapped passthrough sequences to the outer terminal so they reach iTerm2, Ghostty, Kitty, etc.
+
+**Requires tmux 3.3 or later.**
 
 ### `escape-time 0` — Escape key latency
 
-tmux waits up to 500 ms after a bare Escape to decide whether it is a key prefix or a standalone key. Agents use Escape constantly for TUI navigation (vi-mode, modal editors, menu dismissal), and the default delay makes the interface feel sluggish. Setting this to 0 removes the ambiguity window.
+tmux waits after a bare Escape to decide whether it is a key prefix or a standalone key. Agents use Escape constantly for TUI navigation (vi-mode, modal editors, menu dismissal), and the delay causes misfired key sequences. Setting this to 0 removes the ambiguity window.
 
 ## Version requirements
 
 | Setting | Minimum tmux version |
 |---|---|
-| `extended-keys on` | 3.2 |
 | `extended-keys always` | 3.2a |
 | `terminal-features` | 3.2 |
-| `allow-passthrough on` | 3.2 |
+| `allow-passthrough on` | 3.3 |
 | `focus-events on` | 1.8 |
 | `mouse on` (unified) | 2.1 |
 

--- a/docs/src/content/docs/guides/tmux.mdx
+++ b/docs/src/content/docs/guides/tmux.mdx
@@ -1,0 +1,78 @@
+---
+title: Running inside tmux
+description: Host tmux settings required for Shift+Enter, focus events, and mouse support when running jackin' inside a tmux session
+---
+import { Aside, Steps } from '@astrojs/starlight/components'
+
+If you run `jackin console` inside a tmux session, a few host-side tmux settings are required for agents to receive the full keyboard and terminal experience they expect. Without them, Shift+Enter collapses to plain Enter, focus events are lost, and desktop notifications never reach your terminal.
+
+<Aside type="note">
+These settings apply to the **host tmux** — the session you start `jackin console` inside. The container's internal tmux is configured automatically by jackin'; you do not need to touch it.
+</Aside>
+
+## Required configuration
+
+Add the following lines to your `~/.tmux.conf`:
+
+```sh
+# Pass Shift+Enter and other modified keys through to the agent (tmux 3.2+)
+set -s extended-keys on
+set -as terminal-features 'xterm*:extkeys'
+
+# Let editors know when their pane gains or loses focus
+set -g focus-events on
+
+# Mouse: scrollback scrolling, pane click and resize
+set -g mouse on
+
+# Pass OSC sequences through to the outer terminal (desktop notifications, progress bars)
+set -g allow-passthrough on
+
+# Eliminate the Escape-key ambiguity delay — important for TUI agents
+set -sg escape-time 0
+```
+
+Reload without restarting tmux:
+
+```sh
+tmux source-file ~/.tmux.conf
+```
+
+## What each setting does
+
+### `extended-keys` — fixes Shift+Enter
+
+tmux by default collapses modifier+key combinations before forwarding them to the inner pane. Shift+Enter arrives at the agent as plain Enter, which submits the prompt instead of inserting a newline.
+
+`set -s extended-keys on` tells tmux to recognise and re-emit extended key sequences (the xterm CSI-u / `modifyOtherKeys` format). `set -as terminal-features 'xterm*:extkeys'` advertises that capability to inner panes so their terminfo queries confirm support.
+
+**Requires tmux 3.2 or later.** If Shift+Enter still misfires after reloading, switch to `extended-keys always` — that variant forwards extended keys unconditionally without waiting for the inner app to opt in.
+
+### `focus-events` — editor file reloads
+
+When enabled, tmux emits `FocusIn` and `FocusOut` escape sequences to the active pane when the tmux window gains or loses OS focus. Editors running alongside an agent (Neovim, Helix, etc.) use these events to re-read files that the agent modified while the editor was in the background, keeping the display current without a manual reload.
+
+### `mouse on` — scrollback and pane interaction
+
+Enables scroll-wheel scrollback through tmux's buffer, pane selection by click, and pane-border resizing by drag. Without it, scroll events pass through to the inner application as raw characters, which either does nothing or inserts garbage in a shell pane.
+
+### `allow-passthrough on` — desktop notifications and progress bars
+
+Agents write desktop notifications, progress bars, and clipboard updates as OSC escape sequences wrapped in the DCS passthrough envelope. tmux silently drops these by default. With `allow-passthrough on`, they reach your outer terminal (iTerm2, Ghostty, Kitty, etc.) and behave as expected.
+
+### `escape-time 0` — Escape key latency
+
+tmux waits up to 500 ms after a bare Escape to decide whether it is a key prefix or a standalone key. Agents use Escape constantly for TUI navigation (vi-mode, modal editors, menu dismissal), and the default delay makes the interface feel sluggish. Setting this to 0 removes the ambiguity window.
+
+## Version requirements
+
+| Setting | Minimum tmux version |
+|---|---|
+| `extended-keys on` | 3.2 |
+| `extended-keys always` | 3.2a |
+| `terminal-features` | 3.2 |
+| `allow-passthrough on` | 3.2 |
+| `focus-events on` | 1.8 |
+| `mouse on` (unified) | 2.1 |
+
+Check your version with `tmux -V`. On macOS, the system tmux (from Xcode Command Line Tools) is typically too old — install a current version via Homebrew: `brew install tmux`.

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -138,6 +138,22 @@ This means terminal-specific features (such as Ghostty's Kitty keyboard protocol
 
 If the export fails (e.g. `infocmp` is not installed or the terminfo entry is missing), jackin' falls back to `xterm-256color`.
 
+## In-session tmux configuration
+
+Beyond `$TERM` forwarding, the entrypoint applies five tmux session options immediately before exec-ing the agent. The construct image ships Debian trixie tmux (3.5+), so all options are applied unconditionally — no version guard or error suppression.
+
+| Option | Why |
+|---|---|
+| `extended-keys always` | Agents don't emit the per-app activation escape that `on` waits for, so `on` silently fails to forward Shift+Enter. `always` bypasses the opt-in. |
+| `terminal-features 'xterm*:extkeys'` | Paired with `extended-keys`: advertises `modifyOtherKeys` capability to panes so their terminfo queries confirm support. |
+| `focus-events on` | Emits `FocusIn`/`FocusOut` sequences so editors (Neovim, Helix, etc.) reload agent-written files on pane focus return. |
+| `allow-passthrough on` | Container panes cannot reach the outer terminal's OSC surface without this. tmux-aware tools (Claude Code, etc.) wrap their OSC sequences in DCS passthrough when `$TMUX` is set; this option forwards them to the outer terminal. Tools that emit raw OSC without wrapping need `allow-passthrough all` (tmux 3.4+). |
+| `escape-time 0` | Removes the Escape disambiguation delay that misfires in agent TUI vi-mode navigation. |
+
+Implementation: <RepoFile path="docker/runtime/entrypoint.sh" /> (lines at the bottom of the script, before `exec`).
+
+Operators running `jackin console` from inside their own tmux session need matching host-side configuration so that modified keys are forwarded through the host tmux before they reach the container. See the [Running inside tmux](/guides/tmux/) operator guide.
+
 ## Workspace materialization
 
 Workspace mounts pass through three distinct shapes between operator intent and a Docker bind-mount. Keeping these separate is what lets per-mount isolation slot in cleanly:


### PR DESCRIPTION
## Summary

Configures the container's tmux session with five settings that AI coding agents require but were previously missing. The construct image pins Debian trixie tmux (3.5+), so all options are unconditional — no error suppression needed, and a misconfigured option aborts startup loudly rather than silently degrading keyboard behavior. Settings added: `extended-keys always` (fixes Shift+Enter collapsing to plain Enter; `always` is required because agents don't emit the per-app activation escape that `on` waits for), `terminal-features 'xterm*:extkeys'` (advertises `modifyOtherKeys` capability to inner panes), `focus-events on` (editors reload agent-written files on focus return), `allow-passthrough on` (forwards DCS-wrapped OSC sequences — desktop notifications, progress bars, clipboard writes — to the outer terminal; tmux-aware tools like Claude Code wrap automatically when `$TMUX` is set), and `escape-time 0` (removes Escape disambiguation delay that misfires in agent TUI vi-mode navigation). Adds a new operator guide page explaining the matching host-side tmux configuration.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/tmux-agent-keyboard:refs/remotes/origin/fix/tmux-agent-keyboard
git checkout -B fix/tmux-agent-keyboard refs/remotes/origin/fix/tmux-agent-keyboard
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-tmux"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-tmux"
just construct-build-local
export JACKIN_CONSTRUCT_IMAGE="jackin-local/construct:trixie"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run --all-features
```

### User smoke

From inside an existing tmux session on the host (add the host-side config from the new guide first — see Documentation step below):

```sh
cargo run --bin jackin -- console --debug
```

Launch an agent session and verify:
- Shift+Enter inserts a newline inside Claude Code rather than submitting the prompt
- Escape key responds without a noticeable delay in TUI navigation
- Desktop notifications from Claude Code appear in the host terminal (if your outer terminal supports OSC notifications)

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/guides/tmux/**
New page. Verify it appears in the Operator Guide sidebar between Authentication and Security Model, that the required-configuration code block matches the five settings above, that the `allow-passthrough on` section correctly explains DCS wrapping and mentions `allow-passthrough all` for tools that emit raw OSC, and that the version requirements table shows 3.2a for `extended-keys always` and 3.3 for `allow-passthrough on`.

## Migration notes

None.