### PR TITLE
feat(runtime): enable tmux mouse support in container

### DIFF
--- a/docker/runtime/entrypoint.sh
+++ b/docker/runtime/entrypoint.sh
@@ -357,5 +357,6 @@ tmux set-option -g allow-passthrough on
 # Escape disambiguation delay causes misfired key sequences in agent TUI
 # vi-mode navigation.
 tmux set-option -sg escape-time 0
+tmux set-option -g mouse on
 
 exec "${LAUNCH[@]}"


### PR DESCRIPTION
## Summary

Enables tmux mouse support inside jackin container sessions. Claude Code detects when it is running inside tmux and displays a hint recommending `set -g mouse on` when wheel scrolling is not configured. Setting `mouse on` via `tmux set-option -g mouse on` in `entrypoint.sh` — alongside the existing tmux options — silences that hint and gives operators natural wheel-scroll behaviour from the moment the container starts.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jk-a8bcky9v-jackin-thearchitect:refs/remotes/origin/jackin/scratch/jk-a8bcky9v-jackin-thearchitect
git checkout -B jackin/scratch/jk-a8bcky9v-jackin-thearchitect refs/remotes/origin/jackin/scratch/jk-a8bcky9v-jackin-thearchitect
```

### User smoke

```sh
cargo run --bin jackin -- console --debug
```

Launch a container session and verify: (1) Claude Code no longer shows the "add `set -g mouse on` to `~/.tmux.conf`" hint in the status bar, and (2) wheel scroll moves the pane contents as expected.
