### PR TITLE
fix(isolation): keep clone mounts on source branch

### DIFF
--- a/docs/src/content/docs/guides/mounts.mdx
+++ b/docs/src/content/docs/guides/mounts.mdx
@@ -157,7 +157,7 @@ Workspace mounts can be marked **isolated** so that each container gets its own 
 |---|---|
 | `shared` (default) | Host path bind-mounted as-is. |
 | `worktree` | jackin' creates a per-container `git worktree` from the host repo. The container sees its own checkout and scratch branch; refs are shared with the host repo. |
-| `clone` | jackin' creates a per-container `git clone --local`. The container has its own `.git/` and independent refs. |
+| `clone` | jackin' creates a per-container `git clone --local` from the host repo's current branch. The container has its own `.git/` and independent refs; when the host repo has an `origin`, pushes from the container publish to that remote. |
 
 Set isolation per mount with `--mount-isolation <dst>=<type>` on `jackin workspace create` and `jackin workspace edit`. See [Per-mount isolation](/guides/workspaces/#per-mount-isolation) in the workspaces guide for the full validation rules and recommended patterns.
 

--- a/docs/src/content/docs/guides/workspaces.mdx
+++ b/docs/src/content/docs/guides/workspaces.mdx
@@ -118,9 +118,9 @@ Setting a mount's isolation to `worktree` tells jackin' to create a per-containe
 |---|---|
 | `shared` (default) | Host path bind-mounted as-is. |
 | `worktree` | A per-container `git worktree` is created from the host repo. The container sees its own checkout on a scratch branch; refs are still shared with the host repo, so branches the agent creates are visible to you immediately. |
-| `clone` | A per-container `git clone --local` is created. The container has its own `.git/` and independent refs; branches appear on your host only after an explicit push. |
+| `clone` | A per-container `git clone --local` is created from the host repo's current branch. The container has its own `.git/` and independent refs; when the host repo has an `origin`, pushes from the container publish to that remote rather than creating local branches in your host checkout. |
 
-Use `worktree` when you want immediate host-side branch visibility and you trust the agent with the host repo's `.git/`. Use `clone` when ref isolation matters more than immediate host visibility.
+Use `worktree` when you want immediate host-side branch visibility and you trust the agent with the host repo's `.git/`. Use `clone` when you want the same starting branch as the host checkout, but with refs isolated until the agent explicitly pushes.
 
 ### Setting isolation from the CLI
 
@@ -162,9 +162,9 @@ For the exact safety policy (which branches count as safe, how the squash-merged
 If a precondition is not met, the command fails with a clear error pointing at the offending mount.
 
 <Aside type="caution">
-The worktree branches from your host repo's current `HEAD`. If your
-host tree has uncommitted changes, those edits stay on the host —
-they do not travel into the agent's worktree. Pass
+Isolated checkouts start from your host repo's current `HEAD`. If
+your host tree has uncommitted changes, those edits stay on the host —
+they do not travel into the agent's worktree or clone. Pass
 `jackin load --force` (non-interactive) or confirm in the TUI to
 acknowledge that work-in-progress stays behind.
 </Aside>

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -164,7 +164,7 @@ Workspace mounts pass through three distinct shapes between operator intent and 
 | `ResolvedWorkspace` | `resolve_load_workspace` | Expanded host paths plus the merged composition of workspace, ad-hoc, and global mounts. Still independent of the actual container instance. |
 | `MaterializedWorkspace` | post-name-claim materializer | Final host paths Docker should bind-mount for *this* container. Isolated checkouts have been created on disk; isolated `src` values point at the per-container worktree or clone path. |
 
-Materialization happens **after** jackin claims the final unique container name and the per-container state directory exists. For each non-`shared` mount, materialization is idempotent: first load creates the scratch branch from host `HEAD` and records `base_commit`; later loads to the same container reuse the existing checkout as-is — no reset, no rebase, no fast-forward.
+Materialization happens **after** jackin claims the final unique container name and the per-container state directory exists. For each non-`shared` mount, materialization is idempotent: worktree mode creates a scratch branch from host `HEAD`, clone mode runs a local clone of the host repo's current branch, and both modes record `base_commit`. Later loads to the same container reuse the existing checkout as-is — no reset, no rebase, no fast-forward.
 
 On first worktree creation for a host repo, jackin' enables `extensions.worktreeConfig` (bumping `core.repositoryformatversion` to 1 if needed) so per-worktree config writes via `git config --worktree` don't leak into the shared host `.git/config`.
 
@@ -184,8 +184,8 @@ The file lives next to the per-container agent state and `.jackin/` metadata and
 | `mount_dst` | Container destination path (the mount identity) |
 | `original_src` | Resolved host `src` recorded for source-drift detection |
 | `isolation` | Mode (`worktree` or `clone`) |
-| `worktree_path` | Materialized worktree path on the host |
-| `scratch_branch` | Scratch branch name (`jackin/scratch/<container>`) |
+| `worktree_path` | Materialized worktree or clone path on the host |
+| `scratch_branch` | Worktree scratch branch name (`jackin/scratch/<container>`); empty for clone records |
 | `base_commit` | Host `HEAD` at first materialization |
 | `selector_key` | Agent selector key |
 | `container_name` | Final container name |
@@ -197,11 +197,11 @@ Successful cleanup removes the corresponding record rather than keeping a histor
 
 Every command that opens or reopens an agent foreground session — `jackin load`, `jackin hardline`, the operator console — funnels through the same post-session finalizer. After the `docker exec tmux new-session` call returns, jackin' inspects the container and decides:
 
-- **Container is still running** → preserve everything for `jackin hardline` to reconnect later. No isolated-worktree action.
-- **Stopped, non-zero exit or OOM** → preserve the container, DinD, and isolated worktrees so `jackin hardline` can restart in place.
-- **Stopped, exit code 0 (clean)** → attempt safe isolated-worktree cleanup. A worktree is safe to delete only when it has no uncommitted changes and **every** local branch in the worktree is safe — agents routinely rename the scratch branch to `feature/*` before opening a PR, so the safety check enumerates `git for-each-ref refs/heads/` rather than inspecting only the recorded scratch branch. A branch is safe when its tip is at `base_commit`, when its upstream is configured and `git rev-list <upstream>..<branch>` is empty, or when its upstream tracking is `[gone]` (the squash-merged-and-pruned heuristic — without it, the GitHub-default merge-and-delete-branch flow leaves a graveyard of preserved worktrees).
-- **Clean exit with unsafe cleanup**, interactive stdin → ask the operator whether to return to the agent (restart + re-attach), preserve recovery state, or force-delete. The prompt wording branches on whether the worktree is dirty (`uncommitted changes`) or clean-but-unpushed (`unpushed commits on a local branch`).
-- **Clean exit with unsafe cleanup**, non-interactive → preserve the recovery state and print the worktree path plus the per-reason phrasing and how to return, inspect, or discard.
+- **Container is still running** → preserve everything for `jackin hardline` to reconnect later. No isolated-checkout action.
+- **Stopped, non-zero exit or OOM** → preserve the container, DinD, and isolated checkouts so `jackin hardline` can restart in place.
+- **Stopped, exit code 0 (clean)** → attempt safe isolated-checkout cleanup. A checkout is safe to delete only when it has no uncommitted changes and **every** local branch in the checkout is safe — agents routinely rename the worktree scratch branch to `feature/*` before opening a PR, and clone mode starts on the host branch directly, so the safety check enumerates `git for-each-ref refs/heads/` rather than inspecting only the recorded scratch branch. A branch is safe when its tip is at `base_commit`, when its upstream is configured and `git rev-list <upstream>..<branch>` is empty, or when its upstream tracking is `[gone]` (the squash-merged-and-pruned heuristic — without it, the GitHub-default merge-and-delete-branch flow leaves a graveyard of preserved checkouts).
+- **Clean exit with unsafe cleanup**, interactive stdin → ask the operator whether to return to the agent (restart + re-attach), preserve recovery state, or force-delete. The prompt wording branches on whether the checkout is dirty (`uncommitted changes`) or clean-but-unpushed (`unpushed commits on a local branch`).
+- **Clean exit with unsafe cleanup**, non-interactive → preserve the recovery state and print the checkout path plus the per-reason phrasing and how to return, inspect, or discard.
 
 The same finalizer runs after `hardline` attaches, so the cleanup decision is independent of how the foreground session was opened.
 

--- a/docs/src/content/docs/reference/runtime-instance-model.mdx
+++ b/docs/src/content/docs/reference/runtime-instance-model.mdx
@@ -84,7 +84,7 @@ data/
 
 `instances.json` is a global lookup index. It stores enough data to find candidate instances by workspace/directory/role/agent without walking every state directory. If the index is missing, jackin rebuilds it by scanning manifests. The manifest remains canonical.
 
-`isolation.json` is mount-specific. It records materialized isolated mount state such as original source, mount destination, worktree/clone path, scratch branch, base commit, selector key, container name, and preservation status. It is owned by the isolation subsystem, not the instance manifest.
+`isolation.json` is mount-specific. It records materialized isolated mount state such as original source, mount destination, worktree/clone path, worktree scratch branch when applicable, base commit, selector key, container name, and preservation status. It is owned by the isolation subsystem, not the instance manifest.
 
 Implementation lives in <RepoFile path="src/instance/manifest.rs" />, <RepoFile path="src/isolation/state.rs" />, and <RepoFile path="src/instance/mod.rs" />.
 

--- a/src/isolation/branch.rs
+++ b/src/isolation/branch.rs
@@ -1,16 +1,15 @@
 /// Build the scratch branch name for an isolated mount.
 ///
 /// Selector namespace `/` is preserved; an optional `suffix` is
-/// appended to the *final* selector segment with a leading `-`. The
-/// suffix is reserved for clone-instance disambiguation when clone
-/// mode ships (V1.1) — V1 worktree mode always passes `None` because
+/// appended to the *final* selector segment with a leading `-`.
+/// Current worktree materialization passes `None` because
 /// `validate_isolation_layout` rejects multi-isolated-mounts on the
 /// same host repo, so each container has at most one scratch branch
-/// per host repo and the selector alone is unique.
+/// per host repo.
 ///
 /// Examples:
 /// - `branch_name("the-architect", None)` → `jackin/scratch/the-architect`
-/// - `branch_name("the-architect", Some("clone-1"))` → `jackin/scratch/the-architect-clone-1`
+/// - `branch_name("the-architect", Some("repo-1"))` → `jackin/scratch/the-architect-repo-1`
 /// - `branch_name("chainargos/the-architect", None)`
 ///   → `jackin/scratch/chainargos/the-architect`
 pub fn branch_name(selector: &str, suffix: Option<&str>) -> String {
@@ -44,18 +43,18 @@ mod tests {
     }
 
     #[test]
-    fn clone_suffix_appends_to_final_segment_with_namespace() {
+    fn suffix_appends_to_final_segment_with_namespace() {
         assert_eq!(
-            branch_name("chainargos/the-architect", Some("clone-1")),
-            "jackin/scratch/chainargos/the-architect-clone-1"
+            branch_name("chainargos/the-architect", Some("repo-1")),
+            "jackin/scratch/chainargos/the-architect-repo-1"
         );
     }
 
     #[test]
-    fn clone_suffix_appends_without_namespace() {
+    fn suffix_appends_without_namespace() {
         assert_eq!(
-            branch_name("the-architect", Some("clone-2")),
-            "jackin/scratch/the-architect-clone-2"
+            branch_name("the-architect", Some("repo-2")),
+            "jackin/scratch/the-architect-repo-2"
         );
     }
 }

--- a/src/isolation/materialize.rs
+++ b/src/isolation/materialize.rs
@@ -957,7 +957,6 @@ async fn materialize_clone(
         .await?
         .trim()
         .to_string();
-    let scratch_branch = branch_name(container_name, None);
 
     if let Some(parent) = clone_path.parent() {
         std::fs::create_dir_all(parent)
@@ -972,21 +971,6 @@ async fn materialize_clone(
                 "--local",
                 &mount.src,
                 &clone_path.to_string_lossy(),
-            ],
-            None,
-            &crate::docker::RunOptions::default(),
-        )
-        .await?;
-    runner
-        .run(
-            "git",
-            &[
-                "-C",
-                &clone_path.to_string_lossy(),
-                "checkout",
-                "-B",
-                &scratch_branch,
-                &host_head,
             ],
             None,
             &crate::docker::RunOptions::default(),
@@ -1090,7 +1074,7 @@ async fn materialize_clone(
             original_src: mount.src.clone(),
             isolation: MountIsolation::Clone,
             worktree_path: clone_path.to_string_lossy().into(),
-            scratch_branch,
+            scratch_branch: String::new(),
             base_commit: host_head,
             selector_key: selector_key.into(),
             container_name: container_name.into(),
@@ -1706,10 +1690,9 @@ mod tests {
                 .any(|c| c.contains("git clone --local"))
         );
         assert!(
-            runner
-                .run_recorded
-                .iter()
-                .any(|c| c.contains("checkout -B jackin/scratch/jackin-x deadbeef"))
+            !runner.run_recorded.iter().any(|c| c.contains("checkout")),
+            "clone mode must not create or switch to a scratch branch: {:?}",
+            runner.run_recorded
         );
         // Origin rewritten from bind-mount loopback to host's upstream.
         assert!(
@@ -1725,6 +1708,7 @@ mod tests {
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].isolation, MountIsolation::Clone);
         assert_eq!(recs[0].base_commit, "deadbeef");
+        assert_eq!(recs[0].scratch_branch, "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Clone-isolated mounts now stay on the host repo's current branch by relying on `git clone --local` directly instead of creating a `jackin/scratch/*` branch after cloning. Worktree isolation keeps its scratch-branch behavior, while the workspace and internals docs now describe the distinct branch behavior for worktree versus clone mounts.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test"
cd "$HOME/Projects/jackin-project/test"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/clone-isolation-current-branch:refs/remotes/origin/fix/clone-isolation-current-branch
git checkout -B fix/clone-isolation-current-branch refs/remotes/origin/fix/clone-isolation-current-branch
```

### Isolation

```sh
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-427"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-427"
rm -rf "$JACKIN_CONFIG_DIR" "$JACKIN_HOME_DIR"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --all-targets
```

### Tests

```sh
cargo test -p jackin isolation::materialize::tests
cargo nextest run
```

### User smoke

```sh
cargo run --bin jackin -- workspace create verify-clone-isolation --workdir /workspace/jackin --mount "$PWD:/workspace/jackin" --mount-isolation /workspace/jackin=clone --debug
cargo run --bin jackin -- load the-architect verify-clone-isolation --debug
```

In the debug output, the clone-isolated mount should run `git clone --local` and should not run `git checkout -B jackin/scratch/...`.

### Documentation

```sh
cd docs
bun install --frozen-lockfile
bun run dev
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/guides/workspaces/**  
UPDATED page. The per-mount isolation table should say clone mode starts from the host repo's current branch, while worktree mode remains the scratch-branch option.

**http://localhost:4321/guides/mounts/**  
UPDATED page. The mount isolation table should carry the same clone-mode branch and origin-push behavior as the workspaces guide.

**http://localhost:4321/reference/architecture/**  
UPDATED page. Workspace materialization and foreground finalization should describe isolated checkouts generically and reserve scratch-branch behavior for worktree mode.

**http://localhost:4321/reference/runtime-instance-model/**  
UPDATED page. The isolation record summary should say the scratch branch is only present when applicable.

## Migration notes

None. This changes new clone materialization behavior only; existing preserved clone records remain parseable and clone cleanup ignores the scratch-branch field.

