### PR TITLE
ci: speed up builds with mold linker, zigbuild everywhere, and GHA cache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.x86_64-unknown-linux-gnu]
+# mold is 5-10x faster than ld at the link step. Installed via apt in CI;
+# on dev machines: sudo apt-get install mold (Ubuntu 22.04+).
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - run: rustup component add rustfmt clippy
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-
-      - run: rustup component add rustfmt clippy
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -94,14 +95,23 @@ jobs:
       # republished after merge to main. Build the construct image locally and
       # tag it as projectjackin/construct:trixie so the E2E test uses the
       # updated image rather than pulling the outdated one from the registry.
+      - name: Set up Docker Buildx for E2E cache
+        if: needs.changes.outputs.construct == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Expose GitHub Actions cache runtime
+        if: needs.changes.outputs.construct == 'true'
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Build construct image for E2E
         if: needs.changes.outputs.construct == 'true'
         run: |
           set -a && source docker/construct/versions.env && set +a
-          DOCKER_BUILDKIT=1 docker build \
+          docker buildx build \
+            --cache-from type=gha,scope=construct-ci-e2e \
+            --cache-to type=gha,scope=construct-ci-e2e,mode=max \
             --build-arg SHELLFIRM_VERSION="$SHELLFIRM_VERSION" \
             --build-arg TIRITH_VERSION="$TIRITH_VERSION" \
             --build-arg MISE_VERSION="$MISE_VERSION" \
+            --load \
             -t projectjackin/construct:trixie \
             docker/construct/
       # Verify the default-features compile path. Clippy above runs with
@@ -145,6 +155,8 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - name: cargo check on MSRV
         run: cargo check --workspace --all-targets --locked
         env:
@@ -169,6 +181,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            zigbuild: true
           - target: aarch64-unknown-linux-gnu
             zigbuild: true
     steps:
@@ -189,14 +202,11 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
 
       - name: Build validator
-        run: |
-          if [ "${{ matrix.zigbuild }}" = "true" ]; then
-            cargo zigbuild --release --locked --bin jackin-role --target aarch64-unknown-linux-gnu.2.17
-          else
-            cargo build --release --locked --bin jackin-role --target ${{ matrix.target }}
-          fi
+        run: cargo zigbuild --release --locked --bin jackin-role --target ${{ matrix.target }}.2.17
 
       - name: Package validator
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,7 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: mold
-          version: 1.0
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -159,10 +156,7 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: mold
-          version: 1.0
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - name: cargo check on MSRV
         run: cargo check --workspace --all-targets --locked
         env:
@@ -209,10 +203,7 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: mold
-          version: 1.0
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Build validator
         run: cargo zigbuild --release --locked --bin jackin-role --target ${{ matrix.target }}.2.17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,10 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        run: sudo apt-get install -y mold
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: mold
+          version: 1.0
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # When docker/construct/** changes, the published construct:trixie image
@@ -156,7 +159,10 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        run: sudo apt-get install -y mold
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: mold
+          version: 1.0
       - name: cargo check on MSRV
         run: cargo check --workspace --all-targets --locked
         env:
@@ -203,7 +209,10 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        run: sudo apt-get install -y mold
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: mold
+          version: 1.0
 
       - name: Build validator
         run: cargo zigbuild --release --locked --bin jackin-role --target ${{ matrix.target }}.2.17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - run: cargo nextest run --color=always
 
   build:
@@ -87,9 +89,10 @@ jobs:
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            zigbuild: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            cross: true
+            zigbuild: true
     runs-on: ${{ matrix.os }}
     env:
       VERSION: ${{ needs.check-version.outputs.version }}
@@ -115,19 +118,23 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
 
-      - name: Install cross
-        if: matrix.cross
+      - name: Install mold linker
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y mold
+
+      - name: Install cargo-zigbuild
+        if: matrix.zigbuild
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          install_args: "cargo:cross"
+          install_args: "zig cargo:cargo-zigbuild"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
 
       - name: Build
         env:
           JACKIN_VERSION_OVERRIDE: ${{ needs.check-version.outputs.version }}
         run: |
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --locked --target ${{ matrix.target }}
+          if [ "${{ matrix.zigbuild }}" = "true" ]; then
+            cargo zigbuild --release --locked --target ${{ matrix.target }}.2.17
           else
             cargo build --release --locked --target ${{ matrix.target }}
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,7 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: mold
-          version: 1.0
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - run: cargo nextest run --color=always
 
   build:
@@ -123,10 +120,7 @@ jobs:
 
       - name: Install mold linker
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: mold
-          version: 1.0
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install cargo-zigbuild
         if: matrix.zigbuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,10 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
       - name: Install mold linker
-        run: sudo apt-get install -y mold
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: mold
+          version: 1.0
       - run: cargo nextest run --color=always
 
   build:
@@ -120,7 +123,10 @@ jobs:
 
       - name: Install mold linker
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y mold
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: mold
+          version: 1.0
 
       - name: Install cargo-zigbuild
         if: matrix.zigbuild

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,10 @@ cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_sign_loss = "allow"
 cast_precision_loss = "allow"
+
+[profile.dev]
+# Line tables only: ~30-50% smaller artifacts, faster link, stack traces still work.
+debug = 1
+
+[profile.release]
+strip = "symbols"


### PR DESCRIPTION
## Summary

- **`.cargo/config.toml`** (new): mold linker for `x86_64-unknown-linux-gnu` — 5–10x faster link step vs default `ld`
- **`Cargo.toml`**: `[profile.dev] debug = 1` (line tables only, ~30–50% smaller artifacts, faster link) and `[profile.release] strip = "symbols"`
- **`ci.yml`**: install mold in `check`/`msrv`/`build-validator` jobs; remove redundant `rustup component add rustfmt clippy` (already declared in `rust-toolchain.toml components`); switch `build-validator` to `cargo zigbuild` for both Linux targets; add `docker/setup-buildx-action` + `ghaction-github-runtime` + GHA layer cache for the E2E Docker build (was building from scratch on every construct change)
- **`release.yml`**: install mold in `test` and Linux `build` jobs; replace `cross` with `cargo zigbuild` for all Linux targets (both `x86_64` and `aarch64-unknown-linux-gnu.2.17`), matching `preview.yml`'s approach

## Hard-rule callout

No host-side writes. No schema changes. No changelog entry (pre-release). No roadmap items affected.

## What's deferred

Nothing.

## Verify locally

```bash
export TIRITH=0
cargo build 2>&1 | head -5  # should use mold on Linux
```

Check CI passes on all jobs.

## Migration notes

None — CI-only changes plus build profile tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)