### PR TITLE
fix(preview): correct macOS SDK download URL (26.1 release tag)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -143,24 +143,15 @@ jobs:
           # runner is needed. jackin has no Objective-C or Xcode-SDK-only
           # C deps — bollard uses hyperlocal (Unix socket), iana-time-zone
           # links -framework CoreFoundation which Zig stubs cover.
-          # macOS: -undefined dynamic_lookup defers unresolved framework
-          # symbols (e.g. CoreFoundation) to runtime. Zig ships C stdlib
-          # stubs only — Apple framework stubs are not bundled. The flag
-          # is safe here because all referenced frameworks (CoreFoundation
-          # via iana-time-zone) are guaranteed present on any macOS host.
           - target: aarch64-apple-darwin
             zigbuild_target: aarch64-apple-darwin
-            extra_rustflags: "-C link-arg=-undefined -C link-arg=dynamic_lookup"
           - target: x86_64-apple-darwin
             zigbuild_target: x86_64-apple-darwin
-            extra_rustflags: "-C link-arg=-undefined -C link-arg=dynamic_lookup"
           # Linux targets: glibc 2.17 minimum for broad host compatibility.
           - target: aarch64-unknown-linux-gnu
             zigbuild_target: aarch64-unknown-linux-gnu.2.17
-            extra_rustflags: ""
           - target: x86_64-unknown-linux-gnu
             zigbuild_target: x86_64-unknown-linux-gnu.2.17
-            extra_rustflags: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -179,10 +170,31 @@ jobs:
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:
           tool: cargo-zigbuild
+      - name: Create macOS framework stubs
+        if: contains(matrix.target, 'apple')
+        run: |
+          # Zig ships C stdlib stubs but not Apple framework stubs.
+          # CoreFoundation (pulled by iana-time-zone) is always present
+          # on real macOS, so a minimal empty stub here satisfies the
+          # MachO linker's framework-exists check at compile time.
+          # -undefined dynamic_lookup defers symbol resolution to runtime.
+          stub_dir=/tmp/macos-framework-stubs
+          mkdir -p "${stub_dir}/CoreFoundation.framework"
+          cat > "${stub_dir}/CoreFoundation.framework/CoreFoundation.tbd" <<'TBD'
+          --- !tapi-tbd
+          tbd-version:     4
+          targets:         [ x86_64-macos, arm64-macos ]
+          install-name:    '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
+          current-version: 1454.90
+          exports:
+            - targets:     [ x86_64-macos, arm64-macos ]
+              symbols:     []
+          ...
+          TBD
+          echo "RUSTFLAGS=-C link-arg=-F${stub_dir} -C link-arg=-undefined -C link-arg=dynamic_lookup" >> "$GITHUB_ENV"
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}
-          RUSTFLAGS: ${{ matrix.extra_rustflags }}
         run: cargo zigbuild --release --locked --target "$ZIGBUILD_TARGET"
       - name: Package
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -138,11 +138,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # macOS targets cross-compiled from Linux via cargo-zigbuild.
-          # Zig ships macOS SDK stubs (framework libs, libc) so no macOS
-          # runner is needed. jackin has no Objective-C or Xcode-SDK-only
-          # C deps — bollard uses hyperlocal (Unix socket), iana-time-zone
-          # links -framework CoreFoundation which Zig stubs cover.
+          # macOS targets cross-compiled from Linux via cargo-zigbuild +
+          # real macOS SDK. Zig respects SDKROOT for framework lookups;
+          # SDK sourced from joseluisq/macosx-sdks, cached between runs.
           - target: aarch64-apple-darwin
             zigbuild_target: aarch64-apple-darwin
           - target: x86_64-apple-darwin
@@ -170,28 +168,22 @@ jobs:
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
         with:
           tool: cargo-zigbuild
-      - name: Create macOS framework stubs
+      - name: Cache macOS SDK
         if: contains(matrix.target, 'apple')
+        id: sdk-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/macos-sdk
+          key: macos-sdk-15.5
+      - name: Download macOS SDK
+        if: contains(matrix.target, 'apple') && steps.sdk-cache.outputs.cache-hit != 'true'
         run: |
-          # Zig ships C stdlib stubs but not Apple framework stubs.
-          # CoreFoundation (pulled by iana-time-zone) is always present
-          # on real macOS, so a minimal empty stub here satisfies the
-          # MachO linker's framework-exists check at compile time.
-          # -undefined dynamic_lookup defers symbol resolution to runtime.
-          stub_dir=/tmp/macos-framework-stubs
-          mkdir -p "${stub_dir}/CoreFoundation.framework"
-          cat > "${stub_dir}/CoreFoundation.framework/CoreFoundation.tbd" <<'TBD'
-          --- !tapi-tbd
-          tbd-version:     4
-          targets:         [ x86_64-macos, arm64-macos ]
-          install-name:    '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
-          current-version: 1454.90
-          exports:
-            - targets:     [ x86_64-macos, arm64-macos ]
-              symbols:     []
-          ...
-          TBD
-          echo "RUSTFLAGS=-C link-arg=-F${stub_dir} -C link-arg=-undefined -C link-arg=dynamic_lookup" >> "$GITHUB_ENV"
+          mkdir -p /tmp/macos-sdk
+          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX15.5.sdk.tar.xz" \
+            | tar -xJ -C /tmp/macos-sdk
+      - name: Set macOS SDKROOT
+        if: contains(matrix.target, 'apple')
+        run: echo "SDKROOT=/tmp/macos-sdk/MacOSX15.5.sdk" >> "$GITHUB_ENV"
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -179,7 +179,7 @@ jobs:
         if: contains(matrix.target, 'apple') && steps.sdk-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/macos-sdk
-          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX26.1.sdk.tar.xz" \
+          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/26.1/MacOSX26.1.sdk.tar.xz" \
             | tar -xJ -C /tmp/macos-sdk
       - name: Set macOS SDKROOT
         if: contains(matrix.target, 'apple')

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -183,7 +183,11 @@ jobs:
             | tar -xJ -C /tmp/macos-sdk
       - name: Set macOS SDKROOT
         if: contains(matrix.target, 'apple')
-        run: echo "SDKROOT=/tmp/macos-sdk/MacOSX26.1.sdk" >> "$GITHUB_ENV"
+        run: |
+          echo "SDKROOT=/tmp/macos-sdk/MacOSX26.1.sdk" >> "$GITHUB_ENV"
+          # Pin deployment target so the binary runs on macOS 12+ even
+          # though we build with the latest SDK.
+          echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> "$GITHUB_ENV"
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -174,16 +174,16 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/macos-sdk
-          key: macos-sdk-15.5
+          key: macos-sdk-26.1
       - name: Download macOS SDK
         if: contains(matrix.target, 'apple') && steps.sdk-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/macos-sdk
-          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX15.5.sdk.tar.xz" \
+          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX26.1.sdk.tar.xz" \
             | tar -xJ -C /tmp/macos-sdk
       - name: Set macOS SDKROOT
         if: contains(matrix.target, 'apple')
-        run: echo "SDKROOT=/tmp/macos-sdk/MacOSX15.5.sdk" >> "$GITHUB_ENV"
+        run: echo "SDKROOT=/tmp/macos-sdk/MacOSX26.1.sdk" >> "$GITHUB_ENV"
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}


### PR DESCRIPTION
## Summary

Fixes broken macOS SDK download URL introduced in #403.

**Bug:** `replace_all` on `"15.5"` only updated the `actions/cache` key (`macos-sdk-15.5` → `macos-sdk-26.1`) but left the GitHub release tag in the download URL unchanged:

```
# Wrong (404):
releases/download/15.5/MacOSX26.1.sdk.tar.xz

# Fixed:
releases/download/26.1/MacOSX26.1.sdk.tar.xz
```

## Hard-rule callout

CI-only fix. No schema or user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)