### PR TITLE
ci: preserve latest publish concurrency

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -300,6 +300,28 @@ See canonical break in [jackin-project/jackin#266](https://github.com/jackin-pro
 
 Every workflow that writes to a public registry, tag, release, or Homebrew formula MUST gate actual publish step on `main`. PRs + dispatches from feature branches may build + test but must never publish. Derive a single `is_publish` boolean once (in `changes` job), gate every side-effect step on it — do not restate branch conditions inline at multiple steps.
 
+## Publish concurrency: latest wins, shared writers serialize
+
+Publish workflows MUST protect freshness first. Any workflow that publishes a rolling channel, mutable formula, release alias, or "latest" install target must cancel stale runs from the same stream: use a workflow-level `concurrency` group scoped to that stream with `cancel-in-progress: true`. This includes preview-style commit channels and SemVer channels such as `jackin-dev` when multiple source commits can queue before the tap catches up. Otherwise a slower older run can finish after a newer run and overwrite the formula back to an older source.
+
+Shared external writers are a separate concern. When multiple freshness-cancelled workflows write the same protected resource, such as the Homebrew tap, do not put all workflows in one cancelling top-level group. That lets one stream cancel another stream before it publishes. Instead keep each workflow's top-level freshness group separate and add a job-level mutex only around the final shared write, with `cancel-in-progress: false`, so the writers serialize without dropping the other stream.
+
+Pattern:
+
+```yaml
+concurrency:
+  group: homebrew-preview-publish
+  cancel-in-progress: true
+
+jobs:
+  publish-preview:
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
+```
+
+Use distinct top-level freshness groups for distinct publish streams (`homebrew-preview-publish`, `jackin-dev-publish`, etc.). Use the same job-level shared-writer group only for the step/job that mutates the shared resource. If the shared writer cannot prove the source is still publishable, add an explicit freshness check before writing rather than disabling cancellation for the whole workflow.
+
 ## Smoke-test push-only jobs before merging
 
 Jobs gated to `push to main`, `workflow_dispatch && ref == main`, or `workflow_run` events do not run on `pull_request`. If a PR modifies such a job, smoke-test via `gh workflow run --ref <feature-branch>` before merging — PR-time CI never exercises it.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -302,7 +302,7 @@ Every workflow that writes to a public registry, tag, release, or Homebrew formu
 
 ## Publish concurrency: latest wins, shared writers serialize
 
-Publish workflows MUST protect freshness first. Any workflow that publishes a rolling channel, mutable formula, release alias, or "latest" install target must cancel stale runs from the same stream: use a workflow-level `concurrency` group scoped to that stream with `cancel-in-progress: true`. This includes preview-style commit channels and SemVer channels such as `jackin-dev` when multiple source commits can queue before the tap catches up. Otherwise a slower older run can finish after a newer run and overwrite the formula back to an older source.
+Publish workflows MUST protect freshness first. Any workflow that publishes a rolling channel, mutable formula, release alias, or "latest" install target must cancel stale runs from the same stream: use a workflow-level `concurrency` group scoped to that stream with `cancel-in-progress: true`. This includes preview-style commit channels and SemVer channels such as `jackin-dev` when multiple source commits can queue before the tap catches up. Otherwise a slower older run can finish after a newer run and overwrite the formula back to an older source. After any overlapping publish activity, each Homebrew formula must point at the newest valid source for that formula: latest preview commit for preview, latest committed dev version/source for jackin-dev.
 
 Shared external writers are a separate concern. When multiple freshness-cancelled workflows write the same protected resource, such as the Homebrew tap, do not put all workflows in one cancelling top-level group. That lets one stream cancel another stream before it publishes. Instead keep each workflow's top-level freshness group separate and add a job-level mutex only around the final shared write, with `cancel-in-progress: false`, so the writers serialize without dropping the other stream.
 
@@ -320,7 +320,7 @@ jobs:
       cancel-in-progress: false
 ```
 
-Use distinct top-level freshness groups for distinct publish streams (`homebrew-preview-publish`, `jackin-dev-publish`, etc.). Use the same job-level shared-writer group only for the step/job that mutates the shared resource. If the shared writer cannot prove the source is still publishable, add an explicit freshness check before writing rather than disabling cancellation for the whole workflow.
+Use distinct top-level freshness groups for distinct publish streams (`homebrew-preview-publish`, `jackin-dev-publish`, etc.). Use the same job-level shared-writer group only for the step/job that mutates the shared resource. Never queue whole publish workflows as a freshness strategy; queued whole workflows can publish an older artifact after a newer one. If the shared writer cannot prove the source is still publishable, add an explicit freshness check before writing rather than disabling cancellation for the whole workflow.
 
 ## Smoke-test push-only jobs before merging
 

--- a/.github/workflows/jackin-dev.yml
+++ b/.github/workflows/jackin-dev.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: homebrew-tap-publish
-  cancel-in-progress: false
+  group: jackin-dev-publish
+  cancel-in-progress: true
 
 jobs:
   source-changed:
@@ -222,6 +222,9 @@ jobs:
     needs: [source-changed, build-jackin-dev]
     if: needs.source-changed.outputs.source == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/jackin-dev.yml
+++ b/.github/workflows/jackin-dev.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: homebrew-tap-publish
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   source-changed:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: homebrew-tap-publish
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   source-changed:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: homebrew-tap-publish
-  cancel-in-progress: false
+  group: homebrew-preview-publish
+  cancel-in-progress: true
 
 jobs:
   source-changed:
@@ -364,6 +364,9 @@ jobs:
     needs: [source-changed, build-preview, build-jackin-capsule]
     if: needs.source-changed.outputs.source == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

This PR fixes Homebrew publish concurrency so each release stream still publishes the newest source only, while preview and jackin-dev no longer cancel each other when both are triggered by the same successful `main` CI run. It also documents the rule under `.github`: after overlapping publish activity, each Homebrew formula must end at the newest valid source for that formula, never an older run that happened to finish later.

## What ships

- Preview keeps a workflow-level freshness group with `cancel-in-progress: true`, so older preview runs cannot publish after a newer preview run.
- jackin-dev gets its own workflow-level freshness group with `cancel-in-progress: true`, so older dev runs cannot publish after a newer dev run.
- The final tap-writing jobs share `homebrew-tap-publish` with `cancel-in-progress: false`, so only the Homebrew tap mutation is serialized across streams instead of one stream cancelling the other.
- `.github/AGENTS.md` now explains the concurrency rule: latest wins inside each stream, whole publish workflows must not be queued as a freshness strategy, and shared external writers serialize only at the critical write boundary.

## Behavior changes

- A new preview run cancels stale preview runs, and a new jackin-dev run cancels stale jackin-dev runs.
- Preview and jackin-dev no longer cancel each other solely because they both need to write the Homebrew tap.
- The tap writer remains serialized, so simultaneous valid formulas do not race their final PR creation/merge against the tap repository.

## What this addresses

- The jackin-dev workflow triggered for `6c8a08435a34e7142f298e47c0bc2130bb67f949` but was cancelled immediately while preview continued under the same top-level `homebrew-tap-publish` concurrency group.
- The fix prevents stale older runs from overwriting newer formula state while still allowing both release streams to deliver when both are valid.
- The documented rule makes this invariant explicit for future `.github/workflows/` changes.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 637
cd "$(jackin-dev pr path 637)/jackin"
source "$(jackin-dev pr path 637)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, and auto-builds the PR capsule or construct image when the changed files require them. After `source "$(jackin-dev pr path 637)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only for PRs whose diff requires a local capsule build, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.

### Static checks

```sh
actionlint .github/workflows/preview.yml .github/workflows/jackin-dev.yml
git diff --check
```
