### PR TITLE
fix(ci): restrict jackin-dev push trigger to crates/jackin-dev/** only

### DIFF
--- a/.github/workflows/jackin-dev.yml
+++ b/.github/workflows/jackin-dev.yml
@@ -13,8 +13,6 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/actions/sign-and-attest-archive/**"
-      - ".github/workflows/jackin-dev.yml"
       - "crates/jackin-dev/**"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

After #663 narrowed the push trigger, `.github/workflows/jackin-dev.yml` and `.github/actions/sign-and-attest-archive/**` were still listed — causing `assert-version` to fire when either file changed, even though neither affects the binary. Seen immediately: merging #663 itself triggered the workflow, which failed because `jackin-dev-v0.1.12` was already published.

## What ships

- Push trigger reduced to `crates/jackin-dev/**` only — the single path that actually changes the binary
- `pull_request` trigger unchanged (broader paths are correct for `validate-version-bump`)

## What this addresses

- `jackin-dev` workflow firing on CI/workflow file edits → `assert-version` blocking every such merge
- Closes the last gap in the version-bump treadmill fix from #663

## Verify locally

```sh
jackin-dev pr sync 664
cd "$(jackin-dev pr path 664)/jackin"
source "$(jackin-dev pr path 664)/env.sh"
which jackin
```

```sh
actionlint .github/workflows/jackin-dev.yml
```

After merge: a commit touching only `.github/workflows/jackin-dev.yml` must NOT trigger the `jackin-dev` workflow on main.

## Migration notes

None.