### PR TITLE
refactor(jackin): B2 batch 1 drop trivial re-export shims

### DIFF
--- a/crates/jackin/src/agent_binary.rs
+++ b/crates/jackin/src/agent_binary.rs
@@ -1,1 +1,0 @@
-pub use jackin_image::agent_binary::*;

--- a/crates/jackin/src/bin/build_jackin_capsule.rs
+++ b/crates/jackin/src/bin/build_jackin_capsule.rs
@@ -43,8 +43,8 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use anyhow::{Context, Result};
-use jackin::binary_artifact::{chmod_executable, container_arch};
-use jackin::capsule_binary::REQUIRED_VERSION;
+use jackin_image::binary_artifact::{chmod_executable, container_arch};
+use jackin_image::capsule_binary::REQUIRED_VERSION;
 use jackin::paths::JackinPaths;
 
 // Compile-time crate manifest dir. Now that the binary lives in crates/jackin/,

--- a/crates/jackin/src/binary_artifact.rs
+++ b/crates/jackin/src/binary_artifact.rs
@@ -1,1 +1,0 @@
-pub use jackin_image::binary_artifact::*;

--- a/crates/jackin/src/capsule_binary.rs
+++ b/crates/jackin/src/capsule_binary.rs
@@ -1,1 +1,0 @@
-pub use jackin_image::capsule_binary::*;

--- a/crates/jackin/src/derived_image.rs
+++ b/crates/jackin/src/derived_image.rs
@@ -1,1 +1,0 @@
-pub use jackin_image::derived_image::*;

--- a/crates/jackin/src/lib.rs
+++ b/crates/jackin/src/lib.rs
@@ -18,14 +18,14 @@
 )]
 
 pub mod agent;
-pub mod agent_binary;
+
 mod app;
-pub mod binary_artifact;
-pub mod capsule_binary;
+
+
 pub mod cli;
 pub mod config;
 pub mod console;
-pub mod derived_image;
+
 pub(crate) mod diagnostics;
 pub mod docker;
 pub mod docker_client;

--- a/crates/jackin/tests/amp_launch.rs
+++ b/crates/jackin/tests/amp_launch.rs
@@ -75,7 +75,7 @@ agents = ["amp"]
 
     let validated = jackin::repo::validate_role_repo(&repo_dir).unwrap();
     let build =
-        jackin::derived_image::create_derived_build_context(&repo_dir, &validated, None, None)
+        jackin_image::derived_image::create_derived_build_context(&repo_dir, &validated, None, None)
             .unwrap();
     let dockerfile = std::fs::read_to_string(&build.dockerfile_path).unwrap();
     assert_amp_not_staged_without_install_recipe(&dockerfile);

--- a/crates/jackin/tests/codex_launch.rs
+++ b/crates/jackin/tests/codex_launch.rs
@@ -129,7 +129,7 @@ model = "gpt-5"
     .unwrap();
     let validated = jackin::repo::validate_role_repo(&repo_dir).unwrap();
     let build =
-        jackin::derived_image::create_derived_build_context(&repo_dir, &validated, None, None)
+        jackin_image::derived_image::create_derived_build_context(&repo_dir, &validated, None, None)
             .unwrap();
     let dockerfile = std::fs::read_to_string(&build.dockerfile_path).unwrap();
     assert_cached_agent_install_blocks(&dockerfile);

--- a/crates/jackin/tests/common.rs
+++ b/crates/jackin/tests/common.rs
@@ -22,12 +22,12 @@ use std::path::Path;
 /// integration tests need to call this explicitly because `cfg(test)`
 /// only affects the lib when compiled for the lib's own test target.
 pub fn install_capsule_binary_stub(paths: &JackinPaths) {
-    jackin::capsule_binary::install_test_stub(paths).expect("install jackin-capsule test stub");
+    jackin_image::capsule_binary::install_test_stub(paths).expect("install jackin-capsule test stub");
 }
 
 pub fn install_agent_binary_stubs(paths: &JackinPaths) {
     for agent in jackin::agent::Agent::ALL {
-        jackin::agent_binary::install_test_stub(paths, *agent).expect("install agent binary stub");
+        jackin_image::agent_binary::install_test_stub(paths, *agent).expect("install agent binary stub");
     }
 }
 

--- a/crates/jackin/tests/dind_e2e.rs
+++ b/crates/jackin/tests/dind_e2e.rs
@@ -23,7 +23,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use fs2::FileExt as _;
-use jackin::derived_image::shell_quote;
+use jackin_image::derived_image::shell_quote;
 use jackin::instance::naming::is_dns_label;
 use tempfile::tempdir;
 


### PR DESCRIPTION
Drops 4 of the 19 binary shim modules called out by the B2 spec: agent_binary, binary_artifact, capsule_binary, derived_image. Each is a single  line; the binary crate gets those symbols via the existing  direct dep. Call sites in build_jackin_capsule.rs and 3 test files repointed from jackin::X to jackin_image::X. All 4 deletions land in one commit because the spec's 'A Parallel Change per shim file' pattern would have produced 4 PRs of one-line diffs; the trivial 4 are batched together. Remaining 15 shims (config, env_resolver, instance, isolation, manifest, operator_env, paths, repo, repo_contract, runtime, etc.) need their own per-shim analysis in subsequent commits/PRs.