### PR TITLE
ci: upgrade Zig 0.13.0 → 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         if: matrix.zigbuild
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
-          version: "0.13.0"
+          version: "0.16.0"
 
       - name: Install cargo-zigbuild
         if: matrix.zigbuild

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
-          version: "0.13.0"
+          version: "0.16.0"
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:


### PR DESCRIPTION
## Summary

Upgrades Zig from 0.13.0 to 0.16.0 (latest stable per ziglang.org — GitHub releases API lags behind) in both `ci.yml` and `preview.yml`. This also addresses the macOS cross-compilation failure where `iana-time-zone` couldn't find `-framework CoreFoundation` with Zig 0.13.0.

## Hard-rule callout

CI-only change. No schema, host-side, or user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)