### PR TITLE
fix(ci): resolve mise signing and CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-all-features-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-all-features-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-all-features-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-all-features-
             cargo-target-${{ runner.os }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-check-all-features-
       - run: cargo check --workspace --all-targets --all-features --locked
@@ -215,6 +218,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-clippy-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-clippy-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-clippy-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-clippy-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-clippy-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-clippy-
             cargo-target-${{ runner.os }}-clippy-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-clippy-
       - run: rustup component add clippy
@@ -312,6 +318,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-default-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-default-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-check-default-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-default-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-default-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-check-default-
             cargo-target-${{ runner.os }}-check-default-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-check-default-
       # Verify the default-features compile path. Clippy above runs with
@@ -413,6 +422,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-nextest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-nextest-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-nextest-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-nextest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-nextest-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-nextest-
             cargo-target-${{ runner.os }}-nextest-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-nextest-
       - name: Download construct image for E2E
@@ -497,6 +509,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-fuzz-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-fuzz-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-fuzz-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-fuzz-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-fuzz-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-fuzz-
             cargo-target-${{ runner.os }}-fuzz-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-fuzz-
       - name: Fuzz jackin-term parser path
@@ -568,6 +583,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-
             cargo-target-${{ runner.os }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-bench-${{ matrix.bench }}-
       # Build (but don't run) the frame-time and pane-body benchmarks to
@@ -638,6 +656,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-msrv-${{ steps.msrv.outputs.version }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-msrv-${{ steps.msrv.outputs.version }}-
             cargo-target-${{ runner.os }}-msrv-${{ steps.msrv.outputs.version }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-msrv-${{ steps.msrv.outputs.version }}-
       - name: cargo check on MSRV
@@ -750,6 +771,9 @@ jobs:
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-build-validator-${{ matrix.target }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-build-validator-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-build-validator-${{ matrix.target }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-build-validator-${{ matrix.target }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'build.rs', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-build-validator-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ github.base_ref || 'main' }}-build-validator-${{ matrix.target }}-
             cargo-target-${{ runner.os }}-build-validator-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-build-validator-${{ matrix.target }}-
       - name: Build validator (${{ matrix.target }})

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       construct: ${{ steps.dispatch.outputs.construct || steps.filter.outputs.construct }}
+      construct_image: ${{ steps.dispatch.outputs.construct_image || steps.filter.outputs.construct_image }}
       # Single source of truth for "should this run produce / publish
       # registry artifacts" — true on push-to-main and on
       # workflow_dispatch from main, false everywhere else (PRs,
@@ -49,7 +50,9 @@ jobs:
         id: dispatch
         if: github.event_name == 'workflow_dispatch'
         shell: bash
-        run: echo "construct=true" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "construct=true" >> "$GITHUB_OUTPUT"
+          echo "construct_image=true" >> "$GITHUB_OUTPUT"
 
       - name: Classify changed paths
         id: filter
@@ -57,11 +60,21 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
+            # Build the construct image when build plumbing changes, even if the
+            # change should not publish a new immutable construct tag.
             construct:
               - '.github/workflows/construct.yml'
               - 'docker-bake.hcl'
               - 'docker/construct/**'
               - 'crates/jackin-xtask/**'
+            # Require an unpublished docker/construct/VERSION only when inputs
+            # baked into the construct image changed.
+            construct_image:
+              - 'docker-bake.hcl'
+              - 'docker/construct/Dockerfile'
+              - 'docker/construct/fish-config.fish'
+              - 'docker/construct/versions.env'
+              - 'docker/construct/zshrc'
 
       - name: Compute publish flag
         id: flags
@@ -123,7 +136,7 @@ jobs:
           driver: docker-container
 
       - name: Log in to Docker Hub
-        if: needs.changes.outputs.is_publish == 'true'
+        if: needs.changes.outputs.is_publish == 'true' && needs.changes.outputs.construct_image == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -133,25 +146,25 @@ jobs:
         run: mise run construct-init-buildx
 
       - name: Expose GitHub Actions cache runtime
-        if: needs.changes.outputs.is_publish != 'true'
+        if: needs.changes.outputs.is_publish != 'true' || needs.changes.outputs.construct_image != 'true'
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
       - name: Build ${{ matrix.platform }} without push
-        if: needs.changes.outputs.is_publish != 'true'
+        if: needs.changes.outputs.is_publish != 'true' || needs.changes.outputs.construct_image != 'true'
         env:
           CACHE_FROM: type=gha,scope=construct-pr-${{ matrix.platform }}
           CACHE_TO: type=gha,scope=construct-pr-${{ matrix.platform }},mode=max
         run: mise run construct-build-platform ${{ matrix.platform }}
 
       - name: Push ${{ matrix.platform }} image by digest
-        if: needs.changes.outputs.is_publish == 'true'
+        if: needs.changes.outputs.is_publish == 'true' && needs.changes.outputs.construct_image == 'true'
         env:
           CACHE_FROM: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.platform }}
           CACHE_TO: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.platform }},mode=max
         run: mise run construct-push-platform ${{ matrix.platform }}
 
       - name: Upload ${{ matrix.platform }} digest
-        if: needs.changes.outputs.is_publish == 'true'
+        if: needs.changes.outputs.is_publish == 'true' && needs.changes.outputs.construct_image == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: construct-digest-${{ matrix.platform }}
@@ -161,7 +174,7 @@ jobs:
 
   publish-manifest:
     name: publish manifest
-    if: needs.changes.outputs.is_publish == 'true' && needs.changes.outputs.construct == 'true'
+    if: needs.changes.outputs.is_publish == 'true' && needs.changes.outputs.construct_image == 'true'
     needs: [changes, build]
     runs-on: ubuntu-24.04
     permissions:
@@ -253,6 +266,7 @@ jobs:
         run: docker buildx imagetools --help >/dev/null
 
       - name: Verify construct VERSION is not already published
+        if: needs.changes.outputs.construct_image == 'true'
         # PR-time mirror of publish-manifest's version-bump guard. The
         # build job already ran, so reaching here means docker/construct/**
         # content changed; an anonymous public-registry inspect needs no

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -62,7 +62,6 @@ jobs:
               - 'docker-bake.hcl'
               - 'docker/construct/**'
               - 'crates/jackin-xtask/**'
-              - 'mise.toml'
 
       - name: Compute publish flag
         id: flags

--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.6-trixie
+0.5-trixie

--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.5-trixie
+0.6-trixie

--- a/docs/content/docs/(role-authoring)/developing/construct-image.mdx
+++ b/docs/content/docs/(role-authoring)/developing/construct-image.mdx
@@ -131,11 +131,11 @@ REGISTRY_IMAGE=ttl.sh/jackin-construct-$USER mise run construct-publish-manifest
 </Aside>
 ### CI behavior
 
-GitHub Actions reuses the same `mise run` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI triggers when changes touch `docker/construct/**`, <RepoFile path="docker-bake.hcl" />, <RepoFile path="mise.toml" />, the <RepoFile path="crates/jackin-xtask/src/construct.rs" /> task runner, or <RepoFile path=".github/workflows/construct.yml" />.
+GitHub Actions reuses the same `mise run` commands on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners. Construct CI validates broad build plumbing when changes touch `docker/construct/**`, <RepoFile path="docker-bake.hcl" />, the `crates/jackin-xtask/` task runner, or <RepoFile path=".github/workflows/construct.yml" />. It only treats a run as a construct-image publish candidate when changes touch inputs baked into the image itself: <RepoFile path="docker-bake.hcl" />, <RepoFile path="docker/construct/Dockerfile" />, <RepoFile path="docker/construct/versions.env" />, <RepoFile path="docker/construct/zshrc" />, or <RepoFile path="docker/construct/fish-config.fish" />.
 
 Pull requests, plus manual workflow runs against non-`main` branches, build both architectures natively without pushing images. Those validation jobs use the GitHub Actions cache backend; the cache key includes the pinned `MISE_VERSION`, so a Renovate mise bump invalidates the apt install layer while unrelated earlier layers can still be reused. They still do not receive Docker Hub credentials.
 
-Pushes to `main`, plus manual workflow runs against `main`, publish each platform by digest first, then assemble the final multi-platform manifest from those digests. The registry cache uses the same pinned `MISE_VERSION` keying behavior as PR builds. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
+Pushes to `main`, plus manual workflow runs against `main`, publish each platform by digest first, then assemble the final multi-platform manifest from those digests when the run is a construct-image publish candidate. Build-plumbing-only changes still validate the construct workflow, but they skip the immutable-version guard and registry publish path because no baked image input changed. The registry cache uses the same pinned `MISE_VERSION` keying behavior as PR builds. That keeps the public tag surface limited to the canonical release tags instead of leaving permanent public `-amd64` and `-arm64` tags behind.
 
 Published images also carry explicit BuildKit provenance and SBOM attestations.
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 bun = "1.3.14"
+cosign = "3.0.6"
 "cargo:cargo-audit" = "0.22.2"
 "cargo:cargo-deny" = "0.19.8"
 "cargo:cargo-fuzz" = "0.13.1"
@@ -9,6 +10,7 @@ bun = "1.3.14"
 "cargo:cargo-shear" = "1.13.0"
 "cargo:cargo-zigbuild" = "0.22.3"
 node = "24.16.0"
+syft = "1.45.1"
 zig = "0.16.0"
 # rust is read from `rust-toolchain.toml` via the `idiomatic_version_file`
 # setting below — single source of truth for the toolchain channel and components.


### PR DESCRIPTION
## Summary

Release and preview signing now use `mise.toml` as the concrete source of truth for `cosign` and `syft`, so the CI signing action can resolve those shims after `jdx/mise-action` installs the tools and archive signing no longer fails at `cosign sign-blob`. Construct CI now separates broad workflow validation from construct-image publication: build plumbing changes can still run construct validation, but the unpublished-version guard and publish path only run when inputs baked into the construct image change. Cargo target-cache restore now tries the PR base branch before the unscoped fallback, so PR CI can reuse compatible `main` target caches instead of compiling from an empty `target/` tree.

## Hard rule: mise tool source of truth

This PR honours the `.github/AGENTS.md` workflow rule that CI and local tooling are installed through mise, with tool versions pinned in the repository when workflows rely on the shim being active.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-537"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/mise-cosign-shim:refs/remotes/origin/fix/mise-cosign-shim
git checkout -B fix/mise-cosign-shim refs/remotes/origin/fix/mise-cosign-shim
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
export JACKIN_CONFIG_DIR="$JACKIN_PR_TEST_DIR/.config/jackin"
export JACKIN_HOME_DIR="$JACKIN_PR_TEST_DIR/.jackin"
which jackin
```

### Release-tool smoke

```sh
cosign version
syft version
```

Expected: both commands resolve through the repository's mise-managed toolchain without `No version is set for shim` errors.

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

## Migration notes

None.
