### PR TITLE
refactor(tui): G0 shared Elm runtime contract

### DIFF
--- a/crates/jackin-tui/src/lib.rs
+++ b/crates/jackin-tui/src/lib.rs
@@ -7,6 +7,20 @@
 //! [`components`], with color adapters in [`theme`]. Surface crates
 //! own domain state and compose these pieces instead of re-declaring
 //! palette values or reimplementing visual primitives.
+//!
+//! # Architecture Invariant
+//!
+//! `jackin-tui` is a **presentation-layer** design-system crate.
+//! Allowed upstream dependencies: `jackin-core` (domain vocabulary only).
+//! Must **not** depend on any application, infrastructure, or entry crate
+//! (`jackin-runtime`, `jackin-env`, `jackin-docker`, `jackin-launch*`,
+//! `jackin-console`, `jackin-capsule`, or `jackin`).
+//!
+//! The shared Elm runtime contract lives in [`runtime`]: one
+//! [`runtime::UpdateResult`] return per `update` call,
+//! [`runtime::Component`] for event→message translation, and
+//! [`runtime::View`] for model→frame rendering. Surface crates
+//! implement these traits; `jackin-tui` only defines them.
 
 pub mod animation;
 pub mod ansi_text;

--- a/crates/jackin-tui/src/runtime.rs
+++ b/crates/jackin-tui/src/runtime.rs
@@ -234,5 +234,42 @@ impl<E> UpdateResult<E> {
     }
 }
 
+/// TEA component contract: translates raw terminal input events into typed
+/// messages for the app's central `update` function.
+///
+/// `Ev` is the surface-specific event type (e.g. [`crossterm::event::Event`]
+/// for keyboard/mouse-driven surfaces; raw bytes or a decoded action type for
+/// the in-container multiplexer). `Msg` is the domain message the central
+/// `update` consumes. Components maintain their own sub-state (e.g. cursor
+/// position, focus) but must not mutate app model state; they only produce
+/// messages.
+///
+/// # Contract
+///
+/// - `handle_event` is non-blocking and must not perform I/O.
+/// - Returning `None` means the event was not consumed; the runtime may
+///   offer the event to the next component in the chain.
+/// - Returning `Some(msg)` means the event was consumed; the runtime calls
+///   the central `update` with `msg`.
+pub trait Component<Ev, Msg> {
+    fn handle_event(&mut self, event: &Ev) -> Option<Msg>;
+}
+
+/// TEA view contract: renders an app model into one rectangular region of a
+/// ratatui [`ratatui::Frame`].
+///
+/// Implementations are observational: they read `model` but must not mutate
+/// it. All visible output (widget painting, cursor positioning, scroll
+/// indicators) flows through the `frame` and `area` arguments. `View` never
+/// drives subscriptions or spawns work.
+pub trait View<Model> {
+    fn render(
+        &self,
+        model: &Model,
+        frame: &mut ratatui::Frame<'_>,
+        area: ratatui::layout::Rect,
+    );
+}
+
 #[cfg(test)]
 mod tests;

--- a/docs/content/docs/roadmap/codebase-health-enforcement.mdx
+++ b/docs/content/docs/roadmap/codebase-health-enforcement.mdx
@@ -260,7 +260,7 @@ Used by every C/E slice. Pure move; contents are not rewritten.
 
 ### Phase G — unify the TUI runtime (W6; largest)
 
-- [ ] **G0 — design + build the shared contract in `jackin-tui` (D5).** `Model`/`Message`/`update` + a `Component`/`View` contract; one central `update` per app. No stack migrated yet — just the runtime + a doc'd contract.
+- [x] **G0 — design + build the shared contract in `jackin-tui` (D5).** `Model`/`Message`/`update` + a `Component`/`View` contract; one central `update` per app. No stack migrated yet — just the runtime + a doc'd contract.
 - [ ] **G1 — migrate `jackin-launch-tui`** onto it (smallest stack; proves the contract).
 - [ ] **G2 — migrate the capsule TUI** onto it.
 - [ ] **G3 — migrate `jackin-console`**, landing [unify-settings-editor-surfaces](/roadmap/unify-settings-editor-surfaces/) on the shared contract so the editor + settings models become one implementation.


### PR DESCRIPTION
G0 slice shipped. Adds Component and View trait definitions to jackin-tui/src/runtime.rs and an Architecture Invariant header to jackin-tui/src/lib.rs encoding the presentation-layer rule. No stack migration (per spec). jackin-tui verified: cargo fmt, cargo clippy, cargo nextest 220/220 pass. Crates are no-op deps; the new contract symbols are pure type-level definitions.