### PR TITLE
docs(roadmap): add platform support policy & roadmap freshness under Infrastructure

### DIFF
--- a/docs/content/docs/reference/roadmap/(infrastructure)/meta.json
+++ b/docs/content/docs/reference/roadmap/(infrastructure)/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "../architect-code-intelligence-tooling",
     "../construct-user-creation",
-    "../workspace-registry-cache"
+    "../workspace-registry-cache",
+    "../platform-support-and-freshness"
   ]
 }

--- a/docs/content/docs/reference/roadmap/index.mdx
+++ b/docs/content/docs/reference/roadmap/index.mdx
@@ -102,6 +102,7 @@ jackin' is a functional proof of concept, not a stable product line. **`Claude C
 - **[Construct user creation optimization](/reference/roadmap/construct-user-creation/)** — move user creation to the derived layer to eliminate UID/GID remapping (status: deferred — needs design work)
 - **[Workspace registry cache](/reference/roadmap/workspace-registry-cache/)** — opt-in workspace-level zot registry that acts as a pull-through cache for Docker Hub and a local push target; shared across all DinD sidecars in a workspace so base image layers are pulled once and reused, and built images persist across sessions (status: open — design proposal)
 - **[Code-intelligence tooling for the-architect role](/reference/roadmap/architect-code-intelligence-tooling/)** — pilot baking `ast-grep` (structural search CLI), `rust-analyzer` (LSP), the cargo verifiers, and the `fff` file-search MCP server into the-architect, with baked agent guidance so the model uses them; opt-in, role-scoped, and decoupled from jackin core so the approach can be measured before any broader rollout (status: open — ready to implement)
+- **[Platform support policy & roadmap freshness](/reference/roadmap/platform-support-and-freshness/)** — declare macOS as primary platform, Linux as experimental, Windows WSL2 as best-effort, native Windows as out of scope; document Debian-only construct image rationale; add `last_reviewed` frontmatter and freshness check script for all 88+ roadmap items (status: open — design proposal)
 
 ### Operator surface and fleet operations
 

--- a/docs/content/docs/reference/roadmap/platform-support-and-freshness.mdx
+++ b/docs/content/docs/reference/roadmap/platform-support-and-freshness.mdx
@@ -1,0 +1,86 @@
+---
+title: "Platform Support Policy & Roadmap Freshness"
+---
+
+**Status**: Open — design proposal
+
+## Problem
+
+Two documentation and process gaps:
+
+1. **No declared platform support matrix.** Only 2 `#[cfg(windows)]` blocks vs 30+ `#[cfg(unix)]` in the codebase. CI ships macOS and Linux binaries only. Windows is effectively unsupported, but the docs never say so. The next user who tries `cargo install jackin` on Windows hits cryptic errors with no landing page.
+
+2. **Roadmap staleness is invisible.** The roadmap is at 88+ items. No audit catches staleness. An item marked `Status: Open` could be untouched for 18 months. "Open" without a date is misleading.
+
+## Proposal
+
+### Part 1 — Platform support policy page
+
+Write a contributor-facing reference page (`docs/content/docs/reference/platform-support.mdx`) declaring:
+
+| Platform | Status |
+|---|---|
+| macOS (aarch64, latest) | **Primary** — all development and verification happens here |
+| macOS (x86_64, latest) | Supported (via CI) |
+| Linux (aarch64, x86_64) | **Experimental** — community-tested, no in-house test machine today. Will become a priority when jackin' moves to server-side use cases (Kubernetes, remote operation). Community contributions and bug reports welcome. |
+| Windows (WSL2) | Best-effort — uses the Linux build. No dedicated testing. |
+| Windows (native) | Out of scope — jackin's TUI/PTY model relies on Unix primitives. |
+
+Philosophy: jackin' targets the latest versions of everything (latest Debian for the construct image, latest macOS, latest OrbStack). No intention to support older versions. To change this stance, the project needs at least one strong advocate who uses jackin' on that platform and can explain why.
+
+### Part 2 — Base image rationale
+
+Document why the construct image uses Debian only (latest `debian:trixie`): it's the most well-known and predictable base image in the Docker ecosystem, stable, not fragmented. No Alpine or slim variants are planned until a strong advocate appears with a clear use case. This is not a roadmap item for implementation — it's a policy statement.
+
+### Part 3 — Roadmap freshness tracking
+
+Add `last_reviewed: YYYY-MM-DD` frontmatter to every roadmap MDX file. Add `docs/scripts/check-roadmap-freshness.ts` that runs in CI and as `bun run check:roadmap-freshness`:
+
+- Flags items with `last_reviewed > 6 months` as stale.
+- Reports them in the CI output.
+- The script is ~30 lines of TypeScript.
+
+Apply `last_reviewed: 2026-06-02` to every existing roadmap MDX as a baseline. New roadmap items should include the field from creation.
+
+## Non-goals
+
+- Do not add WSL2 first-class support — that requires dedicated testing.
+- Do not add Alpine/slim construct image variants — no advocate or use case exists.
+- Do not archive stale roadmap items. Freshness tracking is sufficient; old items stay.
+- Do not auto-open GitHub issues for stale items — just report in CI.
+
+## Implementation Phases
+
+### Phase 1 — Platform support page
+
+Write `docs/content/docs/reference/platform-support.mdx`. Link from README install section and from `getting-started/installation.mdx`.
+
+### Phase 2 — Base image rationale
+
+Add a section to `docs/content/docs/developing/construct-image.mdx` or create a short standalone page explaining the Debian-only policy and how to advocate for change.
+
+### Phase 3 — Roadmap freshness frontmatter
+
+Mechanically add `last_reviewed: 2026-06-02` to every existing roadmap MDX file's frontmatter.
+
+### Phase 4 — Freshness check script
+
+Create `docs/scripts/check-roadmap-freshness.ts`. Wire into <RepoFile path="docs/package.json" /> scripts and CI.
+
+## Open Questions
+
+1. Should the platform support page live under `reference/` or under `getting-started/`?
+2. What is the staleness threshold? 6 months is suggested but adjustable.
+3. Should the freshness script also check for items missing the `last_reviewed` field entirely?
+
+## Related Files
+
+- <RepoFile path=".github/workflows/preview.yml" />
+- <RepoFile path=".github/workflows/release.yml" />
+- <RepoFile path="docs/scripts/check-roadmap-sidebar.ts" /> (and sibling scripts)
+
+## Cross-references
+
+- [/reference/roadmap/smolvm-backend-research/](/reference/roadmap/smolvm-backend-research/) — Linux/KVM support affects platform matrix
+- [/reference/roadmap/orbstack-isolated-machine-backend/](/reference/roadmap/orbstack-isolated-machine-backend/) — macOS-only backend
+- [/reference/roadmap/selectable-sandbox-backends/](/reference/roadmap/selectable-sandbox-backends/) — backend selection affects platform support


### PR DESCRIPTION
## Summary

Adds a new roadmap item for declaring a platform support policy and introducing roadmap freshness tracking. The page documents macOS as the primary platform, Linux as experimental, Windows WSL2 as best-effort, and native Windows as out of scope. It also proposes `last_reviewed` frontmatter on all roadmap MDX files plus a CI freshness check script.

## Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run check:roadmap-sidebar
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
mkdir -p "$HOME/Projects/jackin-project/test/pr-<PR_NUMBER>"
cd "$HOME/Projects/jackin-project/test/pr-<PR_NUMBER>"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/roadmap-platform-support-freshness:refs/remotes/origin/docs/roadmap-platform-support-freshness
git checkout -B docs/roadmap-platform-support-freshness refs/remotes/origin/docs/roadmap-platform-support-freshness
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
which jackin
```

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/reference/roadmap/platform-support-and-freshness/**
NEW page. Verify the full roadmap page renders — Problem, Proposal (all three parts), Non-goals, Implementation Phases, Open Questions, Related Files (RepoFile links resolve), and Cross-references.

**http://localhost:3000/reference/roadmap/**
UPDATED. Verify the new bullet appears under **Infrastructure improvements** with the correct link and status.

Sidebar under **Infrastructure** — verify "Platform Support Policy & Roadmap Freshness" appears as the fourth entry.

## Migration notes

None.
