### PR TITLE
docs(roadmap): add attribution growth research

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -192,6 +192,7 @@ export default defineConfig({
                         { label: 'Console resource panel', slug: 'reference/roadmap/console-resource-panel' },
                         { label: 'Agent tag protocol', slug: 'reference/roadmap/agent-tag-protocol' },
                         { label: 'GitHub link tracking', slug: 'reference/roadmap/github-link-tracking' },
+                        { label: 'Public attribution and project growth', slug: 'reference/roadmap/public-attribution-and-growth' },
                         { label: 'Custom operator tools', slug: 'reference/roadmap/custom-operator-tools' },
                       ],
                     },

--- a/docs/src/content/docs/reference/roadmap.mdx
+++ b/docs/src/content/docs/reference/roadmap.mdx
@@ -94,6 +94,7 @@ jackin' is a functional proof of concept. **`Claude Code`, `Codex`, `Amp`, `Kimi
 ### Operator surface and fleet operations
 
 - **[Agent Orchestrator Research Program](/reference/roadmap/agent-orchestrator-research/)** — phased research program comparing jackin against `multicode`, Hazmat, Docker Sandboxes, Herdr, and adjacent devcontainer/native-worktree approaches. The fleet track covers live agent observability, per-instance persistent storage, declarative resource limits, autonomous task queue, remote operation, and skill mounts. The containment track adds [session contract and explain mode](/reference/roadmap/session-contract-explain-mode/), [stack integration contracts](/reference/roadmap/stack-integration-contracts/), [network egress policy](/reference/roadmap/network-egress-policy/), and [session snapshot and rollback](/reference/roadmap/session-snapshot-rollback/) so contributors can see the Hazmat/Docker Sandboxes research as actionable roadmap work rather than loose notes. The full leaf list lives in the program doc and the sidebar under **Reference → Roadmap → Agent Orchestrator Research**.
+- **[Public attribution and project growth](/reference/roadmap/public-attribution-and-growth/)** — research how jackin' can use visible software-development surfaces, especially Git commit trailers and PR metadata, to make the project discoverable without silently mutating operator repositories or misusing authorship semantics (status: open — research and design proposal)
 
 ### Codebase health
 

--- a/docs/src/content/docs/reference/roadmap/agent-orchestrator-research.mdx
+++ b/docs/src/content/docs/reference/roadmap/agent-orchestrator-research.mdx
@@ -301,6 +301,7 @@ same session contract and persistent storage decisions.
 | [Console resource panel](/reference/roadmap/console-resource-panel/) | CPU/RAM/disk polling | Resource limits (Phase 1) |
 | [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) | `<multicode:*>` skill-driven tags | Agent runtime status |
 | [GitHub link tracking](/reference/roadmap/github-link-tracking/) | GitHub polling + SQLite cache | Tag protocol; persistent storage (Phase 3) |
+| [Public attribution and project growth](/reference/roadmap/public-attribution-and-growth/) | Orca-style Git commit trailers and PR metadata as discoverability surfaces | Operator handler system; local repo policy |
 | [Custom operator tools](/reference/roadmap/custom-operator-tools/) | `[[tool]]` array (hotkey + exec/prompt) | Operator handler system (Phase 1) |
 
 ### Phase 3 — Persistence and telemetry

--- a/docs/src/content/docs/reference/roadmap/public-attribution-and-growth.mdx
+++ b/docs/src/content/docs/reference/roadmap/public-attribution-and-growth.mdx
@@ -1,0 +1,100 @@
+---
+title: "Public Attribution and Project Growth"
+---
+import RepoFile from '../../../../components/RepoFile.astro'
+
+**Status**: Open — research and design proposal (Phase 2, [Agent Orchestrator Research Program](/reference/roadmap/agent-orchestrator-research/))
+
+## Problem
+
+Jackin's strongest marketing channel is likely to be the work it helps operators ship, not paid promotion. When an agent uses jackin' to produce commits, PRs, issues, docs, or role repositories, the project can stay invisible unless the operator explicitly mentions it. Other agent tools are already using source-control metadata as a lightweight attribution surface: the Orca commit [`5ca6828`](https://github.com/stablyai/orca/commit/5ca68283715d74e5916a2f3b6dcd55b2702e2748) includes `Co-authored-by: Orca <help@stably.ai>` alongside human and agent trailers, making Orca visible in GitHub history and the commit UI.
+
+Jackin should research the same class of growth tactics, but the design needs a stricter bar than "add our name everywhere." Git commit trailers touch operator repositories, project attribution policies, authorship semantics, DCO flows, and trust. A promotional tactic that surprises the operator or pollutes downstream history would conflict with jackin's host-side-effects rule and do more damage than good.
+
+## Why It Matters
+
+- GitHub commit history is where AI-assisted development is already being inspected. A visible jackin' attribution can make the project discoverable at the exact moment a reader asks "what produced this work?"
+- Attribution can explain the orchestration layer separately from the model/runtime layer. A commit may be authored by a human, co-authored by Claude/Codex/Amp/OpenCode, and still have been safely provisioned by jackin'. Those are different claims and should not be collapsed accidentally.
+- Project growth helps the ecosystem. More operators means more role repos, more bug reports, more comparison data against adjacent tools, and more pressure to document the security boundary honestly.
+- The feature is easy to implement badly. The roadmap item exists so jackin' decides the product, ethical, legal, and repository-policy constraints before any code path starts modifying commit messages.
+
+## Research Inputs
+
+- Orca example: [`stablyai/orca@5ca6828`](https://github.com/stablyai/orca/commit/5ca68283715d74e5916a2f3b6dcd55b2702e2748) uses `Co-authored-by: Orca <help@stably.ai>` in a GitHub-visible commit trailer.
+- GitHub's supported multi-author mechanism is the [`Co-authored-by` commit trailer](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors).
+- Git's native trailer tooling is [`git interpret-trailers`](https://git-scm.com/docs/git-interpret-trailers), which should be preferred over ad-hoc string manipulation if jackin' ever edits commit messages.
+- Jackin's current repository policy already requires exactly one agent `Co-authored-by` trailer for AI-authored commits in this repo; see <RepoFile path="AGENTS.md" />. Any jackin' attribution mechanism must respect local project rules like that instead of assuming the product can append a second `Co-authored-by` line.
+
+## Recommended Research Shape
+
+Treat "public attribution" as a small project-growth program with commit trailers as one candidate, not the only tactic.
+
+### Candidate surfaces
+
+| Surface | Visibility | Risk | Notes |
+|---|---|---|---|
+| `Co-authored-by: jackin' ...` trailer | High on GitHub; can show in author UI | High | Implies authorship. Conflicts with repos that reserve `Co-authored-by` for people or agent runtimes. Should only be considered when jackin' materially generated or transformed the commit and the repo policy allows it. |
+| `Generated-with: jackin' <url>` trailer | Medium; visible in raw commit message | Medium | More semantically honest for orchestration, but GitHub does not currently elevate it in the UI. Good default candidate if the goal is attribution without authorship claims. |
+| `Orchestrated-by: jackin' <url>` trailer | Medium; visible in raw commit message | Medium | Best semantic fit for jackin's role as the container/session orchestrator. Needs ecosystem research because custom trailers vary by project. |
+| PR body footer | Medium; visible during review | Low | Operator-controlled and easy to remove. Can link to jackin' and explain the role/runtime/session context without touching immutable commit history. |
+| `agent tag protocol` emission | Operator-visible inside jackin' | Low | Helps jackin' track its own workflows but does not market externally unless mirrored into PR bodies or status checks. |
+| Docs/readme badge for role repos | Medium for role authors | Low | Role authors can opt in to "Built for jackin'" badges without affecting source history. |
+| GitHub App/status check name | High in PR checks | Medium | If jackin' later ships hosted/daemon-backed verification, a status context like `jackin/session` is discoverable and semantically clean. Not a near-term local-only feature. |
+
+### Decision criteria
+
+- **Operator consent.** Attribution must be opt-in at the workspace, role, or explicit command level. No launch, commit helper, PR helper, hook, or future daemon path silently writes promotional metadata into a host repo.
+- **Repository policy compatibility.** Jackin must detect or let the operator configure per-repo rules. If a repo says "exactly one `Co-authored-by` agent trailer," jackin' must not add a second one.
+- **Authorship honesty.** Use `Co-authored-by` only if the claim is accurate in the repo's social contract. Prefer a custom trailer or PR-body footer when jackin' orchestrated the environment but did not author the patch.
+- **Tooling correctness.** Use structured trailer handling (`git interpret-trailers` or a maintained Rust crate if one is clearly better) instead of hand-rolled trailer parsing.
+- **Removeability.** Operators need a one-command way to preview, add, remove, or disable attribution before publishing.
+- **Marketing usefulness.** Measure whether the tactic creates real discovery: issue mentions, repo stars, docs visits, role-repo adoption, or inbound PRs. Avoid history pollution that only creates vanity metrics.
+
+## Host-side Effects
+
+Commit trailers and PR-body footers can write to host-side repositories or remote PR metadata. That makes this roadmap item subject to the hard host-mutation rule in <RepoFile path="AGENTS.md" />.
+
+Any implementation must:
+
+- default to no host-side writes;
+- surface the exact write in the launch summary, commit preview, or PR preview before it happens;
+- require an explicit operator opt-in through a CLI flag, config setting, or confirmation prompt;
+- operate only on the repo/action the operator selected;
+- never install host Git hooks, mutate repo `.git/config`, rewrite existing history, or alter global Git/GitHub CLI config as a convenience path.
+
+## Scope (V1)
+
+- Research note comparing agent/product attribution practices across Orca, Claude Code, Codex, Amp, Cursor, OpenCode, and GitHub Copilot where observable from public commits or docs.
+- A design decision choosing the initial jackin' attribution surface: likely PR-body footer or custom `Orchestrated-by` trailer, with `Co-authored-by` gated behind stronger policy checks if kept at all.
+- A dry-run command or preview-only mode that shows the exact trailer/footer jackin' would add for the current repo and explains why it is or is not allowed.
+- Workspace/role-level opt-in that is off by default.
+- Tests around trailer parsing, local policy suppression, and no-op behavior when attribution is disabled.
+
+## Defer
+
+- Automatic trailer insertion during arbitrary `git commit` calls. Jackin should not become a host Git hook manager in V1.
+- Hosted analytics. Any measurement should start with public, aggregate signals or operator-submitted feedback, not hidden telemetry.
+- A GitHub App/status-check presence. Useful later, but it belongs after jackin' has a daemon/remote story that can honestly own a check run.
+- Cross-platform identity accounts such as a `jackin[bot]` GitHub App user. Decide only after the semantic trailer/footer choice is made.
+
+## Open Questions
+
+- Should jackin' ever use `Co-authored-by`, or should it reserve that trailer for the actual agent runtime and use `Orchestrated-by` / `Generated-with` for the product layer?
+- What should the canonical identity be: `jackin' <...>`, `Jackin <...>`, `jackin-project[bot] <...>`, or a real GitHub App noreply identity?
+- Should role authors be allowed to set a role-specific attribution line, or would that turn every role into a marketing channel with inconsistent policy?
+- Can jackin' infer a repo's trailer policy from local files such as <RepoFile path="AGENTS.md" />, <RepoFile path="COMMITS.md" />, or <RepoFile path="CONTRIBUTING.md" />, or should policy always be explicit config?
+- Is PR-body attribution more valuable because reviewers see it before merge, or less valuable because it disappears from the permanent Git history after squash merges?
+
+## Related Files
+
+- <RepoFile path="AGENTS.md" /> — current agent trailer policy for this repository
+- <RepoFile path="COMMITS.md" /> — commit-message rules that any jackin' helper must respect in this repository
+- Future module, e.g. `src/git/attribution.rs` — trailer/footer preview and policy evaluation if this ships
+- Future CLI surface, e.g. `jackin attribution preview` / `jackin attribution apply`
+
+## See Also
+
+- [Agent Orchestrator Research Program](/reference/roadmap/agent-orchestrator-research/)
+- [Agent tag protocol](/reference/roadmap/agent-tag-protocol/) — internal machine-readable markers for agent sessions
+- [GitHub link tracking](/reference/roadmap/github-link-tracking/) — GitHub-facing workflow awareness
+- [Operator handler system](/reference/roadmap/operator-handler-system/) — operator-mediated actions that can preview before opening/writing


### PR DESCRIPTION
## Summary

Adds a Public Attribution and Project Growth roadmap item for researching whether jackin' should use visible software-development surfaces, especially Git commit trailers and PR metadata, to make the project discoverable. The new roadmap page captures the Orca trailer example, compares attribution surfaces, sets consent and repository-policy constraints, and links the item into the roadmap overview, sidebar, and Agent Orchestrator Research Program.

## Hard rule: host-side effects stay explicit

The roadmap item explicitly applies the repository's host-mutation rule to any future attribution implementation: jackin' must not silently write promotional trailers, PR footers, Git hooks, repo config, or global Git/GitHub CLI state. Any future write must be previewed, scoped, opt-in, and tied to the operator-selected repo/action.

## What's deferred (follow-up PRs)

- Researching observable attribution behavior across Orca, Claude Code, Codex, Amp, Cursor, OpenCode, and GitHub Copilot.
- Choosing the first implementation surface, likely a PR-body footer or custom `Orchestrated-by` trailer rather than default `Co-authored-by` use.
- Implementing any dry-run/apply command, policy detection, or trailer mutation logic.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/public-attribution-growth:refs/remotes/origin/feature/public-attribution-growth
git checkout -B feature/public-attribution-growth refs/remotes/origin/feature/public-attribution-growth
```

### Static checks

```sh
cd docs
bun install --frozen-lockfile
bun run check:repo-links
bunx tsc --noEmit
```

### Tests

```sh
cd docs
bun test
bun run build
```

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/reference/roadmap/public-attribution-and-growth/**  
NEW page. Confirm the Orca trailer example, attribution-surface comparison table, host-side effects section, and V1/deferred scope render cleanly; the sidebar entry should appear under Behind jackin' — Internals → Roadmap → Agent Orchestrator Research → Fleet phase 2 — Live operator surface.

**http://localhost:4321/reference/roadmap/**  
UPDATED page. Confirm Public attribution and project growth appears under Planned → Operator surface and fleet operations.

**http://localhost:4321/reference/roadmap/agent-orchestrator-research/**  
UPDATED page. Confirm Public attribution and project growth appears in Track A Phase 2 with the Orca-style trailer/PR metadata summary.

## Migration notes

None.
