### PR TITLE
feat(construct): bump construct image to 0.4-trixie

### DIFF
--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.3-trixie
+0.4-trixie

--- a/docs/content/docs/(role-authoring)/developing/construct-image.mdx
+++ b/docs/content/docs/(role-authoring)/developing/construct-image.mdx
@@ -21,7 +21,7 @@ and updates the `construct` automatically.
 Every agent Dockerfile starts from the construct:
 
 ```dockerfile
-FROM projectjackin/construct:0.3-trixie
+FROM projectjackin/construct:0.4-trixie
 ```
 
 ## What's inside
@@ -99,7 +99,7 @@ just construct-build-local
 export JACKIN_CONSTRUCT_IMAGE="jackin-local/construct:trixie"
 ```
 
-With `JACKIN_CONSTRUCT_IMAGE` set, jackin' validates role Dockerfiles against the canonical image name as usual (role repos reference a versioned construct tag such as `projectjackin/construct:0.3-trixie`), but substitutes your local image at derived-build time so `docker build` uses `jackin-local/construct:trixie` as the actual base.
+With `JACKIN_CONSTRUCT_IMAGE` set, jackin' validates role Dockerfiles against the canonical image name as usual (role repos reference a versioned construct tag such as `projectjackin/construct:0.4-trixie`), but substitutes your local image at derived-build time so `docker build` uses `jackin-local/construct:trixie` as the actual base.
 
 Use `just construct-inspect` to print the fully resolved Bake config without building the image.
 

--- a/docs/content/docs/(role-authoring)/developing/creating-roles.mdx
+++ b/docs/content/docs/(role-authoring)/developing/creating-roles.mdx
@@ -34,7 +34,7 @@ Creating a custom agent lets you define a specialized environment for a specific
    Start from the generated file and add the tools your role needs:
 
    ```dockerfile
-   FROM projectjackin/construct:0.3-trixie
+   FROM projectjackin/construct:0.4-trixie
 
    # Install Rust via mise
    RUN mise install rust@stable && mise use --global rust@stable
@@ -81,11 +81,11 @@ Use `jackin role migrate` on your own desktop when you are updating a checked-ou
 Your final stage **must** start from the construct image:
 
 ```dockerfile
-FROM projectjackin/construct:0.3-trixie
+FROM projectjackin/construct:0.4-trixie
 ```
 
 <Aside type="caution">
-The final stage must use a versioned construct tag (e.g. `projectjackin/construct:0.3-trixie`). The floating `:trixie` tag, `:latest`, or any other non-versioned tag fails validation. Renovate can track version bumps automatically — the generated role repo includes a Renovate configuration with a regex versioning rule for construct version pins.
+The final stage must use a versioned construct tag (e.g. `projectjackin/construct:0.4-trixie`). The floating `:trixie` tag, `:latest`, or any other non-versioned tag fails validation. Renovate can track version bumps automatically — the generated role repo includes a Renovate configuration with a regex versioning rule for construct version pins.
 </Aside>
 ### Multi-stage builds are supported
 
@@ -99,7 +99,7 @@ COPY tools/ .
 RUN cargo build --release
 
 # Final stage — must use the construct
-FROM projectjackin/construct:0.3-trixie
+FROM projectjackin/construct:0.4-trixie
 COPY --from=builder /build/target/release/my-tool /usr/local/bin/
 ```
 

--- a/docs/content/docs/(role-authoring)/developing/publishing-role-images.mdx
+++ b/docs/content/docs/(role-authoring)/developing/publishing-role-images.mdx
@@ -73,7 +73,7 @@ If your role repo is not on GitHub, or if you use a different CI/CD system (GitL
    Read the version from your Dockerfile's `FROM` line. The version is the part between `:` and `-` in the construct tag:
 
    ```dockerfile
-   FROM projectjackin/construct:0.3-trixie
+   FROM projectjackin/construct:0.4-trixie
    #                            ^^^— this is the construct version
    ```
 

--- a/docs/content/docs/(role-authoring)/developing/role-manifest.mdx
+++ b/docs/content/docs/(role-authoring)/developing/role-manifest.mdx
@@ -83,7 +83,7 @@ The Dockerfile path must:
 - Be relative (no absolute paths)
 - Stay inside the repository (no `../` escapes)
 - Point to a valid Dockerfile
-- Have a final stage that starts with `FROM projectjackin/construct:0.3-trixie` (a versioned construct tag — the floating `:trixie` tag fails validation)
+- Have a final stage that starts with `FROM projectjackin/construct:0.4-trixie` (a versioned construct tag — the floating `:trixie` tag fails validation)
 
 Every agent listed in `agents` must have a matching `[<agent>]` table, even when that table is empty. A manifest with `agents = ["claude", "codex", "amp", "kimi", "opencode"]` needs `[claude]`, `[codex]`, `[amp]`, `[kimi]`, and `[opencode]`.
 

--- a/docs/content/docs/(role-authoring)/guides/role-repos.mdx
+++ b/docs/content/docs/(role-authoring)/guides/role-repos.mdx
@@ -102,11 +102,11 @@ Every role repo must satisfy a contract:
 3. **The Dockerfile path must be relative** and must stay inside the repo checkout (no `../` escapes)
 4. **The final Dockerfile stage must use the construct base**:
    ```dockerfile
-   FROM projectjackin/construct:0.3-trixie
+   FROM projectjackin/construct:0.4-trixie
    ```
    An optional alias is allowed:
    ```dockerfile
-   FROM projectjackin/construct:0.3-trixie AS runtime
+   FROM projectjackin/construct:0.4-trixie AS runtime
    ```
 5. **Earlier stages may use any base image** — multi-stage builds are fully supported
 6. **No symlinks** — the derived build-context generator currently rejects symlinks
@@ -130,7 +130,7 @@ name = "Frontend Engineer"
 ```
 
 ```dockerfile title="Dockerfile"
-FROM projectjackin/construct:0.3-trixie
+FROM projectjackin/construct:0.4-trixie
 
 # Install Node.js via mise
 RUN mise install node@22 && mise use --global node@22


### PR DESCRIPTION
## Summary

Bump the construct image from `0.3-trixie` to `0.4-trixie`. Merging this PR triggers the construct CI workflow which builds and publishes `projectjackin/construct:0.4-trixie` to Docker Hub (amd64 + arm64). All role-authoring docs updated to reference the new version in example Dockerfiles and prose.

After this merges and CI publishes the image, follow-up PRs will update the four agent role repos (architect, smith, sentinel, brown) to `FROM projectjackin/construct:0.4-trixie`.

## What's deferred

- Update jackin-the-architect to `0.4-trixie`
- Update jackin-agent-smith to `0.4-trixie`
- Update jackin-sentinel to `0.4-trixie`
- Update jackin-agent-brown to `0.4-trixie`

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test/pr-502"
cd "$HOME/Projects/jackin-project/test/pr-502"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feat/construct-0.4-trixie:refs/remotes/origin/feat/construct-0.4-trixie
git checkout -B feat/construct-0.4-trixie refs/remotes/origin/feat/construct-0.4-trixie
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
which jackin
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run --all-features
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

## Migration notes

None during pre-release. Agent role repos should be updated to `0.4-trixie` after CI publishes the image.
