### PR TITLE
chore(renovate): fix stuck-branch bug and run lock-file maintenance daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,5 +42,10 @@
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 20,
-  "commitBody": "Signed-off-by: Renovate Bot <renovate@whitesourcesoftware.com>"
+  "commitBody": "Signed-off-by: Renovate Bot <renovate@whitesourcesoftware.com>",
+  "recreateClosed": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["at any time"]
+  }
 }


### PR DESCRIPTION
## Summary

Fixes two Renovate gaps discovered during a full dependency audit on 2026-05-24.

**Bug: Renovate pushes to a branch without opening a PR (`recreateClosed: false` default)**

Renovate updated `@types/react` to 19.2.15 on 2026-05-24 by committing to the existing `renovate/react-monorepo` branch, but never opened a PR. Root cause: the previous PR #371 on that same branch was merged, and Renovate's default `recreateClosed: false` prevents it from reopening a PR on a branch whose last PR was already closed/merged. Setting `recreateClosed: true` fixes this — Renovate will open a new PR even when it reuses an existing branch name.

**Improvement: Lock-file maintenance runs weekly instead of on every trigger**

The `config:best-practices` preset schedules `lockFileMaintenance` (Cargo.lock / bun.lock transitive bumps) for once per week. This means a transitive lockfile drift can sit undetected for up to 7 days. Overriding the schedule to `"at any time"` runs it on every Renovate trigger (push to main + daily 6am cron), keeping lockfiles current without requiring a manual `cargo update` or `bun update`.

**Not changed: `minimumReleaseAge: "3 days"`**

`docker/setup-buildx-action` v4.1.0 and `docker/login-action` v4.2.0 were both released on 2026-05-22 (2 days before the audit). Renovate correctly held them in the stability window — PRs would have appeared automatically on day 3. The 3-day hold is intentional supply-chain hygiene and is kept as-is.

## Test plan

- [ ] CI passes (renovate-validate job validates the schema)
- [ ] Next Renovate run opens a PR for any branch it currently has commits on without a PR

## Verify locally

```sh
cd "$HOME/Projects/jackin-project/test"
if [ -d pr-446 ]; then
  cd pr-446 && git fetch && git checkout chore/improve-renovate-config && git pull
else
  git clone https://github.com/jackin-project/jackin pr-446 && cd pr-446 && git checkout chore/improve-renovate-config
fi

# Validate Renovate config schema
bunx --bun renovate-config-validator renovate.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
