### PR TITLE
docs: move README warning to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # jackin'
 
+> [!WARNING]
+> 🚧 jackin' is in active early development.
+>
+> jackin' is not production-ready. We are actively refining the core concept, runtime integrations, CLI/TUI workflows, schemas, and documentation, and that will introduce major breaking changes before a stable release. Features may be redesigned, replaced, or removed while we find the shape that makes sense. Early adopters are welcome, but the priority right now is concept quality and fast iteration rather than freezing today's behavior. The docs track the rolling preview channel; open issues and roadmap feedback are welcome, but do not treat the current feature set as a compatibility promise.
+
 Jack your AI coding agents in. Isolated worlds, scoped access, full autonomy. You're the Operator. They're already inside.
 
 jackin' is the **ecosystem layer around** AI coding agents — not another agent itself. It runs many agents in parallel, each in its own container, with its own file access, tool profile, and credentials. Every agent runtime ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) `--dangerously-skip-permissions`, [Codex](https://github.com/openai/codex) YOLO, [Amp](https://ampcode.com), Kimi, OpenCode, and the next ones to come) is most productive at full speed — and full speed against your host machine is risky. jackin' moves the boundary off the host, so the runtime can stay fast.
 
 Documentation: <https://jackin.tailrocks.com/>
-
-> [!WARNING]
-> 🚧 jackin' is in active early development.
->
-> jackin' is not production-ready. We are actively refining the core concept, runtime integrations, CLI/TUI workflows, schemas, and documentation, and that will introduce major breaking changes before a stable release. Features may be redesigned, replaced, or removed while we find the shape that makes sense. Early adopters are welcome, but the priority right now is concept quality and fast iteration rather than freezing today's behavior. The docs track the rolling preview channel; open issues and roadmap feedback are welcome, but do not treat the current feature set as a compatibility promise.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- move the early-development warning to the top of `README.md`, directly under the title

## Verification

- `git diff --check`
- inspected the first README section locally

## Verify locally

```sh
PR_NUMBER=431
BRANCH=docs/readme-warning-top
WORKDIR="${TMPDIR:-/tmp}/jackin-pr-${PR_NUMBER}"

if [ -d "$WORKDIR/.git" ]; then
  git -C "$WORKDIR" fetch origin "$BRANCH"
else
  git clone https://github.com/jackin-project/jackin.git "$WORKDIR"
fi

cd "$WORKDIR"
git checkout "$BRANCH"
git pull --ff-only origin "$BRANCH"

git diff --check
sed -n '1,18p' README.md
```
