### PR TITLE
chore(deps): drop exact pins on dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,10 @@ reqwest = { version = "0.13", default-features = false }
 jackin-build-meta = { path = "crates/jackin-build-meta" }
 
 [dev-dependencies]
-assert_cmd = "=2.2.2"
-filetime = "=0.2.29"
-predicates = "=3.1.4"
-tokio = { version = "=1.52.3", features = ["test-util"] }
+assert_cmd = "2"
+filetime = "0.2"
+predicates = "3"
+tokio = { version = "1", features = ["test-util"] }
 
 [features]
 # `e2e` gates real-Docker smoke tests. Default `cargo nextest run` skips them;


### PR DESCRIPTION
## Summary

Drop the `=` exact-version pins on dev-dependencies in `Cargo.toml`:

- `assert_cmd`: `=2.2.2` → `2`
- `filetime`: `=0.2.29` → `0.2`
- `predicates`: `=3.1.4` → `3`
- `tokio` (dev): `=1.52.3` → `1`

Follow Renovate best practices: use semver ranges so Renovate can produce clean, minimal version-bump PRs instead of noisy full-version updates.

No comments explained why these were pinned. If something breaks after this change, a comment should be added naming the reason.

## Verify locally

```sh
cargo check --all-targets
```

Compiles clean.

## Migration notes

None.