### PR TITLE
ci: restore colored cargo and nextest output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -110,7 +111,7 @@ jobs:
       # running nextest both with and without it would re-execute every
       # non-feature-gated test for no extra coverage.
       - run: cargo check --all-targets
-      - run: cargo nextest run --all-features
+      - run: cargo nextest run --all-features --color=always
 
   msrv:
     needs: changes
@@ -123,6 +124,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -162,6 +164,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     strategy:
       matrix:
         include:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -135,6 +135,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -73,7 +74,7 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-
-      - run: cargo nextest run
+      - run: cargo nextest run --color=always
 
   build:
     needs: [check-version, test]
@@ -94,6 +95,7 @@ jobs:
       VERSION: ${{ needs.check-version.outputs.version }}
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10


### PR DESCRIPTION
## Summary

\`actions-rust-lang/setup-rust-toolchain\` set \`CARGO_TERM_COLOR=always\` implicitly as part of its setup. PR #415 replaced it with \`jdx/mise-action\`, which does not set that variable, silently disabling color in all Rust CI job output (cargo compilation lines and nextest test results). Adds \`CARGO_TERM_COLOR: always\` to every Rust job env block in \`ci.yml\`, \`preview.yml\`, and \`release.yml\`, and passes \`--color=always\` to \`cargo nextest run\` since nextest has its own color detection independent of \`CARGO_TERM_COLOR\`.

## Verify locally

### Checkout

Paste this first to bypass the \`tirith\` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin jackin/scratch/jk-sjbgrwe5-jackin-thearchitect:refs/remotes/origin/jackin/scratch/jk-sjbgrwe5-jackin-thearchitect
git checkout -B jackin/scratch/jk-sjbgrwe5-jackin-thearchitect refs/remotes/origin/jackin/scratch/jk-sjbgrwe5-jackin-thearchitect
```

Observe the \`check\` CI job logs after this PR merges — cargo \`Compiling ...\` lines and nextest test result lines should appear in color.