### PR TITLE
chore(jackin-dev): bump version to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-dev"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Bumps `crates/jackin-dev/Cargo.toml` from `0.1.11` to `0.1.12` and updates `Cargo.lock`. The `assert-version` gate in the `jackin-dev` CI workflow blocks every push to main when the version in `Cargo.toml` matches an already-published release tag; `jackin-dev-v0.1.11` was published, so every main push has been failing this gate.

## What ships

- `crates/jackin-dev/Cargo.toml` version `0.1.11` → `0.1.12`
- `Cargo.lock` updated to match

## What this addresses

- `jackin-dev` workflow fails on every main push with `jackin-dev-v0.1.11 already exists; bump crates/jackin-dev/Cargo.toml` — blocking the publish pipeline for `jackin-dev` on all subsequent main commits until the version is advanced

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 662
cd "$(jackin-dev pr path 662)/jackin"
source "$(jackin-dev pr path 662)/env.sh"
which jackin
```

### Static checks

```sh
cargo check -p jackin-dev
```

## Migration notes

None.