### PR TITLE
fix(ci): prepare /tmp/renovate dirs before renovate container runs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,13 @@ jobs:
           restore-keys: |
             renovate-${{ runner.os }}-
 
+      - name: Prepare renovate cache dir
+        # actions/cache restores /tmp/renovate owned by the runner user;
+        # the renovate container user then can't mkdir /tmp/renovate/repos.
+        run: |
+          sudo mkdir -p /tmp/renovate/repos /tmp/renovate/cache
+          sudo chmod -R 0777 /tmp/renovate
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:


### PR DESCRIPTION
## Summary
Since cache persistence was added in #564, every Renovate run fails with:

```
EACCES: permission denied, mkdir '/tmp/renovate/repos'
```

(first failing run: 27316994961)

actions/cache restores `/tmp/renovate/cache`, leaving `/tmp/renovate` owned by the runner user with default perms. The renovate container then runs as a different user and cannot create the sibling `repos` dir.

## Fix
Add a step between the cache restore and the renovate step that pre-creates `/tmp/renovate/repos` and `/tmp/renovate/cache` and makes the tree world-writable, mirroring the existing sudo-based ownership-fix step used for cache save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)