### PR TITLE
perf(ci): sccache for construct xtask jobs and the shellfirm image compile

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -145,6 +145,18 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-${{ runner.arch }}-
 
+      - id: sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Setup mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
         with:
@@ -242,6 +254,18 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-${{ runner.arch }}-
 
+      - id: sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Setup mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
         with:
@@ -328,6 +352,18 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-${{ runner.os }}-${{ runner.arch }}-
+
+      - id: sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Setup mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4

--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -2,10 +2,29 @@ FROM rust:1.96.0-trixie@sha256:fb328f0f58becb23ba1719940a2c94ece8b0b48afa837d05b
 
 ARG SHELLFIRM_VERSION
 
+# Install sccache (pinned) so the shellfirm compile below reuses compiled
+# artifacts from the /sccache-build cache mount instead of starting cold
+# whenever SHELLFIRM_VERSION changes.
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+      amd64) sccache_arch=x86_64 ;; \
+      arm64) sccache_arch=aarch64 ;; \
+      *) printf 'unsupported TARGETARCH for sccache: %s\n' "${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/v0.15.0/sccache-v0.15.0-${sccache_arch}-unknown-linux-musl.tar.gz" \
+      -o /tmp/sccache.tar.gz && \
+    tar -xzf /tmp/sccache.tar.gz -C /usr/local/bin --strip-components=1 \
+      "sccache-v0.15.0-${sccache_arch}-unknown-linux-musl/sccache" && \
+    chmod 0755 /usr/local/bin/sccache && \
+    rm /tmp/sccache.tar.gz && \
+    sccache --version
+
 # Install shellfirm
 # TODO(shellfirm-aarch64-linux-binary): switch to prebuilt download — see TODO.md.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/sccache-build \
+    RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache-build \
     cargo install shellfirm --version "${SHELLFIRM_VERSION}" --locked
 
 FROM debian:trixie-20260610@sha256:5763081d2297e7bd29b27a7e26743a74f9ff0d32e20f8f794f2009150ee59157

--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.7-trixie
+0.8-trixie


### PR DESCRIPTION
The build, publish-manifest, and publish-manifest-rehearsal jobs in construct.yml were the only compiling jobs in the estate without sccache, so each one compiled jackin-xtask cold; they now get the identical soft-fail sccache block ci.yml's Rust jobs already use, at the same position. The construct Dockerfile additionally gains a pinned sccache v0.15.0 install and a /sccache-build cache mount around the shellfirm compile, so a SHELLFIRM_VERSION bump no longer recompiles the whole graph cold on both platforms. Since the Dockerfile is a construct_image input, VERSION is bumped 0.7-trixie -> 0.8-trixie to satisfy the version-unpublished guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)