### PR TITLE
chore(docs): add roadmap sidebar completeness check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,6 +89,10 @@ jobs:
         working-directory: docs
         run: bun run check:repo-links
 
+      - name: Check roadmap sidebar completeness
+        working-directory: docs
+        run: bun run check:roadmap-sidebar
+
   docs-link-check:
     needs: changes
     if: needs.changes.outputs.docs == 'true'

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -52,6 +52,8 @@ This populates `node_modules/` with the platform-specific optional native binari
 - Start dev server: `bun run dev`
 - Build docs: `bun run build`
 - Preview production build: `bun run preview`
+- Check source repository links: `bun run check:repo-links`
+- Check roadmap sidebar completeness: `bun run check:roadmap-sidebar`
 - Check links in the existing production build: `bun run check:links`
 - Rebuild and then check links: `bun run check:links:fresh`
 - Run tests: `bun test`
@@ -85,17 +87,13 @@ bun install --frozen-lockfile
 - `check:repo-links` exists because lychee only checks real links in rendered HTML. Plain code spans like `src/runtime/launch.rs` are not links, so lychee cannot detect when those files are renamed or deleted. The source check makes those references use `<RepoFile />`, then lychee verifies the generated URL.
 - `mailto:` links are included in lychee checks, so use real, intentional email addresses rather than placeholders.
 - Sidebar and top-nav are configured through `meta.json` files and `src/lib/layout.shared.tsx`.
-- **Roadmap sidebar discipline.** Every MDX file under `content/docs/reference/roadmap/` must have a matching entry in `content/docs/reference/roadmap/meta.json` under one of the open-work categories (`Agent Orchestrator Research`, `Codebase health`, `Agent runtimes & authentication`, `Isolation & security`, `Infrastructure`, `Documentation tooling`, `Configuration ergonomics`) or under `Resolved`, as appropriate for the page's `**Status**` field. Whenever you add, rename, delete, or change the status of a roadmap item — or restructure the directory — verify the sidebar still matches the directory contents in the same PR. Operators rely on the sidebar (not the overview prose) to discover open work, so an item reachable only via direct URL or the overview page is effectively hidden. To audit:
+- **Roadmap sidebar discipline.** Every MDX file under `content/docs/reference/roadmap/` must be referenced in at least one `meta.json` under the roadmap directory tree (the sidebar uses a nested group structure: root `meta.json` points to group dirs, each group's `meta.json` points to pages via `../slug` or `../../slug` relative paths). Whenever you add, rename, delete, or change the status of a roadmap item — or restructure the directory — verify the sidebar still matches the directory contents in the same PR. Operators rely on the sidebar (not the overview prose) to discover open work, so an item reachable only via direct URL or the overview page is effectively hidden. To audit, run the dedicated script from `docs/`:
 
   ```sh
-  ls docs/content/docs/reference/roadmap/*.mdx \
-    | xargs -n1 basename -s .mdx | sort > /tmp/roadmap-files
-  jq -r '.. | strings' docs/content/docs/reference/roadmap/meta.json \
-    | grep -E '^[a-z0-9-]+$' | sort -u > /tmp/roadmap-sidebar
-  diff /tmp/roadmap-files /tmp/roadmap-sidebar
+  bun run check:roadmap-sidebar
   ```
 
-  The diff must be empty.
+  The script reports any MDX file with no matching `meta.json` entry and any `meta.json` entry with no matching MDX file. Both directions must be clean.
 - **Roadmap overview discipline.** `content/docs/reference/roadmap/index.mdx` is the entry point operators land on when they want a single picture of *what shipped, what is partial, what is planned, what is deferred, and what is on hold*. The sidebar lists every item alphabetically/by phase; the overview is what tells the reader the **status story**. The two surfaces have different jobs and must be maintained together, not folded into one.
 
   Whenever you add, rename, delete, or change the `**Status**` field of a roadmap item, also update `roadmap.mdx` so the item lands in the section that matches its new status:

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "gen-og": "bun run scripts/gen-og.ts",
     "gen-icons": "bun run scripts/gen-icons.ts",
     "check:repo-links": "bun run scripts/check-repo-links.ts",
+    "check:roadmap-sidebar": "bun run scripts/check-roadmap-sidebar.ts",
     "check:links": "lychee --config lychee.toml --include-fragments --remap \"https://jackin.tailrocks.com/(.*) file://$PWD/.output/public/\\$1\" --remap \"https://github.com/jackin-project/jackin/edit/main/(.*) file://$PWD/../\\$1\" --remap \"https://github.com/jackin-project/jackin/blob/main/(.*) file://$PWD/../\\$1\" --root-dir \"$PWD/.output/public\" '.output/public/**/*.html'",
     "check:links:fresh": "bun run check:repo-links && bun run build && bun run check:links",
     "test": "bun test"

--- a/docs/scripts/check-roadmap-sidebar.ts
+++ b/docs/scripts/check-roadmap-sidebar.ts
@@ -1,0 +1,97 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Every MDX file under content/docs/reference/roadmap/ (excluding index.mdx and
+// files inside parenthesized group subdirectories) must be referenced in at least
+// one meta.json under the same directory tree, so it appears in the docs sidebar.
+// This script enforces that invariant both ways: no MDX without a meta.json entry,
+// and no meta.json entry without a matching MDX file.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const roadmapDir = resolve(__dirname, '..', 'content', 'docs', 'reference', 'roadmap')
+
+interface MetaJson {
+  pages?: string[]
+}
+
+async function collectMetaJsonFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const results: string[] = []
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      results.push(...(await collectMetaJsonFiles(join(dir, entry.name))))
+    } else if (entry.name === 'meta.json') {
+      results.push(join(dir, entry.name))
+    }
+  }
+  return results
+}
+
+// Collect all roadmap-root page slugs referenced across all meta.json files.
+// Page references are relative to the meta.json's directory; we resolve them
+// and keep only those that land directly in roadmapDir (not in subdirectories).
+async function collectSidebarSlugs(metaFiles: string[]): Promise<Set<string>> {
+  const slugs = new Set<string>()
+  for (const metaFile of metaFiles) {
+    const metaDir = dirname(metaFile)
+    const raw = await readFile(metaFile, 'utf8')
+    const meta = JSON.parse(raw) as MetaJson
+    for (const page of meta.pages ?? []) {
+      if (!page.startsWith('.')) continue // skip group dirs and 'index'
+      const absolute = resolve(metaDir, page)
+      const rel = relative(roadmapDir, absolute)
+      // Only include pages that sit directly in roadmapDir (no path separator = no subdir)
+      if (!rel.includes('/') && !rel.includes('\\') && !rel.startsWith('..')) {
+        slugs.add(rel)
+      }
+    }
+  }
+  return slugs
+}
+
+// Collect all MDX file slugs in the roadmap root (exclude index, exclude subdirs).
+async function collectRoadmapSlugs(): Promise<Set<string>> {
+  const entries = await readdir(roadmapDir, { withFileTypes: true })
+  const slugs = new Set<string>()
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith('.mdx') && entry.name !== 'index.mdx') {
+      slugs.add(basename(entry.name, '.mdx'))
+    }
+  }
+  return slugs
+}
+
+const failures: string[] = []
+
+const metaFiles = await collectMetaJsonFiles(roadmapDir)
+const [sidebarSlugs, roadmapSlugs] = await Promise.all([
+  collectSidebarSlugs(metaFiles),
+  collectRoadmapSlugs(),
+])
+
+for (const slug of [...roadmapSlugs].sort()) {
+  if (!sidebarSlugs.has(slug)) {
+    failures.push(`MDX file not in any sidebar meta.json: content/docs/reference/roadmap/${slug}.mdx`)
+  }
+}
+
+for (const slug of [...sidebarSlugs].sort()) {
+  if (!roadmapSlugs.has(slug)) {
+    failures.push(
+      `meta.json references non-existent MDX file: content/docs/reference/roadmap/${slug}.mdx`,
+    )
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Roadmap sidebar is incomplete:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log(
+  `Checked ${roadmapSlugs.size} roadmap pages against ${metaFiles.length} meta.json files. Sidebar is complete.`,
+)


### PR DESCRIPTION
## Summary

- Add `docs/scripts/check-roadmap-sidebar.ts` — verifies every MDX file under `content/docs/reference/roadmap/` is referenced in at least one `meta.json` in the sidebar tree, and every `meta.json` reference has a matching MDX file
- Wire it as `bun run check:roadmap-sidebar` in `docs/package.json` and as a CI step in the `repo-link-check` job in `.github/workflows/docs.yml`
- Fix the audit commands in `docs/AGENTS.md`: the previous shell one-liner only checked the root `meta.json`, silently missing all 75 roadmap pages (they live in nested group/sub-group `meta.json` files using `../slug` and `../../slug` relative paths); replace the broken commands with a pointer to the new script

## Why

The old AGENTS.md audit script was broken by design — it ran `jq -r '.. | strings' docs/content/docs/reference/roadmap/meta.json` which extracts group dir names like `(agent-orchestrator-research)` and `(codebase-health)`, not page slugs. The actual page slugs live in those group directories' meta files. The diff always showed every page as missing, making the script useless.

The new TypeScript script resolves each `meta.json` page entry relative to its own directory, keeps only those that land directly in the roadmap root, and checks both directions. It currently passes cleanly against the 75 roadmap pages across 21 meta.json files.

## Verify locally

```sh
cd docs
bun install --frozen-lockfile
bun run check:roadmap-sidebar
```

Expected output: `Checked 75 roadmap pages against 21 meta.json files. Sidebar is complete.`

Co-authored-by: Claude <noreply@anthropic.com>