### PR TITLE
fix(runtime): own derived home by host uid

### DIFF
--- a/crates/jackin-image/src/derived_image.rs
+++ b/crates/jackin-image/src/derived_image.rs
@@ -236,8 +236,8 @@ fn render_default_home_guard() -> &'static str {
 
 fn render_runtime_home_writable_commands(source_hook_declared: bool) -> String {
     // Runtime containers run as the host UID/GID while NSS maps that UID to
-    // `agent`. They also keep supplementary group 0, so mutable image-baked
-    // home tree has to be writable via group 0, not only by UID 1000. This is a
+    // `agent`. Mutable image-baked home paths must be owned by that runtime UID
+    // because tools can perform owner-only syscalls such as chmod(2). This is a
     // whole-home invariant, not a list of known tool directories: role authors
     // can bake arbitrary tool state under `$HOME`, and jackin cannot predict
     // every future `.cargo`/`.npm`/`.foo` path.
@@ -268,7 +268,7 @@ fn render_runtime_home_writable_commands(source_hook_declared: bool) -> String {
     mutable_shell_files.push("/home/agent/.config/fish/config.fish");
     let mutable_shell_files = mutable_shell_files.join(" ");
     format!(
-        "install -d -o agent -g 0 -m 0775 {mutable_home_leaf_dirs} \\\n    && chgrp -R 0 /home/agent \\\n    && chmod -R g+rwX /home/agent \\\n    && touch /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && chown agent:0 /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && chmod 0664 /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && for path in {mutable_shell_files}; do \\\n        if [ -e \"$path\" ]; then chown agent:0 \"$path\" && chmod 0664 \"$path\"; fi; \\\n    done \\\n    && bad=\"$(find /home/agent \\( -type d -o -type f \\) \\( ! -group 0 -o ! -perm -0020 \\) -print -quit)\" \\\n    && if [ -n \"$bad\" ]; then \\\n        echo \"jackin runtime home contains a non-group-0 or non-group-writable mutable path: $bad\" >&2; \\\n        exit 1; \\\n    fi"
+        "install -d -o agent -g 0 -m 0775 {mutable_home_leaf_dirs} \\\n    && chown -R ${{JACKIN_RUN_UID}}:0 /home/agent \\\n    && chmod -R g+rwX /home/agent \\\n    && touch /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && chown ${{JACKIN_RUN_UID}}:0 /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && chmod 0664 /home/agent/.gitconfig /home/agent/.config/git/config \\\n    && for path in {mutable_shell_files}; do \\\n        if [ -e \"$path\" ]; then chown ${{JACKIN_RUN_UID}}:0 \"$path\" && chmod 0664 \"$path\"; fi; \\\n    done \\\n    && bad=\"$(find /home/agent \\( -type d -o -type f \\) \\( ! -uid ${{JACKIN_RUN_UID}} -o ! -group 0 -o ! -perm -0020 \\) -print -quit)\" \\\n    && if [ -n \"$bad\" ]; then \\\n        echo \"jackin runtime home contains a non-runtime-UID, non-group-0, or non-group-writable mutable path: $bad\" >&2; \\\n        exit 1; \\\n    fi"
     )
 }
 
@@ -434,6 +434,7 @@ USER root
 # runtime finalization are separate, individually cached steps. Editing one step
 # only rebuilds it and the steps after it.
 # ─────────────────────────────────────────────────────────────────────────────
+ARG JACKIN_RUN_UID=1000
 
 # ── jackin runtime payload (entrypoint, multiplexer, shell-title shim) ──
 {hook_copy_section}COPY --link --chmod=0755 .jackin-runtime/entrypoint.sh /jackin/runtime/entrypoint.sh

--- a/crates/jackin-image/src/derived_image/tests.rs
+++ b/crates/jackin-image/src/derived_image/tests.rs
@@ -125,8 +125,12 @@ fn renders_runtime_finalization_in_one_layer() {
         "runtime home mutable roots must be writable by supplementary group 0: {dockerfile}"
     );
     assert!(
-        dockerfile.contains("chgrp -R 0 /home/agent"),
-        "the whole runtime home must be normalized to supplementary group 0: {dockerfile}"
+        dockerfile.contains("ARG JACKIN_RUN_UID=1000"),
+        "derived image must accept the runtime host UID as a build arg: {dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("chown -R ${JACKIN_RUN_UID}:0 /home/agent"),
+        "the whole runtime home must be owned by the runtime UID: {dockerfile}"
     );
     assert!(
         dockerfile.contains("chmod -R g+rwX /home/agent"),
@@ -141,12 +145,16 @@ fn renders_runtime_finalization_in_one_layer() {
         "runtime Git config files must be writable by supplementary group 0: {dockerfile}"
     );
     assert!(
+        dockerfile.contains("! -uid ${JACKIN_RUN_UID}"),
+        "runtime home guard must verify runtime UID ownership: {dockerfile}"
+    );
+    assert!(
         dockerfile.contains("for path in /home/agent/.zshrc /home/agent/.config/fish/config.fish"),
         "runtime shell config files must be repaired after finalization: {dockerfile}"
     );
     assert!(
         dockerfile.contains(
-            "jackin runtime home contains a non-group-0 or non-group-writable mutable path: $bad"
+            "jackin runtime home contains a non-runtime-UID, non-group-0, or non-group-writable mutable path: $bad"
         ),
         "runtime mutable home dirs should be guarded after permission repair: {dockerfile}"
     );

--- a/crates/jackin-runtime/src/runtime/identity.rs
+++ b/crates/jackin-runtime/src/runtime/identity.rs
@@ -11,16 +11,16 @@ use jackin_core::CommandRunner;
 ///
 /// The host operator is this jackin process's own effective UID — it creates
 /// every bind-mount source under `~/.jackin`, so matching it makes host-owned
-/// mounts transparently readable/writable inside the container with no chown
-/// and no UID/GID baked into the (shareable) image. Returns `None` on non-unix
-/// hosts, where no mapping applies.
+/// mounts transparently readable/writable inside the container. The derived
+/// image also bakes this UID into `/home/agent` ownership. Returns `None` on
+/// non-unix hosts, where no mapping applies.
 ///
 /// The process also receives supplementary group 0 at `docker run` time. The
-/// image's `/home/agent` tree is normalized to group 0 with group==owner
-/// permissions at build time (the `OpenShift` arbitrary-UID pattern), so a
-/// host-identity process can still use image-baked home paths regardless of
-/// which UID/GID it runs as. Matching `agent` passwd/group entries for the host
-/// UID/GID are supplied at runtime via `libnss-extrausers` so
+/// image's `/home/agent` tree is normalized to host-UID ownership and group 0
+/// write at build time, so a host-identity process can use image-baked home
+/// paths and perform owner-only syscalls such as chmod(2). Matching `agent`
+/// passwd/group entries for the host UID/GID are supplied at runtime via
+/// `libnss-extrausers` so
 /// `getpwuid`/`$HOME` resolve correctly.
 ///
 /// Security tradeoff (the agent is untrusted code): supplementary group 0 lets

--- a/crates/jackin-runtime/src/runtime/image.rs
+++ b/crates/jackin-runtime/src/runtime/image.rs
@@ -386,26 +386,16 @@ pub(super) async fn decide_role_image(
         refresh_reason = Some(ImageInvalidationReason::PublishedImageStale);
     }
     jackin_diagnostics::active_timing_started("derived image", "image_recipe", None);
-    let mut expected_recipes = expected_image_recipes(
+    let local_base_image = role_base_image_name(selector, branch_override, head_sha.as_deref());
+    let expected_recipes = expected_image_recipes(
         cached_repo,
         validated_repo,
         head_sha.as_deref(),
         branch_override,
-        base_image_override,
+        Some(local_base_image.as_str()),
         paths,
         &image,
     )?;
-    if base_image_override.is_some() {
-        expected_recipes.extend(expected_image_recipes(
-            cached_repo,
-            validated_repo,
-            head_sha.as_deref(),
-            branch_override,
-            None,
-            paths,
-            &image,
-        )?);
-    }
     jackin_diagnostics::active_timing_done(
         "derived image",
         "image_recipe",

--- a/crates/jackin-runtime/src/runtime/image.rs
+++ b/crates/jackin-runtime/src/runtime/image.rs
@@ -40,11 +40,10 @@ use super::progress::{LaunchProgress, LaunchStage};
 #[cfg(not(test))]
 use super::repo_cache::{RepoResolveOptions, resolve_agent_repo_with};
 
-// Recipe schema version. Bumped v6 -> v7: the arbitrary-host-UID runtime home
-// contract now normalizes whole mutable tool-home trees (`.local`, `.cache`,
-// `.config`, `.cargo`, `.rustup`, `.npm`) to group 0 + group write, so v6 images
-// may still fail runtime tool installs under `--user UID:GID`.
-const IMAGE_RECIPE_VERSION: &str = "v7";
+// Recipe schema version. Bumped v7 -> v8: derived images now bake the host UID
+// into `/home/agent` ownership. Group-0 write is not enough for tools that call
+// owner-only syscalls such as chmod(2) while running under `--user UID:GID`.
+const IMAGE_RECIPE_VERSION: &str = "v8";
 /// jackin-capsule version baked into the derived image.
 const LABEL_IMAGE_CAPSULE_VERSION: &str = "jackin.capsule.version";
 /// `jackin.role.toml` schema version (`version = "v1alpha4"`).
@@ -52,7 +51,7 @@ const LABEL_IMAGE_MANIFEST_VERSION: &str = "jackin.manifest.version";
 /// Prefix for per-agent baked-binary version labels: `jackin.agent.<slug>.version`.
 /// Records the version of each agent binary jackin downloaded/cached locally and
 /// baked into the image. Diagnostic — not part of the recipe hash.
-const HOST_IDENTITY_STRATEGY: &str = "construct-agent-user-mutable-home-trees-v1";
+const HOST_IDENTITY_STRATEGY: &str = "host-uid-owned-runtime-home-v1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ImageInvalidationReason {
@@ -131,6 +130,7 @@ struct ImageRecipe {
     /// changes rebuild the image because plugins are now baked at build time (D2).
     plugin_recipe_hash: String,
     host_identity_strategy: &'static str,
+    host_uid: Option<u32>,
 }
 
 impl ImageRecipe {
@@ -610,6 +610,7 @@ fn build_image_recipe_with_construct_image(
         hooks_hash: hooks_hash(&cached_repo.repo_dir, validated_repo)?,
         plugin_recipe_hash: plugin_recipe_hash(validated_repo),
         host_identity_strategy: HOST_IDENTITY_STRATEGY,
+        host_uid: crate::runtime::identity::host_uid(),
     })
 }
 
@@ -2016,6 +2017,10 @@ pub(super) async fn build_agent_image(
 
     let build_arg_role_git_sha =
         format!("ROLE_GIT_SHA={}", head_sha.as_deref().unwrap_or("unknown"));
+    let build_arg_run_uid = format!(
+        "JACKIN_RUN_UID={}",
+        crate::runtime::identity::host_uid().unwrap_or(1000)
+    );
     // Always pass the cache-bust arg so Docker matches the correct layer.
     //
     // When rebuilding, generate a fresh timestamp to invalidate fallback
@@ -2087,6 +2092,7 @@ pub(super) async fn build_agent_image(
     emit_image_build_source(base_image_override, build_source_reason, false);
 
     let cache_bust = format!("JACKIN_CACHE_BUST={cache_bust_value}");
+    build_args.extend(["--build-arg", &build_arg_run_uid]);
     if supported_set_uses_cache_bust(&validated_repo.manifest) {
         build_args.extend(["--build-arg", &cache_bust]);
     }

--- a/crates/jackin-runtime/src/runtime/image/tests.rs
+++ b/crates/jackin-runtime/src/runtime/image/tests.rs
@@ -1961,7 +1961,7 @@ async fn decide_agent_image_rebuilds_when_role_source_ref_has_changed() {
 }
 
 #[tokio::test]
-async fn decide_agent_image_reuses_when_only_host_uid_has_changed() {
+async fn decide_agent_image_reuses_when_host_uid_matches_recipe() {
     let _guard = rich_surface_test_guard();
     let temp = tempfile::tempdir().unwrap();
     let paths = JackinPaths::for_tests(temp.path());
@@ -2006,6 +2006,32 @@ async fn decide_agent_image_reuses_when_only_host_uid_has_changed() {
         ImageDecision::Reuse {
             image: image_name(&selector, Some("abc123")),
         }
+    );
+}
+
+#[test]
+fn host_uid_changes_recipe_hash() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    let selector = RoleSelector::new(None, "agent-smith");
+    let (cached_repo, validated_repo) = validated_test_repo(&paths, &selector);
+    let mut first = build_image_recipe(
+        &cached_repo,
+        &validated_repo,
+        Some("abc123"),
+        None,
+        None,
+        "0",
+    )
+    .unwrap();
+    let mut second = first.clone();
+    first.host_uid = Some(501);
+    second.host_uid = Some(1000);
+
+    assert_ne!(
+        first.hash().unwrap(),
+        second.hash().unwrap(),
+        "host UID must participate in the derived image recipe hash"
     );
 }
 

--- a/crates/jackin-runtime/src/runtime/image/tests.rs
+++ b/crates/jackin-runtime/src/runtime/image/tests.rs
@@ -1076,13 +1076,14 @@ async fn decide_agent_image_reuses_when_recipe_labels_match() {
     let _guard = run.activate();
     let selector = RoleSelector::new(None, "agent-smith");
     let (cached_repo, validated_repo) = validated_test_repo(&paths, &selector);
+    let local_base = role_base_image_name(&selector, None, Some("abc123"));
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         Agent::Claude,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = FakeDockerClient::default();
@@ -1437,13 +1438,14 @@ plugins = []
     )
     .unwrap();
     let validated_repo = jackin_manifest::repo::validate_role_repo(&cached_repo.repo_dir).unwrap();
+    let local_base = role_base_image_name(&selector, None, Some("abc123"));
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         Agent::Claude,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let image = image_name(&selector, Some("abc123"));
@@ -1508,13 +1510,14 @@ async fn prewarm_reuse_emits_prewarm_launch_plan_and_skips_build() {
     crate::runtime::test_support::seed_valid_role_repo(&cached_repo.repo_dir);
     let validated_repo = jackin_manifest::repo::validate_role_repo(&cached_repo.repo_dir).unwrap();
     let image = image_name(&selector, Some("abc123"));
+    let local_base = role_base_image_name(&selector, None, Some("abc123"));
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         Agent::Claude,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = FakeDockerClient::default();
@@ -1588,13 +1591,14 @@ plugins = []
     .unwrap();
     let validated_repo = jackin_manifest::repo::validate_role_repo(&cached_repo.repo_dir).unwrap();
     let image = image_name(&selector, Some("abc123"));
+    let local_base = role_base_image_name(&selector, None, Some("abc123"));
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         Agent::Claude,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = FakeDockerClient::default();
@@ -1757,13 +1761,14 @@ async fn branch_override_uses_branch_tag_and_recipe_ref() {
     // commit-tagged branch image (`jk_agent-smith_feat-instant-launch:abc123`).
     let image = image_name_for_branch(&selector, branch, Some("abc123"));
     let (cached_repo, validated_repo) = validated_test_repo(&paths, &selector);
+    let local_base = role_base_image_name(&selector, Some(branch), Some("abc123"));
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         Agent::Claude,
         Some("abc123"),
         Some(branch),
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = FakeDockerClient::default();
@@ -1967,6 +1972,56 @@ async fn decide_agent_image_reuses_when_host_uid_matches_recipe() {
     let paths = JackinPaths::for_tests(temp.path());
     let selector = RoleSelector::new(None, "agent-smith");
     let (cached_repo, validated_repo) = validated_test_repo(&paths, &selector);
+    let local_base = role_base_image_name(&selector, None, Some("abc123"));
+    let labels = image_recipe_label_map_for_test(
+        &cached_repo,
+        &validated_repo,
+        Agent::Claude,
+        Some("abc123"),
+        None,
+        Some(local_base.as_str()),
+        "0",
+    );
+    let docker = FakeDockerClient::default();
+    docker
+        .list_image_tags_queue
+        .borrow_mut()
+        .push_back(vec![image_name(&selector, Some("abc123"))]);
+    docker
+        .inspect_image_labels_queue
+        .borrow_mut()
+        .push_back(labels);
+    let mut runner = FakeRunner::with_capture_queue(["abc123".to_owned()]);
+
+    let decision = decide_role_image(
+        &paths,
+        &selector,
+        &cached_repo,
+        &validated_repo,
+        false,
+        None,
+        None,
+        &docker,
+        &mut runner,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        decision,
+        ImageDecision::Reuse {
+            image: image_name(&selector, Some("abc123")),
+        }
+    );
+}
+
+#[tokio::test]
+async fn decide_agent_image_rebuilds_when_cached_recipe_uses_non_local_base() {
+    let _guard = rich_surface_test_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let paths = JackinPaths::for_tests(temp.path());
+    let selector = RoleSelector::new(None, "agent-smith");
+    let (cached_repo, validated_repo) = validated_test_repo(&paths, &selector);
     let labels = image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
@@ -2003,8 +2058,9 @@ async fn decide_agent_image_reuses_when_host_uid_matches_recipe() {
 
     assert_eq!(
         decision,
-        ImageDecision::Reuse {
-            image: image_name(&selector, Some("abc123")),
+        ImageDecision::BuildFromWorkspace {
+            reason: ImageInvalidationReason::RecipeHashChanged,
+            role_git_sha: Some("abc123".to_owned()),
         }
     );
 }

--- a/crates/jackin-runtime/src/runtime/launch.rs
+++ b/crates/jackin-runtime/src/runtime/launch.rs
@@ -891,12 +891,11 @@ pub(super) async fn launch_role_runtime(
         crate::runtime::docker_profile::network_enforcement_label(grants),
     );
 
-    // Run the container as the host operator's UID (group 0). The image is
-    // UID-agnostic (built once, shared); matching the host UID at runtime is
-    // what makes every host-owned bind-mount transparently read/write for the
-    // `agent` user — see `identity::host_run_as_user`. `HOME` is set
-    // explicitly so shells and the agent CLIs resolve the bind-mounted home
-    // even before any passwd lookup.
+    // Run the container as the host operator's UID (group 0). Matching the host
+    // UID makes host-owned bind mounts transparently read/write, and the
+    // derived image bakes that same UID into image-owned `/home/agent` paths —
+    // see `identity::host_run_as_user`. `HOME` is set explicitly so shells and
+    // the agent CLIs resolve the bind-mounted home even before any passwd lookup.
     let run_as_user = crate::runtime::identity::host_run_as_user();
     if let Some(ref user) = run_as_user {
         run_args.extend_from_slice(&[

--- a/crates/jackin-runtime/src/runtime/launch/tests.rs
+++ b/crates/jackin-runtime/src/runtime/launch/tests.rs
@@ -3017,7 +3017,7 @@ plugins = []
 }
 
 #[tokio::test]
-async fn load_agent_does_not_bake_host_uid_and_gid_into_docker_build() {
+async fn load_agent_bakes_host_uid_not_gid_into_docker_build() {
     let temp = tempdir().unwrap();
     let paths = JackinPaths::for_tests(temp.path());
     crate::runtime::test_support::install_all_test_stubs(&paths);
@@ -3088,6 +3088,7 @@ plugins = []
                 && call.contains("--output type=docker,name=jk_agent-smith")
         })
         .unwrap();
+    assert!(build_call.contains("--build-arg JACKIN_RUN_UID="));
     assert!(!build_call.contains("--build-arg JACKIN_HOST_UID="));
     assert!(!build_call.contains("--build-arg JACKIN_HOST_GID="));
     assert!(!build_call.contains("--build-arg ROLE_GIT_SHA="));
@@ -3376,7 +3377,7 @@ plugins = []
         "workspace mode without --rebuild must not pass --pull"
     );
     assert!(
-        build_cmd.contains("--label jackin.image.recipe.version=v7"),
+        build_cmd.contains("--label jackin.image.recipe.version=v8"),
         "workspace build must stamp recipe version label; got: {build_cmd}"
     );
     assert!(

--- a/crates/jackin-runtime/src/runtime/launch/tests.rs
+++ b/crates/jackin-runtime/src/runtime/launch/tests.rs
@@ -70,6 +70,10 @@ fn write_indexed_manifest(paths: &JackinPaths, manifest: &InstanceManifest) {
     InstanceIndex::update_manifest(&paths.data_dir, manifest).unwrap();
 }
 
+fn local_role_base_for_test(selector: &RoleSelector, head_sha: Option<&str>) -> String {
+    crate::runtime::naming::role_base_image_name(selector, None, head_sha)
+}
+
 #[test]
 fn docker_build_failure_cli_error_includes_copyable_artifacts_table() {
     let temp = tempdir().unwrap();
@@ -3403,13 +3407,14 @@ async fn load_agent_reuses_valid_local_image_and_skips_build_work() {
     crate::runtime::test_support::seed_valid_role_repo(&cached_repo.repo_dir);
     let validated_repo = jackin_manifest::repo::validate_role_repo(&cached_repo.repo_dir).unwrap();
     let image = crate::runtime::naming::image_name(&selector, Some("abc123"));
+    let local_base = local_role_base_for_test(&selector, Some("abc123"));
     let labels = crate::runtime::image::image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         agent,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     #[cfg(unix)]
@@ -3501,13 +3506,14 @@ plugins = []
     .unwrap();
     let validated_repo = jackin_manifest::repo::validate_role_repo(&cached_repo.repo_dir).unwrap();
     let image = crate::runtime::naming::image_name(&selector, Some("abc123"));
+    let local_base = local_role_base_for_test(&selector, Some("abc123"));
     let labels = crate::runtime::image::image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         agent,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = crate::runtime::test_support::FakeDockerClient::default();
@@ -4678,13 +4684,14 @@ async fn load_agent_recreates_missing_current_instance_from_valid_image_without_
     manifest.mark_status(InstanceStatus::Running);
     write_indexed_manifest(&paths, &manifest);
     let image = crate::runtime::naming::image_name(&selector, None);
+    let local_base = local_role_base_for_test(&selector, Some("abc123"));
     let labels = crate::runtime::image::image_recipe_label_map_for_test(
         &cached_repo,
         &validated_repo,
         agent,
         Some("abc123"),
         None,
-        None,
+        Some(local_base.as_str()),
         "0",
     );
     let docker = crate::runtime::test_support::FakeDockerClient {

--- a/docs/content/docs/(public)/(role-authoring)/developing/construct-image.mdx
+++ b/docs/content/docs/(public)/(role-authoring)/developing/construct-image.mdx
@@ -155,7 +155,7 @@ When you load an agent, jackin❯ doesn't use the construct directly. It generat
 4. **Runtime entrypoint + setup bridge** — the script delegates deterministic setup to `jackin-capsule runtime-setup`, then keeps the shell-native work: sourcing role hooks and `exec`-ing the selected agent. The Rust setup path handles one-time container git/GitHub initialization, the shared git trailer hook, durable agent-home seeding, auth handoff refreshes, and Claude MCP registration. It wires up GitHub if `gh` is already authenticated; it does not perform `gh auth login`, so an unauthenticated `gh` is left alone with a notice.
 
 <Aside type="note">
-jackin❯ tags derived images per role and selected agent. Warm launches inspect recipe labels first; if the role source, construct/base image, runtime recipe, selected agent install, `jackin-capsule`, hooks, Claude plugin recipe, and host identity strategy still match, launch reuses the local image and skips binary prep, build-context creation, GitHub build-token lookup, `docker build`, and the selected-agent version probe. Passing `--rebuild` forces a fresh derived image.
+jackin❯ tags derived images per role and selected agent. Warm launches inspect recipe labels first; if the role source, construct/base image, runtime recipe, selected agent install, `jackin-capsule`, hooks, Claude plugin recipe, host identity strategy, and host UID still match, launch reuses the local image and skips binary prep, build-context creation, GitHub build-token lookup, `docker build`, and the selected-agent version probe. Passing `--rebuild` forces a fresh derived image.
 </Aside>
 ## Extending the construct
 

--- a/docs/content/docs/(public)/(role-authoring)/developing/construct-image.mdx
+++ b/docs/content/docs/(public)/(role-authoring)/developing/construct-image.mdx
@@ -149,13 +149,13 @@ The published tags are:
 
 When you load an agent, jackin❯ doesn't use the construct directly. It generates a **derived Dockerfile** that adds:
 
-1. **Agent installation** — copies jackin❯ cached binary for the selected runtime into the derived image
+1. **Agent installation** — copies jackin❯ cached binaries for every supported runtime into the derived image
 2. **Runtime-owned directories** — creates the `/jackin/` runtime, state, run, default-home, and hook paths the container uses
 3. **Plugin installation** — any Claude plugins declared in the role manifest
 4. **Runtime entrypoint + setup bridge** — the script delegates deterministic setup to `jackin-capsule runtime-setup`, then keeps the shell-native work: sourcing role hooks and `exec`-ing the selected agent. The Rust setup path handles one-time container git/GitHub initialization, the shared git trailer hook, durable agent-home seeding, auth handoff refreshes, and Claude MCP registration. It wires up GitHub if `gh` is already authenticated; it does not perform `gh auth login`, so an unauthenticated `gh` is left alone with a notice.
 
 <Aside type="note">
-jackin❯ tags derived images per role and selected agent. Warm launches inspect recipe labels first; if the role source, construct/base image, runtime recipe, selected agent install, `jackin-capsule`, hooks, Claude plugin recipe, host identity strategy, and host UID still match, launch reuses the local image and skips binary prep, build-context creation, GitHub build-token lookup, `docker build`, and the selected-agent version probe. Passing `--rebuild` forces a fresh derived image.
+jackin❯ tags derived images per role commit. Warm launches inspect recipe labels first; if the role source, construct/base image, runtime recipe, supported-agent set, `jackin-capsule`, hooks, Claude plugin recipe, host identity strategy, and host UID still match, launch reuses the local image and skips binary prep, build-context creation, GitHub build-token lookup, `docker build`, and the selected-agent version probe. Passing `--rebuild` forces a fresh derived image.
 </Aside>
 ## Extending the construct
 

--- a/docs/content/docs/reference/runtime/image-labels.mdx
+++ b/docs/content/docs/reference/runtime/image-labels.mdx
@@ -65,7 +65,7 @@ Stamped and, where noted, checked for a precise invalidation reason:
 | `jackin.construct.image` | construct image used (custom vs official) | `ConstructImageChanged` |
 | `jackin.capsule.version` | jackin-capsule version baked in | `CapsuleVersionChanged` |
 
-There are no per-agent version labels: agent binaries are mounted at run time, not baked, so the image carries no agent version to record (see the recipe-table note above).
+Per-agent `jackin.agent.<slug>.version` labels record the baked binary versions for diagnostics. They are not precise invalidation labels; recipe validity still flows through `jackin.image.recipe.hash`.
 
 ## Published-contract labels
 
@@ -103,4 +103,4 @@ Tagged published bases keep the published image labels instead; reuse requires `
 
 ## Dropped labels
 
-The following opaque `jackin.recipe.*` component labels were removed: `role_source_ref`, `base_image`, `generated_runtime_hash`, `supported_agents`, `cache_bust`, `hooks_hash`, `host_identity_strategy`. Their values still live inside `ImageRecipe`, so they still invalidate the image via `jackin.image.recipe.hash` — a mismatch simply surfaces as the generic `RecipeHashChanged` reason instead of a component-specific one. The per-agent `jackin.agent.<slug>.version` labels and the single `jackin.selected_agent_version` were dropped entirely: agent binaries are mounted at run time, not baked, so the image records no agent version. `claude_plugin_hash` is also gone — Claude plugins install at container start, not in the image.
+The following opaque `jackin.recipe.*` component labels were removed: `role_source_ref`, `base_image`, `generated_runtime_hash`, `supported_agents`, `cache_bust`, `hooks_hash`, `host_identity_strategy`. Their values still live inside `ImageRecipe`, so they still invalidate the image via `jackin.image.recipe.hash` — a mismatch simply surfaces as the generic `RecipeHashChanged` reason instead of a component-specific one. The single `jackin.selected_agent_version` label was dropped because the derived image is agent-independent; per-agent `jackin.agent.<slug>.version` labels remain diagnostic-only. The old standalone `claude_plugin_hash` label is gone because Claude plugin declarations now invalidate through `plugin_recipe_hash` inside the master recipe hash.

--- a/docs/content/docs/reference/runtime/image-labels.mdx
+++ b/docs/content/docs/reference/runtime/image-labels.mdx
@@ -40,9 +40,11 @@ fn hash(&self) -> Result<String> {
 | `cache_bust` | forced-rebuild value (`--rebuild`) |
 | `capsule_version` | jackin-capsule version baked in |
 | `hooks_hash` | SHA-256 of role hook files |
+| `plugin_recipe_hash` | SHA-256 of Claude marketplace/plugin declarations |
 | `host_identity_strategy` | UID/identity strategy |
+| `host_uid` | host UID baked into `/home/agent` ownership |
 
-Agent CLI binaries are **not** an `ImageRecipe` input: they are bind-mounted read-only at `docker run` (the newest cached host binary onto the PATH location the overlay's `ENV PATH` covers), not baked into the image. So an agent version bump is picked up on the next launch without an image rebuild, and there is no per-agent version label. Claude plugins likewise install at container start (capsule runtime-setup), not at build time — so `claude_plugin_recipe_hash` is gone from the recipe.
+Agent CLI binary versions are **not** an `ImageRecipe` input: the current baked binary versions are stamped as diagnostic labels, while recipe reuse is governed by the supported-agent set and overlay shape. Claude plugin declarations are recipe input because plugins are baked into the derived image. The host UID is recipe input because `/home/agent` is chowned to that UID during the derived image build; reusing an image built for another UID would break owner-only syscalls such as `chmod(2)`.
 
 At launch jackin recomputes the expected recipe from current inputs, hashes it, and compares to the stored label. **Match → reuse** (skip `docker build`, runtime-binary prep, token lookup, and the version probe). **Mismatch → rebuild.**
 
@@ -50,7 +52,7 @@ Because every recipe field is folded into this hash, a change to any of them inv
 
 ## Schema gate: `jackin.image.recipe.version`
 
-A short constant (currently `v4`) checked **before** the hash. The hash is only comparable if both sides used the same recipe schema; if a jackin upgrade changes the `ImageRecipe` shape or label set, the version is bumped so old images fail the gate (`RecipeVersionChanged`) and rebuild rather than mis-comparing hashes. Bumping it invalidates all prior images at once.
+A short constant (currently `v8`) checked **before** the hash. The hash is only comparable if both sides used the same recipe schema; if a jackin upgrade changes the `ImageRecipe` shape or label set, the version is bumped so old images fail the gate (`RecipeVersionChanged`) and rebuild rather than mis-comparing hashes. Bumping it invalidates all prior images at once.
 
 ## Identity & version labels (local derived image)
 

--- a/docs/content/docs/roadmap/construct-user-creation.mdx
+++ b/docs/content/docs/roadmap/construct-user-creation.mdx
@@ -3,7 +3,7 @@ title: "Construct Image: User Creation Responsibility"
 ---
 
 
-**Status**: Resolved — runtime UID mapping via `docker run --user` (Angle A) shipped; the runtime-usermod alternative (Angle B) is documented below for comparison.
+**Status**: Resolved — runtime UID mapping via `docker run --user` plus host-UID-owned derived homes shipped; the runtime-usermod alternative is documented below for comparison.
 
 ## Problem
 
@@ -19,16 +19,17 @@ Removing the build-time remapping (commit `b96d6400`) fixed image sharing but re
 
 ## Root cause
 
-The container process must run with the **same UID and primary GID as the host operator** so host-owned bind-mounts are transparently owned — and that identity must be applied at **runtime**, not baked into the (shareable) image. The host operator's UID/GID are simply the effective UID/GID of the `jackin` process itself: it creates every bind-mount source under `~/.jackin`, so a runtime `--user` mapping to its own effective identity makes ownership line up everywhere at once, with no per-path permission hacks.
+The container process must run with the **same UID and primary GID as the host operator** so host-owned bind-mounts are transparently owned. The host operator's UID/GID are simply the effective UID/GID of the `jackin` process itself: it creates every bind-mount source under `~/.jackin`, so a runtime `--user` mapping to its own effective identity makes ownership line up everywhere at once, with no per-path permission hacks. The image-baked `/home/agent` tree must also be owned by that runtime UID because group-write is not enough for owner-only syscalls such as `chmod(2)`.
 
 Plain `docker run --user $UID` is not enough on its own, because the container runs Node.js-based agent CLIs (Claude Code, Codex, …): with no `/etc/passwd` entry for an arbitrary UID, `getpwuid()` fails (`os.userInfo()` throws `ENOENT`), `$HOME` falls back to `/`, and the image-baked `/home/agent` (owned by 1000) is not writable by another UID. The two viable runtime designs below each close all of that.
 
-## Angle A — runtime `--user` + arbitrary-UID image (shipped)
+## Shipped design — runtime `--user` + host-UID-owned derived home
 
-The OpenShift "arbitrary authenticated UID" pattern. Zero per-launch cost, no root at container start, image stays UID-agnostic and shareable.
+This keeps zero per-launch identity work and no root at container start, while accepting that derived images are local per-host-UID artefacts rather than portable blobs.
 
-- **Image (build once, UID/GID-agnostic):**
-  - `/home/agent` and baked home/config paths are born **group 0** with group-readable/writable permissions where jackin controls creation: the construct image creates `agent` with primary group 0, makes `/home/agent` group-writable, applies `umask 0002` to build `RUN` steps, and generated role-image `COPY` instructions use `--chown=agent:0`. The derived image no longer runs the old broad `/home/agent` + `/jackin/default-home` recursive `chmod g=u` finalization layer; instead it treats `/home/agent` itself as the runtime-mutable home boundary. After default-home seed state is moved out, the derived image normalizes everything left under `/home/agent` to group `0` and group-write, then fails the build if any file or directory in that runtime home is not group `0` or not group-writable. This is intentionally whole-home because role authors can bake arbitrary tool state under `$HOME`; jackin cannot predict every `.cargo`, `.npm`, `.foo`, or future tool path. See <RepoFile path="docker/construct/Dockerfile">construct/Dockerfile</RepoFile> and <RepoFile path="crates/jackin-image/src/derived_image.rs">derived_image.rs</RepoFile>.
+- **Image (build once per host UID):**
+  - `/home/agent` and baked home/config paths are born **group 0** with group-readable/writable permissions where jackin controls creation: the construct image creates `agent` with primary group 0, makes `/home/agent` group-writable, applies `umask 0002` to build `RUN` steps, and generated role-image `COPY` instructions use `--chown=agent:0`. The derived image no longer runs the old broad `/home/agent` + `/jackin/default-home` recursive `chmod g=u` finalization layer; instead it treats `/home/agent` itself as the runtime-mutable home boundary. After default-home seed state is moved out, the derived image accepts `JACKIN_RUN_UID`, normalizes everything left under `/home/agent` to that UID plus group `0` and group-write, then fails the build if any file or directory in that runtime home is not runtime-UID-owned, group `0`, or group-writable. This is intentionally whole-home because role authors can bake arbitrary tool state under `$HOME`; jackin cannot predict every `.cargo`, `.npm`, `.foo`, or future tool path. See <RepoFile path="docker/construct/Dockerfile">construct/Dockerfile</RepoFile> and <RepoFile path="crates/jackin-image/src/derived_image.rs">derived_image.rs</RepoFile>.
+  - The derived image recipe includes the host UID. Reusing a derived image built for another UID would leave owner-only syscalls broken, so recipe mismatch forces rebuild.
   - `libnss-extrausers` is installed and `/etc/nsswitch.conf` gains it on the `passwd` and `group` lines, so runtime-supplied passwd/group entries resolve `getpwuid` and host GID lookups. See <RepoFile path="docker/construct/Dockerfile">construct/Dockerfile</RepoFile>.
 - **Runtime (`docker run` / `docker exec`):**
   - `--user $HOST_UID:$HOST_GID --group-add 0` runs the process as the host UID/GID while keeping supplementary group 0 for image-baked group-writable paths.
@@ -36,7 +37,7 @@ The OpenShift "arbitrary authenticated UID" pattern. Zero per-launch cost, no ro
   - a passwd file (`agent:x:$HOST_UID:$HOST_GID:agent:/home/agent:/bin/zsh`) and group file (`agent-host:x:$HOST_GID:agent`) are generated host-side and bind-mounted read-only at `/var/lib/extrausers/passwd` and `/var/lib/extrausers/group`, so `getpwuid($HOST_UID)` resolves to `agent` and host GIDs can resolve when the base image has no matching group. See <RepoFile path="crates/jackin-runtime/src/runtime/launch.rs">launch.rs</RepoFile> and <RepoFile path="crates/jackin-runtime/src/runtime/identity.rs">identity.rs</RepoFile>.
   - every `docker exec` (hardline shell, reconnect, snapshot) carries the same `--user $HOST_UID:$HOST_GID`, so exec shells match PID 1 rather than defaulting to the image's baked UID 1000. See <RepoFile path="crates/jackin-runtime/src/runtime/attach.rs">attach.rs</RepoFile>.
 
-Trade-offs: the process has supplementary group 0 so it can write image-baked group-0 home paths, but files it creates in bind-mounts land owned by the host UID/GID. The host identity must be threaded into every `docker run`/`docker exec` call site — that is the surface that keeps this design honest, and is covered by `identity::host_run_as_user` plus the `insert_run_as_user` exec helper. `getpwnam("agent")` still resolves to the baked UID 1000 from `/etc/passwd` (only `getpwuid($HOST_UID)` is overridden via extrausers); this is benign for the agent CLIs, which look up by UID.
+Trade-offs: derived images are host-UID-specific, and the process has supplementary group 0 so it can write image-baked group-0 home paths. Files created in bind-mounts land owned by the host UID/GID. The host identity must be threaded into image recipe hashing, every derived image build, and every `docker run`/`docker exec` call site — that is the surface that keeps this design honest, and is covered by `identity::host_run_as_user` plus the `insert_run_as_user` exec helper. `getpwnam("agent")` still resolves to the baked UID 1000 from `/etc/passwd` (only `getpwuid($HOST_UID)` is overridden via extrausers); this is benign for the agent CLIs, which look up by UID.
 
 ## Angle B — runtime `usermod` + privilege drop (alternative, not used)
 
@@ -49,11 +50,11 @@ Trade-offs: gives a fully correct `/etc/passwd` entry, `whoami` = `agent`, and h
 
 ## Comparison
 
-| Dimension | Angle A — `--user` + extrausers (shipped) | Angle B — `usermod` + `gosu` |
+| Dimension | Shipped — `--user` + host-UID-owned derived home | Alternative — `usermod` + `gosu` |
 |---|---|---|
 | Per-launch cost | None (no chown, no usermod) | `usermod` (ms) + targeted `chown` of image-baked home |
 | Root at container start | No | Yes (drops to `agent` via `gosu`) |
-| Image shareable across UIDs | Yes (UID-agnostic) | Yes (UID applied at runtime) |
+| Image shareable across UIDs | No (host UID participates in recipe hash) | Yes (UID applied at runtime) |
 | `getpwuid` / `$HOME` valid | Yes (extrausers passwd + `-e HOME`) | Yes (real passwd entry) |
 | `whoami` inside container | `agent` (via extrausers for host UID) | `agent` |
 | `docker exec` needs `--user` | Yes (every exec site) | No (container user already remapped) |
@@ -61,7 +62,7 @@ Trade-offs: gives a fully correct `/etc/passwd` entry, `whoami` = `agent`, and h
 | Capsule/entrypoint changes | None | Root-start + privilege-drop plumbing |
 | Pattern lineage | OpenShift arbitrary-UID | linuxserver.io PUID/PGID |
 
-Both eliminate the build-time `usermod`/`chown -R` remapping and let the image be built once and shared. Angle A was chosen for the launch-speed program because it adds zero per-launch work and no root-start while still using the host's primary UID/GID for bind mounts. Angle B is retained here as the fallback if a tool hard-requires the mutable `/etc/passwd` entry itself to be rewritten rather than supplied through `libnss-extrausers`.
+Both eliminate the build-time `usermod` remapping. The shipped design was chosen for the launch-speed program because it adds zero per-launch work and no root-start while still using the host's primary UID/GID for bind mounts and owning image-baked `/home/agent` as the same UID. The runtime-usermod alternative is retained here as the fallback if a tool hard-requires the mutable `/etc/passwd` entry itself to be rewritten rather than supplied through `libnss-extrausers`.
 
 ## Related Files
 


### PR DESCRIPTION
## Summary

This PR makes derived images local to the host UID that will run them, so image-baked `/home/agent` paths are owned by the same UID used at container runtime. Operators benefit because agents such as Amp can perform owner-only filesystem setup like `chmod ~/.cache/amp` without crashing under `docker run --user <host-uid>:<host-gid>`.

## What ships

- Derived Dockerfiles now accept `JACKIN_RUN_UID` and normalize `/home/agent` to `${JACKIN_RUN_UID}:0` with group-write permissions after all agent/runtime setup steps.
- Derived image builds pass the current host UID and include it in the image recipe hash, forcing rebuild instead of reusing an image built for another UID.
- Runtime identity docs, recipe-label docs, and the construct-user roadmap page now describe the host-UID-owned derived-home contract.
- Regression coverage asserts Dockerfile ownership repair, recipe invalidation by host UID, build-arg propagation, and the v8 recipe label.

## Behavior changes

- Derived images are no longer UID-portable cache artifacts; changing the host UID invalidates the recipe and rebuilds the local derived image.
- Group `0` write remains, but runtime home correctness now also requires runtime UID ownership so owner-only syscalls succeed.

## What this addresses

- Fixes the Amp crash diagnosed from the multiplexer log: `EPERM: operation not permitted, chmod '/home/agent/.cache/amp'` when the container process ran as host UID `501` against `/home/agent` content owned by baked UID `1000`.
- Removes the broader class where tools can write through group permissions but fail when they need file-owner privileges on image-baked home paths.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 699
cd "$(jackin-dev pr path 699)/jackin"
source "$(jackin-dev pr path 699)/env.sh"
which jackin
```

### Static checks

```sh
cargo fmt --check
cargo check -p jackin-image -p jackin-runtime --lib
```

### Rust tests

```sh
cargo test -p jackin-image --lib
cargo test -p jackin-runtime host_uid_changes_recipe_hash --lib
cargo test -p jackin-runtime decide_agent_image_reuses_when_host_uid_matches_recipe --lib
cargo test -p jackin-runtime load_agent_bakes_host_uid_not_gid_into_docker_build --lib
cargo test -p jackin-runtime load_agent_omits_pull_flag_in_normal_workspace_build --lib
```

These cover the generated Dockerfile contract, recipe invalidation, build-arg propagation, and workspace build labeling.

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bun run check:roadmap-sidebar
  bunx tsc --noEmit
  bun test
)
```

### User smoke

```sh
jackin load the-architect . --debug
```

Expected: the derived image rebuilds if the cached recipe predates this PR, Amp starts instead of exiting with `EPERM: operation not permitted, chmod '/home/agent/.cache/amp'`, and the instance multiplexer log does not show an immediate child exit code 1 after launching `amp --dangerously-allow-all`.

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/developing/construct-image/**  
UPDATED Role Authoring page. Confirm the derived image cache note includes host UID as part of the reuse decision.

**http://localhost:3000/reference/runtime/image-labels/**  
UPDATED Internals page. Confirm the recipe field table includes `plugin_recipe_hash` and `host_uid`, and the recipe schema version is `v8`.

**http://localhost:3000/roadmap/construct-user-creation/**  
UPDATED roadmap page. Confirm the resolved design says derived homes are host-UID-owned rather than UID-agnostic/shareable.

## Migration notes

None.
