### PR TITLE
fix(ci+docs): use GH_READONLY_TOKEN and throttle api.github.com for lychee

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -343,7 +343,7 @@ jobs:
           sitemap-url: ${{ steps.sitemap.outputs.url }}
           edit-url: ${{ env.JACKIN_REPO_EDIT_URL }}
           blob-url: ${{ env.JACKIN_REPO_BLOB_URL }}
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GH_READONLY_TOKEN }}
           external-links: "false"
 
   check-deployed:
@@ -365,7 +365,7 @@ jobs:
           sitemap-url: ${{ env.DOCS_SITE_URL }}/sitemap.xml
           edit-url: ${{ env.JACKIN_REPO_EDIT_URL }}
           blob-url: ${{ env.JACKIN_REPO_BLOB_URL }}
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GH_READONLY_TOKEN }}
 
   # Skip on schedule because schedule runs only `check-deployed` and a
   # one-job aggregator on schedule has no value.

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -60,8 +60,9 @@ exclude = [
   # Medium serves this public stack write-up to browsers but returns HTTP 403 to
   # lychee from GitHub Actions.
   "https://paul-hackenberger\\.medium\\.com/the-ultimate-token-saving-stack-rtk-caveman-and-tokensave-163badadd9ec",
-  # graemerocher/multicode is a private repository; blob links are remapped to
-  # the GitHub Contents API which returns 403 from GitHub Actions.
+  # graemerocher/multicode has many blob links (≥48) that remap to GitHub
+  # Contents API calls; the volume triggers GitHub's secondary rate limit
+  # (403) even with the api.github.com host throttle below.
   "https://api\\.github\\.com/repos/graemerocher/multicode/",
   # qdrant.tech returns connection failures from the GitHub Actions network.
   "https://qdrant\\.tech/",
@@ -88,5 +89,11 @@ include_mail = true
 scheme = ["https", "http", "file", "mailto"]
 
 [hosts."github.com"]
+concurrency = 4
+request_interval = "500ms"
+
+# blob→API remaps hit api.github.com; mirror the same throttle so the
+# GitHub secondary rate limit is not triggered by the default concurrency=32.
+[hosts."api.github.com"]
 concurrency = 4
 request_interval = "500ms"

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -12,60 +12,26 @@ cache = true
 # are also throttled below to make a 429 less likely.
 accept = ["100..=103", "200..=299", "429"]
 exclude = [
+  # chatgpt.com returns 403 to all automated clients including lychee.
   "https://chatgpt\\.com/",
-  # Zylos serves this public research page to browsers and search crawlers, but
-  # returns HTTP 402 to lychee in CI.
-  "https://zylos\\.ai/research/2026-04-01-ai-agent-input-ready-detection-cursor-vs-regex",
-  # ccmux is reachable in browsers and search crawlers, but lychee reports it
-  # as network-unreachable in some environments.
-  "https://ccmux\\.ai/",
-  # Imbue's Sculptor page is public but has failed as network-unreachable from
-  # GitHub Actions while passing local link checks.
-  "https://imbue\\.com/sculptor/",
-  # NN/g serves this public article to browsers, but returns HTTP 403 to lychee
-  # from GitHub Actions.
-  "https://www\\.nngroup\\.com/articles/visibility-system-status/",
-  # mise's public docs root has returned network-unreachable from lychee while
-  # passing in browsers.
-  "https://mise\\.jdx\\.dev/",
-  # libvterm's public project page has failed with connection errors from
-  # GitHub Actions while remaining browser-accessible.
-  "https://www\\.leonerd\\.org\\.uk/code/libvterm/",
-  # BigGo's public Ghostty/libghostty-vt article has timed out from GitHub
-  # Actions while remaining browser-accessible.
-  "https://biggo\\.com/news/202509240113_Ghostty_libghostty-vt_Library_Terminal_Emulation",
   # GitHub issue-list links are remapped to the API during static docs checks;
   # the API endpoint can return 403 from GitHub Actions even for public repos.
   "https://api\\.github\\.com/repos/jackin-project/jackin/issues",
   # ACM DOI pages are public in browsers/search but return 403 to lychee in CI.
   "https://dl\\.acm\\.org/doi/10\\.1145/3735636",
-  # Milvus pages below are public, but currently loop through redirects for
-  # lychee from GitHub Actions.
+  # Milvus pages below loop through redirects infinitely (verified locally:
+  # 302 → 302 → … hitting max-redirects with no final destination).
   "https://milvus\\.io/blog/claude-context-vs-claude-code-complete-code-context-solution-for-ai-coding-assistants\\.md",
   "https://milvus\\.io/blog/claude-context-reduce-claude-code-token-usage\\.md",
   "https://milvus\\.io/docs/overview\\.md",
-  # Manus blog post is public in browsers but returns HTTP 403 to lychee in CI.
-  "https://manus\\.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus",
-  # GitHub gist below is public but fails with connection errors from lychee in CI.
-  "https://gist\\.github\\.com/maman/de31d48cd960366ce9caec32b569d32a",
-  # Public vendor/project pages below intermittently reject or fail requests
-  # from the link-check environment.
+  # grok.com/supergrok returns 403 to all automated clients.
   "https://grok\\.com/supergrok",
-  "https://orcahq\\.ai/",
-  "https://zotregistry\\.dev/?",
-  "https://www\\.amazon\\.science/publications/keyword-search-is-all-you-need-achieving-rag-level-performance-without-vector-databases-using-agentic-tool-use",
-  "https://docs\\.weaviate\\.io/weaviate",
-  "https://www\\.pinecone\\.io/learn/vector-database/",
-  "https://www\\.ory\\.com/brand",
-  # Medium serves this public stack write-up to browsers but returns HTTP 403 to
-  # lychee from GitHub Actions.
+  # Medium returns 403 to all automated clients for this page.
   "https://paul-hackenberger\\.medium\\.com/the-ultimate-token-saving-stack-rtk-caveman-and-tokensave-163badadd9ec",
   # graemerocher/multicode has many blob links (≥48) that remap to GitHub
   # Contents API calls; the volume triggers GitHub's secondary rate limit
   # (403) even with the api.github.com host throttle below.
   "https://api\\.github\\.com/repos/graemerocher/multicode/",
-  # qdrant.tech returns connection failures from the GitHub Actions network.
-  "https://qdrant\\.tech/",
 ]
 exclude_all_private = true
 exclude_path = ["(^|/)404\\.html$"]

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -60,6 +60,11 @@ exclude = [
   # Medium serves this public stack write-up to browsers but returns HTTP 403 to
   # lychee from GitHub Actions.
   "https://paul-hackenberger\\.medium\\.com/the-ultimate-token-saving-stack-rtk-caveman-and-tokensave-163badadd9ec",
+  # graemerocher/multicode is a private repository; blob links are remapped to
+  # the GitHub Contents API which returns 403 from GitHub Actions.
+  "https://api\\.github\\.com/repos/graemerocher/multicode/",
+  # qdrant.tech returns connection failures from the GitHub Actions network.
+  "https://qdrant\\.tech/",
 ]
 exclude_all_private = true
 exclude_path = ["(^|/)404\\.html$"]


### PR DESCRIPTION
## Summary

Fixes the deployed-docs link check failing on every push to `main`. Two CI configuration gaps caused lychee to hit GitHub's secondary rate limit on API calls remapped from blob URLs, producing false 403 errors on links that are valid and reachable. Also removes 16 stale exclusions that were verified locally as accessible.

## What ships

- `check-deployed-docs` action now receives `GH_READONLY_TOKEN` (the dedicated read-only PAT) instead of `github.token` — both the post-deploy gating call and the scheduled verification call. The standard `GITHUB_TOKEN` has a lower per-workflow rate budget and is shared with every other Actions step, making it insufficient when lychee checks thousands of GitHub blob links.
- `[hosts."api.github.com"]` throttle added to `docs/lychee.toml` matching the existing `github.com` config (`concurrency = 4`, `request_interval = "500ms"`). Lychee remaps all `github.com/X/Y/blob/BRANCH/PATH` URLs to `api.github.com/repos/X/Y/contents/PATH?ref=BRANCH` before checking — the existing host throttle only applied to direct `github.com` URLs and did not cover the remapped targets.
- `graemerocher/multicode` excluded from lychee's Contents API checks as defence-in-depth. The repo has ≥48 blob links across the docs; even with proper token and throttling, that volume can trigger GitHub's secondary rate limit (which returns 403, not 429). Exclusion comment corrected from the original incorrect "private repository" claim.
- 16 stale exclusions removed after verifying each URL returns 200 locally with both browser and lychee user-agents: zylos.ai, ccmux.ai, imbue.com/sculptor/, nngroup.com, mise.jdx.dev, leonerd.org.uk, biggo.com, manus.im, gist.github.com/maman, orcahq.ai, zotregistry.dev, amazon.science, docs.weaviate.io, pinecone.io, ory.com/brand, qdrant.tech. Comments on remaining exclusions updated to reflect verified behaviour.

## What this addresses

- Deployed-docs CI job failing on every merge to `main` due to 403s on GitHub API calls for remapped blob URLs from `graemerocher/multicode` and related repos.
- Root cause: `github.token` (low rate limit, shared) passed to lychee instead of the read-only PAT already used elsewhere in `docs.yml`.
- Secondary cause: `api.github.com` remapped requests ran at global `max_concurrency = 32`, bypassing the `github.com` host throttle entirely.
- CI non-determinism: a required check whose outcome depended on unauthenticated API rate-limit state rather than code correctness.
- Exclusion list bloat from stale entries added when sites were temporarily unreachable from GitHub Actions but are now accessible.

## Not included

- Removing the `graemerocher/multicode` exclusion once CI is confirmed stable across several runs — can be done as a follow-up.
- Fixing the CI cache slowdown (cross-workflow Cargo cache bucket isolation, sccache hit rate) — separate issue.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
export JACKIN_PR_TEST_DIR="$HOME/Projects/jackin-project/test/pr-623"
mkdir -p "$JACKIN_PR_TEST_DIR"
cd "$JACKIN_PR_TEST_DIR"

if [ ! -d jackin/.git ]; then
  git clone https://github.com/jackin-project/jackin.git
fi

cd jackin
git fetch -f origin pull/623/head:refs/remotes/origin/pr-623-head
git checkout -B pr-623 refs/remotes/origin/pr-623-head
cargo xtask pr prepare 623 --config copy --replace-config
cd "$JACKIN_PR_TEST_DIR/jackin"
source "$JACKIN_PR_TEST_DIR/env.sh"
which jackin
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bunx tsc --noEmit
  bun test
)
```

### Documentation

Review `docs/lychee.toml` diff: confirm `[hosts."api.github.com"]` section present at end of file, only `graemerocher/multicode` and the known bot-blocked/broken URLs remain in the exclusion list, previously stale entries removed.

Review `.github/workflows/docs.yml` diff: confirm both `check-deployed-docs` calls use `${{ secrets.GH_READONLY_TOKEN }}` not `${{ github.token }}`.

## Migration notes

None.
