### PR TITLE
docs(roadmap): link the four Phase 2 split-* design pages from codebase-readability.mdx

### DIFF
--- a/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
+++ b/docs/src/content/docs/reference/roadmap/codebase-readability.mdx
@@ -157,6 +157,17 @@ Split the largest files. Snapshot tests (Phase 1) and DRY extractions (Phase 1.5
 
 The original Phase 2 listed 4 files. The deep audit found **33 files exceed 800 lines**, with **28 files exceeding 1000 lines** (re-baked 2026-05-18).
 
+### Design pages
+
+The four Tier A files with the longest history under this program already have dedicated split-plan pages — they describe the proposed module shape, the existing call sites that block a naïve split, and the snapshot/test gates required before the move:
+
+- [Split `runtime/launch.rs`](/reference/roadmap/split-runtime-launch/) — 7966L, the hardest file in the codebase
+- [Split `console/manager/input/editor.rs`](/reference/roadmap/split-input-editor/) — 4002L, one file per editor tab
+- [Split `operator_env.rs`](/reference/roadmap/split-operator-env/) — 3573L, separate shared API, CLI client, env resolution, diagnostics, and picker metadata
+- [Split `app/mod.rs`](/reference/roadmap/split-app-mod/) — 2932L, separate dispatch from workspace/config command handlers
+
+The remaining Tier A/B/C entries below do not yet have dedicated design pages; the LOC measurements and risk notes are the current planning surface for them.
+
 ### Tier A — files over 2000 lines (14 files, highest priority)
 
 | File | LOC | Key risk | Mega-functions inside |


### PR DESCRIPTION
## Summary

PR #337's deep-audit rewrite of Phase 2 swapped a single linked-name table for the current Tier A/B/C LOC tables and lost the leaf links to the four existing split-* roadmap pages (`split-runtime-launch`, `split-input-editor`, `split-operator-env`, `split-app-mod`). The pages stayed in the sidebar, but the parent program doc and the roadmap overview no longer reached them — so an operator browsing Codebase health → Phase 2 saw the LOC measurements with no path to the design plans those measurements had motivated. Three subsequent re-bakes (#355, #366, #387) did not re-introduce the links. This PR adds a short "Design pages" subsection at the top of Phase 2 in `codebase-readability.mdx` linking each of the four pages with its LOC and one-line scope, and notes that the remaining Tier A/B/C entries do not yet have dedicated pages. The Tier A/B/C tables themselves stay unchanged.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/roadmap-orphan-split-pages:refs/remotes/origin/fix/roadmap-orphan-split-pages
git checkout -B fix/roadmap-orphan-split-pages refs/remotes/origin/fix/roadmap-orphan-split-pages
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Page to walk:

**http://localhost:4321/reference/roadmap/codebase-readability/#phase-2--file-splits-confirmation-required**  
UPDATED page. New "Design pages" subsection sits between the Phase 2 intro paragraph and the "Tier A — files over 2000 lines" heading. Confirm the four bullet links resolve to the matching split-* roadmap pages and that the Tier A/B/C tables below render unchanged. Sidebar entry is unchanged under **Reference → Roadmap → Codebase health → Phase 2 — File splits**.
