### PR TITLE
fix(ci): narrow jackin-dev trigger, skip build on PRs, fix homebrew-tap PR flow

### DIFF
--- a/.github/workflows/jackin-dev.yml
+++ b/.github/workflows/jackin-dev.yml
@@ -15,11 +15,7 @@ on:
     paths:
       - ".github/actions/sign-and-attest-archive/**"
       - ".github/workflows/jackin-dev.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
       - "crates/jackin-dev/**"
-      - "mise.toml"
-      - "rust-toolchain.toml"
   workflow_dispatch:
     inputs:
       lanes:
@@ -28,6 +24,10 @@ on:
         type: choice
         default: github
         options: [github, velnor, both]
+
+concurrency:
+  group: jackin-dev-publish
+  cancel-in-progress: true
 
 jobs:
   validate-version-bump:
@@ -186,6 +186,7 @@ jobs:
         run: echo "jackin-dev version publication is checked only on main"
 
   build:
+    if: github.event_name != 'pull_request'
     needs: [version, matrix-setup, assert-version]
     runs-on: ${{ fromJSON(matrix.config.runner) }}
     timeout-minutes: 60
@@ -325,6 +326,9 @@ jobs:
     needs: [version, matrix-setup, assert-version, build]
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -354,6 +358,7 @@ jobs:
           path: homebrew-tap
       - name: Rewrite jackin-dev formula
         env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           read_sha() {
@@ -407,5 +412,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/jackin-dev.rb
-          git commit -m "Update jackin-dev to ${VERSION}"
-          git push origin main
+          if git diff --cached --quiet --exit-code; then
+            echo "jackin-dev formula already up to date for ${VERSION}"
+            exit 0
+          fi
+          branch="jackin-dev/formula-${VERSION}"
+          git switch -c "$branch"
+          git commit -m "chore: update jackin-dev to ${VERSION}"
+          git push -u origin "$branch"
+          pr_url=$(gh pr create \
+            --repo jackin-project/homebrew-tap \
+            --title "chore: update jackin-dev to ${VERSION}" \
+            --body "Automated formula update for jackin-dev ${VERSION}. Release: https://github.com/jackin-project/jackin/releases/tag/jackin-dev-v${VERSION}" \
+            --base main \
+            --head "$branch")
+          echo "Opened PR: $pr_url"
+          gh pr merge "$pr_url" --squash --delete-branch


### PR DESCRIPTION
PR #632 ("CI speed-up") replaced the `source-changed` gate and `workflow_run` trigger with a broad `push` path filter that included `Cargo.lock`. This caused the workflow to fire on virtually every main merge — not just jackin-dev changes — producing 18 consecutive failures (8 `assert-version` blocks, 10 `homebrew-tap` push rejections) and forcing 10 unnecessary version bumps (v0.1.2→v0.1.12) over 5 days.

The same PR changed the homebrew-tap formula step from `gh pr create + merge` to a direct `git push origin main`, which is rejected by homebrew-tap's `protect-main` ruleset. The formula has not updated successfully since Jun 23.

## What ships

- **Push trigger tightened** — `Cargo.lock`, `Cargo.toml`, `mise.toml`, `rust-toolchain.toml` removed from push paths; only `crates/jackin-dev/**`, `.github/workflows/jackin-dev.yml`, and `.github/actions/sign-and-attest-archive/**` remain. Workflow fires on main only when jackin-dev itself changes.
- **`build` gated to non-PR events** — 4-target cross-compile (aarch64/x86_64 × macOS/Linux) no longer runs on pull requests. `validate-version-bump` is sufficient PR-time enforcement; removing the build matrix saves ~10 min per jackin-dev-touching PR.
- **Homebrew-tap formula update restored to PR flow** — replaces `git push origin main` with `git switch -c jackin-dev/formula-<version>` + `gh pr create` + `gh pr merge --squash --delete-branch`. Uses `GH_TOKEN: HOMEBREW_TAP_TOKEN` for `gh` commands. No-ops if formula already up to date.
- **Missing concurrency group added** — workflow-level `jackin-dev-publish / cancel-in-progress: true` prevents stale runs from overwriting a newer formula; job-level `homebrew-tap-publish / cancel-in-progress: false` serializes concurrent streams on the shared tap write without dropping either.

## What this addresses

- `assert-version` failing on every renovate/deps merge to main because `Cargo.lock` triggered the workflow even when jackin-dev didn't change
- `homebrew-tap` formula update rejected since Jun 23 — `protect-main` ruleset on homebrew-tap requires PRs, direct push was always blocked
- Expensive 4-target cross-compile running on PRs for every change touching the broad path set
- No concurrency guard meaning overlapping publish runs could race

## Not included

- Restoring the `workflow_run` trigger from before PR #632 — narrowing push paths is sufficient and simpler
- Backfilling the homebrew-tap formula for v0.1.2–v0.1.11 — those releases exist; formula will self-heal when the next jackin-dev version ships after this PR

## Verify locally

### Checkout

```sh
jackin-dev pr sync 663
cd "$(jackin-dev pr path 663)/jackin"
source "$(jackin-dev pr path 663)/env.sh"
which jackin
```

### Static checks

```sh
actionlint .github/workflows/jackin-dev.yml
```

### Trigger verification

After merge, confirm:
1. A renovate `Cargo.lock` merge does NOT trigger the `jackin-dev` workflow on main
2. A commit touching `crates/jackin-dev/` DOES trigger it and publishes successfully
3. The homebrew-tap PR is opened, auto-merged, and the formula points at the new release

## Migration notes

None. The `assert-version` safety net on main remains — it just won't fire spuriously on non-jackin-dev commits.
