### PR TITLE
test(capsule): echo-back render conformance harness and pty-fixture extractor

### DIFF
--- a/CAPSULE_RENDERING_FINDINGS.md
+++ b/CAPSULE_RENDERING_FINDINGS.md
@@ -44,13 +44,13 @@ PR 1 — scroller + scrollbar + stopgap (`fix/capsule-scrollback-redraw`, PR #55
 - [ ] P1.12 Merged — `BLOCKED(operator)`: per-PR merge authorization required; PR will be marked ready and merge requested. — Evidence:
 
 PR 2 — echo-back harness + fixtures (`chore/capsule-render-conformance`)
-- [ ] P2.1 VirtualClient + I1 assertion helper — Evidence:
-- [ ] P2.2 Deterministic harness driving `compose_pending_frame` — Evidence:
-- [ ] P2.3 `jackin-xtask pty-fixture` subcommand — Evidence:
-- [ ] P2.4 Fixtures: recorded (or synthetic-only if S0 blocked) + Unicode/CSI synthetic set — Evidence:
-- [ ] P2.5 Scenario suite green; remaining failures `#[ignore = "fixed by PR 3/4"]` — Evidence:
+- [x] P2.1 VirtualClient + I1 assertion helper — Evidence: `render_conformance_tests.rs` `VirtualClient` (second `DamageGrid`) + `assert_screen_matches_model` (grapheme, full `Attrs`, wide flags over each pane rect) + `assert_cursor_contract`.
+- [x] P2.2 Deterministic harness driving `compose_pending_frame` — Evidence: `feed_and_compose` marks the pane dirty and calls `compose_pending_frame` directly; no ticker, no sleeps; scenarios cover streaming, full scroll cycle (incl. wheel-to-zero), focus swap, resize, dialog open/close, alt-screen enter/exit, selection.
+- [x] P2.3 `jackin-xtask pty-fixture` subcommand — Evidence: `crates/jackin-xtask/src/pty_fixture.rs` (`cargo xtask pty-fixture <run.jsonl> <label> <out.bin>`); unit tests `extracts_matching_label_from_raw_log_line` et al. green (`cargo test -p jackin-xtask`: 8 passed).
+- [x] P2.4 Fixtures: synthetic-only (S0 blocked) + Unicode/CSI synthetic set — Evidence: synthetic streams in the harness (SGR streaming, alt-screen, combining/VS16/ZWJ, wide-lead overwrite, DECSTR, DSR); `tests/fixtures/pty/` created with recording instructions; recorded fixtures remain blocked on S0.1.
+- [x] P2.5 Scenario suite green; remaining failures `#[ignore = "fixed by PR 3/4"]` — Evidence: `cargo test -p jackin-capsule`: 467 passed / 6 ignored; the 6 ignored (grapheme/VS16/ZWJ, wide-lead, DECSTR, DSR clamp) all FAIL when forced with `--ignored` (transcript 2026-06-10) — the executable spec for PR 4. The harness also exposed a PR 1 stopgap hole (default-blank residue), fixed on the PR 1 branch by the sentinel-baseline commit.
 - [ ] P2.6 §7 PR 2 docs row; §6.1 output; PR ready; CI green — Evidence:
-- [ ] P2.7 Merged — `BLOCKED(operator)` — Evidence:
+- [ ] P2.7 Merged — `BLOCKED(operator)`: per-PR merge authorization required. — Evidence:
 
 PR 3 — single writer + derived rendering (`refactor/capsule-single-render-path`)
 - [ ] P3.1 `ClientWriter` sole socket owner; `?2026` frame brackets — Evidence:

--- a/CAPSULE_RENDERING_FINDINGS.md
+++ b/CAPSULE_RENDERING_FINDINGS.md
@@ -40,7 +40,7 @@ PR 1 — scroller + scrollbar + stopgap (`fix/capsule-scrollback-redraw`, PR #55
 - [x] P1.8 Step-8 tests added and passing — Evidence: `cargo test -p jackin-capsule` 459 passed / 0 failed (transcript 2026-06-10); new tests named in P1.2–P1.7 evidence.
 - [ ] P1.9 Manual smoke matrix executed (`--debug`) — `BLOCKED(operator)`: needs an interactive Docker-capable host terminal. Recipe: `cargo run --bin jackin -- console --debug`; stream Codex; wheel up 3 pages → view holds still; wheel down to bottom (wheel only) → input box + live footer return; type while scrolled → snap; focus swap while scrolled → no cursor in history.
 - [x] P1.10 §7 PR 1 docs row applied — Evidence: `reference/tui/components.mdx` "One scrollbar renderer" rule; `reference/capsule/multiplexer-design-rules.mdx` Scrollback rules (repaint-on-offset-change, cursor hidden while scrolled, anchored view). (`tui-design-decisions.mdx` named by AGENTS.md does not exist; `reference/tui/` pages are its current home.)
-- [ ] P1.11 §6.1 block run with passing output; PR ready; CI green (`gh pr checks`) — Evidence:
+- [x] P1.11 §6.1 block run with passing output; PR ready; CI green (`gh pr checks`) — Evidence: fmt/clippy/`cargo test --workspace` (exit 0) + capsule eval build shown in-session 2026-06-10; PR #555 marked ready; `gh pr checks 555` all pass (ci-required, cargo nextest, clippy, fmt, msrv, fuzz, docs-required, construct-required) on head 95b39a5e after merging origin/main (#552 provider change).
 - [ ] P1.12 Merged — `BLOCKED(operator)`: per-PR merge authorization required; PR will be marked ready and merge requested. — Evidence:
 
 PR 2 — echo-back harness + fixtures (`chore/capsule-render-conformance`)

--- a/TESTING.md
+++ b/TESTING.md
@@ -34,6 +34,27 @@ cargo nextest run --all-features
 
 Do **not** use `cargo test` — always use `cargo nextest run`.
 
+## Recording capsule render-conformance fixtures
+
+The capsule's echo-back render-conformance harness
+(`crates/jackin-capsule/src/daemon/render_conformance_tests.rs`) replays PTY byte streams through
+the multiplexer and asserts the emitted frames reproduce the pane model on a virtual client
+terminal. Synthetic streams live in the harness; real-agent fixtures are recorded from a `--debug`
+run:
+
+1. Run a session with `--debug` (for example `cargo run --bin jackin -- console --debug`) and
+   exercise the agent. Note the run id the CLI prints.
+2. Extract one session's PTY stream from the run log into a binary fixture:
+
+   ```sh
+   cargo xtask pty-fixture ~/.jackin/data/diagnostics/runs/<run-id>.jsonl <session-label> \
+     crates/jackin-capsule/tests/fixtures/pty/<agent>-<scenario>.bin
+   ```
+
+   The session label is the pane label shown in the capsule tab (e.g. `Codex`). The extractor also
+   accepts a raw in-container `multiplexer.log`.
+3. Reference the fixture from a harness scenario with `include_bytes!`.
+
 ## Merge-readiness Verification
 
 Do not run formatting, clippy, and the full test suite before every commit by

--- a/crates/jackin-capsule/src/daemon.rs
+++ b/crates/jackin-capsule/src/daemon.rs
@@ -1190,4 +1190,6 @@ async fn handle_client_frame(mux: &mut Multiplexer, frame: ClientFrame) {
 }
 
 #[cfg(test)]
+mod render_conformance_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/jackin-capsule/src/daemon/render_conformance_tests.rs
+++ b/crates/jackin-capsule/src/daemon/render_conformance_tests.rs
@@ -1,0 +1,590 @@
+//! Echo-back conformance harness — the I1 (screen == model) enforcer.
+//!
+//! Replays PTY bytes through the multiplexer, feeds every composed frame into
+//! a virtual client terminal (a second `DamageGrid` emulating the operator's
+//! outer terminal), and asserts cell-exact equality between each visible
+//! pane's grid and the client screen within the pane rect, plus the
+//! frame-model cursor contract. Composition is driven deterministically —
+//! direct `compose_pending_frame` / `compose_full_redraw` calls, no ticker,
+//! no sleeps.
+//!
+//! Scenarios that still fail after PR 1 of the capsule rendering plan are the
+//! executable spec for PR 3 / PR 4 and carry `#[ignore]` tags naming the
+//! fixing PR. Recorded fixtures land in `tests/fixtures/pty/` once a Stage-0
+//! operator run id exists; until then the byte streams below are synthetic.
+
+use super::tests::{single_pane_tab_mux, split_tab_mux, test_session, test_session_with_agent};
+use super::{FullRedrawReason, InputEvent, Multiplexer, STATUS_BAR_ROWS};
+use crate::tui::app::{CursorVisibilityState, cursor_visible_for_state};
+use jackin_term::{Cell, DamageGrid};
+
+/// The outer terminal: a second `DamageGrid` sized to the attach client.
+/// `apply` is `process()`; the capsule's own `?2026` brackets and mode
+/// toggles parse harmlessly. Passthrough events are drained and dropped —
+/// they carry no cell content.
+struct VirtualClient {
+    grid: DamageGrid,
+}
+
+impl VirtualClient {
+    fn new(rows: u16, cols: u16) -> Self {
+        Self {
+            grid: DamageGrid::new(rows, cols, 0),
+        }
+    }
+
+    fn apply(&mut self, frame: &[u8]) {
+        self.grid.process(frame);
+        drop(self.grid.drain_passthrough());
+        drop(self.grid.dirty_spans());
+    }
+
+    fn resize(&mut self, rows: u16, cols: u16) {
+        self.grid.set_size(rows, cols);
+    }
+
+    fn cell_text(cell: Option<&Cell>) -> String {
+        match cell {
+            Some(c) if !c.contents.is_empty() => c.contents().to_owned(),
+            _ => " ".to_owned(),
+        }
+    }
+}
+
+/// Feed PTY bytes into one session and compose the resulting frame exactly
+/// the way the daemon's event loop would: mark the pane dirty, compose, and
+/// hand the bytes to the virtual client. Out-of-band passthrough and mode
+/// transitions are drained and dropped — they never carry cells.
+fn feed_and_compose(
+    mux: &mut Multiplexer,
+    client: &mut VirtualClient,
+    session_id: u64,
+    bytes: &[u8],
+) {
+    if let Some(session) = mux.sessions.get_mut(&session_id) {
+        session.feed_pty(bytes);
+        drop(session.drain_passthrough());
+        drop(session.drain_mode_transitions());
+    }
+    mux.dirty_panes.insert(session_id);
+    let frame = mux.compose_pending_frame();
+    client.apply(&frame);
+}
+
+/// I1: after a frame, the client screen equals every visible pane's grid
+/// (grapheme, full attribute set, wide flags) within the pane rect. Only
+/// valid while no dialog covers the panes and no selection overlay is
+/// active — those scenarios assert after the overlay is dismissed.
+fn assert_screen_matches_model(mux: &mut Multiplexer, client: &VirtualClient, context: &str) {
+    assert!(
+        !mux.dialog_open(),
+        "{context}: I1 cell comparison requires no dialog over the panes"
+    );
+    let (client_rows, client_cols) = client.grid.size();
+    let client_view = client.grid.scrollback_view(0, client_rows);
+    let panes = mux.visible_panes();
+    assert!(!panes.is_empty(), "{context}: no visible panes");
+    for pane in &panes {
+        let session = mux
+            .sessions
+            .get(&pane.id)
+            .unwrap_or_else(|| panic!("{context}: pane {} has no session", pane.id));
+        let view = session
+            .shadow_grid
+            .scrollback_view(session.scrollback_offset, pane.inner.rows);
+        for row in 0..pane.inner.rows.min(view.rows) {
+            for col in 0..pane.inner.cols.min(view.cols) {
+                let screen_row = pane.inner.row + row;
+                let screen_col = pane.inner.col + col;
+                if screen_row >= client_rows || screen_col >= client_cols {
+                    continue;
+                }
+                let model = view.cell(row, col);
+                let client_cell = client_view.cell(screen_row, screen_col);
+                let model_text = VirtualClient::cell_text(model);
+                let client_text = VirtualClient::cell_text(client_cell);
+                assert_eq!(
+                    model_text, client_text,
+                    "{context}: grapheme mismatch pane {} cell ({row},{col}) / screen ({screen_row},{screen_col})",
+                    pane.id
+                );
+                let default = Cell::default();
+                let model_cell = model.unwrap_or(&default);
+                let client_cell = client_cell.unwrap_or(&default);
+                assert_eq!(
+                    model_cell.attrs, client_cell.attrs,
+                    "{context}: attr mismatch pane {} cell ({row},{col}) text {model_text:?}",
+                    pane.id
+                );
+                assert_eq!(
+                    (model_cell.is_wide, model_cell.is_wide_continuation),
+                    (client_cell.is_wide, client_cell.is_wide_continuation),
+                    "{context}: wide-flag mismatch pane {} cell ({row},{col}) text {model_text:?}",
+                    pane.id
+                );
+            }
+        }
+    }
+}
+
+/// Frame-model cursor contract: the client cursor is visible exactly when
+/// `cursor_visible_for_state` says so for the focused pane, and when visible
+/// it sits at the focused pane's VT cursor translated into screen space.
+fn assert_cursor_contract(mux: &mut Multiplexer, client: &VirtualClient, context: &str) {
+    let dialog_open = mux.dialog_open();
+    let focused = mux.active_focused_id();
+    let pane = focused.and_then(|id| mux.visible_panes().into_iter().find(|p| p.id == id));
+    let expected_visible = match (focused, &pane) {
+        (Some(id), Some(_)) => {
+            let session = mux.sessions.get(&id).expect("focused session");
+            cursor_visible_for_state(CursorVisibilityState {
+                dialog_open,
+                focused_pane_available: true,
+                focused_session_received_output: session.received_output,
+                scrollback_active: session.scrollback_offset != 0,
+                agent_cursor_hidden: session.shadow_grid.hide_cursor(),
+            })
+        }
+        _ => false,
+    };
+    assert_eq!(
+        !client.grid.hide_cursor(),
+        expected_visible,
+        "{context}: cursor visibility violates the frame-model contract"
+    );
+    if expected_visible {
+        let id = focused.expect("visible cursor implies focused pane");
+        let pane = pane.expect("visible cursor implies pane rect");
+        let session = mux.sessions.get(&id).expect("focused session");
+        let (vt_row, vt_col) = session.shadow_grid.cursor_position();
+        assert_eq!(
+            client.grid.cursor_position(),
+            (pane.inner.row + vt_row, pane.inner.col + vt_col),
+            "{context}: cursor position must be the focused pane's VT cursor in screen space"
+        );
+    }
+}
+
+fn assert_frame_conformance(mux: &mut Multiplexer, client: &VirtualClient, context: &str) {
+    assert_screen_matches_model(mux, client, context);
+    assert_cursor_contract(mux, client, context);
+}
+
+/// Single pane sized to the pane's inner rect, with the session installed and
+/// the first-attach frame applied to a fresh virtual client.
+fn attached_single_pane() -> (Multiplexer, VirtualClient, u64) {
+    let mut mux = single_pane_tab_mux();
+    let pane = mux.visible_panes().into_iter().next().expect("one pane");
+    let (session, rx) = test_session(pane.inner.rows, pane.inner.cols);
+    // The reply receiver is dropped intentionally: these scenarios never
+    // read DSR replies. Sessions that need it use test_session directly.
+    drop(rx);
+    mux.sessions.insert(1, session);
+    let mut client = VirtualClient::new(mux.term_rows, mux.term_cols);
+    let frame = mux.compose_full_redraw(FullRedrawReason::FirstAttach);
+    client.apply(&frame);
+    (mux, client, 1)
+}
+
+/// Synthetic Codex-style stream chunk: SGR-colored, wrapped prose lines.
+fn codex_chunk(i: usize) -> Vec<u8> {
+    format!(
+        "\x1b[38;5;39mcodex\x1b[0m line {i}: \x1b[1mthinking\x1b[0m about \x1b[38;2;0;255;65mrendering\x1b[0m\r\n"
+    )
+    .into_bytes()
+}
+
+#[test]
+fn stream_keeps_screen_equal_to_model() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..60 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+        if i % 13 == 0 {
+            assert_frame_conformance(&mut mux, &client, &format!("stream chunk {i}"));
+        }
+    }
+    assert_frame_conformance(&mut mux, &client, "stream end");
+}
+
+#[test]
+fn full_scroll_cycle_keeps_screen_equal_to_model() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..60 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+
+    // Wheel up three steps into history.
+    for step in 0..3 {
+        let frame = mux.handle_input(InputEvent::MousePress {
+            row: STATUS_BAR_ROWS + 1,
+            col: 1,
+            button: 64,
+        });
+        if let Some(frame) = frame {
+            client.apply(&frame);
+        }
+        assert_frame_conformance(&mut mux, &client, &format!("wheel up step {step}"));
+    }
+    assert_ne!(mux.sessions.get(&sid).unwrap().scrollback_offset, 0);
+
+    // Stream while scrolled: the anchored view must stay equal to the model.
+    for i in 60..70 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+    assert_frame_conformance(&mut mux, &client, "anchored feed while scrolled");
+
+    // Wheel back to the live tail — wheel only.
+    while mux.sessions.get(&sid).unwrap().scrollback_offset != 0 {
+        let frame = mux.handle_input(InputEvent::MousePress {
+            row: STATUS_BAR_ROWS + 1,
+            col: 1,
+            button: 65,
+        });
+        if let Some(frame) = frame {
+            client.apply(&frame);
+        }
+    }
+    assert_frame_conformance(&mut mux, &client, "wheel back to live");
+}
+
+#[test]
+fn focus_swap_mid_stream_keeps_screen_equal_to_model() {
+    let mut mux = split_tab_mux();
+    let panes = mux.visible_panes();
+    assert_eq!(panes.len(), 2);
+    for pane in &panes {
+        let (session, rx) = test_session_with_agent(
+            pane.inner.rows,
+            pane.inner.cols,
+            Some(format!("agent-{}", pane.id)),
+        );
+        drop(rx);
+        mux.sessions.insert(pane.id, session);
+    }
+    let mut client = VirtualClient::new(mux.term_rows, mux.term_cols);
+    let frame = mux.compose_full_redraw(FullRedrawReason::FirstAttach);
+    client.apply(&frame);
+
+    for i in 0..20 {
+        feed_and_compose(&mut mux, &mut client, panes[0].id, &codex_chunk(i));
+        feed_and_compose(
+            &mut mux,
+            &mut client,
+            panes[1].id,
+            format!("pane two output {i}\r\n").as_bytes(),
+        );
+    }
+    assert_frame_conformance(&mut mux, &client, "split stream");
+
+    // Click into the second pane mid-stream, then keep streaming.
+    let target = &panes[1];
+    let frame = mux.handle_input(InputEvent::MousePress {
+        row: target.inner.row + 1,
+        col: target.inner.col + 1,
+        button: 0,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+    for i in 20..30 {
+        feed_and_compose(&mut mux, &mut client, panes[0].id, &codex_chunk(i));
+    }
+    assert_frame_conformance(&mut mux, &client, "focus swap mid-stream");
+}
+
+#[test]
+fn resize_mid_stream_keeps_screen_equal_to_model() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..30 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+
+    mux.resize(30, 100);
+    client.resize(30, 100);
+    let frame = mux.compose_full_redraw(FullRedrawReason::Resize);
+    client.apply(&frame);
+    assert_frame_conformance(&mut mux, &client, "after grow resize");
+
+    for i in 30..40 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+    assert_frame_conformance(&mut mux, &client, "stream after resize");
+}
+
+#[test]
+fn dialog_open_close_over_streaming_leaves_no_residue() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..20 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+
+    let frame = mux
+        .apply_action(crate::tui::message::Action::OpenGithubContext)
+        .expect("opening a dialog composes a frame");
+    client.apply(&frame);
+    assert!(mux.dialog_open());
+
+    // Stream under the open dialog — frames keep flowing.
+    for i in 20..30 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+
+    let frame = mux.apply_dialog_action(crate::tui::components::dialog::DialogAction::Dismiss);
+    client.apply(&frame);
+    assert!(!mux.dialog_open());
+    assert_frame_conformance(&mut mux, &client, "after dialog close over streaming");
+}
+
+#[test]
+fn alt_screen_session_enter_exit_keeps_screen_equal_to_model() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..20 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+
+    // Claude-style alt-screen TUI: enter, paint a frame, exit.
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[?1049h\x1b[2J\x1b[H");
+    feed_and_compose(
+        &mut mux,
+        &mut client,
+        sid,
+        b"\x1b[1;1H\x1b[44m claude \x1b[0m\x1b[3;2HWelcome back\x1b[10;2H> ",
+    );
+    assert_frame_conformance(&mut mux, &client, "alt screen painted");
+
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[?1049l");
+    assert_frame_conformance(&mut mux, &client, "after alt-screen exit");
+}
+
+#[test]
+fn clear_screen_during_selection_overlay_converges_after_clear() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..20 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+    let pane = mux.visible_panes().into_iter().next().expect("one pane");
+
+    // Drag a selection so composition routes through the Ratatui path
+    // (the direct-patch tier refuses while a selection is active).
+    let press_row = pane.inner.row + 2;
+    let press_col = pane.inner.col + 1;
+    let frame = mux.handle_input(InputEvent::MousePress {
+        row: press_row,
+        col: press_col,
+        button: 0,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+    let frame = mux.handle_input(InputEvent::MousePress {
+        row: press_row + 1,
+        col: press_col + 10,
+        button: 32,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+
+    // The program clears its screen while the selection overlay is active.
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[2J\x1b[H$ ");
+
+    // Release and click once to clear the selection overlay.
+    let frame = mux.handle_input(InputEvent::MouseRelease {
+        row: press_row + 1,
+        col: press_col + 10,
+        button: 0,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+    let frame = mux.handle_input(InputEvent::MousePress {
+        row: press_row,
+        col: press_col,
+        button: 0,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+    let frame = mux.handle_input(InputEvent::MouseRelease {
+        row: press_row,
+        col: press_col,
+        button: 0,
+    });
+    if let Some(frame) = frame {
+        client.apply(&frame);
+    }
+
+    assert_frame_conformance(&mut mux, &client, "screen cleared during selection");
+}
+
+#[test]
+fn selection_residue_cleared_after_copy_click() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    for i in 0..20 {
+        feed_and_compose(&mut mux, &mut client, sid, &codex_chunk(i));
+    }
+    let pane = mux.visible_panes().into_iter().next().expect("one pane");
+    let press_row = pane.inner.row + 2;
+    let press_col = pane.inner.col + 1;
+    for event in [
+        InputEvent::MousePress {
+            row: press_row,
+            col: press_col,
+            button: 0,
+        },
+        InputEvent::MousePress {
+            row: press_row + 1,
+            col: press_col + 8,
+            button: 32,
+        },
+        InputEvent::MouseRelease {
+            row: press_row + 1,
+            col: press_col + 8,
+            button: 0,
+        },
+        // The follow-up click clears the highlight.
+        InputEvent::MousePress {
+            row: press_row,
+            col: press_col,
+            button: 0,
+        },
+        InputEvent::MouseRelease {
+            row: press_row,
+            col: press_col,
+            button: 0,
+        },
+    ] {
+        if let Some(frame) = mux.handle_input(event) {
+            client.apply(&frame);
+        }
+    }
+    assert!(mux.selection.is_none());
+    assert_frame_conformance(&mut mux, &client, "after selection cleared");
+}
+
+// ---------------------------------------------------------------------------
+// Model-expectation cases (PR 4): these assert the *correct* terminal-model
+// semantics. They are red against the current jackin-term model and flip
+// green when PR 4 lands; the echo-back equality above cannot catch them
+// because the virtual client shares the model's bugs.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "fixed by PR 4 (grapheme-cluster cells): combining marks currently overwrite their base character"]
+fn combining_mark_joins_base_character() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    feed_and_compose(&mut mux, &mut client, sid, "e\u{301}!".as_bytes());
+    let session = mux.sessions.get(&sid).unwrap();
+    let view = session.shadow_grid.scrollback_view(0, 1);
+    assert_eq!(
+        view.cell(0, 0).map(Cell::contents),
+        Some("e\u{301}"),
+        "combining acute must join the base cell as one grapheme cluster"
+    );
+    assert_eq!(
+        view.cell(0, 1).map(Cell::contents),
+        Some("!"),
+        "the next glyph lands in the next cell, not over the cluster"
+    );
+}
+
+#[test]
+#[ignore = "fixed by PR 4 (grapheme-cluster cells): VS16 sequences are currently split across cells"]
+fn vs16_emoji_stays_one_cluster() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    feed_and_compose(&mut mux, &mut client, sid, "\u{2601}\u{fe0f}X".as_bytes());
+    let session = mux.sessions.get(&sid).unwrap();
+    let view = session.shadow_grid.scrollback_view(0, 1);
+    assert_eq!(
+        view.cell(0, 0).map(Cell::contents),
+        Some("\u{2601}\u{fe0f}"),
+        "VS16 emoji presentation must stay in the base cell"
+    );
+}
+
+#[test]
+#[ignore = "fixed by PR 4 (grapheme-cluster cells): ZWJ sequences are currently split across cells"]
+fn zwj_family_emoji_stays_one_cluster() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    let family = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}";
+    feed_and_compose(&mut mux, &mut client, sid, family.as_bytes());
+    let session = mux.sessions.get(&sid).unwrap();
+    let view = session.shadow_grid.scrollback_view(0, 1);
+    assert_eq!(
+        view.cell(0, 0).map(Cell::contents),
+        Some(family),
+        "the full ZWJ sequence must live in one cell"
+    );
+}
+
+#[test]
+#[ignore = "fixed by PR 4 (wide-lead overwrite): overwriting a wide lead currently leaves the continuation cell stale"]
+fn wide_lead_overwrite_blanks_continuation() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    feed_and_compose(&mut mux, &mut client, sid, "\u{4f60}".as_bytes());
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[1;1HA");
+    let session = mux.sessions.get(&sid).unwrap();
+    let view = session.shadow_grid.scrollback_view(0, 1);
+    let continuation = view.cell(0, 1).expect("continuation cell");
+    assert!(
+        !continuation.is_wide_continuation && continuation.contents.is_empty(),
+        "overwriting the wide lead must blank the continuation cell, got {continuation:?}"
+    );
+}
+
+#[test]
+#[ignore = "fixed by PR 4 (DECSTR in-grid): soft reset is currently forwarded raw to the client instead of being handled by the grid"]
+fn decstr_soft_reset_is_handled_in_grid() {
+    let (mut mux, mut client, sid) = attached_single_pane();
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[1m\x1b[?25l\x1b[5;10r");
+    feed_and_compose(&mut mux, &mut client, sid, b"\x1b[!p");
+    let session = mux.sessions.get_mut(&sid).unwrap();
+    assert!(
+        !session.shadow_grid.hide_cursor(),
+        "DECSTR must reset cursor visibility in the grid"
+    );
+    session.feed_pty(b"x");
+    let passthrough = session.drain_passthrough();
+    assert!(
+        passthrough.iter().all(|seq| !seq.ends_with(b"p")),
+        "DECSTR must never be forwarded to the client: {passthrough:?}"
+    );
+    let view = session.shadow_grid.scrollback_view(0, 1);
+    let cell = view
+        .cell(
+            session.shadow_grid.cursor_position().0,
+            session.shadow_grid.cursor_position().1.saturating_sub(1),
+        )
+        .expect("written cell");
+    assert!(
+        !cell.attrs.bold,
+        "DECSTR must reset SGR attributes before the next write"
+    );
+}
+
+#[test]
+#[ignore = "fixed by PR 4 (DSR clamp): the cursor-position report currently exposes the deferred-wrap phantom column cols+1"]
+fn dsr_cursor_report_clamps_phantom_column() {
+    let mut mux = single_pane_tab_mux();
+    let pane = mux.visible_panes().into_iter().next().expect("one pane");
+    let cols = pane.inner.cols;
+    let (session, mut input_rx) = test_session(pane.inner.rows, cols);
+    mux.sessions.insert(1, session);
+    let mut client = VirtualClient::new(mux.term_rows, mux.term_cols);
+    let frame = mux.compose_full_redraw(FullRedrawReason::FirstAttach);
+    client.apply(&frame);
+
+    // Fill the first row to the last column: the cursor enters the
+    // deferred-wrap state whose internal column is cols (0-based phantom).
+    let fill = "x".repeat(usize::from(cols));
+    feed_and_compose(&mut mux, &mut client, 1, fill.as_bytes());
+    feed_and_compose(&mut mux, &mut client, 1, b"\x1b[6n");
+
+    let reply = input_rx.try_recv().expect("DSR reply goes to the agent");
+    let reply = String::from_utf8(reply).expect("CPR is ASCII");
+    let expected = format!("\x1b[1;{cols}R");
+    assert_eq!(
+        reply, expected,
+        "CPR must clamp the phantom column to the last real column"
+    );
+}

--- a/crates/jackin-capsule/src/daemon/tests.rs
+++ b/crates/jackin-capsule/src/daemon/tests.rs
@@ -94,7 +94,7 @@ fn test_mux(rows: u16, cols: u16) -> Multiplexer {
     .unwrap_or_else(|error| panic!("test multiplexer construction failed: {error}"))
 }
 
-fn single_pane_tab_mux() -> Multiplexer {
+pub(super) fn single_pane_tab_mux() -> Multiplexer {
     single_pane_tab_mux_with_size(24, 80)
 }
 
@@ -296,7 +296,7 @@ fn full_frame_updates_outer_terminal_title_on_branch_switch() {
     );
 }
 
-fn test_session(rows: u16, cols: u16) -> (Session, mpsc::UnboundedReceiver<Vec<u8>>) {
+pub(super) fn test_session(rows: u16, cols: u16) -> (Session, mpsc::UnboundedReceiver<Vec<u8>>) {
     test_session_with_agent(rows, cols, Some("codex".to_owned()))
 }
 
@@ -383,7 +383,7 @@ fn feed_top_anchored_inline_history(session: &mut Session, region_bottom: u16, l
     session.feed_pty(b"\x1b[r");
 }
 
-fn test_session_with_agent(
+pub(super) fn test_session_with_agent(
     rows: u16,
     cols: u16,
     agent: Option<String>,
@@ -446,7 +446,7 @@ fn split_metadata_inherits_focused_provider() {
     assert_eq!(env, expected_env);
 }
 
-fn split_tab_mux() -> Multiplexer {
+pub(super) fn split_tab_mux() -> Multiplexer {
     let mut mux = test_mux(24, 80);
     let mut tab = Tab::new_single("Shell", 1, "test");
     assert!(tab.tree.split_h(1, 2, SplitPosition::After));

--- a/crates/jackin-capsule/tests/fixtures/pty/README.md
+++ b/crates/jackin-capsule/tests/fixtures/pty/README.md
@@ -1,0 +1,3 @@
+# Recorded PTY fixtures for the render-conformance harness
+
+Binary PTY byte streams (`<agent>-<scenario>.bin`) recorded from real agent sessions and replayed by `crates/jackin-capsule/src/daemon/render_conformance_tests.rs`. Record with `cargo xtask pty-fixture <run.jsonl> <session-label> <out.bin>` from a `--debug` run — see the "Recording capsule render-conformance fixtures" section in the repository's TESTING.md. The directory currently holds no recordings: the Stage-0 operator capture in CAPSULE_RENDERING_FINDINGS.md is blocked on an operator run id, and the harness ships synthetic streams until it lands.

--- a/crates/jackin-term/README.md
+++ b/crates/jackin-term/README.md
@@ -172,6 +172,16 @@ SocketBackend       ← focused live GridPatch rows encode directly; complex fra
    including resize/shrink, locking the Defect 44 erase-to-EOL contract.
 5. **Round-trip property test** (Phase 2+): "any mutation sequence → full re-emit → reproduces
    the ground-truth grid."
+6. **Emit-side echo-back conformance** (capsule): the multiplexer's
+   render-conformance harness in
+   `crates/jackin-capsule/src/daemon/render_conformance_tests.rs` closes the loop from the other
+   side — every frame the capsule composes is replayed into a second `DamageGrid` standing in for
+   the operator's outer terminal, and the harness asserts cell-exact equality (grapheme, attrs,
+   wide flags) between the pane grid and that virtual client, plus the frame-model cursor
+   contract. jackin-term is therefore both the model under test and the reference emulator that
+   verifies the emit path. Recorded PTY fixtures for it are extracted from `--debug` run logs with
+   `cargo xtask pty-fixture <run.jsonl> <session-label> <out.bin>` into
+   `crates/jackin-capsule/tests/fixtures/pty/`.
 
 `vt100` is fully retired from this crate: no production dependency, dev-dependency, fuzz
 dependency, benchmark baseline, or source-policy exception remains.

--- a/crates/jackin-xtask/src/main.rs
+++ b/crates/jackin-xtask/src/main.rs
@@ -6,6 +6,7 @@
 //! invokes rather than reimplementing in flag assembly.
 
 mod construct;
+mod pty_fixture;
 
 use std::process::ExitCode;
 
@@ -23,12 +24,16 @@ enum Command {
     /// Construct base-image build and publish tasks.
     #[command(subcommand)]
     Construct(construct::ConstructCommand),
+    /// Extract a PTY byte-stream fixture from a `--debug` run log for the
+    /// capsule render-conformance harness.
+    PtyFixture(pty_fixture::PtyFixtureArgs),
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let result = match cli.command {
         Command::Construct(cmd) => construct::run(cmd),
+        Command::PtyFixture(args) => pty_fixture::run(args),
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/jackin-xtask/src/pty_fixture.rs
+++ b/crates/jackin-xtask/src/pty_fixture.rs
@@ -35,7 +35,7 @@ pub(crate) fn run(args: PtyFixtureArgs) -> Result<()> {
     let mut chunks = 0usize;
     for line in raw.lines() {
         // Run JSONL embeds the capsule log line inside JSON string fields;
-        // serde's unescape recovers the original text. Raw log lines are
+        // the serde unescape recovers the original text. Raw log lines are
         // scanned as-is.
         if line.trim_start().starts_with('{')
             && let Ok(value) = serde_json::from_str::<serde_json::Value>(line)

--- a/crates/jackin-xtask/src/pty_fixture.rs
+++ b/crates/jackin-xtask/src/pty_fixture.rs
@@ -1,0 +1,152 @@
+//! Extract a recorded PTY byte stream from a `--debug` run log.
+//!
+//! `jackin-xtask pty-fixture <run.jsonl> <session-label> <out.bin>` scans the
+//! log for the capsule's `session feed_pty bytes:` debug lines, filters them
+//! to one session label, decodes the hex byte dumps, and concatenates them in
+//! order into a binary fixture for the echo-back conformance harness
+//! (`crates/jackin-capsule/src/daemon/render_conformance_tests.rs`). The
+//! input may be the host diagnostics run JSONL (feed lines embedded in JSON
+//! string fields) or a raw `multiplexer.log` — both line shapes are handled.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+
+#[derive(Args)]
+pub(crate) struct PtyFixtureArgs {
+    /// Diagnostics run log: `~/.jackin/data/diagnostics/runs/<run-id>.jsonl`
+    /// or a raw capsule `multiplexer.log`.
+    run_log: PathBuf,
+    /// Session label to extract — the `label=` field of the
+    /// `session feed_pty bytes:` lines (e.g. `Codex`).
+    session_label: String,
+    /// Output fixture path, conventionally
+    /// `crates/jackin-capsule/tests/fixtures/pty/<agent>-<scenario>.bin`.
+    out_bin: PathBuf,
+}
+
+pub(crate) fn run(args: PtyFixtureArgs) -> Result<()> {
+    let raw = fs::read_to_string(&args.run_log)
+        .with_context(|| format!("failed to read {}", args.run_log.display()))?;
+
+    let mut out = Vec::new();
+    let mut chunks = 0usize;
+    for line in raw.lines() {
+        // Run JSONL embeds the capsule log line inside JSON string fields;
+        // serde's unescape recovers the original text. Raw log lines are
+        // scanned as-is.
+        if line.trim_start().starts_with('{')
+            && let Ok(value) = serde_json::from_str::<serde_json::Value>(line)
+        {
+            visit_strings(&value, &mut |text| {
+                if let Some(bytes) = extract_feed_pty_bytes(text, &args.session_label) {
+                    out.extend_from_slice(&bytes);
+                    chunks += 1;
+                }
+            });
+            continue;
+        }
+        if let Some(bytes) = extract_feed_pty_bytes(line, &args.session_label) {
+            out.extend_from_slice(&bytes);
+            chunks += 1;
+        }
+    }
+
+    if chunks == 0 {
+        bail!(
+            "no `session feed_pty bytes:` lines with label={} in {} — was the run recorded with --debug?",
+            args.session_label,
+            args.run_log.display()
+        );
+    }
+
+    if let Some(parent) = args.out_bin.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&args.out_bin, &out)
+        .with_context(|| format!("failed to write {}", args.out_bin.display()))?;
+    #[expect(
+        clippy::print_stdout,
+        reason = "xtask is a CLI; the summary is its user-facing output"
+    )]
+    {
+        println!(
+            "wrote {} bytes from {chunks} PTY chunks to {}",
+            out.len(),
+            args.out_bin.display()
+        );
+    }
+    Ok(())
+}
+
+fn visit_strings(value: &serde_json::Value, visit: &mut impl FnMut(&str)) {
+    match value {
+        serde_json::Value::String(s) => visit(s),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                visit_strings(item, visit);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values() {
+                visit_strings(item, visit);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Parse one capsule debug line of the shape
+/// `... session feed_pty bytes: agent=Some("codex") label=Codex len=42 bytes=[1b, 5b, ...]`
+/// returning the decoded bytes when the label matches.
+fn extract_feed_pty_bytes(line: &str, label: &str) -> Option<Vec<u8>> {
+    let rest = &line[line.find("session feed_pty bytes:")?..];
+    let label_value = rest
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("label="))?;
+    if label_value != label {
+        return None;
+    }
+    let hex = &rest[rest.find("bytes=[")? + "bytes=[".len()..];
+    let hex = &hex[..hex.find(']')?];
+    let mut out = Vec::new();
+    for byte in hex.split(',') {
+        let byte = byte.trim();
+        if byte.is_empty() {
+            continue;
+        }
+        out.push(u8::from_str_radix(byte, 16).ok()?);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_feed_pty_bytes;
+
+    #[test]
+    fn extracts_matching_label_from_raw_log_line() {
+        let line = "[jackin-capsule debug] session feed_pty bytes: agent=Some(\"codex\") label=Codex len=4 bytes=[1b, 5b, 32, 4a]";
+        assert_eq!(
+            extract_feed_pty_bytes(line, "Codex"),
+            Some(vec![0x1b, 0x5b, 0x32, 0x4a])
+        );
+    }
+
+    #[test]
+    fn rejects_other_labels_and_prefix_collisions() {
+        let line = "[jackin-capsule debug] session feed_pty bytes: agent=None label=Shell len=1 bytes=[41]";
+        assert_eq!(extract_feed_pty_bytes(line, "Codex"), None);
+        assert_eq!(extract_feed_pty_bytes(line, "Shel"), None);
+    }
+
+    #[test]
+    fn rejects_lines_without_marker_or_bytes() {
+        assert_eq!(extract_feed_pty_bytes("render: kind=full", "Codex"), None);
+        let truncated = "session feed_pty bytes: label=Codex len=1 bytes=[41";
+        assert_eq!(extract_feed_pty_bytes(truncated, "Codex"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Second PR of the four-PR capsule rendering program in `CAPSULE_RENDERING_FINDINGS.md` (§5 PR 2): the echo-back conformance harness — the mechanical enforcer of invariant I1 (screen == model) — plus the fixture-recording tooling. Test-only: zero behavior change. A `VirtualClient` (a second jackin-term `DamageGrid` standing in for the operator's outer terminal) applies every frame the multiplexer composes; after each step the harness asserts cell-exact equality (grapheme, full attribute set, wide flags) between every visible pane's grid and the client screen inside the pane rect, plus the frame-model cursor contract (visibility per `cursor_visible_for_state`, position at the focused pane's VT cursor in screen space). Composition is deterministic — direct `compose_pending_frame` calls, no ticker, no sleeps. Green scenarios: streaming, the full scroll cycle including the wheel-only return to live, focus swap mid-stream, resize mid-stream, dialog open/close over streaming, alt-screen enter/exit, selection residue, and clear-during-selection. Six model-expectation cases are the executable spec for PR 4 and carry `#[ignore]` tags naming the fixing change (grapheme clusters, VS16/ZWJ emoji, wide-lead overwrite, DECSTR in-grid, DSR clamp); all six fail when forced with `--ignored`. A new `cargo xtask pty-fixture <run.jsonl> <session-label> <out.bin>` subcommand turns a `--debug` run log into a binary PTY fixture; recorded fixtures stay blocked on the Stage-0 operator run id, so the harness ships synthetic streams.

This PR is stacked on `fix/capsule-scrollback-redraw` (#555) and targets that branch; it retargets `main` after #555 merges. While building the harness it exposed a residue hole in #555's convergence stopgap (default-blank cells never re-emitted); the fix (sentinel baseline) landed on the #555 branch and the harness scenarios that caught it run green here.

## What's deferred (follow-up PRs)

- PR 3 — single writer + derived rendering (`refactor/capsule-single-render-path`): merge criterion is flipping this PR's PR-3-tagged expectations green with no harness regression.
- PR 4 — jackin-term model correctness + CSI gating: flips the six `#[ignore]` model-expectation cases green.
- Recorded real-agent fixtures (`tests/fixtures/pty/*.bin`): BLOCKED(operator) on a Stage-0 `--debug` run id; `cargo xtask pty-fixture` makes the recording one command once it exists.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-557"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin chore/capsule-render-conformance:refs/remotes/origin/chore/capsule-render-conformance
git checkout -B chore/capsule-render-conformance refs/remotes/origin/chore/capsule-render-conformance
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
export JACKIN_CONFIG_DIR="$HOME/.config/jackin-pr-557"
export JACKIN_HOME_DIR="$HOME/.jackin-pr-557"
which jackin
```

Then build and export the jackin-capsule binary so the smoke steps below use it:

```sh
eval "$(cargo run --bin build-jackin-capsule -- --export)"
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run -E 'test(/render_conformance/)'
cargo nextest run -E 'package(jackin-xtask)'
cargo nextest run --all-features
```

The harness suite is `daemon::render_conformance_tests::*`; the six `#[ignore]`-tagged model-expectation cases should FAIL when forced — that red is the point:

```sh
cargo test -p jackin-capsule --lib render_conformance -- --ignored
```

### jackin-capsule smoke

```sh
jackin load the-architect . --debug
```

Inside the container, verify:

- Row 0 status bar is visible: `jackin'  [<agent-name>]`
- Agent TUI starts and renders correctly below the status bar
- `Ctrl+\` opens the command palette (override with `JACKIN_PALETTE_KEY`)
- Mouse clicks, arrow keys, and paste reach the agent unmodified
- This PR is test-only: behavior matches #555 exactly; the smoke confirms no regression from the harness landing.

## Migration notes

None.
