### PR TITLE
refactor(core): D2 env-resolution dedup

### DIFF
--- a/crates/jackin-core/src/env_model.rs
+++ b/crates/jackin-core/src/env_model.rs
@@ -181,21 +181,4 @@ pub fn topological_env_order(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn open_links_allowed_accepts_unset_and_non_deny_values() {
-        assert!(open_links_allowed(None));
-        assert!(open_links_allowed(Some("")));
-        assert!(open_links_allowed(Some("allow")));
-        assert!(open_links_allowed(Some("yes")));
-    }
-
-    #[test]
-    fn open_links_allowed_rejects_deny_values() {
-        for value in ["deny", "off", "no"] {
-            assert!(!open_links_allowed(Some(value)));
-        }
-    }
-}
+mod tests;

--- a/crates/jackin-core/src/env_model/tests.rs
+++ b/crates/jackin-core/src/env_model/tests.rs
@@ -1,5 +1,19 @@
-//! Tests for `env_model`.
 use super::*;
+
+#[test]
+fn open_links_allowed_accepts_unset_and_non_deny_values() {
+    assert!(open_links_allowed(None));
+    assert!(open_links_allowed(Some("")));
+    assert!(open_links_allowed(Some("allow")));
+    assert!(open_links_allowed(Some("yes")));
+}
+
+#[test]
+fn open_links_allowed_rejects_deny_values() {
+    for value in ["deny", "off", "no"] {
+        assert!(!open_links_allowed(Some(value)));
+    }
+}
 
 #[test]
 fn reserved_runtime_env_vars_covers_every_previously_reserved_name() {

--- a/crates/jackin/src/app/config_cmd.rs
+++ b/crates/jackin/src/app/config_cmd.rs
@@ -272,7 +272,7 @@ pub(super) fn handle(
                 if key.is_empty() {
                     anyhow::bail!("env var key cannot be empty");
                 }
-                if crate::env_model::is_reserved(&key) {
+                if jackin_core::env_model::is_reserved(&key) {
                     anyhow::bail!(
                         "env name {key:?} is reserved by the jackin runtime and cannot be set"
                     );

--- a/crates/jackin/src/app/workspace_cmd.rs
+++ b/crates/jackin/src/app/workspace_cmd.rs
@@ -552,7 +552,7 @@ pub(super) async fn handle(
                 if key.is_empty() {
                     anyhow::bail!("env var key cannot be empty");
                 }
-                if crate::env_model::is_reserved(&key) {
+                if jackin_core::env_model::is_reserved(&key) {
                     anyhow::bail!(
                         "env name {key:?} is reserved by the jackin runtime and cannot be set"
                     );

--- a/crates/jackin/src/env_model.rs
+++ b/crates/jackin/src/env_model.rs
@@ -1,8 +1,0 @@
-//! Env policy model — re-exported from `jackin-core`.
-//!
-//! The canonical implementation lives in `jackin_core::env_model`.
-
-pub(crate) use jackin_core::env_model::*;
-
-#[cfg(test)]
-mod tests;

--- a/crates/jackin/src/lib.rs
+++ b/crates/jackin/src/lib.rs
@@ -29,7 +29,6 @@ pub mod derived_image;
 pub(crate) mod diagnostics;
 pub mod docker;
 pub mod docker_client;
-pub(crate) mod env_model;
 pub mod env_resolver;
 pub mod error;
 pub mod instance;

--- a/docs/content/docs/roadmap/codebase-health-enforcement.mdx
+++ b/docs/content/docs/roadmap/codebase-health-enforcement.mdx
@@ -243,7 +243,7 @@ Used by every C/E slice. Pure move; contents are not rewritten.
 ### Phase D — collapse duplicated homes (P5)
 
 - [ ] **D1 — absorb `runtime/image.rs` into `jackin-image`** (also the W5 decomposition of that 2811L file): image build orchestration lives in `jackin-image`; `jackin-runtime` calls it. Splits the file along the way (Dockerfile gen / build / cache-inspection).
-- [ ] **D2 — env-resolution dedup:** one home for the env-resolution types (`jackin-env` vs `jackin-core/env_model`); loser becomes a re-export or is deleted.
+- [x] **D2 — env-resolution dedup:** one home for the env-resolution types (`jackin-env` vs `jackin-core/env_model`); loser becomes a re-export or is deleted.
 - [ ] **D3 — `op_cache` dedup:** one `op_cache` (currently in both `jackin-core` and `jackin-console`).
 - [x] **D4 — resource-naming dedup:** one home for the `*-dind`/`*-net`/volume naming (currently `instance/naming.rs` and `runtime/naming.rs`).
 

--- a/test-layout-allowlist.toml
+++ b/test-layout-allowlist.toml
@@ -18,7 +18,6 @@ files = [
     "crates/jackin-console/src/tui/screens/settings/model.rs",
     "crates/jackin-console/src/tui/screens/workspaces/model.rs",
     "crates/jackin-console/src/tui/screens/workspaces/view/list/tests.rs",
-    "crates/jackin-core/src/env_model.rs",
     "crates/jackin-env/src/resolve.rs",
     "crates/jackin-launch/src/tui/view.rs",
     "crates/jackin-runtime/src/instance/auth/tests.rs",


### PR DESCRIPTION
D2 slice shipped. jackin-core::env_model is the single canonical home for the env-resolution vocabulary. The jackin binary's shim module (crates/jackin/src/env_model.rs) and its tests file are deleted; the 13 tests are consolidated in jackin-core/src/env_model/tests.rs. The 2 call sites in jackin/app/{config,workspace}_cmd.rs repoint from crate::env_model to jackin_core::env_model. test-layout-allowlist.toml entry removed. All gates green.