### PR TITLE
ci: persist the Renovate repository cache between runs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Cache Renovate repository cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: /tmp/renovate/cache
+          key: renovate-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            renovate-${{ runner.os }}-
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:
@@ -22,6 +30,7 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: false
+          RENOVATE_REPOSITORY_CACHE: enabled
           # Pin the git author identity so the DCO sign-off trailer in
           # renovate.json::commitBody always matches the commit-author
           # email. DCO-2 requires the Signed-off-by email to equal the
@@ -29,3 +38,7 @@ jobs:
           # default author would silently break DCO on every Renovate PR.
           RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@whitesourcesoftware.com>"
           LOG_LEVEL: debug
+
+      - name: Fix Renovate cache ownership for save
+        if: always()
+        run: sudo chown -R "$(whoami)" /tmp/renovate 2>/dev/null || true


### PR DESCRIPTION
Persist Renovate's repository cache (`/tmp/renovate/cache`) across workflow runs with `actions/cache`, and enable it via `RENOVATE_REPOSITORY_CACHE: enabled`. A final `always()` step chowns `/tmp/renovate` back to the runner user so the post-job cache save can read files written by the Renovate container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)