### PR TITLE
fix(xtask): make construct publish-manifest idempotent on published versions

### DIFF
--- a/crates/jackin-xtask/src/construct.rs
+++ b/crates/jackin-xtask/src/construct.rs
@@ -308,6 +308,19 @@ fn push_platform(cfg: &Config, platform: Platform) -> Result<()> {
 }
 
 fn assert_version_unpublished(cfg: &Config) -> Result<()> {
+    if version_published(cfg)? {
+        bail!(
+            "{} already exists in the registry.\nBump {VERSION_FILE} before publishing a new construct version.",
+            cfg.ref_for(&cfg.version_tag)
+        );
+    }
+    Ok(())
+}
+
+/// Probe the registry for the immutable per-version tag. An indeterminate
+/// probe (auth/network failure) is an error so an outage is never mistaken
+/// for a published or unpublished version.
+fn version_published(cfg: &Config) -> Result<bool> {
     if cfg.version_tag.is_empty() || cfg.version_tag == "unknown" {
         bail!(
             "VERSION_TAG is '{}' — {VERSION_FILE} is missing or empty.",
@@ -324,10 +337,8 @@ fn assert_version_unpublished(cfg: &Config) -> Result<()> {
         .with_context(|| format!("running docker buildx imagetools inspect {reference}"))?;
     let stderr = String::from_utf8_lossy(&output.stderr);
     match classify_inspect(output.status.success(), &stderr) {
-        VersionStatus::Unpublished => Ok(()),
-        VersionStatus::AlreadyPublished => Err(anyhow!(
-            "{reference} already exists in the registry.\nBump {VERSION_FILE} before publishing a new construct version."
-        )),
+        VersionStatus::AlreadyPublished => Ok(true),
+        VersionStatus::Unpublished => Ok(false),
         VersionStatus::UnknownError => Err(anyhow!(
             "registry check for {reference} failed unexpectedly:\n{}",
             stderr.trim()
@@ -337,6 +348,32 @@ fn assert_version_unpublished(cfg: &Config) -> Result<()> {
 
 fn publish_manifest(cfg: &Config) -> Result<()> {
     cfg.guard_local_publish()?;
+
+    // Same version-bump invariant the PR rehearsal enforces, with one
+    // difference: at publish time an existing tag is a successful no-op, not
+    // an error. The per-version tag is immutable, so re-running the publish
+    // workflow against an unchanged docker/construct/VERSION (e.g. a manual
+    // dispatch from main) has nothing left to publish. Image changes that
+    // forget the VERSION bump still fail before merge, because the PR-time
+    // rehearsal runs assert-version-unpublished, which keeps treating the
+    // collision as an error.
+    match manifest_action(version_published(cfg)?) {
+        ManifestAction::SkipAlreadyPublished => {
+            #[expect(
+                clippy::print_stdout,
+                reason = "xtask is a CLI; the skip notice is its progress output"
+            )]
+            {
+                println!(
+                    "{} already published; skipping manifest publish (bump {VERSION_FILE} to publish a new one)",
+                    cfg.ref_for(&cfg.version_tag)
+                );
+            }
+            return Ok(());
+        }
+        ManifestAction::Publish => {}
+    }
+
     let mut refs = Vec::new();
     for platform in [Platform::Amd64, Platform::Arm64] {
         let digest_file = format!("{}/{}.digest", cfg.digest_dir, platform.name());
@@ -352,10 +389,6 @@ fn publish_manifest(cfg: &Config) -> Result<()> {
         }
         refs.push(format!("{}@{}", cfg.registry_image, digest));
     }
-
-    // Same version-bump invariant the PR rehearsal enforces, so a content change
-    // that forgets to bump VERSION fails on the PR rather than post-merge.
-    assert_version_unpublished(cfg)?;
 
     let mut create = docker(["buildx", "imagetools", "create"]);
     for tag in [&cfg.stable_tag, &cfg.sha_tag, &cfg.version_tag] {
@@ -395,6 +428,27 @@ enum VersionStatus {
     Unpublished,
     AlreadyPublished,
     UnknownError,
+}
+
+/// What `publish-manifest` does after probing the registry for the immutable
+/// version tag.
+#[derive(Debug, PartialEq, Eq)]
+enum ManifestAction {
+    /// Tag absent: assemble and push the multi-platform manifest.
+    Publish,
+    /// Tag present: succeed without publishing. The tag is immutable and this
+    /// run could only recreate it, so the re-run is an idempotent no-op rather
+    /// than a failure. Forgotten VERSION bumps still fail at PR time via
+    /// `assert-version-unpublished`, which errors on the same condition.
+    SkipAlreadyPublished,
+}
+
+fn manifest_action(version_published: bool) -> ManifestAction {
+    if version_published {
+        ManifestAction::SkipAlreadyPublished
+    } else {
+        ManifestAction::Publish
+    }
 }
 
 /// Classify a `docker buildx imagetools inspect` result. A success means the
@@ -562,6 +616,16 @@ mod tests {
             classify_inspect(false, "unauthorized: authentication required"),
             VersionStatus::UnknownError
         );
+    }
+
+    #[test]
+    fn published_version_skips_manifest_publish() {
+        assert_eq!(manifest_action(true), ManifestAction::SkipAlreadyPublished);
+    }
+
+    #[test]
+    fn unpublished_version_publishes_manifest() {
+        assert_eq!(manifest_action(false), ManifestAction::Publish);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`cargo xtask construct publish-manifest` treats an already-published `docker/construct/VERSION` tag as a hard error, so any manual `workflow_dispatch` of the Construct Image workflow from `main` without a VERSION bump deterministically reds the run (CI run 27308794775, job `publish manifest`). The guard against overwriting an immutable tag is correct; failing the whole run is not. This PR makes the publish step an idempotent no-op when the version tag already exists, while the PR-time rehearsal keeps failing on the same condition so forgotten VERSION bumps are still caught before merge.

## What ships

- `construct publish-manifest` now exits successfully with a clear notice — `construct:<version> already published; skipping manifest publish (bump docker/construct/VERSION to publish a new one)` — when the immutable version tag already exists in the registry, instead of erroring. Nothing is pushed on the skip path, so an existing tag can never be overwritten with a different digest.
- `construct assert-version-unpublished` (the PR-time rehearsal guard) is unchanged: it still errors when the tag exists, so image changes that forget the VERSION bump still fail on the PR.
- Indeterminate registry probes (auth/network failures) remain hard errors on both paths, so an outage is never mistaken for a published or unpublished version.
- Unit coverage pins the new decision: a published version skips the manifest publish, an unpublished one proceeds.

## Behavior changes

- Re-dispatching the Construct Image workflow from `main` with an unchanged `docker/construct/VERSION` now ends green with a skip notice instead of a red `publish manifest` job. Publishing a new construct version still requires bumping `docker/construct/VERSION`.

## What this addresses

- Manual `workflow_dispatch` reruns of construct.yml on an unchanged VERSION were guaranteed failures, producing red runs on `main` that signal nothing actionable.
- The immutable-tag invariant is now enforced in the right place with the right severity: error at PR time (rehearsal), no-op at publish time.

## Not included

- No `docker/construct/VERSION` bump — this PR changes only the xtask decision logic.
- No digest comparison against the published tag; the skip path never pushes, which is sufficient to keep published tags immutable.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-568"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
mise trust
git fetch -f origin fix/construct-publish-manifest-idempotent:refs/remotes/origin/fix/construct-publish-manifest-idempotent
git checkout -B fix/construct-publish-manifest-idempotent refs/remotes/origin/fix/construct-publish-manifest-idempotent
mise trust
mise install
cargo build --bin jackin
export PATH="$PWD/target/debug:$PATH"
export JACKIN_CONFIG_DIR="$JACKIN_PR_TEST_DIR/.config/jackin"
export JACKIN_HOME_DIR="$JACKIN_PR_TEST_DIR/.jackin"
which jackin
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run -p jackin-xtask
```

### User smoke

Replay the exact failure from run 27308794775 — publish-manifest against the already-published construct version (anonymous registry read; `CI=true` only bypasses the local-publish guard, and the skip path returns before anything would be pushed):

```sh
CI=true cargo run -q -p jackin-xtask -- construct publish-manifest
echo "exit=$?"
# expect: "projectjackin/construct:<version> already published; skipping manifest publish (bump docker/construct/VERSION to publish a new one)" and exit=0
```

Confirm the PR rehearsal guard still fails on the same condition:

```sh
CI=true cargo run -q -p jackin-xtask -- construct assert-version-unpublished
echo "exit=$?"
# expect: "already exists in the registry" error and exit=1
```

Confirm an unpublished tag still takes the publish path (it proceeds past the guard and only then fails on the absent digest artifacts in a local shell):

```sh
CI=true CONSTRUCT_VERSION_TAG=0.99-trixie DIGEST_DIR=/tmp/no-digests cargo run -q -p jackin-xtask -- construct publish-manifest
echo "exit=$?"
# expect: "missing digest file for amd64" error and exit=1
```
