### PR TITLE
fix(env): widen launch op read timeout

### DIFF
--- a/crates/jackin-env/src/op_cli.rs
+++ b/crates/jackin-env/src/op_cli.rs
@@ -9,7 +9,7 @@ use jackin_core::op_types::{OpAccount, OpField, OpItem, OpVault};
 
 const OP_DEFAULT_BIN: &str = "op";
 const OP_DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-const OP_LAUNCH_ENV_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const OP_LAUNCH_ENV_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(2);
 pub(crate) const OP_STDERR_MAX: usize = 4 * 1024;
 const OP_SPAWN_RETRIES: usize = 5;
 const TEXT_FILE_BUSY_OS_ERROR: i32 = 26;
@@ -43,7 +43,7 @@ impl OpCli {
     }
 
     /// Launch-time operator-env reads run on the foreground path, but real
-    /// 1Password app/daemon wakeups can exceed the default 30s budget while
+    /// 1Password app/daemon wake-up delays can exceed the default 30s budget while
     /// still completing successfully. Keep this finite and below the fully
     /// interactive SSO budget so a wedged `op` still fails with a bounded error.
     pub fn new_launch_env() -> Self {
@@ -122,18 +122,7 @@ impl Default for OpCli {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn launch_env_runner_uses_wider_bounded_timeout() {
-        let runner = OpCli::new_launch_env();
-
-        assert_eq!(runner.binary, OP_DEFAULT_BIN);
-        assert_eq!(runner.timeout, std::time::Duration::from_secs(120));
-        assert_eq!(runner.account, None);
-    }
-}
+mod tests;
 
 fn format_exit_status(status: std::process::ExitStatus) -> String {
     status

--- a/crates/jackin-env/src/op_cli.rs
+++ b/crates/jackin-env/src/op_cli.rs
@@ -9,6 +9,7 @@ use jackin_core::op_types::{OpAccount, OpField, OpItem, OpVault};
 
 const OP_DEFAULT_BIN: &str = "op";
 const OP_DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const OP_LAUNCH_ENV_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 pub(crate) const OP_STDERR_MAX: usize = 4 * 1024;
 const OP_SPAWN_RETRIES: usize = 5;
 const TEXT_FILE_BUSY_OS_ERROR: i32 = 26;
@@ -37,6 +38,18 @@ impl OpCli {
         Self {
             binary: OP_DEFAULT_BIN.to_owned(),
             timeout: OP_DEFAULT_TIMEOUT,
+            account: None,
+        }
+    }
+
+    /// Launch-time operator-env reads run on the foreground path, but real
+    /// 1Password app/daemon wakeups can exceed the default 30s budget while
+    /// still completing successfully. Keep this finite and below the fully
+    /// interactive SSO budget so a wedged `op` still fails with a bounded error.
+    pub fn new_launch_env() -> Self {
+        Self {
+            binary: OP_DEFAULT_BIN.to_owned(),
+            timeout: OP_LAUNCH_ENV_TIMEOUT,
             account: None,
         }
     }
@@ -105,6 +118,20 @@ impl OpCli {
 impl Default for OpCli {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_env_runner_uses_wider_bounded_timeout() {
+        let runner = OpCli::new_launch_env();
+
+        assert_eq!(runner.binary, OP_DEFAULT_BIN);
+        assert_eq!(runner.timeout, std::time::Duration::from_secs(120));
+        assert_eq!(runner.account, None);
     }
 }
 

--- a/crates/jackin-env/src/op_cli/tests.rs
+++ b/crates/jackin-env/src/op_cli/tests.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+#[test]
+fn launch_env_runner_uses_wider_bounded_timeout() {
+    let runner = OpCli::new_launch_env();
+
+    assert_eq!(runner.binary, OP_DEFAULT_BIN);
+    assert_eq!(runner.timeout, std::time::Duration::from_mins(2));
+    assert_eq!(runner.account, None);
+}

--- a/crates/jackin-env/src/resolve.rs
+++ b/crates/jackin-env/src/resolve.rs
@@ -110,7 +110,7 @@ pub fn resolve_op_uri_to_ref(
         _ => bail!("malformed op:// URI (expected 3 or 4 path segments): {input}"),
     };
 
-    // Item segment may carry [subtitle] filter — jackin❯'s display extension.
+    // Item segment may carry [subtitle] filter — a display extension from jackin❯.
     // Nested condition makes map_or awkward; allow the if-let pattern here.
     #[allow(clippy::option_if_let_else)]
     let (item_name, subtitle_filter): (&str, Option<&str>) = if let Some(open) = item_seg.rfind('[')
@@ -378,7 +378,7 @@ pub fn resolve_operator_env(
 ) -> anyhow::Result<std::collections::BTreeMap<String, String>> {
     // Each `op://` ref pins its own account at read time
     // (`OpRef::account`), so the runner carries no instance-level account.
-    let runner = OpCli::new();
+    let runner = OpCli::new_launch_env();
     resolve_operator_env_with(config, role_selector, workspace_name, &runner, |name| {
         std::env::var(name)
     })
@@ -396,7 +396,7 @@ pub fn resolve_operator_env_matching<F>(
 where
     F: Fn(&str) -> bool,
 {
-    let runner = OpCli::new();
+    let runner = OpCli::new_launch_env();
     resolve_operator_env_with_matching(
         config,
         role_selector,

--- a/docs/content/docs/(public)/guides/environment-variables.mdx
+++ b/docs/content/docs/(public)/guides/environment-variables.mdx
@@ -137,7 +137,9 @@ COLORTERM=truecolor
    jackin config env set ANTHROPIC_API_KEY "op://Personal/Anthropic/key"
    ```
 
-Each `jackin load` that references `op://...` values shells out to `op read <ref>` per key. `op` failures (missing item, expired session, binary not on PATH) are reported in a single message that names every failing key. Each `op` invocation has a 30-second timeout.
+Each `jackin load` that references `op://...` values shells out to `op read <ref>` per key. 1Password values are resolved concurrently, and `op` failures (missing item, expired session, binary not on PATH) are reported in a single message that names every failing key. Each launch-time `op` invocation has a 120-second timeout so cold 1Password app and daemon wakeups can finish without turning into false credential failures.
+
+Prefer references picked through the 1Password picker in jackin❯ or otherwise backed by 1Password IDs. The 1Password CLI can resolve human-readable vault and item names, but ID-backed references are the stable and efficient form for launch-time automation. jackin❯ does not persist resolved secret values; it stores the reference metadata and asks `op` again when the value is needed.
 
 ## Launch diagnostic
 

--- a/docs/content/docs/reference/developer-reference/specs/runtime-launch.mdx
+++ b/docs/content/docs/reference/developer-reference/specs/runtime-launch.mdx
@@ -33,6 +33,7 @@ load_role (public API)
 | INV-4 | Foreground-attach finalization runs before teardown classification — isolated worktrees are finalized before deciding whether to preserve or clean the container | `finalize_foreground_session` happens before the `inspect_container_state(...)` cleanup match |
 | INV-5 | Cleanup classification preserves restartable sessions and tears down clean exits | `Running` / crash paths disarm cleanup; clean-exit path runs cleanup |
 | INV-6 | `render_exit` runs on both success and error exits from `load_role_with` | both `Ok(_)` and `Err(error)` arms call `render_exit` |
+| INV-7 | Operator `op://` env refs resolve concurrently with a bounded launch budget — 1Password app/daemon wakeups must not serialize the foreground path, and a wedged `op` must still fail instead of blocking forever | `resolve_operator_env` uses the launch-env `OpCli` budget and `resolve_operator_env_with_matching` spawns one resolver worker per included key |
 
 ## Test seams
 


### PR DESCRIPTION
## Summary

This PR widens the launch-time 1Password read budget for operator env vars so cold 1Password app and daemon wakeups stop failing at the previous 30-second threshold. Operators with multiple `op://` credentials keep the existing concurrent resolution path, but each `op read` now has enough bounded time to complete when 1Password is slow rather than broken.

## What ships

- Launch-time operator env resolution now uses a dedicated 120-second 1Password CLI budget, leaving quick probes and fully interactive token flows on their existing budgets.
- Operator `op://` env refs continue resolving concurrently, so multiple secrets overlap instead of serializing startup.
- The Environment Variables guide now documents concurrent resolution, the 120-second launch timeout, ID-backed 1Password references, and the rule that resolved secret values are not persisted.
- The runtime launch behavioral spec now records the concurrent bounded 1Password resolution invariant so future launch refactors keep the reliability contract.

## Behavior changes

- A launch that previously failed after 30 seconds while 1Password was still waking up can now wait up to 120 seconds per `op read` before reporting a bounded credential-resolution error.
- The change does not add a persistent secret cache, does not disable the 1Password CLI cache, and does not change account selectors stored in config.

## What this addresses

- Local measurement showed valid `op read` calls taking `29s` cold and canonical UUID reads varying up to about `20.7s`; all-four sequential batches ranged from `16.2s` to `72.9s`, while existing diagnostics showed all four launch reads timing out together at about `30.0s`.
- Official 1Password docs confirm IDs are the faster and more stable reference form, account selection should be explicit for multi-account scripts, and the CLI already has an encrypted in-memory daemon cache enabled by default on Unix-like systems.
- The root cause was not missing parallelism or missing secret caching. The architecture already resolved env refs in parallel and already stored canonical references, but the default 30-second subprocess budget was reused for foreground launch reads whose real dependency can legitimately exceed that threshold.

## Not included

- No persistent cache of resolved secret values. jackin❯ continues storing references and re-asking `op` when a value is needed.
- No account selector migration. Measurements did not prove that replacing the stored account selector with the 1Password USER ID improves the all-ref launch case.
- No workaround for 1Password named-reference lookup variance beyond documenting ID-backed references as the preferred automation form.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 709
cd "$(jackin-dev pr path 709)/jackin"
source "$(jackin-dev pr path 709)/env.sh"
which jackin
```

### Static checks

```sh
cargo fmt --check
cargo check -p jackin-env
```

### Rust tests

```sh
cargo test -p jackin-env
```

The package tests cover operator env concurrency, on-demand filtering, and the new launch-env timeout constructor.

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  bun run check:repo-links
  bun run check:roadmap-sidebar
  bunx tsc --noEmit
  bun test
)
```

### Documentation

```sh
(
  cd docs
  bun run dev -- --host 127.0.0.1
)
```

**http://localhost:3000/guides/environment-variables/**  
Confirm the 1Password CLI setup section describes concurrent `op://` resolution, the 120-second launch timeout, ID-backed references, and no persistence of resolved secret values.

**http://localhost:3000/reference/developer-reference/specs/runtime-launch/**  
Confirm the behavioral invariants table includes the bounded concurrent operator `op://` env resolution invariant.

### User smoke

```sh
jackin load the-architect . --debug
```

Expected: with operator env containing valid `op://` refs, launch no longer fails at the old 30-second threshold while 1Password is still resolving. If 1Password is genuinely wedged, the launch still fails with a bounded 120-second `op read` timeout naming the failing env key.

## Migration notes

None.
