### PR TITLE
fix(tui): share dialog palette across surfaces

### DIFF
--- a/crates/jackin-capsule/src/daemon.rs
+++ b/crates/jackin-capsule/src/daemon.rs
@@ -4365,12 +4365,12 @@ fn append_osc_window_title(buf: &mut Vec<u8>, title: &str) {
     buf.extend_from_slice(b"\x1b\\");
 }
 
-const BRANCH_CONTEXT_BAR_BG: &str = "\x1b[48;2;255;255;255m";
+const BRANCH_CONTEXT_BAR_BG: &str = jackin_tui::ansi::rgb_bg(jackin_tui::WHITE);
 const BRANCH_CONTEXT_BAR_HOVER_BG: &str = "\x1b[48;2;225;245;255m";
-const BRANCH_CONTEXT_BAR_FG: &str = "\x1b[38;2;0;0;0m";
-const BRANCH_CONTEXT_BAR_LINK_FG: &str = "\x1b[38;2;0;80;180m";
+const BRANCH_CONTEXT_BAR_FG: &str = jackin_tui::ansi::rgb_fg(jackin_tui::BLACK);
+const BRANCH_CONTEXT_BAR_LINK_FG: &str = jackin_tui::ansi::rgb_fg(jackin_tui::LINK_BLUE);
 const BRANCH_CONTEXT_BAR_HOVER_FG: &str = "\x1b[38;2;0;55;140m";
-const BRANCH_CONTEXT_BAR_BOLD: &str = "\x1b[1m";
+const BRANCH_CONTEXT_BAR_BOLD: &str = jackin_tui::ansi::BOLD;
 use jackin_tui::ansi::RESET;
 
 #[allow(clippy::too_many_arguments)]
@@ -5935,8 +5935,12 @@ mod tests {
 
     fn assert_focused_scroll_chrome(frame: &[u8], context: &str) {
         let rendered = String::from_utf8_lossy(frame);
+        let focused_scroll_fg = format!(
+            "\x1b[0;{}",
+            jackin_tui::ansi::rgb_fg(jackin_tui::PHOSPHOR_GREEN)
+        );
         assert!(
-            rendered.contains("\x1b[0;38;2;0;255;65m"),
+            rendered.contains(&focused_scroll_fg),
             "focused {context} should use green chrome"
         );
         assert!(
@@ -6136,7 +6140,7 @@ mod tests {
                     .to_string();
 
             assert!(
-                frame.contains("\x1b[0;48;2;0;0;0m"),
+                frame.contains(jackin_tui::ansi::reset_rgb_bg(jackin_tui::DIALOG_BACKDROP)),
                 "{context} should paint an opaque black backdrop: {frame:?}"
             );
             assert!(
@@ -6144,11 +6148,17 @@ mod tests {
                 "{context} should hide the top status brand pill behind the dialog: {frame:?}"
             );
             assert!(
-                !frame.contains("\x1b[38;2;80;80;80m┌"),
+                !frame.contains(&format!(
+                    "{}┌",
+                    jackin_tui::ansi::rgb_fg(jackin_tui::BORDER_GRAY)
+                )),
                 "{context} should hide inactive pane borders behind the dialog: {frame:?}"
             );
             assert!(
-                !frame.contains("\x1b[38;2;0;255;65m┌"),
+                !frame.contains(&format!(
+                    "{}┌",
+                    jackin_tui::ansi::rgb_fg(jackin_tui::PHOSPHOR_GREEN)
+                )),
                 "{context} should hide the active pane border behind the dialog: {frame:?}"
             );
         }

--- a/crates/jackin-capsule/src/daemon.rs
+++ b/crates/jackin-capsule/src/daemon.rs
@@ -5936,7 +5936,8 @@ mod tests {
     fn assert_focused_scroll_chrome(frame: &[u8], context: &str) {
         let rendered = String::from_utf8_lossy(frame);
         let focused_scroll_fg = format!(
-            "\x1b[0;{}",
+            "{}{}",
+            jackin_tui::ansi::RESET,
             jackin_tui::ansi::rgb_fg(jackin_tui::PHOSPHOR_GREEN)
         );
         assert!(

--- a/crates/jackin-capsule/src/daemon.rs
+++ b/crates/jackin-capsule/src/daemon.rs
@@ -2962,7 +2962,12 @@ impl Multiplexer {
         // stays hidden from the `?25l` above (append_cursor_state
         // no-ops while a dialog is open).
         if self.dialog_open() {
-            fill_screen(&mut buf, self.term_rows, self.term_cols, (0, 0, 0));
+            fill_screen(
+                &mut buf,
+                self.term_rows,
+                self.term_cols,
+                jackin_tui::DIALOG_BACKDROP,
+            );
             if let Some(dialog) = self.dialog_top() {
                 let github = self.github_context_view();
                 dialog.render_with_hover(

--- a/crates/jackin-capsule/src/dialog.rs
+++ b/crates/jackin-capsule/src/dialog.rs
@@ -46,17 +46,20 @@ impl<'a> PullRequestStatus<'a> {
     }
 }
 
-use jackin_tui::ansi::{BG_DARK, BOLD, RESET};
+use jackin_tui::{
+    BLACK, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE,
+    ansi::{BG_DARK, BOLD, RESET, rgb_bg, rgb_fg},
+};
 
 const PALETTE_WIDTH: u16 = 50;
 const CONTAINER_INFO_WIDTH: u16 = 86;
-const FG_GREEN: &str = "\x1b[38;2;0;255;65m"; // PHOSPHOR_GREEN
-const FG_DIM: &str = "\x1b[38;2;0;140;30m"; // PHOSPHOR_DIM
-const FG_BORDER: &str = "\x1b[38;2;0;80;18m"; // PHOSPHOR_DARK
-const FG_WHITE: &str = "\x1b[38;2;255;255;255m"; // WHITE
+const FG_GREEN: &str = rgb_fg(PHOSPHOR_GREEN);
+const FG_DIM: &str = rgb_fg(PHOSPHOR_DIM);
+const FG_BORDER: &str = rgb_fg(PHOSPHOR_DARK);
+const FG_WHITE: &str = rgb_fg(WHITE);
 const FG_CLICK_HOVER: &str = "\x1b[38;2;180;255;180m"; // lifted clickable value
-const SELECT_BG: &str = "\x1b[48;2;0;255;65m"; // PHOSPHOR_GREEN bg
-const SELECT_FG: &str = "\x1b[38;2;0;0;0m"; // BLACK fg
+const SELECT_BG: &str = rgb_bg(PHOSPHOR_GREEN);
+const SELECT_FG: &str = rgb_fg(BLACK);
 const SELECT_MARK: &str = "▸ ";
 const UNSELECT_MARK: &str = "  ";
 

--- a/crates/jackin-capsule/src/dialog.rs
+++ b/crates/jackin-capsule/src/dialog.rs
@@ -1796,8 +1796,8 @@ fn render_centered_line(
 /// with `move_to` before calling.
 fn write_confirm_button(buf: &mut Vec<u8>, label: &str, focused: bool) {
     if focused {
-        buf.extend_from_slice(b"\x1b[48;2;255;255;255m"); // WHITE bg
-        buf.extend_from_slice(b"\x1b[38;2;0;0;0m"); // BLACK fg
+        buf.extend_from_slice(rgb_bg(WHITE).as_bytes());
+        buf.extend_from_slice(SELECT_FG.as_bytes());
     } else {
         buf.extend_from_slice(BG_DARK.as_bytes());
         buf.extend_from_slice(FG_GREEN.as_bytes());

--- a/crates/jackin-capsule/src/dialog.rs
+++ b/crates/jackin-capsule/src/dialog.rs
@@ -60,6 +60,7 @@ const FG_WHITE: &str = rgb_fg(WHITE);
 const FG_CLICK_HOVER: &str = "\x1b[38;2;180;255;180m"; // lifted clickable value
 const SELECT_BG: &str = rgb_bg(PHOSPHOR_GREEN);
 const SELECT_FG: &str = rgb_fg(BLACK);
+const CONFIRM_BG: &str = rgb_bg(WHITE);
 const SELECT_MARK: &str = "▸ ";
 const UNSELECT_MARK: &str = "  ";
 
@@ -1796,7 +1797,7 @@ fn render_centered_line(
 /// with `move_to` before calling.
 fn write_confirm_button(buf: &mut Vec<u8>, label: &str, focused: bool) {
     if focused {
-        buf.extend_from_slice(rgb_bg(WHITE).as_bytes());
+        buf.extend_from_slice(CONFIRM_BG.as_bytes());
         buf.extend_from_slice(SELECT_FG.as_bytes());
     } else {
         buf.extend_from_slice(BG_DARK.as_bytes());

--- a/crates/jackin-capsule/src/render.rs
+++ b/crates/jackin-capsule/src/render.rs
@@ -482,8 +482,8 @@ fn emit_bg(buf: &mut Vec<u8>, color: ColorKey) {
 
 /// Paint the whole terminal with a solid background colour, fully hiding
 /// whatever was beneath. Used as the opaque backdrop behind modal dialogs.
-pub fn fill_screen(buf: &mut Vec<u8>, term_rows: u16, term_cols: u16, rgb: (u8, u8, u8)) {
-    let (r, g, b) = rgb;
+pub fn fill_screen(buf: &mut Vec<u8>, term_rows: u16, term_cols: u16, rgb: jackin_tui::Rgb) {
+    let jackin_tui::Rgb { r, g, b } = rgb;
     for row in 0..term_rows {
         let _ = write!(buf, "\x1b[{};1H\x1b[0;48;2;{r};{g};{b}m", row + 1);
         for _ in 0..term_cols {

--- a/crates/jackin-capsule/src/render.rs
+++ b/crates/jackin-capsule/src/render.rs
@@ -4,6 +4,7 @@
 
 use std::io::Write;
 
+use jackin_tui::ansi::{RESET, fg};
 use unicode_width::UnicodeWidthChar;
 use vt100::{Color, Screen};
 
@@ -247,9 +248,9 @@ pub fn draw_scrollbar(
     // Active pane uses the brand phosphor-green; inactive panes a
     // neutral gray that matches their inactive border colour.
     let thumb_color = if focused {
-        "\x1b[0;38;2;0;255;65m"
+        jackin_tui::PHOSPHOR_GREEN
     } else {
-        "\x1b[0;38;2;160;160;160m"
+        jackin_tui::Rgb::new(160, 160, 160)
     };
 
     // Thumb rows are 0-based relative to the interior; skip the top
@@ -262,10 +263,11 @@ pub fn draw_scrollbar(
             track_start_row + thumb.thumb_top + r + 1,
             col + 1
         );
-        buf.extend_from_slice(thumb_color.as_bytes());
+        buf.extend_from_slice(RESET.as_bytes());
+        fg(buf, thumb_color);
         buf.extend_from_slice("█".as_bytes());
     }
-    buf.extend_from_slice(b"\x1b[0m");
+    buf.extend_from_slice(RESET.as_bytes());
 }
 
 fn cell_attrs(cell: &vt100::Cell) -> Attrs {

--- a/crates/jackin-capsule/src/statusbar.rs
+++ b/crates/jackin-capsule/src/statusbar.rs
@@ -20,7 +20,11 @@
 /// click-region maths.
 use std::io::Write as _;
 
-use jackin_tui::{TAB_GAP, TabCell, lay_out_tabs};
+use jackin_tui::{
+    BLACK, BORDER_GRAY, PHOSPHOR_DIM, PHOSPHOR_GREEN, TAB_GAP, TabCell, WHITE,
+    ansi::{BOLD, RESET, rgb_bg, rgb_fg},
+    lay_out_tabs,
+};
 
 use crate::layout::Tab;
 
@@ -38,25 +42,24 @@ use crate::protocol::AgentState;
 const JACKIN_CONTAINER_NAME_ENV: &str = "JACKIN_CONTAINER_NAME";
 const JACKIN_INSTANCE_ID_ENV: &str = "JACKIN_INSTANCE_ID";
 
-const BRAND_BG: &str = "\x1b[48;2;0;255;65m"; // PHOSPHOR_GREEN bg
-const BRAND_FG: &str = "\x1b[38;2;0;0;0m"; // black
-const BRAND_BOLD: &str = "\x1b[1m";
+const BRAND_BG: &str = rgb_bg(PHOSPHOR_GREEN);
+const BRAND_FG: &str = rgb_fg(BLACK);
+const BRAND_BOLD: &str = BOLD;
 
 // Tab-cell backgrounds live in `jackin-tui` (TAB_BG_*) so the console tab
 // strips and this status bar can't drift; emitted here via `ansi::bg`.
-const TAB_FG_INACTIVE: &str = "\x1b[38;2;255;255;255m"; // WHITE
-const TAB_FG_ACTIVE: &str = "\x1b[38;2;255;255;255m"; // WHITE on graphite
-const TAB_UNDERLINE_FG: &str = "\x1b[38;2;255;255;255m"; // WHITE
+const TAB_FG_INACTIVE: &str = rgb_fg(WHITE);
+const TAB_FG_ACTIVE: &str = rgb_fg(WHITE);
+const TAB_UNDERLINE_FG: &str = rgb_fg(WHITE);
 const GLYPH_BLOCKED_FG: &str = "\x1b[38;2;255;60;60m"; // bright red — "waiting for operator"
 
-const HINT_FG: &str = "\x1b[38;2;0;140;30m"; // PHOSPHOR_DIM
+const HINT_FG: &str = rgb_fg(PHOSPHOR_DIM);
 const BUTTON_BG_IDLE: &str = "\x1b[48;2;18;70;130m"; // restrained blue
 const BUTTON_BG_IDLE_HOVER: &str = "\x1b[48;2;32;92;158m"; // hover lift
-const BUTTON_FG_IDLE: &str = "\x1b[38;2;255;255;255m"; // WHITE
+const BUTTON_FG_IDLE: &str = rgb_fg(WHITE);
 const BUTTON_BG_AWAITING: &str = "\x1b[48;2;96;180;255m"; // active blue
 const BUTTON_BG_AWAITING_HOVER: &str = "\x1b[48;2;132;202;255m"; // active hover lift
-const BUTTON_FG_AWAITING: &str = "\x1b[38;2;0;0;0m"; // BLACK
-use jackin_tui::ansi::{BOLD, RESET};
+const BUTTON_FG_AWAITING: &str = rgb_fg(BLACK);
 
 const BRAND_TEXT: &str = " jackin' ";
 const BRAND_PAD_COLS: u16 = 1; // single space between brand pill and first tab
@@ -427,8 +430,8 @@ fn tab_display_label(name: &str) -> String {
 /// not compete with the focused pane. Title text in the top border
 /// stays bright white when the pane is focused so the operator can
 /// locate the keystroke target at a glance.
-const BORDER_ACTIVE: &str = "\x1b[38;2;0;255;65m"; // jackin_tui::PHOSPHOR_GREEN
-const BORDER_INACTIVE: &str = "\x1b[38;2;80;80;80m"; // jackin_tui::BORDER_GRAY (80,80,80)
+const BORDER_ACTIVE: &str = rgb_fg(PHOSPHOR_GREEN);
+const BORDER_INACTIVE: &str = rgb_fg(BORDER_GRAY);
 const TITLE_ACTIVE: &str = "\x1b[1;38;2;255;255;255m"; // bright white, bold
 const TITLE_INACTIVE: &str = "\x1b[38;2;160;160;160m"; // mid gray
 

--- a/crates/jackin-capsule/tests/status_bar.rs
+++ b/crates/jackin-capsule/tests/status_bar.rs
@@ -43,8 +43,8 @@ fn active_tab_background_differs_from_brand_pill() {
     let mut bar = StatusBar::new();
     let tab = Tab::new_single("Codex", 7);
     let s = render(&mut bar, 80, &[tab], 0, &[]);
-    let brand_green_bg = "\x1b[48;2;0;255;65m";
-    let active_tab_graphite_bg = "\x1b[48;2;42;42;42m";
+    let brand_green_bg = jackin_tui::ansi::rgb_bg(jackin_tui::PHOSPHOR_GREEN);
+    let active_tab_graphite_bg = jackin_tui::ansi::rgb_bg(jackin_tui::TAB_BG_ACTIVE);
     assert_eq!(
         s.matches(brand_green_bg).count(),
         1,

--- a/crates/jackin-tui/src/lib.rs
+++ b/crates/jackin-tui/src/lib.rs
@@ -504,12 +504,21 @@ pub mod ansi {
     pub const POINTER_DEFAULT: &str = "\x1b]22;default\x1b\\";
     pub const INVERSE: &str = "\x1b[7m";
 
+    /// Canonical brand pill used by plain ANSI surfaces.
+    pub const BRAND_PILL: &str = "\x1b[1m\x1b[48;2;0;255;65m\x1b[38;2;0;0;0m jackin' \x1b[0m";
+
+    /// Help/banner form of the brand pill.
+    pub const BRAND_BANNER: &str =
+        "\n  \x1b[1m\x1b[48;2;0;255;65m\x1b[38;2;0;0;0m jackin' \x1b[0m\n";
+
     /// Build a foreground SGR for a shared RGB token.
     pub const fn rgb_fg(rgb: Rgb) -> &'static str {
         match (rgb.r, rgb.g, rgb.b) {
             (0, 255, 65) => "\x1b[38;2;0;255;65m",
             (0, 140, 30) => "\x1b[38;2;0;140;30m",
             (0, 80, 18) => "\x1b[38;2;0;80;18m",
+            (0, 80, 180) => "\x1b[38;2;0;80;180m",
+            (80, 80, 80) => "\x1b[38;2;80;80;80m",
             (255, 255, 255) => "\x1b[38;2;255;255;255m",
             (0, 0, 0) => "\x1b[38;2;0;0;0m",
             _ => panic!("unsupported RGB foreground token"),
@@ -520,9 +529,19 @@ pub mod ansi {
     pub const fn rgb_bg(rgb: Rgb) -> &'static str {
         match (rgb.r, rgb.g, rgb.b) {
             (0, 255, 65) => "\x1b[48;2;0;255;65m",
+            (42, 42, 42) => "\x1b[48;2;42;42;42m",
             (20, 24, 22) => "\x1b[48;2;20;24;22m",
+            (255, 255, 255) => "\x1b[48;2;255;255;255m",
             (0, 0, 0) => "\x1b[48;2;0;0;0m",
             _ => panic!("unsupported RGB background token"),
+        }
+    }
+
+    /// Build a reset+background SGR for a shared RGB token.
+    pub const fn reset_rgb_bg(rgb: Rgb) -> &'static str {
+        match (rgb.r, rgb.g, rgb.b) {
+            (0, 0, 0) => "\x1b[0;48;2;0;0;0m",
+            _ => panic!("unsupported reset RGB background token"),
         }
     }
 

--- a/crates/jackin-tui/src/lib.rs
+++ b/crates/jackin-tui/src/lib.rs
@@ -38,9 +38,24 @@ pub const PHOSPHOR_DIM: Rgb = Rgb::new(0, 140, 30);
 /// Dark green used for panel borders and dot separators.
 pub const PHOSPHOR_DARK: Rgb = Rgb::new(0, 80, 18);
 
-/// Pure black background for modal dialogs that need to mask the
-/// agent's content behind the overlay.
+/// Pure black base colour.
 pub const BLACK: Rgb = Rgb::new(0, 0, 0);
+
+/// Opaque full-screen backdrop behind modal dialogs. Capsule and the
+/// host launch cockpit both use this colour so overlays do not drift
+/// between terminal surfaces.
+pub const DIALOG_BACKDROP: Rgb = BLACK;
+
+/// Dialog box surface colour. Kept distinct from `DIALOG_BACKDROP` as
+/// a named token even though the current visual contract uses the same
+/// pure black for both.
+pub const DIALOG_SURFACE: Rgb = BLACK;
+
+/// Focused scroll/thumb accent for modal scroll regions.
+pub const DIALOG_SCROLL_THUMB: Rgb = PHOSPHOR_GREEN;
+
+/// Scroll track and unfocused dialog border colour.
+pub const DIALOG_SCROLL_TRACK: Rgb = PHOSPHOR_DARK;
 
 /// White used for titles, hotkey glyphs, and the active-tab underline.
 pub const WHITE: Rgb = Rgb::new(255, 255, 255);
@@ -470,14 +485,13 @@ pub fn vertical_thumb(track_rows: u16, filled: usize, offset: usize) -> Option<V
 /// placement) in one place stops the two surfaces from drifting
 /// apart when one side picks up a tweak the other forgets.
 pub mod ansi {
-    use super::{INPUT_BG_DIM, PHOSPHOR_DARK, PHOSPHOR_GREEN, Rgb, WHITE};
+    use super::{DIALOG_SURFACE, INPUT_BG_DIM, PHOSPHOR_DARK, PHOSPHOR_GREEN, Rgb, WHITE};
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD as BASE64;
     use std::io::Write as _;
 
-    /// Pure-black background for modal overlays. Matches the
-    /// `BG_DARK` constant the in-container dialog renderer uses.
-    pub const BG_DARK: &str = "\x1b[48;2;0;0;0m";
+    /// Pure-black dialog surface background for modal overlays.
+    pub const BG_DARK: &str = rgb_bg(DIALOG_SURFACE);
     pub const RESET: &str = "\x1b[0m";
     pub const BOLD: &str = "\x1b[1m";
 
@@ -489,6 +503,28 @@ pub mod ansi {
     pub const POINTER_HAND: &str = "\x1b]22;pointer\x1b\\";
     pub const POINTER_DEFAULT: &str = "\x1b]22;default\x1b\\";
     pub const INVERSE: &str = "\x1b[7m";
+
+    /// Build a foreground SGR for a shared RGB token.
+    pub const fn rgb_fg(rgb: Rgb) -> &'static str {
+        match (rgb.r, rgb.g, rgb.b) {
+            (0, 255, 65) => "\x1b[38;2;0;255;65m",
+            (0, 140, 30) => "\x1b[38;2;0;140;30m",
+            (0, 80, 18) => "\x1b[38;2;0;80;18m",
+            (255, 255, 255) => "\x1b[38;2;255;255;255m",
+            (0, 0, 0) => "\x1b[38;2;0;0;0m",
+            _ => panic!("unsupported RGB foreground token"),
+        }
+    }
+
+    /// Build a background SGR for a shared RGB token.
+    pub const fn rgb_bg(rgb: Rgb) -> &'static str {
+        match (rgb.r, rgb.g, rgb.b) {
+            (0, 255, 65) => "\x1b[48;2;0;255;65m",
+            (20, 24, 22) => "\x1b[48;2;20;24;22m",
+            (0, 0, 0) => "\x1b[48;2;0;0;0m",
+            _ => panic!("unsupported RGB background token"),
+        }
+    }
 
     /// OSC 52 clipboard-write sequence. Targets the system clipboard (`c`)
     /// and uses BEL termination, which is accepted by Ghostty, Kitty, iTerm2,

--- a/crates/jackin-tui/src/lib.rs
+++ b/crates/jackin-tui/src/lib.rs
@@ -41,18 +41,18 @@ pub const PHOSPHOR_DARK: Rgb = Rgb::new(0, 80, 18);
 /// Pure black base colour.
 pub const BLACK: Rgb = Rgb::new(0, 0, 0);
 
-/// Opaque full-screen backdrop behind modal dialogs in the capsule
-/// multiplexer. Emitted as raw RGB so the overlay fully masks the
-/// pane content beneath.
+/// Opaque full-screen backdrop behind modal dialogs. Capsule and the
+/// host launch cockpit both use this colour so overlays do not drift
+/// between terminal surfaces.
 pub const DIALOG_BACKDROP: Rgb = BLACK;
 
-/// Dialog box surface colour for the capsule modals. Currently the same
-/// pure black as `DIALOG_BACKDROP`.
+/// Dialog box surface colour. Kept distinct from `DIALOG_BACKDROP` as
+/// a named token even though the current visual contract uses the same
+/// pure black for both.
 pub const DIALOG_SURFACE: Rgb = BLACK;
 
-/// Modal scrollbar thumb colour. Dim phosphor so the chrome reads as
-/// ambient rather than competing with focused content.
-pub const DIALOG_SCROLL_THUMB: Rgb = PHOSPHOR_DIM;
+/// Focused scroll/thumb accent for modal scroll regions.
+pub const DIALOG_SCROLL_THUMB: Rgb = PHOSPHOR_GREEN;
 
 /// Scroll track and unfocused dialog border colour.
 pub const DIALOG_SCROLL_TRACK: Rgb = PHOSPHOR_DARK;

--- a/crates/jackin-tui/src/lib.rs
+++ b/crates/jackin-tui/src/lib.rs
@@ -41,18 +41,18 @@ pub const PHOSPHOR_DARK: Rgb = Rgb::new(0, 80, 18);
 /// Pure black base colour.
 pub const BLACK: Rgb = Rgb::new(0, 0, 0);
 
-/// Opaque full-screen backdrop behind modal dialogs. Capsule and the
-/// host launch cockpit both use this colour so overlays do not drift
-/// between terminal surfaces.
+/// Opaque full-screen backdrop behind modal dialogs in the capsule
+/// multiplexer. Emitted as raw RGB so the overlay fully masks the
+/// pane content beneath.
 pub const DIALOG_BACKDROP: Rgb = BLACK;
 
-/// Dialog box surface colour. Kept distinct from `DIALOG_BACKDROP` as
-/// a named token even though the current visual contract uses the same
-/// pure black for both.
+/// Dialog box surface colour for the capsule modals. Currently the same
+/// pure black as `DIALOG_BACKDROP`.
 pub const DIALOG_SURFACE: Rgb = BLACK;
 
-/// Focused scroll/thumb accent for modal scroll regions.
-pub const DIALOG_SCROLL_THUMB: Rgb = PHOSPHOR_GREEN;
+/// Modal scrollbar thumb colour. Dim phosphor so the chrome reads as
+/// ambient rather than competing with focused content.
+pub const DIALOG_SCROLL_THUMB: Rgb = PHOSPHOR_DIM;
 
 /// Scroll track and unfocused dialog border colour.
 pub const DIALOG_SCROLL_TRACK: Rgb = PHOSPHOR_DARK;
@@ -504,10 +504,8 @@ pub mod ansi {
     pub const POINTER_DEFAULT: &str = "\x1b]22;default\x1b\\";
     pub const INVERSE: &str = "\x1b[7m";
 
-    /// Canonical brand pill used by plain ANSI surfaces.
-    pub const BRAND_PILL: &str = "\x1b[1m\x1b[48;2;0;255;65m\x1b[38;2;0;0;0m jackin' \x1b[0m";
-
-    /// Help/banner form of the brand pill.
+    /// Help/banner form of the brand pill, shared with the host and
+    /// capsule status bars so every surface shows the same logo.
     pub const BRAND_BANNER: &str =
         "\n  \x1b[1m\x1b[48;2;0;255;65m\x1b[38;2;0;0;0m jackin' \x1b[0m\n";
 
@@ -530,7 +528,6 @@ pub mod ansi {
         match (rgb.r, rgb.g, rgb.b) {
             (0, 255, 65) => "\x1b[48;2;0;255;65m",
             (42, 42, 42) => "\x1b[48;2;42;42;42m",
-            (20, 24, 22) => "\x1b[48;2;20;24;22m",
             (255, 255, 255) => "\x1b[48;2;255;255;255m",
             (0, 0, 0) => "\x1b[48;2;0;0;0m",
             _ => panic!("unsupported RGB background token"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,16 +13,8 @@ pub(super) const HELP_STYLES: Styles = Styles::styled()
     .invalid(AnsiColor::Red.on_default().effects(Effects::BOLD))
     .error(AnsiColor::Red.on_default().effects(Effects::BOLD));
 
-// The canonical jackin' logo — the ` jackin' ` brand pill (black bold on
-// phosphor-green), identical to the host and capsule status bars. Used as the
-// help banner so every surface shows the one logo.
-pub(super) const BANNER: &str = concat!(
-    "\n  ",
-    "\x1b[1m\x1b[48;2;0;255;65m\x1b[38;2;0;0;0m",
-    " jackin' ",
-    "\x1b[0m",
-    "\n"
-);
+// The canonical jackin' logo, shared with the host and capsule status bars.
+pub(super) const BANNER: &str = jackin_tui::ansi::BRAND_BANNER;
 
 pub mod cleanup;
 pub mod config;

--- a/src/console/manager/input/save.rs
+++ b/src/console/manager/input/save.rs
@@ -526,15 +526,14 @@ fn build_confirm_save_lines(
     config: &AppConfig,
     collapse_lines: &[ratatui::text::Line<'static>],
 ) -> Vec<ratatui::text::Line<'static>> {
-    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::style::{Modifier, Style};
     use ratatui::text::{Line, Span};
 
-    let phosphor_green = Color::Rgb(0, 255, 65);
-    let phosphor_dim = Color::Rgb(0, 140, 30);
-    let white = Color::Rgb(255, 255, 255);
-    let heading = Style::default().fg(white).add_modifier(Modifier::BOLD);
-    let value = Style::default().fg(phosphor_green);
-    let dim = Style::default().fg(phosphor_dim);
+    let heading = Style::default()
+        .fg(crate::console::widgets::WHITE)
+        .add_modifier(Modifier::BOLD);
+    let value = Style::default().fg(crate::console::widgets::PHOSPHOR_GREEN);
+    let dim = Style::default().fg(crate::console::widgets::PHOSPHOR_DIM);
 
     let mut out: Vec<Line<'static>> = Vec::new();
 
@@ -851,10 +850,9 @@ fn append_env_map_diff_lines(
 fn collapse_section_lines(
     collapses: &[crate::workspace::Removal],
 ) -> Vec<ratatui::text::Line<'static>> {
-    use ratatui::style::{Color, Style};
+    use ratatui::style::Style;
     use ratatui::text::{Line, Span};
-    let phosphor_dim = Color::Rgb(0, 140, 30);
-    let style = Style::default().fg(phosphor_dim);
+    let style = Style::default().fg(crate::console::widgets::PHOSPHOR_DIM);
     collapses
         .iter()
         .map(|r| {
@@ -2503,12 +2501,11 @@ pub(super) fn build_settings_save_lines(
     use ratatui::style::{Color, Modifier, Style};
     use ratatui::text::{Line, Span};
 
-    let green = Color::Rgb(0, 255, 65);
-    let dim = Color::Rgb(0, 140, 30);
-    let white = Color::Rgb(255, 255, 255);
-    let heading = Style::default().fg(white).add_modifier(Modifier::BOLD);
-    let add_style = Style::default().fg(green);
-    let remove_style = Style::default().fg(dim);
+    let heading = Style::default()
+        .fg(crate::console::widgets::WHITE)
+        .add_modifier(Modifier::BOLD);
+    let add_style = Style::default().fg(crate::console::widgets::PHOSPHOR_GREEN);
+    let remove_style = Style::default().fg(crate::console::widgets::PHOSPHOR_DIM);
     let sep_style = Style::default().fg(Color::Rgb(0, 50, 12));
 
     let mut out: Vec<Line<'static>> = Vec::new();

--- a/src/console/widgets/file_browser/render.rs
+++ b/src/console/widgets/file_browser/render.rs
@@ -221,8 +221,7 @@ mod tests {
             cell.symbol()
         );
         assert_eq!(
-            cell.fg,
-            Color::Rgb(255, 255, 255),
+            cell.fg, WHITE,
             "non-git entry name should render in WHITE, got {:?}",
             cell.fg
         );
@@ -261,8 +260,7 @@ mod tests {
             name_cell.symbol()
         );
         assert_eq!(
-            name_cell.fg,
-            Color::Rgb(255, 255, 255),
+            name_cell.fg, WHITE,
             "git entry name should render in WHITE, got {:?}",
             name_cell.fg
         );
@@ -277,8 +275,7 @@ mod tests {
             paren_cell.symbol()
         );
         assert_eq!(
-            paren_cell.fg,
-            Color::Rgb(0, 255, 65),
+            paren_cell.fg, PHOSPHOR_GREEN,
             "git suffix should render in PHOSPHOR_GREEN, got {:?}",
             paren_cell.fg
         );

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -32,6 +32,26 @@ pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(
     tui_palette::PHOSPHOR_DARK.g,
     tui_palette::PHOSPHOR_DARK.b,
 );
+pub(crate) const DIALOG_BACKDROP: Color = Color::Rgb(
+    tui_palette::DIALOG_BACKDROP.r,
+    tui_palette::DIALOG_BACKDROP.g,
+    tui_palette::DIALOG_BACKDROP.b,
+);
+pub(crate) const DIALOG_SURFACE: Color = Color::Rgb(
+    tui_palette::DIALOG_SURFACE.r,
+    tui_palette::DIALOG_SURFACE.g,
+    tui_palette::DIALOG_SURFACE.b,
+);
+pub(crate) const DIALOG_SCROLL_THUMB: Color = Color::Rgb(
+    tui_palette::DIALOG_SCROLL_THUMB.r,
+    tui_palette::DIALOG_SCROLL_THUMB.g,
+    tui_palette::DIALOG_SCROLL_THUMB.b,
+);
+pub(crate) const DIALOG_SCROLL_TRACK: Color = Color::Rgb(
+    tui_palette::DIALOG_SCROLL_TRACK.r,
+    tui_palette::DIALOG_SCROLL_TRACK.g,
+    tui_palette::DIALOG_SCROLL_TRACK.b,
+);
 pub(crate) const WHITE: Color = Color::Rgb(
     tui_palette::WHITE.r,
     tui_palette::WHITE.g,

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -32,6 +32,11 @@ pub(crate) const PHOSPHOR_DARK: Color = Color::Rgb(
     tui_palette::PHOSPHOR_DARK.g,
     tui_palette::PHOSPHOR_DARK.b,
 );
+pub(crate) const INPUT_BG_DIM: Color = Color::Rgb(
+    tui_palette::INPUT_BG_DIM.r,
+    tui_palette::INPUT_BG_DIM.g,
+    tui_palette::INPUT_BG_DIM.b,
+);
 pub(crate) const DIALOG_BACKDROP: Color = Color::Rgb(
     tui_palette::DIALOG_BACKDROP.r,
     tui_palette::DIALOG_BACKDROP.g,

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -37,6 +37,16 @@ pub(crate) const INPUT_BG_DIM: Color = Color::Rgb(
     tui_palette::INPUT_BG_DIM.g,
     tui_palette::INPUT_BG_DIM.b,
 );
+pub(crate) const DIALOG_BACKDROP: Color = Color::Rgb(
+    tui_palette::DIALOG_BACKDROP.r,
+    tui_palette::DIALOG_BACKDROP.g,
+    tui_palette::DIALOG_BACKDROP.b,
+);
+pub(crate) const DIALOG_SURFACE: Color = Color::Rgb(
+    tui_palette::DIALOG_SURFACE.r,
+    tui_palette::DIALOG_SURFACE.g,
+    tui_palette::DIALOG_SURFACE.b,
+);
 pub(crate) const DIALOG_SCROLL_THUMB: Color = Color::Rgb(
     tui_palette::DIALOG_SCROLL_THUMB.r,
     tui_palette::DIALOG_SCROLL_THUMB.g,

--- a/src/console/widgets/mod.rs
+++ b/src/console/widgets/mod.rs
@@ -37,16 +37,6 @@ pub(crate) const INPUT_BG_DIM: Color = Color::Rgb(
     tui_palette::INPUT_BG_DIM.g,
     tui_palette::INPUT_BG_DIM.b,
 );
-pub(crate) const DIALOG_BACKDROP: Color = Color::Rgb(
-    tui_palette::DIALOG_BACKDROP.r,
-    tui_palette::DIALOG_BACKDROP.g,
-    tui_palette::DIALOG_BACKDROP.b,
-);
-pub(crate) const DIALOG_SURFACE: Color = Color::Rgb(
-    tui_palette::DIALOG_SURFACE.r,
-    tui_palette::DIALOG_SURFACE.g,
-    tui_palette::DIALOG_SURFACE.b,
-);
 pub(crate) const DIALOG_SCROLL_THUMB: Color = Color::Rgb(
     tui_palette::DIALOG_SCROLL_THUMB.r,
     tui_palette::DIALOG_SCROLL_THUMB.g,

--- a/src/console/widgets/save_discard.rs
+++ b/src/console/widgets/save_discard.rs
@@ -71,17 +71,15 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
-    let phosphor = Color::Rgb(0, 255, 65);
-    let phosphor_dark = Color::Rgb(0, 80, 18);
-    let white = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
+pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(phosphor_dark))
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
         .title(Span::styled(
             " Unsaved changes ",
-            Style::default().fg(white).add_modifier(Modifier::BOLD),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(ratatui::widgets::Clear, area);
@@ -100,7 +98,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
     frame.render_widget(
         Paragraph::new(Span::styled(
             state.prompt.clone(),
-            Style::default().fg(white).add_modifier(Modifier::BOLD),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ))
         .alignment(Alignment::Center),
         chunks[0],
@@ -109,10 +107,12 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SaveDiscardState) {
     // Buttons — focused row highlights on white; unfocused stays flush
     // with the modal background so only the focused choice pops.
     let focused_style = Style::default()
-        .bg(white)
+        .bg(WHITE)
         .fg(Color::Black)
         .add_modifier(Modifier::BOLD);
-    let unfocused_style = Style::default().fg(phosphor).add_modifier(Modifier::BOLD);
+    let unfocused_style = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
 
     let save_style = if state.focus == SaveDiscardFocus::Save {
         focused_style

--- a/src/console/widgets/scope_picker.rs
+++ b/src/console/widgets/scope_picker.rs
@@ -71,27 +71,27 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-pub fn render(frame: &mut Frame, area: Rect, state: &ScopePickerState) {
-    let phosphor = Color::Rgb(0, 255, 65);
-    let phosphor_dark = Color::Rgb(0, 80, 18);
-    let white = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
+pub fn render(frame: &mut Frame, area: Rect, state: &ScopePickerState) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(phosphor_dark))
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
         .title(Span::styled(
             state.title,
-            Style::default().fg(white).add_modifier(Modifier::BOLD),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(ratatui::widgets::Clear, area);
     frame.render_widget(block, area);
 
     let focused_style = Style::default()
-        .bg(white)
+        .bg(WHITE)
         .fg(Color::Black)
         .add_modifier(Modifier::BOLD);
-    let unfocused_style = Style::default().fg(phosphor).add_modifier(Modifier::BOLD);
+    let unfocused_style = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
 
     let all_style = if state.focused == ScopeChoice::AllAgents {
         focused_style

--- a/src/console/widgets/scrollable.rs
+++ b/src/console/widgets/scrollable.rs
@@ -9,7 +9,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Widget},
 };
 
-use super::{PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE};
+use super::{DIALOG_SCROLL_THUMB, DIALOG_SCROLL_TRACK, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
 pub(crate) const fn viewport_width(area: Rect) -> usize {
     area.width.saturating_sub(2) as usize
@@ -380,8 +380,8 @@ impl Widget for FixedScrollbar {
                 FixedScrollbarOrientation::Horizontal => ("━", "·", area.x, area.y, 1, 0),
                 FixedScrollbarOrientation::Vertical => ("█", "·", area.x, area.y, 0, 1),
             };
-        let thumb_style = Style::default().fg(PHOSPHOR_DIM);
-        let track_style = Style::default().fg(PHOSPHOR_DARK);
+        let thumb_style = Style::default().fg(DIALOG_SCROLL_THUMB);
+        let track_style = Style::default().fg(DIALOG_SCROLL_TRACK);
         for idx in 0..track_len {
             let in_thumb = (thumb_start..thumb_end).contains(&idx);
             let i = idx as u16;
@@ -448,6 +448,7 @@ mod tests {
         scrollbar_offset_for_track_position, scrollbar_position_for_offset,
         scrollbar_thumb_geometry,
     };
+    use crate::console::widgets::{DIALOG_SCROLL_THUMB, DIALOG_SCROLL_TRACK};
     use ratatui::{Terminal, backend::TestBackend, layout::Rect, text::Line};
 
     #[test]
@@ -484,6 +485,24 @@ mod tests {
         assert_eq!(rendered_thumb_len(0), 8);
         assert_eq!(rendered_thumb_len(1), 8);
         assert_eq!(rendered_thumb_len(2), 8);
+    }
+
+    #[test]
+    fn scrollbar_uses_shared_dialog_scroll_palette() {
+        let backend = TestBackend::new(1, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_vertical_scrollbar_in_area(frame, Rect::new(0, 0, 1, 10), 20, 5, 0);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "█");
+        assert_eq!(buffer[(0, 0)].fg, DIALOG_SCROLL_THUMB);
+        assert_eq!(buffer[(0, 9)].symbol(), "·");
+        assert_eq!(buffer[(0, 9)].fg, DIALOG_SCROLL_TRACK);
     }
 
     #[test]

--- a/src/console/widgets/source_picker.rs
+++ b/src/console/widgets/source_picker.rs
@@ -75,18 +75,16 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-pub fn render(frame: &mut Frame, area: Rect, state: &SourcePickerState) {
-    let phosphor = Color::Rgb(0, 255, 65);
-    let phosphor_dark = Color::Rgb(0, 80, 18);
-    let white = Color::Rgb(255, 255, 255);
+use super::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
+pub fn render(frame: &mut Frame, area: Rect, state: &SourcePickerState) {
     let title = format!(" Source for {} ", state.key);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(phosphor_dark))
+        .border_style(Style::default().fg(PHOSPHOR_DARK))
         .title(Span::styled(
             title,
-            Style::default().fg(white).add_modifier(Modifier::BOLD),
+            Style::default().fg(WHITE).add_modifier(Modifier::BOLD),
         ));
     let inner = block.inner(area);
     frame.render_widget(ratatui::widgets::Clear, area);
@@ -102,12 +100,14 @@ pub fn render(frame: &mut Frame, area: Rect, state: &SourcePickerState) {
         .split(inner);
 
     let focused_style = Style::default()
-        .bg(white)
+        .bg(WHITE)
         .fg(Color::Black)
         .add_modifier(Modifier::BOLD);
-    let unfocused_style = Style::default().fg(phosphor).add_modifier(Modifier::BOLD);
+    let unfocused_style = Style::default()
+        .fg(PHOSPHOR_GREEN)
+        .add_modifier(Modifier::BOLD);
     let disabled_style = Style::default()
-        .fg(phosphor_dark)
+        .fg(PHOSPHOR_DARK)
         .add_modifier(Modifier::DIM);
 
     let plain_style = if state.focused == SourceChoice::Plain {

--- a/src/console/widgets/text_input.rs
+++ b/src/console/widgets/text_input.rs
@@ -131,10 +131,7 @@ use ratatui::{
     widgets::{Block, Borders},
 };
 
-use super::{DANGER_RED, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
-/// Almost-invisible dim background so the input region is visible
-/// even when empty.
-const INPUT_BG_DIM: Color = Color::Rgb(20, 24, 22);
+use super::{DANGER_RED, INPUT_BG_DIM, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
 pub fn render(frame: &mut Frame, area: Rect, state: &TextInputState) {
     use ratatui::{

--- a/src/runtime/progress.rs
+++ b/src/runtime/progress.rs
@@ -14,8 +14,7 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::console::widgets::select_list::{self, SelectListState};
 use crate::console::widgets::{
-    DANGER_RED, DIALOG_BACKDROP, DIALOG_SURFACE, LINK_BLUE, ModalOutcome, PHOSPHOR_DARK,
-    PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE,
+    DANGER_RED, LINK_BLUE, ModalOutcome, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE,
 };
 use crate::diagnostics::RunDiagnostics;
 use jackin_tui::HintSpan;
@@ -1611,10 +1610,10 @@ const BUILD_LOG_HINT: &[HintSpan<'static>] = &[
 fn render_build_log_dialog(frame: &mut Frame<'_>, area: Rect, view: &LaunchView) {
     use crate::console::widgets::scrollable::{render_scrollable_block, viewport_height};
 
-    // Shared dialog backdrop fully hides the cockpit behind the overlay
-    // (same solid look as the capsule modals).
+    // Opaque black backdrop fully hides the cockpit behind the overlay (same
+    // solid look as the capsule modals).
     frame.render_widget(
-        Block::default().style(Style::default().bg(DIALOG_BACKDROP)),
+        Block::default().style(Style::default().bg(Color::Black)),
         area,
     );
 
@@ -1683,7 +1682,7 @@ fn wrap_build_log_line(line: &str, width: usize) -> Vec<Line<'static>> {
         return vec![Line::from(String::new())];
     }
 
-    let default_style = Style::default().fg(Color::Gray).bg(DIALOG_SURFACE);
+    let default_style = Style::default().fg(Color::Gray).bg(Color::Black);
     let spans = crate::ansi_text::styled_spans(line.trim_end(), default_style);
     wrap_build_log_spans(spans, width)
 }
@@ -1749,7 +1748,7 @@ fn push_wrapped_build_line(
             0,
             Span::styled(
                 BUILD_LOG_WRAP_PREFIX,
-                Style::default().fg(PHOSPHOR_DIM).bg(DIALOG_SURFACE),
+                Style::default().fg(PHOSPHOR_DIM).bg(Color::Black),
             ),
         );
     }

--- a/src/runtime/progress.rs
+++ b/src/runtime/progress.rs
@@ -14,7 +14,8 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::console::widgets::select_list::{self, SelectListState};
 use crate::console::widgets::{
-    DANGER_RED, LINK_BLUE, ModalOutcome, PHOSPHOR_DARK, PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE,
+    DANGER_RED, DIALOG_BACKDROP, DIALOG_SURFACE, LINK_BLUE, ModalOutcome, PHOSPHOR_DARK,
+    PHOSPHOR_DIM, PHOSPHOR_GREEN, WHITE,
 };
 use crate::diagnostics::RunDiagnostics;
 use jackin_tui::HintSpan;
@@ -1610,10 +1611,10 @@ const BUILD_LOG_HINT: &[HintSpan<'static>] = &[
 fn render_build_log_dialog(frame: &mut Frame<'_>, area: Rect, view: &LaunchView) {
     use crate::console::widgets::scrollable::{render_scrollable_block, viewport_height};
 
-    // Opaque black backdrop fully hides the cockpit behind the overlay (same
-    // solid look as the capsule modals).
+    // Shared dialog backdrop fully hides the cockpit behind the overlay
+    // (same solid look as the capsule modals).
     frame.render_widget(
-        Block::default().style(Style::default().bg(Color::Black)),
+        Block::default().style(Style::default().bg(DIALOG_BACKDROP)),
         area,
     );
 
@@ -1682,7 +1683,7 @@ fn wrap_build_log_line(line: &str, width: usize) -> Vec<Line<'static>> {
         return vec![Line::from(String::new())];
     }
 
-    let default_style = Style::default().fg(Color::Gray).bg(Color::Black);
+    let default_style = Style::default().fg(Color::Gray).bg(DIALOG_SURFACE);
     let spans = crate::ansi_text::styled_spans(line.trim_end(), default_style);
     wrap_build_log_spans(spans, width)
 }
@@ -1748,7 +1749,7 @@ fn push_wrapped_build_line(
             0,
             Span::styled(
                 BUILD_LOG_WRAP_PREFIX,
-                Style::default().fg(PHOSPHOR_DIM).bg(Color::Black),
+                Style::default().fg(PHOSPHOR_DIM).bg(DIALOG_SURFACE),
             ),
         );
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -168,11 +168,14 @@ macro_rules! debug_log {
 
 // ── Shared color palette ─────────────────────────────────────────────────
 
-const WHITE: (u8, u8, u8) = (255, 255, 255);
+const fn palette_tuple(color: jackin_tui::Rgb) -> (u8, u8, u8) {
+    (color.r, color.g, color.b)
+}
 
-const PHOSPHOR_GREEN: (u8, u8, u8) = (0, 255, 65);
-const PHOSPHOR_DIM: (u8, u8, u8) = (0, 140, 30);
-const PHOSPHOR_DARK: (u8, u8, u8) = (0, 80, 18);
+const WHITE: (u8, u8, u8) = palette_tuple(jackin_tui::WHITE);
+const PHOSPHOR_GREEN: (u8, u8, u8) = palette_tuple(jackin_tui::PHOSPHOR_GREEN);
+const PHOSPHOR_DIM: (u8, u8, u8) = palette_tuple(jackin_tui::PHOSPHOR_DIM);
+const PHOSPHOR_DARK: (u8, u8, u8) = palette_tuple(jackin_tui::PHOSPHOR_DARK);
 
 const fn rgb(color: (u8, u8, u8)) -> owo_colors::Rgb {
     owo_colors::Rgb(color.0, color.1, color.2)


### PR DESCRIPTION
## Summary

The launch Docker build log now uses the same near-black modal backdrop, dark surface, phosphor border, and phosphor scrollbar treatment as Capsule dialogs. The shared palette lives in `jackin-tui` and is reused by the host console widgets, plain CLI banner, Capsule dialogs, Capsule status chrome, and launch overlay so operators see one consistent terminal UI palette instead of each surface carrying its own literal colors.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test/pr-468"
cd "$HOME/Projects/jackin-project/test/pr-468"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/docker-build-overlay-background:refs/remotes/origin/fix/docker-build-overlay-background
git checkout -B fix/docker-build-overlay-background refs/remotes/origin/fix/docker-build-overlay-background
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
which jackin
```

Then build and export the jackin-capsule binary so the smoke steps below use it:

```sh
eval "$(cargo run --bin build-jackin-capsule -- --export)"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo test -p jackin-tui
cargo test -p jackin-capsule dialog
cargo test -p jackin-capsule render
cargo test --lib console::widgets::scrollable::tests
cargo test --lib progress::tests
cargo test --lib
```

These tests cover the shared palette helpers, Capsule dialog/render paths, the shared scrollable widget chrome, and the launch Docker build overlay rendering.

### User smoke

```sh
jackin console --debug
```

From the console, launch `the-architect` against the current directory. While the launch cockpit is building the derived image, click the Docker build activity to open the build-log overlay; verify the overlay background is near-black rather than gray, the bordered log surface is dark, and the border and scrollbar use the same bright phosphor green as Capsule dialogs. Use `↑`/`↓`, `PgUp`/`PgDn`, and `Esc` to confirm the footer hints and scroll behavior still work.

For a faster repeat check, run the launch directly:

```sh
jackin load the-architect . --debug
```

Open the Docker build log during the derived-image stage and verify the same dialog palette and scroll chrome.

### jackin-capsule smoke

```sh
jackin load the-architect . --debug
```

Inside the container, verify:

- Row 0 status bar is visible: `jackin'  [<agent-name>]`
- Agent TUI starts and renders correctly below the status bar
- `Ctrl+\` opens the command palette (override with `JACKIN_PALETTE_KEY`)
- Mouse clicks, arrow keys, and paste reach the agent unmodified
- Open a Capsule dialog and verify its backdrop, border, scrollbar, focused buttons, and status chrome still use the shared black/phosphor palette

## Migration notes

None.
