### PR TITLE
fix(capsule): advertise truecolor in panes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -85,6 +85,7 @@ cd jackin
 mise trust
 git fetch -f origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
 git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
+mise trust
 mise install
 cargo build --bin jackin
 export PATH="$PWD/target/debug:$PATH"

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -100,6 +100,7 @@ cd jackin
 mise trust
 git fetch -f origin <BRANCH_NAME>:refs/remotes/origin/<BRANCH_NAME>
 git checkout -B <BRANCH_NAME> refs/remotes/origin/<BRANCH_NAME>
+mise trust
 mise install
 cargo build --bin jackin
 export PATH="$PWD/target/debug:$PATH"

--- a/crates/jackin-capsule/src/session.rs
+++ b/crates/jackin-capsule/src/session.rs
@@ -1655,9 +1655,12 @@ pub fn build_shell_command(env_passthrough: &[(String, String)], cwd: &Path) -> 
 /// reported per attach through the Capsule protocol; pane PTYs keep a
 /// conservative baseline so a running session can be reattached from Ghostty,
 /// Kitty, iTerm, Warp, or any other xterm-compatible client without retaining
-/// assumptions from the terminal that launched the container.
+/// assumptions from the terminal that launched the container. `COLORTERM`
+/// intentionally advertises jackin's 24-bit color path without tying the pane
+/// to a host-specific terminfo entry.
 fn apply_terminal_env(cmd: &mut CommandBuilder) {
     cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
     for key in ["LANG", "LC_ALL"] {
         if let Ok(value) = std::env::var(key) {
             cmd.env(key, value);
@@ -1753,6 +1756,28 @@ mod tests {
         assert_eq!(
             cmd.get_env("TERM").and_then(|value| value.to_str()),
             Some("xterm-256color")
+        );
+    }
+
+    #[test]
+    fn build_agent_command_advertises_truecolor() {
+        let env = vec![("COLORTERM".to_string(), "24bit".to_string())];
+        let cmd = build_agent_command("claude", None, &env, Path::new("/workspace"));
+
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|value| value.to_str()),
+            Some("truecolor")
+        );
+    }
+
+    #[test]
+    fn build_shell_command_advertises_truecolor() {
+        let env = vec![("COLORTERM".to_string(), "false".to_string())];
+        let cmd = build_shell_command(&env, Path::new("/workspace"));
+
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|value| value.to_str()),
+            Some("truecolor")
         );
     }
 

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -11,7 +11,15 @@ cache = true
 # 429 is accepted to keep CI useful under external rate limits. GitHub requests
 # are also throttled below to make a 429 less likely.
 accept = ["100..=103", "200..=299", "429"]
-exclude = ["https://chatgpt\\.com/"]
+exclude = [
+  "https://chatgpt\\.com/",
+  # Zylos serves this public research page to browsers and search crawlers, but
+  # returns HTTP 402 to lychee in CI.
+  "https://zylos\\.ai/research/2026-04-01-ai-agent-input-ready-detection-cursor-vs-regex",
+  # ccmux is reachable in browsers and search crawlers, but lychee reports it
+  # as network-unreachable in some environments.
+  "https://ccmux\\.ai/",
+]
 exclude_all_private = true
 exclude_path = ["(^|/)404\\.html$"]
 

--- a/docs/src/content/docs/guides/environment-variables.mdx
+++ b/docs/src/content/docs/guides/environment-variables.mdx
@@ -92,6 +92,17 @@ Trying to set one of these is rejected before the agent launches.
 
 Role identity, workspace workdir, supported agent slugs, and manifest model overrides are handed to Capsule through a generated launch config instead of being duplicated as container-wide environment variables. The [Capsule reference](/reference/jackin-capsule/#how-state-moves-across-the-boundary) documents the internal handoff.
 
+## Pane terminal defaults
+
+Every shell and agent pane receives a stable terminal capability baseline:
+
+```text
+TERM=xterm-256color
+COLORTERM=truecolor
+```
+
+`TERM=xterm-256color` keeps the pane tied to a conservative terminfo entry that remains safe when a long-lived container is reattached from a different terminal app. `COLORTERM=truecolor` tells agent CLIs and TUIs that 24-bit color output is available by default. jackin' sets this value directly instead of copying the host's `COLORTERM`, so a pane launched from Ghostty, Kitty, iTerm, Warp, SSH, or another xterm-compatible client sees the same deterministic environment.
+
 ## 1Password CLI setup
 
 1. Install the [1Password CLI](https://developer.1password.com/docs/cli/get-started/).

--- a/docs/src/content/docs/reference/architecture.mdx
+++ b/docs/src/content/docs/reference/architecture.mdx
@@ -146,7 +146,7 @@ The DinD sidecar auto-generates TLS certificates at startup into a shared Docker
 
 ## Terminal capability model
 
-Pane PTYs run with a stable `TERM=xterm-256color` baseline. jackin' does not copy the host terminal's `$TERM` into the long-lived container environment, because a preserved instance can be reattached later from a different terminal app. A pane that started while the operator used Ghostty must still be safe to reattach from Kitty, iTerm, Warp, SSH, or a plain xterm-compatible terminal.
+Pane PTYs run with a stable `TERM=xterm-256color` baseline and `COLORTERM=truecolor`. jackin' does not copy the host terminal's `$TERM` into the long-lived container environment, because a preserved instance can be reattached later from a different terminal app. A pane that started while the operator used Ghostty must still be safe to reattach from Kitty, iTerm, Warp, SSH, or a plain xterm-compatible terminal. `COLORTERM=truecolor` is a deterministic capability hint for agent CLIs and TUIs, not a host-specific terminal identity.
 
 Terminal-specific enhancements are attached-client state instead. Every foreground attach (`jackin load`, `jackin hardline`, and console attach) runs a short-lived Capsule client through `docker exec`; that client reports its current `TERM`, `TERM_PROGRAM`, and `COLORTERM` in the attach handshake. The PID 1 daemon stores that identity only for the active client and refreshes it on every takeover, so jackin-owned output enhancements follow the terminal the operator is using now.
 
@@ -159,7 +159,7 @@ The container no longer runs tmux for agent sessions. The Capsule owns the PTYs 
 | Former tmux concern | Capsule behavior |
 |---|---|
 | Modified keys | Client-side input parsing preserves xterm/Kitty/CSI-u key sequences and forwards pane input unmodified unless it is a jackin'-owned palette or prefix command. |
-| Terminal feature advertisement | Pane PTYs run with `TERM=xterm-256color`; outer-terminal identity is reported per attach and used only for client-side enhancements. |
+| Terminal feature advertisement | Pane PTYs run with `TERM=xterm-256color` and `COLORTERM=truecolor`; outer-terminal identity is reported per attach and used only for client-side enhancements. |
 | Focus events | The attach client enables focus reporting on the outer terminal and forwards focus-in/focus-out only to panes that requested it. |
 | OSC passthrough | Focused-pane OSC 0/1/2 titles, OSC 8 hyperlinks, OSC 9 notifications, and OSC 52 clipboard writes are forwarded with per-family opt-outs. OSC 7 is captured for pane titles and not forwarded to the host. |
 | Escape timing | The input parser treats Escape as data for the pane except when a jackin' dialog is open; dialogs receive normalized legacy keys even after an embedded TUI enables progressive keyboard reporting. |

--- a/docs/src/content/docs/reference/multiplexer-design-rules.mdx
+++ b/docs/src/content/docs/reference/multiplexer-design-rules.mdx
@@ -31,7 +31,7 @@ Every capability the base image supports must reach the agent inside the pane.
 
 - Forward `xterm`-style extended key sequences verbatim (Kitty protocol, CSI u, etc.).
 - Never swallow, re-encode, or normalize key sequences before passing them to the active pane's PTY.
-- `TERM=xterm-256color` is set for all pane PTYs. The multiplexer itself must advertise `extkeys` capability to the sessions it spawns so that agent CLIs which query `TERM` get the right answer.
+- `TERM=xterm-256color` and `COLORTERM=truecolor` are set for all pane PTYs. The multiplexer itself must advertise `extkeys` capability to the sessions it spawns so that agent CLIs which query `TERM` get the right answer.
 
 ### Mouse events
 

--- a/docs/src/content/docs/reference/multiplexer-design-rules.mdx
+++ b/docs/src/content/docs/reference/multiplexer-design-rules.mdx
@@ -67,6 +67,8 @@ Every capability the base image supports must reach the agent inside the pane.
 ### True color and 256-color
 
 - The multiplexer's own UI elements (status bar, borders, dialog) use ANSI 256-color and 24-bit color.
+- Pane PTYs advertise `COLORTERM=truecolor` by default so agent CLIs and TUIs can enable 24-bit color without guessing from `TERM`.
+- Do not copy the host's `COLORTERM` into pane sessions. The pane environment is deterministic because a preserved jackin' instance can be reattached from a different terminal later.
 - Pane content is passed through without color transformation. Never re-encode pane output colors.
 
 ### Bracketed paste


### PR DESCRIPTION
## Summary

jackin' pane sessions now advertise truecolor support by default while keeping their stable `TERM=xterm-256color` baseline. Agent CLIs and TUIs, including Claude Code, can detect `COLORTERM=truecolor` inside shell and agent panes without inheriting host-specific terminal identity; the operator and contributor docs now explain that default, the shared PR checkout recipe now trusts the PR branch's mise config immediately before `mise install`, and the docs link checker ignores two external research/comparison URLs that reject lychee despite remaining browser-visible.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test/pr-464"
cd "$HOME/Projects/jackin-project/test/pr-464"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/colorterm-passthrough:refs/remotes/origin/fix/colorterm-passthrough
git checkout -B fix/colorterm-passthrough refs/remotes/origin/fix/colorterm-passthrough
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
which jackin
```

Then build and export the jackin-capsule binary so the smoke steps below use it:

```sh
eval "$(cargo run --bin build-jackin-capsule -- --export)"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo test -p jackin-capsule
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
  bun run check:links:fresh
)
```

### User smoke

```sh
jackin load the-architect . --debug
```

Open a shell pane and run:

```sh
printf '%s\n' "$TERM" "$COLORTERM"
```

Expected output:

```text
xterm-256color
truecolor
```

### jackin-capsule smoke

```sh
jackin load the-architect . --debug
```

Inside the container, verify:

- Row 0 status bar is visible: `jackin'  [<agent-name>]`
- Agent TUI starts and renders correctly below the status bar
- `Ctrl+Backslash` opens the command palette (override with `JACKIN_PALETTE_KEY`)
- Mouse clicks, arrow keys, and paste reach the agent unmodified
- A shell or agent pane reports `COLORTERM=truecolor` while `TERM` remains `xterm-256color`

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Astro serves at `http://localhost:4321/`. Pages to walk:

**http://localhost:4321/guides/environment-variables/**  
UPDATED Pane terminal defaults. Confirm the operator-facing guide explains `TERM=xterm-256color`, `COLORTERM=truecolor`, and why jackin' sets the value deterministically.

**http://localhost:4321/reference/architecture/**  
UPDATED Terminal capability model. Confirm it describes stable pane `TERM` plus deterministic `COLORTERM=truecolor`.

**http://localhost:4321/reference/multiplexer-design-rules/**  
UPDATED terminal pass-through and true-color expectations. Confirm the pane PTY rule names both `TERM=xterm-256color` and `COLORTERM=truecolor`, and that the true-color section says not to copy the host `COLORTERM`.

## Migration notes

None.
