### PR TITLE
chore(deps): update dependency @types/react to v19.2.15

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -25,7 +25,7 @@
         "@fontsource/jetbrains-mono": "5.2.8",
         "@resvg/resvg-js": "2.6.2",
         "@types/bun": "1.3.14",
-        "@types/react": "19.2.14",
+        "@types/react": "19.2.15",
         "@types/react-dom": "19.2.3",
         "satori": "0.26.0",
         "typescript": "6.0.3",
@@ -379,7 +379,7 @@
 
     "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+    "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -35,7 +35,7 @@
     "@fontsource/jetbrains-mono": "5.2.8",
     "@resvg/resvg-js": "2.6.2",
     "@types/bun": "1.3.14",
-    "@types/react": "19.2.14",
+    "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "satori": "0.26.0",
     "typescript": "6.0.3"


### PR DESCRIPTION
## Summary

- Updates `@types/react` from `19.2.14` to `19.2.15` in `docs/package.json` and `docs/bun.lock`

Renovate pushed this update to the `renovate/react-monorepo` branch on 2026-05-24 but never opened a PR (reused the branch from the previously merged PR #371 without re-opening).

## Test plan

- [ ] CI passes (docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)