### PR TITLE
ci: reduce target-cache quota pressure, warm nextest from check cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,6 @@ jobs:
             cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-nextest-
             cargo-target-${{ runner.os }}-${{ runner.arch }}-nextest-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ runner.arch }}-nextest-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
       - name: Download construct image for E2E
         if: needs.changes.outputs.construct_image == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,8 @@ jobs:
             cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-nextest-
             cargo-target-${{ runner.os }}-${{ runner.arch }}-nextest-${{ hashFiles('Cargo.lock') }}-
             cargo-target-${{ runner.os }}-${{ runner.arch }}-nextest-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-check-all-features-${{ hashFiles('Cargo.lock') }}-
       - name: Download construct image for E2E
         if: needs.changes.outputs.construct_image == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -571,21 +573,17 @@ jobs:
         run: sccache --show-stats
 
   bench-build:
-    needs: [changes, check-all-features]
+    # One job builds both benches: the two matrix legs compiled the shared
+    # dependency graph twice with two separate target caches (cache-quota
+    # pressure -> eviction churn). bench-build also no longer waits on
+    # check-all-features — they validate independently.
+    needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
-    name: cargo bench build (${{ matrix.bench }})
+    name: cargo bench build
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_TERM_COLOR: always
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - bench: console-frame
-            command: cargo build --bench console_frame -p jackin
-          - bench: pane-body
-            command: cargo build --bench pane_body -p jackin-capsule
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Cache Rust toolchain
@@ -626,20 +624,22 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target
-          key: cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
+          key: cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
           restore-keys: |
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ matrix.bench }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-${{ matrix.bench }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-bench-${{ matrix.bench }}-${{ hashFiles('Cargo.lock') }}-
-            cargo-target-${{ runner.os }}-${{ runner.arch }}-bench-${{ matrix.bench }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.head_ref || github.ref_name }}-bench-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-${{ github.base_ref || 'main' }}-bench-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-bench-${{ hashFiles('Cargo.lock') }}-
+            cargo-target-${{ runner.os }}-${{ runner.arch }}-bench-
       # Build (but don't run) the frame-time and pane-body benchmarks to
       # ensure they compile on every CI run. Full criterion runs happen
       # locally or in dedicated perf workflows.
-      - run: ${{ matrix.command }}
+      - run: |
+          cargo build --bench console_frame -p jackin
+          cargo build --bench pane_body -p jackin-capsule
       - name: Show sccache stats
         if: always() && steps.sccache.outcome == 'success'
         run: sccache --show-stats


### PR DESCRIPTION
Addresses the cold `Compiling <dep>` walls observed in nextest runs (universal caching mandate: an unchanged rerun must recompile nothing). Eight per-job target caches pressed against the 10 GB quota and evicted each other.

- **bench-build**: one job builds both benches (was a 2-leg matrix compiling the shared dep graph twice into two separate caches); also un-serialized from `check-all-features`.
- **nextest restore-keys** now falls back to `check-all-features`' branch/main caches (same `--all-features` dev profile, near-identical dep graph) — an evicted nextest cache warm-starts instead of going cold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)