### PR TITLE
feat(role): add published-image subcommand to jackin-role

### DIFF
--- a/src/bin/role.rs
+++ b/src/bin/role.rs
@@ -23,6 +23,8 @@ enum Command {
     Migrate(RoleRepoPathArgs),
     /// Print the construct image version tag pinned in the role Dockerfile
     ConstructVersion(RoleRepoPathArgs),
+    /// Print the published Docker image declared in the role manifest
+    PublishedImage(RoleRepoPathArgs),
 }
 
 fn main() -> ExitCode {
@@ -31,6 +33,7 @@ fn main() -> ExitCode {
         Command::Validate(args) => role_authoring::run(RoleCommand::Validate(args)),
         Command::Migrate(args) => role_authoring::run(RoleCommand::Migrate(args)),
         Command::ConstructVersion(args) => role_authoring::run(RoleCommand::ConstructVersion(args)),
+        Command::PublishedImage(args) => role_authoring::run(RoleCommand::PublishedImage(args)),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/src/cli/role.rs
+++ b/src/cli/role.rs
@@ -128,6 +128,9 @@ pub enum RoleCommand {
     /// Print the construct image version tag pinned in the role Dockerfile
     #[command(before_help = BANNER, styles = HELP_STYLES)]
     ConstructVersion(RoleRepoPathArgs),
+    /// Print the published Docker image declared in the role manifest
+    #[command(before_help = BANNER, styles = HELP_STYLES)]
+    PublishedImage(RoleRepoPathArgs),
 }
 
 /// Role repository path argument shared by `validate` and `migrate`.

--- a/src/role_authoring.rs
+++ b/src/role_authoring.rs
@@ -13,6 +13,7 @@ pub fn run(command: RoleCommand) -> anyhow::Result<()> {
         RoleCommand::Migrate(args) => migrate(args),
         RoleCommand::Create(args) => create(&args),
         RoleCommand::ConstructVersion(args) => construct_version(args),
+        RoleCommand::PublishedImage(args) => published_image(args),
     }
 }
 
@@ -27,6 +28,17 @@ fn construct_version(args: RoleRepoPathArgs) -> anyhow::Result<()> {
     let repo_dir = resolve_repo_path(args.path)?;
     let validated = validate_role_repo(&repo_dir)?;
     println!("{}", validated.dockerfile.construct_version);
+    Ok(())
+}
+
+fn published_image(args: RoleRepoPathArgs) -> anyhow::Result<()> {
+    let repo_dir = resolve_repo_path(args.path)?;
+    let validated = validate_role_repo(&repo_dir)?;
+    let image = validated
+        .manifest
+        .published_image
+        .ok_or_else(|| anyhow::anyhow!("no published_image declared in jackin.role.toml"))?;
+    println!("{image}");
     Ok(())
 }
 
@@ -272,5 +284,52 @@ mod tests {
     #[test]
     fn display_name_title_cases_slug_words() {
         assert_eq!(display_name("backend-engineer"), "Backend Engineer");
+    }
+
+    #[test]
+    fn published_image_prints_declared_image() {
+        let temp = tempdir().unwrap();
+        write_scaffold_with_manifest(
+            temp.path(),
+            r#"version = "v1alpha3"
+dockerfile = "Dockerfile"
+published_image = "docker.io/myorg/my-role"
+
+[claude]
+plugins = []
+"#,
+        );
+        published_image(RoleRepoPathArgs {
+            path: Some(temp.path().to_path_buf()),
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn published_image_errors_when_not_declared() {
+        let temp = tempdir().unwrap();
+        write_scaffold_with_manifest(
+            temp.path(),
+            r#"version = "v1alpha3"
+dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+        );
+        let err = published_image(RoleRepoPathArgs {
+            path: Some(temp.path().to_path_buf()),
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("no published_image"), "{err:#}");
+    }
+
+    fn write_scaffold_with_manifest(path: &Path, manifest: &str) {
+        std::fs::write(
+            path.join("Dockerfile"),
+            "FROM projectjackin/construct:0.2-trixie\n",
+        )
+        .unwrap();
+        std::fs::write(path.join("jackin.role.toml"), manifest).unwrap();
     }
 }

--- a/tests/role_cli.rs
+++ b/tests/role_cli.rs
@@ -124,3 +124,46 @@ fn role_create_normalizes_namespaced_role_to_lowercase() {
     let readme = std::fs::read_to_string(repo.join("README.md")).unwrap();
     assert!(readme.contains("`chainargos/backend`"), "{readme}");
 }
+
+#[test]
+fn role_published_image_prints_declared_image() {
+    let temp = tempfile::tempdir().unwrap();
+    write_role_repo(
+        temp.path(),
+        r#"version = "v1alpha3"
+dockerfile = "Dockerfile"
+published_image = "docker.io/myorg/my-role"
+
+[claude]
+plugins = []
+"#,
+    );
+
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .args(["role", "published-image", temp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("docker.io/myorg/my-role\n");
+}
+
+#[test]
+fn role_published_image_errors_when_not_declared() {
+    let temp = tempfile::tempdir().unwrap();
+    write_role_repo(
+        temp.path(),
+        r#"version = "v1alpha3"
+dockerfile = "Dockerfile"
+
+[claude]
+plugins = []
+"#,
+    );
+
+    Command::cargo_bin("jackin")
+        .unwrap()
+        .args(["role", "published-image", temp.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no published_image"));
+}


### PR DESCRIPTION
Add `jackin-role published-image` (and `jackin role published-image`) subcommand that reads `published_image` from `jackin.role.toml` and prints it to stdout. Exits non-zero with a clear error when the field is absent. Mirrors the existing `construct-version` subcommand in shape and implementation.

This command will be used by the upcoming `jackin-role-action` publish reusable workflow to extract the image name from the manifest rather than requiring each role repo to repeat it in their workflow YAML.