### PR TITLE
fix(ci): require jackin-dev version bump

### DIFF
--- a/.github/workflows/jackin-dev.yml
+++ b/.github/workflows/jackin-dev.yml
@@ -1,6 +1,7 @@
 name: jackin-dev
 
 on:
+  pull_request:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -15,6 +16,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-version-bump:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Require jackin-dev version bump for artifact changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          diff_files=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")
+          source_changed=false
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            case "$path" in
+              Cargo.toml|Cargo.lock|crates/jackin-dev/**)
+                source_changed=true
+                ;;
+            esac
+          done <<< "$diff_files"
+
+          if [ "$source_changed" != true ]; then
+            exit 0
+          fi
+
+          base_version=$(
+            git show "${BASE_SHA}:crates/jackin-dev/Cargo.toml" |
+              sed -n 's/^version = "\(.*\)"/\1/p' |
+              head -1
+          )
+          head_version=$(
+            sed -n 's/^version = "\(.*\)"/\1/p' crates/jackin-dev/Cargo.toml |
+              head -1
+          )
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "::error::jackin-dev artifact inputs changed; bump crates/jackin-dev/Cargo.toml from ${head_version}"
+            exit 1
+          fi
+
   source-changed:
     if: >-
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-dev"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
Fixes jackin-dev publication after artifact inputs changed without a package version bump, and adds a PR guard so future jackin-dev artifact input changes require a jackin-dev version change before merge.

## What ships
- Bumps `crates/jackin-dev` from `0.1.2` to `0.1.3` so the current changed artifact input set has a fresh release identity.
- Adds a pull-request check in the `jackin-dev` workflow that fails when `Cargo.toml`, `Cargo.lock`, or `crates/jackin-dev/**` changes without a `crates/jackin-dev/Cargo.toml` version bump.

## Behavior changes
`jackin-dev` publish no longer fails on main because it attempts to reuse `jackin-dev-v0.1.2` for a different source SHA. Future PRs that change jackin-dev artifact inputs must bump the jackin-dev package version before merge.

## What this addresses
Main CI/CD failed on commit `86ae74dd73e7d5c845efe32e5087b18fcbf2b89b` because `jackin-dev-v0.1.2` already existed for `b01e315ea93315daf22ab2fe45fadd428064ddb0`.

## Verify locally

### Checkout
```bash
gh pr checkout <PR_NUMBER>
```

### Automated checks
```bash
git diff --check
cargo check -p jackin-dev --locked
```

## Migration notes
None.