### PR TITLE
Fix static server function cache output for GitHub Pages

### DIFF
--- a/docs/scripts/prerender-static.ts
+++ b/docs/scripts/prerender-static.ts
@@ -102,6 +102,10 @@ const child = Bun.spawn(
   ['bunx', 'vite', 'preview', '--host', host, '--port', String(port), '--strictPort'],
   {
     cwd: root,
+    env: {
+      ...process.env,
+      TSS_CLIENT_OUTPUT_DIR: outDir,
+    },
     stdout: 'pipe',
     stderr: 'pipe',
   },


### PR DESCRIPTION
## What changed
- Pass `TSS_CLIENT_OUTPUT_DIR` to the preview server used by `docs/scripts/prerender-static.ts` so TanStack static server-function cache files are emitted into the published docs output.

## Why
- GitHub Pages was 404ing the hashed `__tsr/staticServerFnCache/*.json` files during hydration.
- TanStack static server functions expect those cache files to exist in the build output when prerendering static pages.

## Verification
- `bun run build` in `docs/`
- Confirmed `docs/.output/public/__tsr/staticServerFnCache/` is populated after the build
