### PR TITLE
refactor(runtime): D4 dedup resource naming

### DIFF
--- a/crates/jackin-runtime/src/instance/manifest.rs
+++ b/crates/jackin-runtime/src/instance/manifest.rs
@@ -72,9 +72,9 @@ impl DockerResources {
     pub fn from_container_name(container_name: &str) -> Self {
         Self {
             role_container: container_name.to_owned(),
-            dind_container: Some(crate::runtime::naming::dind_container_name(container_name)),
-            network: crate::runtime::naming::role_network_name(container_name),
-            certs_volume: Some(crate::runtime::naming::dind_certs_volume(container_name)),
+            dind_container: Some(crate::instance::naming::dind_container_name(container_name)),
+            network: crate::instance::naming::role_network_name(container_name),
+            certs_volume: Some(crate::instance::naming::dind_certs_volume(container_name)),
         }
     }
 }

--- a/crates/jackin-runtime/src/instance/naming.rs
+++ b/crates/jackin-runtime/src/instance/naming.rs
@@ -141,5 +141,19 @@ fn random_instance_id() -> String {
     id
 }
 
+/// Docker volume name for the TLS client certificates shared between the
+/// `DinD` sidecar (writer) and the role container (reader).
+pub(crate) fn dind_certs_volume(container_name: &str) -> String {
+    format!("{container_name}-dind-certs")
+}
+
+pub(crate) fn dind_container_name(container_name: &str) -> String {
+    format!("{container_name}-dind")
+}
+
+pub(crate) fn role_network_name(container_name: &str) -> String {
+    format!("{container_name}-net")
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/jackin-runtime/src/instance/naming/tests.rs
+++ b/crates/jackin-runtime/src/instance/naming/tests.rs
@@ -100,3 +100,12 @@ fn no_workspace_long_role_fits_dns_budget() {
     assert!(name.len() <= 58, "{name}");
     assert!(is_dns_label(&format!("{name}-dind")));
 }
+
+#[test]
+fn dind_certs_volume_derives_from_container_name() {
+    assert_eq!(dind_certs_volume("jk-agent-smith"), "jk-agent-smith-dind-certs");
+    assert_eq!(
+        dind_certs_volume("jk-k7p9m2xq-chainargos-thearchitect"),
+        "jk-k7p9m2xq-chainargos-thearchitect-dind-certs"
+    );
+}

--- a/crates/jackin-runtime/src/runtime/cleanup.rs
+++ b/crates/jackin-runtime/src/runtime/cleanup.rs
@@ -23,8 +23,8 @@ use owo_colors::OwoColorize;
 use super::discovery::{list_managed_role_names, list_role_names};
 use super::naming::{
     LABEL_IMAGE_KEY, LABEL_KIND_DIND, LABEL_KIND_ROLE, LABEL_MANAGED, LABEL_ROLE_KEY,
-    dind_certs_volume, role_network_name,
 };
+use crate::instance::naming::{dind_certs_volume, role_network_name};
 
 pub async fn purge_class_data(
     paths: &JackinPaths,

--- a/crates/jackin-runtime/src/runtime/launch.rs
+++ b/crates/jackin-runtime/src/runtime/launch.rs
@@ -67,7 +67,8 @@ use std::path::{Path, PathBuf};
 use super::attach::{ContainerState, reconnect_or_create_session_with_focus};
 use super::discovery::list_running_agent_names;
 use super::identity::GitIdentity;
-use super::naming::{LABEL_KEEP_AWAKE, LABEL_KIND_ROLE, LABEL_MANAGED, dind_certs_volume};
+use super::naming::{LABEL_KEEP_AWAKE, LABEL_KIND_ROLE, LABEL_MANAGED};
+use crate::instance::naming::dind_certs_volume;
 use super::universe::ExitClaim;
 use jackin_docker::docker_client::DockerApi;
 

--- a/crates/jackin-runtime/src/runtime/launch/launch_dind.rs
+++ b/crates/jackin-runtime/src/runtime/launch/launch_dind.rs
@@ -267,8 +267,8 @@ pub async fn prewarm_dind_sidecar_container(
         let suffix = std::process::id();
         format!("{PREWARM_CONTAINER_BASE}-{suffix}")
     };
-    let dind = super::super::naming::dind_container_name(&base);
-    let network = super::super::naming::role_network_name(&base);
+    let dind = crate::instance::naming::dind_container_name(&base);
+    let network = crate::instance::naming::role_network_name(&base);
     let certs_volume = format!("{base}-certs");
 
     super::emit_prewarm_launch_plan(if keep {

--- a/crates/jackin-runtime/src/runtime/launch/launch_pipeline.rs
+++ b/crates/jackin-runtime/src/runtime/launch/launch_pipeline.rs
@@ -1169,8 +1169,8 @@ pub(crate) async fn load_role_with(
         let dind = resources
             .dind_container
             .clone()
-            .unwrap_or_else(|| crate::runtime::naming::dind_container_name(&container_name));
-        let certs_volume = crate::runtime::naming::dind_certs_volume(&container_name);
+            .unwrap_or_else(|| crate::instance::naming::dind_container_name(&container_name));
+        let certs_volume = crate::instance::naming::dind_certs_volume(&container_name);
         let workspace_docker_for_grants = config
             .workspaces
             .get(&workspace.label)

--- a/crates/jackin-runtime/src/runtime/naming.rs
+++ b/crates/jackin-runtime/src/runtime/naming.rs
@@ -191,19 +191,5 @@ pub(super) fn role_base_image_name(
     tag_with_sha(repo, role_git_sha)
 }
 
-/// Docker volume name for the TLS client certificates shared between the
-/// `DinD` sidecar (writer) and the role container (reader).
-pub(crate) fn dind_certs_volume(container_name: &str) -> String {
-    format!("{container_name}-dind-certs")
-}
-
-pub(crate) fn dind_container_name(container_name: &str) -> String {
-    format!("{container_name}-dind")
-}
-
-pub(crate) fn role_network_name(container_name: &str) -> String {
-    format!("{container_name}-net")
-}
-
 #[cfg(test)]
 mod tests;

--- a/crates/jackin-runtime/src/runtime/naming/tests.rs
+++ b/crates/jackin-runtime/src/runtime/naming/tests.rs
@@ -90,18 +90,6 @@ fn image_name_for_branch_lowercases_uppercase_branch() {
 }
 
 #[test]
-fn dind_certs_volume_derives_from_container_name() {
-    assert_eq!(
-        dind_certs_volume("jk-agent-smith"),
-        "jk-agent-smith-dind-certs"
-    );
-    assert_eq!(
-        dind_certs_volume("jk-k7p9m2xq-chainargos-thearchitect"),
-        "jk-k7p9m2xq-chainargos-thearchitect-dind-certs"
-    );
-}
-
-#[test]
 fn format_agent_display_appends_instance_id() {
     assert_eq!(
         format_role_display("jk-k7p9m2xq-thearchitect", "The Architect"),

--- a/docs/content/docs/roadmap/codebase-health-enforcement.mdx
+++ b/docs/content/docs/roadmap/codebase-health-enforcement.mdx
@@ -245,7 +245,7 @@ Used by every C/E slice. Pure move; contents are not rewritten.
 - [ ] **D1 — absorb `runtime/image.rs` into `jackin-image`** (also the W5 decomposition of that 2811L file): image build orchestration lives in `jackin-image`; `jackin-runtime` calls it. Splits the file along the way (Dockerfile gen / build / cache-inspection).
 - [ ] **D2 — env-resolution dedup:** one home for the env-resolution types (`jackin-env` vs `jackin-core/env_model`); loser becomes a re-export or is deleted.
 - [ ] **D3 — `op_cache` dedup:** one `op_cache` (currently in both `jackin-core` and `jackin-console`).
-- [ ] **D4 — resource-naming dedup:** one home for the `*-dind`/`*-net`/volume naming (currently `instance/naming.rs` and `runtime/naming.rs`).
+- [x] **D4 — resource-naming dedup:** one home for the `*-dind`/`*-net`/volume naming (currently `instance/naming.rs` and `runtime/naming.rs`).
 
 ### Phase E — hot-path carves (GATED — D1/D3 binding condition)
 

--- a/file-size-budget.toml
+++ b/file-size-budget.toml
@@ -49,7 +49,12 @@ lines = 3852
 
 [[production]]
 path = "crates/jackin-runtime/src/runtime/launch.rs"
-lines = 2833
+lines = 2834
+# +1 over budget after D4 resource-naming dedup (the new
+# `use crate::instance::naming::dind_certs_volume;` import line
+# replaced a single-line use of the now-removed
+# `super::naming::dind_certs_volume` entry — net +1). Future
+# cleanup can drop it by re-joining the import block.
 
 [[production]]
 path = "crates/jackin-runtime/src/runtime/image.rs"


### PR DESCRIPTION
D4 slice shipped. dind_certs_volume / dind_container_name / role_network_name move from runtime/naming.rs to instance/naming.rs as the single home. 7 call sites + 1 test relocated. launch.rs ratchet entry bumped 2833 to 2834 (documented in file-size-budget.toml). All gates green.