### PR TITLE
ci: pin cargo-zigbuild version in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 bun = "1.3.14"
 "cargo:cargo-nextest" = "0.9.136"
+"cargo:cargo-zigbuild" = "0.22.3"
 just = "1.51.0"
 node = "24.15.0"
 zig = "0.16.0"


### PR DESCRIPTION
## Summary

Fixes the `build-validator (aarch64-unknown-linux-gnu)` CI job that began failing after #415 switched tool installation to `jdx/mise-action`. That PR pinned `cargo:cargo-nextest` in `mise.toml` but omitted `cargo-zigbuild`, which the aarch64 matrix leg installs via `install_args`. Mise requires a version entry in `mise.toml` for any tool not specified inline — without it the shim invocation fails with `No version is set for shim: cargo-zigbuild`. Adding `"cargo:cargo-zigbuild" = "0.22.3"` (current latest on crates.io) restores the same pattern used for `cargo-nextest`.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jk-sjbgrwe5-jackin-thearchitect:refs/remotes/origin/jackin/scratch/jk-sjbgrwe5-jackin-thearchitect
git checkout -B jackin/scratch/jk-sjbgrwe5-jackin-thearchitect refs/remotes/origin/jackin/scratch/jk-sjbgrwe5-jackin-thearchitect
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Tests

```sh
cargo nextest run --all-features
```