### PR TITLE
fix(preview): correct macOS SDK download URL (26.1 release tag)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -179,7 +179,7 @@ jobs:
         if: contains(matrix.target, 'apple') && steps.sdk-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/macos-sdk
-          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/15.5/MacOSX26.1.sdk.tar.xz" \
+          curl -fsSL "https://github.com/joseluisq/macosx-sdks/releases/download/26.1/MacOSX26.1.sdk.tar.xz" \
             | tar -xJ -C /tmp/macos-sdk
       - name: Set macOS SDKROOT
         if: contains(matrix.target, 'apple')


### PR DESCRIPTION
One-line fix: release tag in download URL was still `15.5` after the SDK version bump. URL now correctly uses `26.1` as the release tag.