### PR TITLE
fix(version): align preview artifact versions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,8 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
       sha: ${{ steps.source.outputs.sha }}
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+      version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Resolve source SHA
         id: source
@@ -127,6 +129,41 @@ jobs:
           done <<< "$diff_files"
 
           echo "source=$source" >> "$GITHUB_OUTPUT"
+
+      - name: Compute preview metadata
+        id: meta
+        if: steps.filter.outputs.source == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          FULL_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          base_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          base_version=${base_version%-dev}
+          short_sha=$(printf '%s' "$FULL_SHA" | cut -c1-7)
+          # Derive the preview counter from GitHub's server-side commit history
+          # instead of `git rev-list --count HEAD` so the version stays
+          # monotonic even if the runner checkout is unexpectedly shallow.
+          # shellcheck disable=SC2016
+          graphql_query='query($owner: String!, $name: String!, $oid: GitObjectID!) { repository(owner: $owner, name: $name) { object(oid: $oid) { ... on Commit { history(first: 1) { totalCount } } } } }'
+          commit_count=$(
+            jq -cn \
+              --arg query "$graphql_query" \
+              --arg owner "$GITHUB_REPOSITORY_OWNER" \
+              --arg name "${GITHUB_REPOSITORY#*/}" \
+              --arg oid "$FULL_SHA" \
+              '{query: $query, variables: {owner: $owner, name: $name, oid: $oid}}' |
+              curl -fsSL \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data @- \
+                https://api.github.com/graphql |
+              jq -er '.data.repository.object.history.totalCount'
+          )
+          {
+            echo "full_sha=$FULL_SHA"
+            echo "short_sha=$short_sha"
+            echo "version=${base_version}-preview.${commit_count}+${short_sha}"
+          } >> "$GITHUB_OUTPUT"
 
   build-preview:
     needs: source-changed
@@ -234,6 +271,7 @@ jobs:
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}
+          JACKIN_VERSION_OVERRIDE: ${{ needs.source-changed.outputs.version }}
         run: cargo zigbuild --release --locked --target "$ZIGBUILD_TARGET"
       - name: Package
         env:
@@ -341,15 +379,8 @@ jobs:
       - name: Build
         env:
           ZIGBUILD_TARGET: ${{ matrix.zigbuild_target }}
-          FULL_SHA: ${{ needs.source-changed.outputs.sha }}
-        run: |
-          # Compute version string in the same format as build.rs:
-          # "{CARGO_PKG_VERSION}+{7-char-sha}" so jackin-capsule --version
-          # matches what the host jackin CLI reports.
-          base_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
-          short_sha=$(printf '%s' "$FULL_SHA" | cut -c1-7)
-          export JACKIN_VERSION_OVERRIDE="${base_version}+${short_sha}"
-          cargo zigbuild --release --locked -p jackin-capsule --target "$ZIGBUILD_TARGET"
+          JACKIN_VERSION_OVERRIDE: ${{ needs.source-changed.outputs.version }}
+        run: cargo zigbuild --release --locked -p jackin-capsule --target "$ZIGBUILD_TARGET"
       - name: Publish binary as release asset
         env:
           ARCH: ${{ matrix.arch }}
@@ -422,40 +453,6 @@ jobs:
               ;;
           esac
 
-      - name: Compute preview metadata
-        id: meta
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          FULL_SHA: ${{ needs.source-changed.outputs.sha }}
-        run: |
-          base_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
-          base_version=${base_version%-dev}
-          short_sha=$(printf '%s' "$FULL_SHA" | cut -c1-7)
-          # Derive the preview counter from GitHub's server-side commit history
-          # instead of `git rev-list --count HEAD` so the version stays
-          # monotonic even if the runner checkout is unexpectedly shallow.
-          # shellcheck disable=SC2016
-          graphql_query='query($owner: String!, $name: String!, $oid: GitObjectID!) { repository(owner: $owner, name: $name) { object(oid: $oid) { ... on Commit { history(first: 1) { totalCount } } } } }'
-          commit_count=$(
-            jq -cn \
-              --arg query "$graphql_query" \
-              --arg owner "$GITHUB_REPOSITORY_OWNER" \
-              --arg name "${GITHUB_REPOSITORY#*/}" \
-              --arg oid "$FULL_SHA" \
-              '{query: $query, variables: {owner: $owner, name: $name, oid: $oid}}' |
-              curl -fsSL \
-                -H "Authorization: Bearer $GITHUB_TOKEN" \
-                -H "Content-Type: application/json" \
-                --data @- \
-                https://api.github.com/graphql |
-              jq -er '.data.repository.object.history.totalCount'
-          )
-          {
-            echo "full_sha=$FULL_SHA"
-            echo "short_sha=$short_sha"
-            echo "version=${base_version}-preview.${commit_count}+${short_sha}"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Read platform SHA256s
         id: shas
         run: |
@@ -471,7 +468,7 @@ jobs:
       - name: Produce and sign capsule manifest
         uses: ./.github/actions/sign-capsule-manifest
         with:
-          version: ${{ steps.meta.outputs.version }}
+          version: ${{ needs.source-changed.outputs.version }}
           arm64-sha: ${{ steps.shas.outputs.capsule_arm64_linux }}
           x86-sha: ${{ steps.shas.outputs.capsule_x86_linux }}
           github-token: ${{ secrets.GH_READONLY_TOKEN }}
@@ -479,7 +476,7 @@ jobs:
       - name: Publish preview GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ needs.source-changed.outputs.version }}
           SHA: ${{ needs.source-changed.outputs.sha }}
         run: |
           set -euo pipefail
@@ -548,8 +545,8 @@ jobs:
 
       - name: Rewrite preview formula
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
-          FULL_SHA: ${{ steps.meta.outputs.full_sha }}
+          VERSION: ${{ needs.source-changed.outputs.version }}
+          FULL_SHA: ${{ needs.source-changed.outputs.sha }}
           ARM64_SHA256: ${{ steps.shas.outputs.arm64_macos }}
           X86_SHA256: ${{ steps.shas.outputs.x86_macos }}
           LINUX_ARM64_SHA256: ${{ steps.shas.outputs.arm64_linux }}
@@ -633,8 +630,8 @@ jobs:
         id: pr_body
         env:
           OLD_SHA: ${{ steps.prev.outputs.old_sha }}
-          NEW_SHA: ${{ steps.meta.outputs.full_sha }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          NEW_SHA: ${{ needs.source-changed.outputs.sha }}
+          VERSION: ${{ needs.source-changed.outputs.version }}
         run: |
           body_file="${RUNNER_TEMP}/pr-body.md"
           # shellcheck disable=SC2016
@@ -670,8 +667,8 @@ jobs:
         working-directory: homebrew-tap
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ steps.meta.outputs.version }}
-          SHORT_SHA: ${{ steps.meta.outputs.short_sha }}
+          VERSION: ${{ needs.source-changed.outputs.version }}
+          SHORT_SHA: ${{ needs.source-changed.outputs.short_sha }}
           PR_BODY_FILE: ${{ steps.pr_body.outputs.body_file }}
         run: |
           git add Formula/jackin-preview.rb

--- a/crates/jackin/src/bin/role.rs
+++ b/crates/jackin/src/bin/role.rs
@@ -14,7 +14,7 @@ use jackin::role_authoring;
 /// Used by CI (jackin-role-action) and role authors to validate the role
 /// contract, migrate manifests, and extract metadata from role repositories.
 #[derive(Parser)]
-#[command(name = "jackin-role", version)]
+#[command(name = "jackin-role", version = env!("JACKIN_VERSION"))]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/docs/content/docs/reference/capsule/index.mdx
+++ b/docs/content/docs/reference/capsule/index.mdx
@@ -323,7 +323,7 @@ The policy is read once per session at spawn time; an agent that exports the env
 
 ## Distribution and versioning
 
-`jackin-capsule` is versioned identically to the `jackin` CLI — both use the same <RepoFile path="crates/jackin/build.rs">crates/jackin/build.rs</RepoFile> logic that produces `{cargo_pkg_version}+{7-char-git-sha}`. The host CLI's version string and the binary's `--version` output always match.
+`jackin-capsule` is versioned identically to the `jackin` CLI. Both binaries use the shared <RepoFile path="crates/jackin-build-meta/src/lib.rs">jackin-build-meta</RepoFile> build-script helper: local and pull-request builds fall back to `{cargo_pkg_version}+{7-char-git-sha}`, which is currently the `0.6.0-dev+<sha>` shape, while the main-branch preview workflow injects the published `0.6.0-preview.<count>+<sha>` string through `JACKIN_VERSION_OVERRIDE`. The host CLI, `jackin-role`, and `jackin-capsule --version` output must match the version string embedded in the artifact being tested or published.
 
 ### How jackin' acquires the binary
 


### PR DESCRIPTION
## Summary

This PR makes the version string embedded in published preview artifacts match the Homebrew preview formula, while preserving the `-dev+sha` version format for unmerged pull-request and local builds.

## What ships

- Main-branch preview publishing computes `0.6.0-preview.<count>+<sha>` before artifact builds and passes that exact value into both host and capsule build scripts.
- `jackin`, `jackin-role`, and `jackin-capsule` now expose the same artifact version format through `--version` when a preview override is present.
- The capsule distribution reference documents the split between pull-request/local `0.6.0-dev+<sha>` builds and main preview `0.6.0-preview.<count>+<sha>` artifacts.

## Behavior changes

- Homebrew preview artifacts built from `main` should report the same version as the tap PR, for example `0.6.0-preview.869+717b345`, instead of a dev-style `0.6.0-dev+717b345` string.
- Pull-request and local builds without `JACKIN_VERSION_OVERRIDE` continue to report `0.6.0-dev+<sha>`, so PR testing remains visibly distinct from merged preview artifacts.

## What this addresses

- Operators testing a Homebrew preview install can now compare `brew info jackin@preview`, the tap PR title, `jackin --version`, and `jackin-capsule --version` without seeing conflicting version schemes.
- Operators testing an unmerged PR can still identify the binary as a development build from its `0.6.0-dev+<sha>` output.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-593"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
git fetch -f origin pull/593/head:refs/remotes/origin/pr-593-head
git checkout -B pr-593 refs/remotes/origin/pr-593-head
cargo xtask pr prepare 593 --config copy --replace-config
cd "$JACKIN_PR_TEST_DIR/jackin"
source "$JACKIN_PR_TEST_DIR/env.sh"
which jackin
```

### Static checks

```sh
cargo fmt --check
yq '.' .github/workflows/preview.yml >/dev/null
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

### User smoke

```sh
JACKIN_VERSION_OVERRIDE='0.6.0-preview.869+717b345' cargo run --locked -q -p jackin --bin jackin -- --version
JACKIN_VERSION_OVERRIDE='0.6.0-preview.869+717b345' cargo run --locked -q -p jackin --bin jackin-role -- --version
JACKIN_VERSION_OVERRIDE='0.6.0-preview.869+717b345' cargo run --locked -q -p jackin-capsule -- --version
```

Expected: the commands print `jackin 0.6.0-preview.869+717b345`, `jackin-role 0.6.0-preview.869+717b345`, and `jackin-capsule 0.6.0-preview.869+717b345`.

```sh
cargo run --locked -q -p jackin --bin jackin -- --version
cargo run --locked -q -p jackin --bin jackin-role -- --version
cargo run --locked -q -p jackin-capsule -- --version
```

Expected: the commands keep the PR/local development shape, printing `0.6.0-dev+<current-sha>` for all three binaries.

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/reference/capsule/**  
UPDATED contributor reference. Confirm Distribution and versioning explains PR/local `0.6.0-dev+<sha>` builds and main preview `0.6.0-preview.<count>+<sha>` artifacts.

## Migration notes

None.
