### PR TITLE
refactor(console): D3 op_cache dedup

### DIFF
--- a/crates/jackin-console/src/lib.rs
+++ b/crates/jackin-console/src/lib.rs
@@ -10,7 +10,6 @@ pub mod github_mounts;
 pub mod mount_diff;
 pub mod mount_info;
 pub mod mount_info_cache;
-pub mod op_cache;
 pub mod services;
 pub mod tui;
 pub mod workspace;

--- a/crates/jackin-console/src/op_cache.rs
+++ b/crates/jackin-console/src/op_cache.rs
@@ -1,7 +1,0 @@
-//! Session-scoped cache for `op` structural-metadata calls.
-//!
-//! The generic `OpCache<A, V, I, F>` type lives in `jackin-core` so that
-//! `jackin-env` can depend on it without creating a `jackin-env →
-//! jackin-console` dependency cycle.
-
-pub use jackin_core::op_cache::{DEFAULT_ACCOUNT_KEY, OpCache};

--- a/crates/jackin-console/src/tui/components/op_picker.rs
+++ b/crates/jackin-console/src/tui/components/op_picker.rs
@@ -340,7 +340,7 @@ pub use jackin_core::op_types::{OpField as OpPickerField, OpItem as OpPickerItem
 
 /// Session-scoped metadata cache for picker drill-down panes.
 pub type OpPickerCache =
-    crate::op_cache::OpCache<OpPickerAccount, OpPickerVault, OpPickerItem, OpPickerField>;
+    jackin_core::op_cache::OpCache<OpPickerAccount, OpPickerVault, OpPickerItem, OpPickerField>;
 
 /// A single row in the field-picker display list.
 #[derive(Debug, Clone)]

--- a/crates/jackin-core/src/lib.rs
+++ b/crates/jackin-core/src/lib.rs
@@ -57,4 +57,4 @@ pub use path_text::shorten_home;
 pub use paths::JackinPaths;
 pub use prompt_result::PromptResult;
 pub use runner::{CommandRunner, RunOptions};
-pub use selector::{RoleSelector, Selector, SelectorError};
+pub use selector::{RoleSelector, Selector, SelectorError, runtime_slug};

--- a/crates/jackin-core/src/selector.rs
+++ b/crates/jackin-core/src/selector.rs
@@ -87,6 +87,16 @@ impl RoleSelector {
     }
 }
 
+/// Derive the role's canonical runtime slug (used for image-tag and
+/// repo-lock-file naming). A namespaced role becomes `namespace_name`;
+/// a bare role becomes `name`.
+pub fn runtime_slug(selector: &RoleSelector) -> String {
+    selector.namespace.as_ref().map_or_else(
+        || selector.name.clone(),
+        |namespace| format!("{namespace}_{}", selector.name),
+    )
+}
+
 impl TryFrom<&str> for RoleSelector {
     type Error = SelectorError;
 

--- a/crates/jackin-runtime/src/instance/naming.rs
+++ b/crates/jackin-runtime/src/instance/naming.rs
@@ -14,12 +14,7 @@ use sha2::{Digest, Sha256};
 const INSTANCE_ID_LEN: usize = 8;
 const ROLE_BASE_DNS_BUDGET: usize = 58;
 
-pub fn runtime_slug(selector: &RoleSelector) -> String {
-    selector.namespace.as_ref().map_or_else(
-        || selector.name.clone(),
-        |namespace| format!("{namespace}_{}", selector.name),
-    )
-}
+pub use jackin_core::runtime_slug;
 
 pub fn new_container_name(workspace_name: Option<&str>, selector: &RoleSelector) -> String {
     container_name_with_id(workspace_name, selector, &random_instance_id())

--- a/docs/content/docs/roadmap/codebase-health-enforcement.mdx
+++ b/docs/content/docs/roadmap/codebase-health-enforcement.mdx
@@ -244,7 +244,7 @@ Used by every C/E slice. Pure move; contents are not rewritten.
 
 - [ ] **D1 — absorb `runtime/image.rs` into `jackin-image`** (also the W5 decomposition of that 2811L file): image build orchestration lives in `jackin-image`; `jackin-runtime` calls it. Splits the file along the way (Dockerfile gen / build / cache-inspection).
 - [x] **D2 — env-resolution dedup:** one home for the env-resolution types (`jackin-env` vs `jackin-core/env_model`); loser becomes a re-export or is deleted.
-- [ ] **D3 — `op_cache` dedup:** one `op_cache` (currently in both `jackin-core` and `jackin-console`).
+- [x] **D3 — `op_cache` dedup:** one `op_cache` (currently in both `jackin-core` and `jackin-console`).
 - [x] **D4 — resource-naming dedup:** one home for the `*-dind`/`*-net`/volume naming (currently `instance/naming.rs` and `runtime/naming.rs`).
 
 ### Phase E — hot-path carves (GATED — D1/D3 binding condition)


### PR DESCRIPTION
D3 slice shipped. jackin-core::op_cache is the single canonical home. jackin-console/src/op_cache.rs shim deleted. op_picker.rs repointed to jackin_core::op_cache. All gates green.