### PR TITLE
ci: migrate cargo tool installs to jdx/mise-action with cargo: backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
           # below; leaving the action's default RUSTFLAGS would also
           # apply it to `cargo build`/`cargo check`/`cargo nextest run`.
           rustflags: ""
-      - uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo-nextest
+          tool: cargo:cargo-nextest@0.9.136
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -170,9 +170,9 @@ jobs:
 
       - name: Install cargo-zigbuild
         if: matrix.zigbuild
-        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo-zigbuild
+          tool: cargo:cargo-zigbuild@0.22.3
 
       - name: Build validator
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
           rustflags: ""
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo:cargo-nextest@0.9.136
+          install_args: "cargo:cargo-nextest"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -162,17 +163,12 @@ jobs:
           cache-key: validator-${{ matrix.target }}
           rustflags: ""
 
-      - name: Install Zig
+      - name: Install Zig and cargo-zigbuild
         if: matrix.zigbuild
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: zig@0.16.0
-
-      - name: Install cargo-zigbuild
-        if: matrix.zigbuild
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          tool: cargo:cargo-zigbuild@0.22.3
+          install_args: "zig cargo:cargo-zigbuild"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build validator
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: "cargo:cargo-nextest"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -168,7 +168,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: "zig cargo:cargo-zigbuild"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
 
       - name: Build validator
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -164,7 +164,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: "zig cargo:cargo-zigbuild"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - name: Cache macOS SDK
         if: contains(matrix.target, 'apple')
         id: sdk-cache

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -160,14 +160,11 @@ jobs:
           target: ${{ matrix.target }}
           cache-key: preview-${{ matrix.target }}
           rustflags: ""
-      - name: Install Zig
+      - name: Install Zig and cargo-zigbuild
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: zig@0.16.0
-      - name: Install cargo-zigbuild
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          tool: cargo:cargo-zigbuild@0.22.3
+          install_args: "zig cargo:cargo-zigbuild"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache macOS SDK
         if: contains(matrix.target, 'apple')
         id: sdk-cache

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -165,9 +165,9 @@ jobs:
         with:
           tool: zig@0.16.0
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo-zigbuild
+          tool: cargo:cargo-zigbuild@0.22.3
       - name: Cache macOS SDK
         if: contains(matrix.target, 'apple')
         id: sdk-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,9 @@ jobs:
         with:
           # Toolchain channel comes from rust-toolchain.toml.
           rustflags: ""
-      - uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2.79.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo-nextest
+          tool: cargo:cargo-nextest@0.9.136
       - run: cargo nextest run
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
           rustflags: ""
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          tool: cargo:cargo-nextest@0.9.136
+          install_args: "cargo:cargo-nextest"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo nextest run
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: "cargo:cargo-nextest"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - run: cargo nextest run
 
   build:

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,8 @@ bun = "1.3.14"
 just = "1.51.0"
 node = "24.15.0"
 zig = "0.16.0"
+"cargo:cargo-nextest" = "0.9.136"
+"cargo:cargo-zigbuild" = "0.22.3"
 # rust is read from `rust-toolchain.toml` via the `idiomatic_version_file`
 # setting below — single source of truth for the toolchain channel.
 


### PR DESCRIPTION
## Summary

Completes the migration to `jdx/mise-action` (Node.js 24) by replacing the remaining `taiki-e/install-action` usages with `jdx/mise-action` using the `cargo:` backend.

**Why `cargo:` prefix works where plain `tool: cargo-nextest` failed:** The `cargo:` backend routes through `cargo install`, placing the binary directly into `~/.cargo/bin/` which is already in PATH from `setup-rust-toolchain`. Cargo subcommand discovery finds `cargo-nextest` there without relying on mise shims.

**Trade-off:** `cargo:` backend builds from source on cache miss. mise caches the install directory between runs, so only the first run (or a version bump) pays the build cost. Subsequent runs get a cache hit and install in seconds.

**mise.toml** gains `"cargo:cargo-nextest" = "0.9.136"` and `"cargo:cargo-zigbuild" = "0.22.3"` so developers can run `mise install` locally and get the exact same tool versions as CI.

All three workflows now use only `jdx/mise-action` for tool installation — no more `taiki-e/install-action` or `mlugg/setup-zig`.

## Hard-rule callout

CI-only change (plus mise.toml tool version declarations). No schema or user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)