### PR TITLE
docs(roadmap): update existing items + strengthen solo-maintainer rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ jackin' has exactly one human contributor — the operator. There is no second r
 - Multi-agent review (running `code-reviewer` / `comment-analyzer` / `silent-failure-hunter` / etc. in parallel before requesting merge) is the substitute for the missing second human. Treat those review passes as load-bearing rather than optional polish.
 - For irreversible or high-blast-radius changes, prefer asking the operator to confirm one more time over assuming the green CI run is sufficient. The cost of pausing 30 seconds is much lower than the cost of a bad merge that an absent second reviewer would have caught.
 
+Practices designed for multi-developer teams (CODEOWNERS, mandatory second-human review, pair programming conventions, team-oriented workflow tooling) should not be proposed without a concrete plan for how a second human will participate. Until the project gains additional human contributors, the solo-maintainer constraint means team-oriented tooling adds maintenance burden without corresponding benefit.
+
 This rule retires when the project gains additional human reviewers.
 
 ## Project status: pre-release (agent-only)

--- a/docs/content/docs/reference/roadmap/cargo-workspace-split.mdx
+++ b/docs/content/docs/reference/roadmap/cargo-workspace-split.mdx
@@ -41,11 +41,16 @@ jackin/
 - **Tier 2**: `operator_env/`, `runtime/`, `repo/`
 - **Tier 3**: `console/` — **almost** no import from `runtime/` (2 call sites need fixing first)
 
+## Visibility is the real blocker
+
+The LOC-based triggers above are useful heuristics, but the actual blocker for a meaningful workspace split is visibility discipline. Today 89% of functions are `pub` (423 `pub fn` vs 55 `pub(crate) fn`), so an external consumer importing `jackin::*` would be coupled to internals immediately. Any crate boundary drawn under the current visibility surface would either expose too much (defeating the purpose of the split) or require a sweeping `pub` → `pub(crate)` pass that touches nearly every module. The visibility pass — already roadmap'd as [the `pub(crate)` visibility item](/reference/roadmap/pub-crate-visibility/) — is the real prerequisite: it makes each crate's public API a deliberate, auditable surface rather than an accidental one.
+
 ## Prerequisites before this phase
 
-1. **Phase 2 file splits** — establish clean internal module boundaries
-2. **Phase 1.5 DRY extractions** — reduce duplication that would otherwise be frozen into crate APIs
-3. **Fix the 2 console→runtime dependencies** — `register_agent_repo` and `RepoError` must move to a shared module or through a trait
+1. **Visibility pass** — complete the `pub(crate)` migration ([`pub-crate-visibility`](/reference/roadmap/pub-crate-visibility/)) so crate boundaries are enforceable
+2. **Phase 2 file splits** — establish clean internal module boundaries
+3. **Phase 1.5 DRY extractions** — reduce duplication that would otherwise be frozen into crate APIs
+4. **Fix the 2 console→runtime dependencies** — `register_agent_repo` and `RepoError` must move to a shared module or through a trait
 
 ## Related files
 

--- a/docs/content/docs/reference/roadmap/multi-runtime-support.mdx
+++ b/docs/content/docs/reference/roadmap/multi-runtime-support.mdx
@@ -23,6 +23,8 @@ The project now has basic built-in runtime support. The remaining work is parity
 - runtime-specific auth and state behavior where Codex, Amp, Kimi, or OpenCode need something more than `sync`, `api_key`, and `ignore`;
 - clearer version/update behavior for non-Claude runtimes.
 
+Once the [agent runtime trait extraction](/reference/roadmap/agent-runtime-trait/) lands, adding a new runtime becomes a one-file addition (implement the trait, register the variant) instead of the current ~7-file edit across `runtime/`, `config/`, `console/`, and the entrypoint. That trait is the structural prerequisite for most of the parity-depth items above.
+
 ## Non-Goals
 
 - A third-party runtime marketplace.


### PR DESCRIPTION
## Summary

Three documentation updates to existing roadmap items and agent rules: rescope the Cargo workspace split item to identify visibility discipline as the real blocker (with cross-reference to the `pub-crate-visibility` roadmap item), cross-link the multi-runtime support item to the agent runtime trait extraction roadmap item, and strengthen the solo-maintainer rule in `AGENTS.md` to discourage proposing team-oriented practices until additional human contributors join.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
mkdir -p "$HOME/Projects/jackin-project/test/pr-PR_NUMBER"
cd "$HOME/Projects/jackin-project/test/pr-PR_NUMBER"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin docs/roadmap-update-existing-items:refs/remotes/origin/docs/roadmap-update-existing-items
git checkout -B docs/roadmap-update-existing-items refs/remotes/origin/docs/roadmap-update-existing-items
mise trust
mise install
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/reference/roadmap/cargo-workspace-split/**  
UPDATED. New "Visibility is the real blocker" section and updated prerequisites list with cross-reference to `pub-crate-visibility`.

**http://localhost:3000/reference/roadmap/multi-runtime-support/**  
UPDATED. New paragraph in "Remaining Work" cross-linking to the agent runtime trait extraction roadmap item.
