### PR TITLE
fix(ci): restore build-validator job accidentally dropped in #632

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,6 +877,62 @@ jobs:
           fi
           cargo audit "${args[@]}"
 
+  build-validator:
+    needs: [changes, clippy]
+    # Run on push-to-main when Rust inputs change, and on any
+    # workflow_dispatch so a maintainer can re-build the validator
+    # artifacts on demand without waiting for a Rust-touching push.
+    if: >-
+      (github.event_name == 'push' &&
+       github.ref == 'refs/heads/main' &&
+       needs.changes.outputs.rust == 'true') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: cargo build validator (${{ matrix.target }})
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TERM_COLOR: always
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Cache Rust toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+          key: rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}
+          restore-keys: |
+            rustup-${{ runner.os }}-${{ runner.arch }}-
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install_args: "rust zig cargo:cargo-zigbuild"
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: ${{ github.job }}-${{ matrix.target }}
+          cache-all-crates: "true"
+      - run: rustup target add ${{ matrix.target }}
+      - name: Build validator (${{ matrix.target }})
+        run: cargo zigbuild --release --locked --bin jackin-role --target ${{ matrix.target }}.2.17
+      - name: Package validator
+        run: |
+          archive="jackin-role-${{ matrix.target }}.tar.gz"
+          tar -czf "$archive" -C "target/${{ matrix.target }}/release" jackin-role
+          sha256sum "$archive" > "$archive.sha256"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jackin-role-${{ matrix.target }}
+          path: |
+            jackin-role-${{ matrix.target }}.tar.gz
+            jackin-role-${{ matrix.target }}.tar.gz.sha256
+          retention-days: 7
+
   # Single stable check name for branch-protection required-status,
   # regardless of which gated jobs skipped under it.
   ci-required:
@@ -896,6 +952,7 @@ jobs:
       - fuzz
       - bench-build
       - msrv
+      - build-validator
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary

This PR restores the `build-validator` CI job that was accidentally dropped from `ci.yml` during the CI speed-up refactor in #632. Without it, no `jackin-role` validator artifacts are produced, causing the `validate` check to fail in every role repo that uses `jackin-role-action`.

## What ships

- `build-validator` job re-added to `ci.yml` — builds `jackin-role` for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu` using `cargo zigbuild`, packages and uploads artifacts with 7-day retention
- `build-validator` restored to `ci-required` needs so branch-protection gate tracks the job
- `actions/cache` pin updated from v5 → v6 to match the rest of `ci.yml`
- `check-all-features` dependency replaced with `clippy` (equivalent `--all-features` compile gate; `check-all-features` was itself removed in #632)

## What this addresses

- Role repo CI (`jackin-the-architect`, `jackin-agent-smith`, `jackin-sentinel`, `jackin-agent-jones`, others) was failing with `Failed to resolve a preview validator build from jackin-project/jackin` — the `download-jackin-role.sh` script in `jackin-role-action` searches the last 20 successful `ci.yml` runs on main for a `jackin-role-x86_64-unknown-linux-gnu` artifact; no run since Jun 23 has produced one
- Last artifact (run `28018426284`, Jun 23) is beyond the 20-run search window and expires Jun 30
- Restoring the job unblocks all open role PRs once this merges and CI produces a fresh artifact

## Not included

- Increasing `per_page` in `download-jackin-role.sh` — the root fix is restoring the job; changing the script is follow-up hardening
- Any change to the `jackin-role-action` pin in role repos — they pick up the fresh artifact automatically once this lands

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 661
cd "$(jackin-dev pr path 661)/jackin"
source "$(jackin-dev pr path 661)/env.sh"
which jackin
```

### Static checks

```sh
actionlint .github/workflows/ci.yml
```

### User smoke

After this PR merges, verify a fresh `jackin-role-x86_64-unknown-linux-gnu` artifact appears in the next successful `ci.yml` run on main, then re-run validate on a role PR to confirm it passes.

## Migration notes

None.