### PR TITLE
fix(entrypoint): prevent blank line between git trailers in prepare-commit-msg

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -107,9 +107,17 @@ case "${2:-}" in
 esac
 
 # Append $2 trailer to commit-msg file $1 unless it is already present.
+# If the last non-empty line is already a trailer (Key: value), append
+# directly so the block stays contiguous. Otherwise prepend a blank line
+# to separate the new trailer from the body.
 _append_trailer() {
     if ! grep -qF "$2" "$1"; then
-        printf '\n%s\n' "$2" >> "$1" || {
+        _last=$(grep -v '^[[:space:]]*$' "$1" | tail -1)
+        if printf '%s' "$_last" | grep -qE '^[A-Za-z-]+: .+'; then
+            printf '%s\n' "$2" >> "$1"
+        else
+            printf '\n%s\n' "$2" >> "$1"
+        fi || {
             echo "[jackin prepare-commit-msg] ERROR: failed to append $3 to $1" >&2
             exit 1
         }


### PR DESCRIPTION
## Summary

- `_append_trailer` in the `prepare-commit-msg` hook used `printf '\n%s\n'` unconditionally, inserting a blank line before every trailer it appended
- This is correct for the first trailer (separates body from trailer block), but wrong for subsequent trailers — the blank line breaks the contiguous block that `git interpret-trailers` and GitHub expect
- Commits with both `JACKIN_GIT_COAUTHOR_TRAILER=1` and `JACKIN_GIT_DCO=1` produced `Co-authored-by` and `Signed-off-by` separated by a blank line, so GitHub did not link the co-author avatar and did not treat them as a single trailer block

Fix: before appending, check if the last non-empty line of the commit-msg file already matches `Key: value` (trailer pattern). If yes, append directly (no leading `\n`); if no, keep the `\n` separator to split from the body.

## Hard-rule callout

No host-side writes. The hook lives inside the container at `/jackin/state/git-hooks/prepare-commit-msg` and is written by `entrypoint.sh` on container startup — host git config is never touched.

## What's deferred

Nothing.

## Verify locally

```sh
export TIRITH=0
```

Inside a running jackin container with `JACKIN_GIT_COAUTHOR_TRAILER=1` and `JACKIN_GIT_DCO=1` set:

```sh
cd /some/repo
git commit --allow-empty -m "test: verify trailer contiguity"
git log -1 --format="%B" | tail -5
```

Expected — no blank line between trailers:
```
Co-authored-by: Claude <noreply@anthropic.com>
Signed-off-by: Your Name <you@example.com>
```

Also verify the single-trailer case still works (body → blank → trailer, not body → double-blank → trailer).

## Migration notes

None. The hook is regenerated from `entrypoint.sh` on every container start; existing containers pick up the fix on their next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)