### PR TITLE
feat(providers): per-provider model overrides in role manifests

### DIFF
--- a/.codebook.toml
+++ b/.codebook.toml
@@ -439,6 +439,7 @@ words = [
   "Okta",
   "Oneshot",
   "oom",
+  "openai",
   "OpenCode",
   "openssh",
   "openssl",

--- a/crates/jackin-capsule/src/daemon/multiplexer_utils.rs
+++ b/crates/jackin-capsule/src/daemon/multiplexer_utils.rs
@@ -38,12 +38,26 @@ impl Multiplexer {
     /// (the `-m` flag); without it `OpenCode` falls back to its default provider
     /// block. Every other agent uses the role-manifest model and the provider
     /// only redirects auth env.
+    ///
+    /// Resolution for `OpenCode` + a picked provider: the role manifest's
+    /// `[opencode.providers.<id>].model` override, then the provider's built-in
+    /// default, then the agent's role-manifest model.
     pub(super) fn launch_model(&self, agent: &str, provider_label: Option<&str>) -> Option<&str> {
-        provider_label
+        if let Some(provider) = provider_label
             .filter(|_| agent == "opencode")
             .and_then(jackin_protocol::Provider::from_label)
-            .and_then(jackin_protocol::Provider::opencode_model)
-            .or_else(|| self.model_for_agent(agent))
+        {
+            if let Some(model) = self
+                .launch_config
+                .provider_model(agent, provider.manifest_id())
+            {
+                return Some(model);
+            }
+            if let Some(model) = provider.opencode_model() {
+                return Some(model);
+            }
+        }
+        self.model_for_agent(agent)
     }
 
     /// Providers selectable for `agent`. An empty vec means only the
@@ -99,6 +113,21 @@ impl Multiplexer {
             && let Some(profile) = provider.codex_profile()
         {
             env.push(("JACKIN_CODEX_PROFILE".to_owned(), profile.to_owned()));
+        }
+        // Claude maps a provider to a model through the `ANTHROPIC_DEFAULT_*_MODEL`
+        // env the provider injects. A role's `[claude.providers.<id>].model`
+        // override replaces those defaults so the operator can pin a different
+        // model for that provider without editing the agent default.
+        if agent_slug == "claude"
+            && let Some(model) = self
+                .launch_config
+                .provider_model(agent_slug, provider.manifest_id())
+        {
+            for (key, value) in &mut env {
+                if key.starts_with("ANTHROPIC_DEFAULT_") && key.ends_with("_MODEL") {
+                    *value = model.to_owned();
+                }
+            }
         }
         env
     }

--- a/crates/jackin-capsule/src/daemon/tests.rs
+++ b/crates/jackin-capsule/src/daemon/tests.rs
@@ -88,6 +88,7 @@ fn test_mux(rows: u16, cols: u16) -> Multiplexer {
             workdir: "/workspace".to_owned(),
             agents: Vec::new(),
             models: BTreeMap::new(),
+            provider_models: BTreeMap::new(),
             initial_provider: None,
         },
     )
@@ -3548,6 +3549,51 @@ fn launch_model_uses_picked_provider_for_opencode() {
     assert_eq!(mux.launch_model("codex", Some("MiniMax")), None);
     // A provider with no opencode model falls back to the role-manifest model.
     assert_eq!(mux.launch_model("opencode", Some("Anthropic")), None);
+}
+
+#[test]
+fn launch_model_prefers_manifest_provider_override_for_opencode() {
+    let mut mux = test_mux(24, 80);
+    mux.launch_config.provider_models.insert(
+        "opencode".to_owned(),
+        BTreeMap::from([("minimax".to_owned(), "minimax/custom".to_owned())]),
+    );
+    // The role's [opencode.providers.minimax].model override beats the built-in default.
+    assert_eq!(
+        mux.launch_model("opencode", Some("MiniMax")),
+        Some("minimax/custom")
+    );
+    // A provider with no override still uses the built-in default.
+    assert_eq!(
+        mux.launch_model("opencode", Some("Z.AI")),
+        Some("zai/glm-5.1")
+    );
+}
+
+#[test]
+fn provider_spawn_env_applies_claude_manifest_model_override() {
+    let mut mux = test_mux(24, 80);
+    mux.provider_keys
+        .insert(jackin_protocol::Provider::Minimax, "mk".to_owned());
+    mux.launch_config.provider_models.insert(
+        "claude".to_owned(),
+        BTreeMap::from([("minimax".to_owned(), "MiniMax-Pro".to_owned())]),
+    );
+    let env = mux.provider_spawn_env("claude", jackin_protocol::Provider::Minimax);
+    let model_vars: Vec<_> = env
+        .iter()
+        .filter(|(k, _)| k.starts_with("ANTHROPIC_DEFAULT_") && k.ends_with("_MODEL"))
+        .collect();
+    assert!(
+        !model_vars.is_empty(),
+        "claude+MiniMax must set ANTHROPIC_DEFAULT_*_MODEL"
+    );
+    for (key, value) in model_vars {
+        assert_eq!(
+            value, "MiniMax-Pro",
+            "{key} must carry the manifest override"
+        );
+    }
 }
 
 #[test]

--- a/crates/jackin-capsule/src/runtime_setup.rs
+++ b/crates/jackin-capsule/src/runtime_setup.rs
@@ -340,12 +340,29 @@ fn setup_codex(copy_auth: bool) -> Result<()> {
 /// the only deliverable Codex cell (Responses-API compatible); GLM and Kimi
 /// are deferred. Both writes are idempotent across repeated setup invocations.
 fn write_codex_provider_config(codex_dir: &Path) -> Result<()> {
-    write_codex_provider_config_inner(codex_dir, nonempty_env("MINIMAX_API_KEY").is_some())
+    write_codex_provider_config_inner(
+        codex_dir,
+        nonempty_env("MINIMAX_API_KEY").is_some(),
+        &codex_minimax_model(),
+    )
+}
+
+/// `MiniMax` model Codex routes to: the role's `[codex.providers.minimax].model`
+/// override (carried in the capsule config) when set, else the built-in default.
+fn codex_minimax_model() -> String {
+    crate::config::load_optional()
+        .and_then(|config| config.provider_model("codex", "minimax").map(str::to_owned))
+        .unwrap_or_else(|| jackin_protocol::MINIMAX_DEFAULT_MODEL.to_owned())
 }
 
 /// Core of [`write_codex_provider_config`] with env reading lifted out so tests
-/// drive the MiniMax-present decision directly (no process-global env mutation).
-fn write_codex_provider_config_inner(codex_dir: &Path, minimax_present: bool) -> Result<()> {
+/// drive the MiniMax-present decision and the model directly (no process-global
+/// env or config mutation).
+fn write_codex_provider_config_inner(
+    codex_dir: &Path,
+    minimax_present: bool,
+    model: &str,
+) -> Result<()> {
     if !minimax_present {
         return Ok(());
     }
@@ -408,7 +425,7 @@ fn write_codex_provider_config_inner(codex_dir: &Path, minimax_present: bool) ->
             profile_path.display()
         );
     } else {
-        let profile = codex_minimax_profile_toml()?;
+        let profile = codex_minimax_profile_toml(model)?;
         fs::write(&profile_path, profile.as_bytes()).with_context(|| {
             format!(
                 "failed to write MiniMax profile config to {}",
@@ -421,8 +438,8 @@ fn write_codex_provider_config_inner(codex_dir: &Path, minimax_present: bool) ->
         ));
     }
 
-    // ── minimax.models.json: model catalog so MiniMax-M3 has real metadata ──────
-    write_codex_minimax_catalog(codex_dir)?;
+    // ── minimax.models.json: model catalog so the MiniMax model has real metadata ─
+    write_codex_minimax_catalog(codex_dir, model)?;
 
     Ok(())
 }
@@ -465,15 +482,15 @@ fn codex_minimax_provider_toml() -> Result<String> {
 /// is clamped to the active model's fallback cap (~272k), so it can never raise
 /// the window for a custom model. `minimax.models.json` carries the real 512k
 /// window instead (see [`write_codex_minimax_catalog`]).
-fn codex_minimax_profile_toml() -> Result<String> {
+fn codex_minimax_profile_toml(model: &str) -> Result<String> {
     #[derive(serde::Serialize)]
-    struct ProfileConfig {
+    struct ProfileConfig<'a> {
         model_provider: &'static str,
-        model: &'static str,
+        model: &'a str,
     }
     let config = ProfileConfig {
         model_provider: "minimax",
-        model: jackin_protocol::MINIMAX_DEFAULT_MODEL,
+        model,
     };
     toml::to_string(&config).context("failed to serialize Codex MiniMax profile config")
 }
@@ -492,7 +509,7 @@ fn codex_minimax_profile_toml() -> Result<String> {
 ///
 /// Best-effort: if Codex is missing or its output won't parse, the catalog is
 /// skipped and Codex falls back to its generic metadata — the model still runs.
-fn write_codex_minimax_catalog(codex_dir: &Path) -> Result<()> {
+fn write_codex_minimax_catalog(codex_dir: &Path, model: &str) -> Result<()> {
     let catalog_path = codex_dir.join("minimax.models.json");
     if catalog_path.exists() {
         crate::cdebug!(
@@ -507,7 +524,7 @@ fn write_codex_minimax_catalog(codex_dir: &Path) -> Result<()> {
         );
         return Ok(());
     };
-    let catalog = build_minimax_catalog(&template);
+    let catalog = build_minimax_catalog(&template, model);
     let body = serde_json::to_string_pretty(&catalog)
         .context("failed to serialize MiniMax model catalog")?;
     fs::write(&catalog_path, body.as_bytes()).with_context(|| {
@@ -547,9 +564,9 @@ fn codex_catalog_template_entry() -> Option<serde_json::Map<String, serde_json::
 /// the `MiniMax` context window, with the template model's promo fields cleared.
 fn build_minimax_catalog(
     template: &serde_json::Map<String, serde_json::Value>,
+    model: &str,
 ) -> serde_json::Value {
     let mut entry = template.clone();
-    let model = jackin_protocol::MINIMAX_DEFAULT_MODEL;
     entry.insert("slug".to_owned(), json!(model));
     entry.insert("display_name".to_owned(), json!(model));
     entry.insert(

--- a/crates/jackin-capsule/src/runtime_setup/tests.rs
+++ b/crates/jackin-capsule/src/runtime_setup/tests.rs
@@ -212,8 +212,10 @@ fn codex_provider_config_is_idempotent_across_repeated_runs() {
     let dir = tempfile::tempdir().expect("tempdir");
     let codex_dir = dir.path();
     // Two runs (simulating container reuse) must not duplicate the table or profile.
-    write_codex_provider_config_inner(codex_dir, true).expect("first write");
-    write_codex_provider_config_inner(codex_dir, true).expect("second write");
+    write_codex_provider_config_inner(codex_dir, true, jackin_protocol::MINIMAX_DEFAULT_MODEL)
+        .expect("first write");
+    write_codex_provider_config_inner(codex_dir, true, jackin_protocol::MINIMAX_DEFAULT_MODEL)
+        .expect("second write");
     let body = fs::read_to_string(codex_dir.join("config.toml")).expect("read config.toml");
     assert_eq!(
         body.matches("[model_providers.minimax]").count(),
@@ -230,7 +232,8 @@ fn codex_provider_config_is_idempotent_across_repeated_runs() {
 fn codex_provider_config_writes_v2_profile_file() {
     let dir = tempfile::tempdir().expect("tempdir");
     let codex_dir = dir.path();
-    write_codex_provider_config_inner(codex_dir, true).expect("write");
+    write_codex_provider_config_inner(codex_dir, true, jackin_protocol::MINIMAX_DEFAULT_MODEL)
+        .expect("write");
     let profile = fs::read_to_string(codex_dir.join("minimax.config.toml")).expect("read profile");
     assert!(
         profile.contains("model_provider = \"minimax\""),
@@ -256,6 +259,19 @@ fn codex_provider_config_writes_v2_profile_file() {
 }
 
 #[test]
+fn codex_provider_config_honors_model_override() {
+    // A role's [codex.providers.minimax].model override reaches the profile.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let codex_dir = dir.path();
+    write_codex_provider_config_inner(codex_dir, true, "MiniMax-Pro").expect("write");
+    let profile = fs::read_to_string(codex_dir.join("minimax.config.toml")).expect("read profile");
+    assert!(
+        profile.contains("model = \"MiniMax-Pro\""),
+        "profile must carry the per-provider override model"
+    );
+}
+
+#[test]
 fn codex_provider_config_preserves_operator_content() {
     let dir = tempfile::tempdir().expect("tempdir");
     let codex_dir = dir.path();
@@ -265,7 +281,8 @@ fn codex_provider_config_preserves_operator_content() {
         b"# existing operator config\n[settings]\nsome_key = true\n",
     )
     .expect("write existing config");
-    write_codex_provider_config_inner(codex_dir, true).expect("write with existing content");
+    write_codex_provider_config_inner(codex_dir, true, jackin_protocol::MINIMAX_DEFAULT_MODEL)
+        .expect("write with existing content");
     let body = fs::read_to_string(&config_path).expect("read config.toml");
     // Original content preserved.
     assert!(body.contains("# existing operator config"));
@@ -278,7 +295,8 @@ fn codex_provider_config_preserves_operator_content() {
 fn codex_provider_config_noop_without_minimax_key() {
     let dir = tempfile::tempdir().expect("tempdir");
     let codex_dir = dir.path();
-    write_codex_provider_config_inner(codex_dir, false).expect("noop write");
+    write_codex_provider_config_inner(codex_dir, false, jackin_protocol::MINIMAX_DEFAULT_MODEL)
+        .expect("noop write");
     assert!(
         !codex_dir.join("config.toml").exists(),
         "no config.toml should be written when MiniMax key absent"
@@ -309,16 +327,15 @@ fn build_minimax_catalog_patches_identity_and_window() {
         "supports_parallel_tool_calls": true
     });
     let template = template.as_object().expect("template object").clone();
-    let catalog = build_minimax_catalog(&template);
+    // A non-default model proves the catalog slug is driven by the `model`
+    // argument (the per-provider override), not a hardcoded constant.
+    let catalog = build_minimax_catalog(&template, "MiniMax-Custom");
     let models = catalog["models"].as_array().expect("models array");
     assert_eq!(models.len(), 1);
     let entry = &models[0];
-    // Identity rewritten to the MiniMax model so it matches the profile's `model`.
-    assert_eq!(entry["slug"], jackin_protocol::MINIMAX_DEFAULT_MODEL);
-    assert_eq!(
-        entry["display_name"],
-        jackin_protocol::MINIMAX_DEFAULT_MODEL
-    );
+    // Identity rewritten to the passed model so it matches the profile's `model`.
+    assert_eq!(entry["slug"], "MiniMax-Custom");
+    assert_eq!(entry["display_name"], "MiniMax-Custom");
     // Real MiniMax window, lifting the fallback cap; compact at 90% of it.
     let window = jackin_protocol::MINIMAX_CONTEXT_WINDOW;
     assert_eq!(entry["context_window"], window);

--- a/crates/jackin-core/src/constants.rs
+++ b/crates/jackin-core/src/constants.rs
@@ -17,7 +17,7 @@ pub const DOCKERFILE_NAME: &str = "Dockerfile";
 pub const CLAUDE_OAUTH_TOKEN_ENV: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 
 /// Current role manifest schema version. Serde default for `RoleManifest.version`.
-pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha4";
+pub const CURRENT_MANIFEST_VERSION: &str = "v1alpha5";
 
 /// Serde-default helper for `RoleManifest.version`.
 pub fn current_manifest_version() -> String {

--- a/crates/jackin-core/src/manifest.rs
+++ b/crates/jackin-core/src/manifest.rs
@@ -96,6 +96,49 @@ impl RoleManifest {
             Agent::Grok => self.grok.as_ref().and_then(|c| c.model.as_deref()),
         }
     }
+
+    /// Per-(agent, provider) model override from the manifest, if the role set
+    /// one under `[<agent>.providers.<provider_id>]`. `provider_id` is the
+    /// provider's stable lowercase slug (e.g. `minimax`). Only `claude`, `codex`,
+    /// and `opencode` carry provider tables; other agents always return `None`.
+    pub fn agent_provider_model(&self, agent: Agent, provider_id: &str) -> Option<&str> {
+        let providers = match agent {
+            Agent::Claude => &self.claude.as_ref()?.providers,
+            Agent::Codex => &self.codex.as_ref()?.providers,
+            Agent::Opencode => &self.opencode.as_ref()?.providers,
+            Agent::Amp | Agent::Kimi | Agent::Grok => return None,
+        };
+        providers.get(provider_id)?.model.as_deref()
+    }
+
+    /// Every `(provider_id, model)` override declared for `agent`, used by the
+    /// host to populate the capsule's provider-model map. Empty when the agent
+    /// has no provider tables or none of them set a model.
+    pub fn agent_provider_models(&self, agent: Agent) -> Vec<(&str, &str)> {
+        let providers = match agent {
+            Agent::Claude => self.claude.as_ref().map(|c| &c.providers),
+            Agent::Codex => self.codex.as_ref().map(|c| &c.providers),
+            Agent::Opencode => self.opencode.as_ref().map(|c| &c.providers),
+            Agent::Amp | Agent::Kimi | Agent::Grok => None,
+        };
+        providers
+            .into_iter()
+            .flatten()
+            .filter_map(|(id, override_)| override_.model.as_deref().map(|m| (id.as_str(), m)))
+            .collect()
+    }
+}
+
+/// Per-provider model override, keyed by the provider's stable lowercase slug
+/// (e.g. `minimax`) under `[<agent>.providers.<id>]`. Applied when that provider
+/// is the selected provider for the agent — `OpenCode` has no model of its own and
+/// Claude/Codex map a selected provider to a model, so a role can pin a different
+/// model per provider without changing the agent's default `model`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderModelOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -105,6 +148,8 @@ pub struct CodexConfig {
     /// otherwise Codex's own default is used.
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub providers: BTreeMap<String, ProviderModelOverride>,
 }
 
 /// Per-role Amp configuration.
@@ -137,6 +182,8 @@ pub struct KimiConfig {
 pub struct OpencodeConfig {
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub providers: BTreeMap<String, ProviderModelOverride>,
 }
 
 /// Per-role Grok Build configuration.
@@ -234,6 +281,8 @@ pub struct ClaudeConfig {
     pub marketplaces: Vec<ClaudeMarketplaceConfig>,
     #[serde(default)]
     pub plugins: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub providers: BTreeMap<String, ProviderModelOverride>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/jackin-image/src/derived_image/tests.rs
+++ b/crates/jackin-image/src/derived_image/tests.rs
@@ -536,6 +536,7 @@ fn renders_claude_plugin_installs_after_claude_cli() {
             "superpowers@superpowers-marketplace".to_owned(),
             "quote'plugin@market".to_owned(),
         ],
+        providers: std::collections::BTreeMap::new(),
     };
     let dockerfile = render_derived_dockerfile(
         "FROM projectjackin/construct:0.1-trixie\n",

--- a/crates/jackin-manifest/src/manifest.rs
+++ b/crates/jackin-manifest/src/manifest.rs
@@ -63,6 +63,7 @@ fn validate_feature_versions(
 ) -> anyhow::Result<()> {
     let v1alpha3 = jackin_config::parse_version("v1alpha3")?;
     let v1alpha4 = jackin_config::parse_version("v1alpha4")?;
+    let v1alpha5 = jackin_config::parse_version("v1alpha5")?;
     if manifest_version < &v1alpha3
         && (manifest
             .agents
@@ -83,6 +84,24 @@ fn validate_feature_versions(
     {
         anyhow::bail!(
             "role \"{role_name}\" manifest is at {manifest_version} but uses v1alpha4 agent fields, which requires v1alpha4; run \"jackin role migrate <role-repo-path>\" to upgrade the local copy"
+        );
+    }
+    if manifest_version < &v1alpha5
+        && (manifest
+            .claude
+            .as_ref()
+            .is_some_and(|c| !c.providers.is_empty())
+            || manifest
+                .codex
+                .as_ref()
+                .is_some_and(|c| !c.providers.is_empty())
+            || manifest
+                .opencode
+                .as_ref()
+                .is_some_and(|c| !c.providers.is_empty()))
+    {
+        anyhow::bail!(
+            "role \"{role_name}\" manifest is at {manifest_version} but uses v1alpha5 per-provider model overrides ([<agent>.providers]), which requires v1alpha5; run \"jackin role migrate <role-repo-path>\" to upgrade the local copy"
         );
     }
     Ok(())

--- a/crates/jackin-manifest/src/manifest/tests.rs
+++ b/crates/jackin-manifest/src/manifest/tests.rs
@@ -103,7 +103,7 @@ fn loads_per_provider_model_overrides() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 agents = ["claude", "opencode"]
 
@@ -204,7 +204,7 @@ plugins = []
 
     let err = load_role_manifest(temp.path()).unwrap_err();
     let chain = format!("{err:#}");
-    assert!(chain.contains("only understands up to v1alpha4"), "{chain}");
+    assert!(chain.contains("only understands up to v1alpha5"), "{chain}");
 }
 
 #[test]
@@ -287,6 +287,31 @@ plugins = []
     let err = load_role_manifest(temp.path()).unwrap_err();
     let chain = format!("{err:#}");
     assert!(chain.contains("requires v1alpha4"), "{chain}");
+}
+
+#[test]
+fn rejects_old_manifest_using_provider_overrides() {
+    // A pre-v1alpha5 manifest that uses [<agent>.providers.<id>] is rejected
+    // with a migrate hint, since the feature did not exist at that version.
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("jackin.role.toml"),
+        r#"version = "v1alpha4"
+dockerfile = "Dockerfile"
+agents = ["opencode"]
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+
+[opencode.providers.minimax]
+model = "minimax/MiniMax-M3"
+"#,
+    )
+    .unwrap();
+
+    let err = load_role_manifest(temp.path()).unwrap_err();
+    let chain = format!("{err:#}");
+    assert!(chain.contains("requires v1alpha5"), "{chain}");
 }
 
 #[test]

--- a/crates/jackin-manifest/src/manifest/tests.rs
+++ b/crates/jackin-manifest/src/manifest/tests.rs
@@ -98,6 +98,54 @@ model = "zai-coding-plan/glm-5.1"
 }
 
 #[test]
+fn loads_per_provider_model_overrides() {
+    use jackin_core::Agent;
+    let temp = tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("jackin.role.toml"),
+        r#"version = "v1alpha4"
+dockerfile = "Dockerfile"
+agents = ["claude", "opencode"]
+
+[claude]
+model = "claude-sonnet-4-6"
+
+[claude.providers.minimax]
+model = "MiniMax-M3"
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+
+[opencode.providers.minimax]
+model = "minimax/MiniMax-M3"
+
+[opencode.providers.zai]
+model = "zai-coding-plan/glm-5.1"
+"#,
+    )
+    .unwrap();
+
+    let m = load_role_manifest(temp.path()).unwrap();
+    // Per-(agent, provider) override resolves; the agent default is untouched.
+    assert_eq!(
+        m.agent_provider_model(Agent::Claude, "minimax"),
+        Some("MiniMax-M3")
+    );
+    assert_eq!(m.agent_model(Agent::Claude), Some("claude-sonnet-4-6"));
+    assert_eq!(
+        m.agent_provider_model(Agent::Opencode, "minimax"),
+        Some("minimax/MiniMax-M3")
+    );
+    assert_eq!(
+        m.agent_provider_model(Agent::Opencode, "zai"),
+        Some("zai-coding-plan/glm-5.1")
+    );
+    // Unset pairs and unset agents return None.
+    assert_eq!(m.agent_provider_model(Agent::Opencode, "kimi"), None);
+    assert_eq!(m.agent_provider_model(Agent::Codex, "minimax"), None);
+}
+
+#[test]
 fn rejects_unknown_agent_name() {
     let temp = tempdir().unwrap();
     std::fs::write(

--- a/crates/jackin-manifest/src/migrations.rs
+++ b/crates/jackin-manifest/src/migrations.rs
@@ -30,6 +30,11 @@ const MANIFEST_MIGRATIONS: &[jackin_config::MigrationStep] = &[
     },
     jackin_config::MigrationStep {
         from: "v1alpha3",
+        to: "v1alpha4",
+        migrate: jackin_config::noop_migration,
+    },
+    jackin_config::MigrationStep {
+        from: "v1alpha4",
         to: CURRENT_MANIFEST_VERSION,
         migrate: jackin_config::noop_migration,
     },

--- a/crates/jackin-manifest/src/migrations/tests.rs
+++ b/crates/jackin-manifest/src/migrations/tests.rs
@@ -13,9 +13,9 @@ fn migrates_missing_manifest_version() {
     let parsed: toml::Value = toml::from_str(&out).unwrap();
 
     assert_eq!(old, "legacy");
-    assert_eq!(new, "v1alpha4");
-    assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha4");
-    assert!(out.starts_with("version = \"v1alpha4\""), "{out}");
+    assert_eq!(new, "v1alpha5");
+    assert_eq!(parsed["version"].as_str().unwrap(), "v1alpha5");
+    assert!(out.starts_with("version = \"v1alpha5\""), "{out}");
     assert!(out.contains("# keep me"), "{out}");
 }
 
@@ -33,15 +33,15 @@ fn migrates_v1alpha1_manifest_to_current() {
     let out = std::fs::read_to_string(&path).unwrap();
 
     assert_eq!(old, "v1alpha1");
-    assert_eq!(new, "v1alpha4");
-    assert!(out.starts_with("version = \"v1alpha4\""), "{out}");
+    assert_eq!(new, "v1alpha5");
+    assert!(out.starts_with("version = \"v1alpha5\""), "{out}");
 }
 
 #[test]
 fn current_manifest_migration_is_noop() {
     let temp = tempdir().unwrap();
     let path = temp.path().join("jackin.role.toml");
-    let manifest = "version = \"v1alpha4\"\ndockerfile = \"Dockerfile\"\n";
+    let manifest = "version = \"v1alpha5\"\ndockerfile = \"Dockerfile\"\n";
     std::fs::write(&path, manifest).unwrap();
 
     assert!(migrate_manifest_file(&path).unwrap().is_none());
@@ -60,14 +60,14 @@ fn rejects_newer_manifest_version() {
 
     let err = migrate_manifest_file(&path).unwrap_err();
     assert!(
-        err.to_string().contains("only understands up to v1alpha4"),
+        err.to_string().contains("only understands up to v1alpha5"),
         "{err}"
     );
 }
 
 #[test]
 fn validate_manifest_version_accepts_current() {
-    let doc: DocumentMut = "version = \"v1alpha4\"\n".parse().unwrap();
+    let doc: DocumentMut = "version = \"v1alpha5\"\n".parse().unwrap();
     validate_manifest_version(&doc).unwrap();
 }
 
@@ -83,7 +83,7 @@ fn validate_manifest_version_rejects_newer() {
     let doc: DocumentMut = "version = \"v2alpha1\"\n".parse().unwrap();
     let err = validate_manifest_version(&doc).unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("only understands up to v1alpha4"), "{msg}");
+    assert!(msg.contains("only understands up to v1alpha5"), "{msg}");
 }
 
 #[test]

--- a/crates/jackin-protocol/src/lib.rs
+++ b/crates/jackin-protocol/src/lib.rs
@@ -30,6 +30,12 @@ pub struct CapsuleConfig {
     pub agents: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub models: BTreeMap<String, String>,
+    /// Per-(agent, provider) model overrides from the role manifest. Outer key
+    /// is the agent slug, inner key the provider's lowercase slug
+    /// ([`Provider::manifest_id`]). Selects the model the capsule uses when the
+    /// operator picks that provider for that agent, overriding the agent default.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_models: BTreeMap<String, BTreeMap<String, String>>,
     /// When the operator picked a specific provider in the console's
     /// launch flow (before the container existed), this field tells the
     /// capsule's initial spawn to use that provider and env overrides
@@ -147,6 +153,21 @@ impl Provider {
             .find(|provider| provider.label() == label)
     }
 
+    /// Stable lowercase slug used as the provider key in role manifests
+    /// (`[<agent>.providers.<id>]`) and the capsule provider-model map. Distinct
+    /// from [`Provider::label`] (the display/wire identifier) so the operator-
+    /// facing config key stays stable and lowercase.
+    #[must_use]
+    pub const fn manifest_id(self) -> &'static str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::Openai => "openai",
+            Self::Zai => "zai",
+            Self::Minimax => "minimax",
+            Self::Kimi => "kimi",
+        }
+    }
+
     /// Env overrides that redirect Claude Code to this provider via the
     /// Anthropic-compatible surface. Anthropic needs none. Each alt provider
     /// sets the base URL, auth token (when present), model-tier mapping vars,
@@ -214,6 +235,17 @@ impl CapsuleConfig {
 
     pub fn model_for_agent(&self, agent: &str) -> Option<&str> {
         self.models.get(agent).map(String::as_str)
+    }
+
+    /// Model override for `(agent, provider_id)`, where `provider_id` is a
+    /// [`Provider::manifest_id`] slug. `None` when the role set no override for
+    /// that pair, leaving the caller's own default in force.
+    #[must_use]
+    pub fn provider_model(&self, agent: &str, provider_id: &str) -> Option<&str> {
+        self.provider_models
+            .get(agent)?
+            .get(provider_id)
+            .map(String::as_str)
     }
 }
 

--- a/crates/jackin-runtime/src/runtime/launch.rs
+++ b/crates/jackin-runtime/src/runtime/launch.rs
@@ -363,11 +363,20 @@ pub(super) fn capsule_config(
 ) -> jackin_protocol::CapsuleConfig {
     let mut agents = Vec::new();
     let mut models = std::collections::BTreeMap::new();
+    let mut provider_models = std::collections::BTreeMap::new();
     for agent in manifest.supported_agents() {
         agents.push(agent.slug().to_owned());
         let model = manifest.agent_model(agent);
         if let Some(model) = model {
             models.insert(agent.slug().to_owned(), model.to_owned());
+        }
+        let per_provider = manifest.agent_provider_models(agent);
+        if !per_provider.is_empty() {
+            let inner = per_provider
+                .into_iter()
+                .map(|(id, model)| (id.to_owned(), model.to_owned()))
+                .collect();
+            provider_models.insert(agent.slug().to_owned(), inner);
         }
     }
     jackin_protocol::CapsuleConfig {
@@ -375,6 +384,7 @@ pub(super) fn capsule_config(
         workdir: workdir.to_owned(),
         agents,
         models,
+        provider_models,
         initial_provider,
     }
 }

--- a/crates/jackin-runtime/src/runtime/launch/tests.rs
+++ b/crates/jackin-runtime/src/runtime/launch/tests.rs
@@ -136,7 +136,7 @@ fn capsule_config_serializes_manifest_models() {
     let temp = tempdir().unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp", "kimi", "opencode"]
 
@@ -2710,7 +2710,7 @@ async fn load_agent_uses_prebuilt_when_construct_version_matches() {
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -2767,7 +2767,7 @@ async fn load_agent_falls_back_to_workspace_when_construct_version_stale() {
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 
@@ -2830,7 +2830,7 @@ async fn load_agent_uses_prebuilt_when_construct_version_label_absent() {
     .unwrap();
     std::fs::write(
         repo_dir.join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 published_image = "docker.io/myorg/my-role:latest"
 

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-legacy/after.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-legacy/after.toml
@@ -1,4 +1,4 @@
-version = "v1alpha4"
+version = "v1alpha5"
 # Sample role manifest carried through the legacy migration chain.
 
 dockerfile = "Dockerfile"

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-legacy/meta.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-legacy/meta.toml
@@ -1,4 +1,4 @@
 from_version = "legacy"
-target_version = "v1alpha4"
+target_version = "v1alpha5"
 target_version_shipped = "2026-05-11"
-summary = "Migrates legacy role manifest through v1alpha1 to v1alpha4. Comments and existing keys are preserved, with version written first. Run `jackin-role migrate <role-repo-path>` to apply."
+summary = "Migrates legacy role manifest through v1alpha1, v1alpha2, v1alpha3, v1alpha4, to v1alpha5. Comments and existing keys are preserved, with version written first. Run `jackin-role migrate <role-repo-path>` to apply."

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha1/after.toml
@@ -1,4 +1,4 @@
-version = "v1alpha4"
+version = "v1alpha5"
 dockerfile = "Dockerfile"
 agents = ["claude"]
 

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha1/meta.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha1/meta.toml
@@ -1,4 +1,4 @@
 from_version = "v1alpha1"
-target_version = "v1alpha4"
+target_version = "v1alpha5"
 target_version_shipped = "2026-05-11"
-summary = "Restamps role manifest as v1alpha4 and moves version to the first line."
+summary = "Restamps role manifest from v1alpha1 through v1alpha2, v1alpha3, v1alpha4, to v1alpha5, moving version to the first line."

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha2/meta.toml
@@ -1,4 +1,4 @@
 from_version = "v1alpha2"
-target_version = "v1alpha4"
+target_version = "v1alpha5"
 target_version_shipped = "2026-05-14"
-summary = "Restamps role manifest as v1alpha4 and moves version to the first line. Formalizes OpenCode as v1alpha3 and keeps the chain composable through the later Kimi v1alpha4 restamp."
+summary = "Restamps role manifest from v1alpha2 through v1alpha3 (OpenCode), v1alpha4 (Kimi), to v1alpha5 (per-provider model overrides). All steps are no-op restamps."

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha3/meta.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha3/meta.toml
@@ -1,4 +1,4 @@
 from_version = "v1alpha3"
-target_version = "v1alpha4"
+target_version = "v1alpha5"
 target_version_shipped = "2026-05-17"
-summary = "Restamps role manifest as v1alpha4 and moves version to the first line. Formalizes Kimi agent support after v1alpha3 shipped with OpenCode."
+summary = "Restamps role manifest from v1alpha3 through v1alpha4 (Kimi) to v1alpha5 (per-provider model overrides). All steps are no-op restamps."

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/after.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/after.toml
@@ -1,12 +1,9 @@
 version = "v1alpha5"
 dockerfile = "Dockerfile"
-agents = ["claude", "kimi", "opencode"]
+agents = ["claude", "opencode"]
 
 [claude]
-plugins = []
-
-[kimi]
-model = "kimi-k2"
+model = "claude-sonnet-4-6"
 
 [opencode]
 model = "zai-coding-plan/glm-5.1"

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/before.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/before.toml
@@ -1,9 +1,9 @@
-version = "v1alpha5"
+version = "v1alpha4"
 dockerfile = "Dockerfile"
 agents = ["claude", "opencode"]
 
 [claude]
-plugins = []
+model = "claude-sonnet-4-6"
 
 [opencode]
 model = "zai-coding-plan/glm-5.1"

--- a/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/meta.toml
+++ b/crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/meta.toml
@@ -1,0 +1,4 @@
+from_version = "v1alpha4"
+target_version = "v1alpha5"
+target_version_shipped = "2026-06-10"
+summary = "Restamps role manifest as v1alpha5. Adds optional [<agent>.providers.<id>] tables for per-provider model overrides (Claude/Codex/OpenCode); additive, so the migration is a no-op restamp and existing manifests load unchanged."

--- a/crates/jackin/tests/fixtures/roles/jackin-sentinel/jackin.role.toml
+++ b/crates/jackin/tests/fixtures/roles/jackin-sentinel/jackin.role.toml
@@ -1,4 +1,4 @@
-version = "v1alpha4"
+version = "v1alpha5"
 dockerfile = "Dockerfile"
 agents = ["claude", "codex", "amp", "kimi", "opencode", "grok"]
 

--- a/crates/jackin/tests/role_cli.rs
+++ b/crates/jackin/tests/role_cli.rs
@@ -56,12 +56,12 @@ agents = ["opencode"]
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest v1alpha2 -> v1alpha4",
+            "Migrated manifest v1alpha2 -> v1alpha5",
         ))
         .stdout(predicate::str::contains("Role repository is valid"));
 
     let manifest = std::fs::read_to_string(temp.path().join("jackin.role.toml")).unwrap();
-    assert!(manifest.starts_with("version = \"v1alpha4\""), "{manifest}");
+    assert!(manifest.starts_with("version = \"v1alpha5\""), "{manifest}");
 }
 
 #[test]

--- a/crates/jackin/tests/validate_cli.rs
+++ b/crates/jackin/tests/validate_cli.rs
@@ -12,7 +12,7 @@ fn write_role_repo(temp: &tempfile::TempDir, dockerfile: &str, manifest: &str) {
     std::fs::write(temp.path().join("jackin.role.toml"), manifest).unwrap();
 }
 
-const VALID_MANIFEST: &str = r#"version = "v1alpha4"
+const VALID_MANIFEST: &str = r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 
 [claude]
@@ -107,7 +107,7 @@ fn validate_fails_for_invalid_manifest() {
     std::fs::write(temp.path().join("Dockerfile"), VERSIONED_FROM).unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 unknown_field = true
 
@@ -138,7 +138,7 @@ fn validate_passes_when_manifest_uses_dockerfile_in_subdirectory() {
     .unwrap();
     std::fs::write(
         temp.path().join("jackin.role.toml"),
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "docker/role.Dockerfile"
 
 [claude]
@@ -161,7 +161,7 @@ fn validate_fails_for_invalid_preflight_hook() {
     write_role_repo(
         &temp,
         VERSIONED_FROM,
-        r#"version = "v1alpha4"
+        r#"version = "v1alpha5"
 dockerfile = "Dockerfile"
 
 [hooks]
@@ -221,12 +221,12 @@ fn migrate_updates_legacy_manifest() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Migrated manifest legacy -> v1alpha4",
+            "Migrated manifest legacy -> v1alpha5",
         ))
         .stdout(predicate::str::contains("Role repository is valid"));
 
     let out = std::fs::read_to_string(temp.path().join("jackin.role.toml")).unwrap();
-    assert!(out.contains(r#"version = "v1alpha4""#), "{out}");
+    assert!(out.contains(r#"version = "v1alpha5""#), "{out}");
 }
 
 #[test]
@@ -243,7 +243,7 @@ fn migrate_rejects_newer_manifest_version() {
         .args(["migrate", temp.path().to_str().unwrap()])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("only understands up to v1alpha4"));
+        .stderr(predicate::str::contains("only understands up to v1alpha5"));
 }
 
 #[test]

--- a/docs/content/docs/(role-authoring)/developing/role-manifest.mdx
+++ b/docs/content/docs/(role-authoring)/developing/role-manifest.mdx
@@ -206,6 +206,36 @@ agents = ["opencode"]
 model = "zai-coding-plan/glm-5.1"
 ```
 
+## `[<agent>.providers.<provider>]`
+
+Claude Code, Codex, and OpenCode can run against alternative providers chosen from the provider picker at session launch. By default each provider uses jackin's built-in model for that agent. A `[<agent>.providers.<provider>]` table overrides the model used **when that provider is the selected provider**, without changing the agent's own `model` default. This matters most for OpenCode, which has no model of its own and resolves its model entirely from the selected provider.
+
+| Field | Required | Description |
+|---|---|---|
+| `model` | No | Model used when this provider is selected for the agent. For OpenCode, the `provider/model` string passed to `opencode -m`; for Claude and Codex, the provider's model name |
+
+`<provider>` is the provider's lowercase id: `anthropic`, `openai`, `zai`, `minimax`, or `kimi`. Resolution order when a provider is picked: the `[<agent>.providers.<provider>]` model, then jackin's built-in default for that pair, then the agent's own `model`.
+
+```toml title="jackin.role.toml"
+[claude]
+model = "claude-sonnet-4-6"
+
+# Pin a different model when MiniMax is picked for Claude.
+[claude.providers.minimax]
+model = "MiniMax-M3"
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+
+# OpenCode routes through the selected provider's block, so the model names
+# its provider id as well.
+[opencode.providers.minimax]
+model = "minimax/MiniMax-M3"
+
+[opencode.providers.zai]
+model = "zai-coding-plan/glm-5.1"
+```
+
 ### `[[claude.marketplaces]]`
 
 Each marketplace block declares one Claude marketplace source to register before plugin installation.

--- a/docs/content/docs/reference/roadmap/alternative-llm-providers.mdx
+++ b/docs/content/docs/reference/roadmap/alternative-llm-providers.mdx
@@ -2,7 +2,7 @@
 title: "Alternative LLM Providers (MiniMax, Kimi, GLM everywhere)"
 ---
 
-**Status**: Partially implemented — Phases 1–4 shipped on `main` (catalog + Claude Code + Codex MiniMax + Codex OpenAI default + OpenCode + operator Auth-tab rows + provider picker that collapses the agent's native auth); Codex GLM and Kimi cells remain deferred pending upstream Responses-API endpoint.
+**Status**: Partially implemented — Phases 1–4 shipped on `main` (catalog + Claude Code + Codex MiniMax + Codex OpenAI default + OpenCode + operator Auth-tab rows + provider picker that collapses the agent's native auth + per-provider model overrides in role manifests via `[<agent>.providers.<id>]`); Codex GLM and Kimi cells remain deferred pending upstream Responses-API endpoint.
 
 > **Registry note.** Provider routing now lives behind the workspace crate registry. The durable design record for the runtime/provider adapter work lives in [Architecture](/reference/getting-oriented/architecture/#agentruntime-and-provider-registry).
 

--- a/docs/content/docs/reference/runtime/schema-versions.mdx
+++ b/docs/content/docs/reference/runtime/schema-versions.mdx
@@ -26,11 +26,49 @@ The split-workspace layout described in [Configuration File](/reference/runtime/
 |---|---|---|---|
 | `~/.config/jackin/config.toml` | `v1alpha6` | jackin | Automatic on startup |
 | `~/.config/jackin/workspaces/<name>.toml` | `v1alpha6` | jackin | Automatic on startup |
-| `jackin.role.toml` | `v1alpha4` | Role repository | Desktop: `jackin role migrate <role-repo-path>`; CI/automation: `jackin-role migrate <role-repo-path>` |
+| `jackin.role.toml` | `v1alpha5` | Role repository | Desktop: `jackin role migrate <role-repo-path>`; CI/automation: `jackin-role migrate <role-repo-path>` |
 
 ## Timeline
 
 Each entry is one upgrade path the current binary applies. <RepoFile path="crates/jackin/tests/migration_fixtures.rs" /> walks every fixture on every CI run, so a regression breaks here before it breaks on a delayed operator's machine. Newest first; append, never edit.
+
+### Manifest `v1alpha5` — 2026-06-10
+
+| File kind | Predecessor | Migration mode | Fixture |
+|---|---|---|---|
+| Role manifest (`jackin.role.toml`) | `v1alpha4` | Desktop: `jackin role migrate <role-repo-path>`; CI/automation: `jackin-role migrate <role-repo-path>` | <RepoFile path="crates/jackin/tests/fixtures/migrations/manifest/from-v1alpha4/meta.toml" /> |
+
+**Summary**: adds optional `[<agent>.providers.<id>]` tables to the `[claude]`, `[codex]`, and `[opencode]` agent configs for per-provider model overrides. The `providers` map is an additive field with a `serde` default of empty, so existing manifests round-trip cleanly and the migration is a no-op restamp. A manifest stamped older than `v1alpha5` that uses a `providers` table is rejected with a `jackin role migrate` hint, the same way the OpenCode (`v1alpha3`) and Kimi (`v1alpha4`) agent fields are gated.
+
+**Before** (v1alpha4 manifest):
+
+```toml
+version = "v1alpha4"
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+```
+
+**After** (v1alpha5 — no change needed; the `providers` map defaults to empty):
+
+```toml
+version = "v1alpha5"
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+```
+
+**Example with a per-provider override** (a role pins a model when MiniMax is picked for OpenCode):
+
+```toml
+version = "v1alpha5"
+
+[opencode]
+model = "zai-coding-plan/glm-5.1"
+
+[opencode.providers.minimax]
+model = "minimax/MiniMax-M3"
+```
 
 ### `v1alpha6` — 2026-06-04
 


### PR DESCRIPTION
## Summary

Roles can now pin a model per selected provider, directly in `jackin.role.toml`, via `[<agent>.providers.<id>]` tables. When the operator picks a provider for Claude, Codex, or OpenCode at session launch, jackin uses the role's per-provider model override instead of its built-in default — without changing the agent's own `model`. This matters most for OpenCode, which has no model of its own and resolves its model entirely from the selected provider, but it works the same for Claude and Codex. The role manifest schema bumps to `v1alpha5`.

## What ships

- A `[<agent>.providers.<id>]` table in the role manifest, where `<id>` is the provider's lowercase slug (`anthropic`, `openai`, `zai`, `minimax`, `kimi`). Its `model` overrides the model used when that provider is selected for the agent.
- Resolution when a provider is picked: the manifest override, then jackin's built-in default for that (agent, provider) pair, then the agent's own `model`.
- The override reaches every place a provider pick decides the model: OpenCode's `-m` flag, Claude's `ANTHROPIC_DEFAULT_*_MODEL` env, and the Codex `--profile` model plus its model catalog.
- Role-authoring docs document the new table; the alternative-LLM-providers roadmap notes the capability; the schema-versions reference gains a `v1alpha5` timeline entry.

## Behavior changes

- The role manifest schema is now `v1alpha5`. The change is additive — the `providers` map defaults to empty — so existing manifests migrate with a no-op restamp and load unchanged.
- A manifest stamped older than `v1alpha5` that uses a `[<agent>.providers]` table is rejected with a `jackin role migrate <role-repo-path>` hint, the same gate the OpenCode (`v1alpha3`) and Kimi (`v1alpha4`) agent fields use.

## What this addresses

- OpenCode has no model of its own, so the selected provider must supply one. Roles previously had a single `[opencode] model` that applied to every provider pick; this lets a role map each provider to its own model.
- Gives Claude and Codex the same per-provider control where a role wants a different model for an alternative provider than for the agent's native one.

## Not included

- Whether OpenCode propagates a custom provider's key/baseURL at runtime (the `@ai-sdk/*` custom-provider path) is version-dependent and tracked by open upstream issues; this PR is the model-selection lever, not that runtime-auth question.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-556"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin feature/per-provider-model-override:refs/remotes/origin/feature/per-provider-model-override
git checkout -B feature/per-provider-model-override refs/remotes/origin/feature/per-provider-model-override
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
export JACKIN_CONFIG_DIR="$JACKIN_PR_TEST_DIR/.config/jackin"
export JACKIN_HOME_DIR="$JACKIN_PR_TEST_DIR/.jackin"
which jackin
```

Then build and export the jackin-capsule binary so the smoke steps below use it:

```sh
eval "$(cargo run --bin build-jackin-capsule -- --export)"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

The manifest parse of `[<agent>.providers.<id>]`, the older-stamp feature gate, the host→capsule carry, the three model sinks, and the migration-fixture chain to `v1alpha5` are covered in `jackin-manifest`, `jackin-protocol`, `jackin-capsule`, and `jackin`.

```sh
cargo nextest run -p jackin-core -p jackin-protocol -p jackin-manifest -p jackin-capsule -p jackin
cargo nextest run --all-features
```

### Schema migration smoke

Copy a role repo into the PR test directory and migrate the copy — the manifest restamps `v1alpha4` → `v1alpha5` with no field change:

```sh
mkdir -p "$JACKIN_PR_TEST_DIR/role-migrate"
printf 'version = "v1alpha4"\ndockerfile = "Dockerfile"\nagents = ["opencode"]\n\n[opencode]\nmodel = "zai-coding-plan/glm-5.1"\n' \
  > "$JACKIN_PR_TEST_DIR/role-migrate/jackin.role.toml"
cargo run --bin jackin-role -- migrate "$JACKIN_PR_TEST_DIR/role-migrate"
head -1 "$JACKIN_PR_TEST_DIR/role-migrate/jackin.role.toml"
```

Expected: `Migrated manifest v1alpha4 -> v1alpha5`, and the file's first line is `version = "v1alpha5"` with the rest unchanged.

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

### jackin-capsule smoke

Add a `[<agent>.providers.<id>]` override to a role's `jackin.role.toml` (e.g. the-architect's), then:

```sh
jackin load the-architect . --debug
```

Inside the container, verify:

- Row 0 status bar is visible: `jackin'  [<agent-name>]`
- Agent TUI starts and renders correctly below the status bar
- `Ctrl+\` opens the command palette (override with `JACKIN_PALETTE_KEY`)
- Mouse clicks, arrow keys, and paste reach the agent unmodified
- Pick the overridden provider for OpenCode: the launch uses the override `provider/model` (visible as `opencode -m <override>` in `--debug`), not the agent default. For Claude, picking the overridden provider sets `ANTHROPIC_DEFAULT_*_MODEL` to the override; for Codex, `~/.codex/minimax.config.toml` and the model catalog carry the override model.

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/developing/role-manifest/**  
UPDATED — new "`[<agent>.providers.<provider>]`" section. Confirm the field table, the provider-id list, the resolution order, and the example render correctly.

**http://localhost:3000/reference/runtime/schema-versions/**  
UPDATED — current-versions table shows `jackin.role.toml` at `v1alpha5`, and a new "Manifest `v1alpha5`" timeline entry sits at the top with the before/after restamp example.

## Migration notes

Role manifests bump to `v1alpha5`. The change is additive (the new `providers` table defaults to empty), so the migration is a no-op restamp and existing manifests load unchanged. Role authors update a local role repo with `jackin role migrate <role-repo-path>`; CI/automation uses `jackin-role migrate <role-repo-path>`. A manifest that adopts the new `[<agent>.providers]` table must declare `version = "v1alpha5"` or jackin rejects it with a migrate hint.
