### PR TITLE
fix(ci): split docs deploy verification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -264,6 +264,8 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      page-url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: read
       pages: write
@@ -279,6 +281,17 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
+  verify-deployed:
+    needs: deploy
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       # Build a sitemap URL that is robust against future
       # actions/deploy-pages versions changing whether `page_url`
       # carries a trailing slash. The current contract has one, but
@@ -288,7 +301,7 @@ jobs:
         id: sitemap
         shell: bash
         env:
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          PAGE_URL: ${{ needs.deploy.outputs.page-url }}
         run: |
           set -euo pipefail
           echo "url=${PAGE_URL%/}/sitemap.xml" >> "$GITHUB_OUTPUT"
@@ -328,7 +341,7 @@ jobs:
   # one-job aggregator on schedule has no value.
   docs-required:
     if: always() && github.event_name != 'schedule'
-    needs: [changes, repo-link-check, docs-link-check, spell-check-docs, spell-check-source, deploy, check-deployed]
+    needs: [changes, repo-link-check, docs-link-check, spell-check-docs, spell-check-source, deploy, verify-deployed, check-deployed]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

This PR fixes the Docs workflow deployment gate so GitHub Pages publishing and deployed-site link verification no longer share one timeout budget. Maintainers get a more accurate `docs-required` result on `main`: a recovered deployed-link retry no longer turns into a cancelled deployment job because Pages queue time consumed most of the combined job timer.

## What ships

- The Docs workflow keeps GitHub Pages publishing in `deploy` and moves live deployed-site verification into a separate `verify-deployed` job.
- `deploy` exposes the page URL as a job output, and `verify-deployed` uses that URL to run the same post-deploy link contract as before.
- `docs-required` gates `deploy`, `verify-deployed`, and the existing checks, so branch protection still observes one stable required check name.

## Behavior changes

- A slow Pages deployment queue no longer steals time from deployed-link verification; each phase has its own 10-minute job budget.
- If publishing succeeds but deployed-link verification fails, `docs-required` still fails through the new `verify-deployed` dependency.

## What this addresses

- The July 2, 2026 Docs run for commit `1842a09683a250c38a90bedab5ddc26dc66ccc35` went red because `deploy` timed out after Pages queued for about 6m33s and lychee needed a retry after a transient 503. The second lychee attempt found `0 Errors`, but GitHub cancelled the job at the shared 10-minute timeout and `docs-required` treated that cancellation as a failure.
- The root workflow issue was combining publish latency and verification latency inside one job timeout, so a transient external delay could report as a failed required check after the underlying verification had already recovered.

## Not included

- This PR does not relax the aggregator: cancelled or failed gated jobs still fail `docs-required`.
- This PR does not let feature branches publish GitHub Pages; the deploy path remains gated to `push` or `workflow_dispatch` on `main`.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 711
cd "$(jackin-dev pr path 711)/jackin"
source "$(jackin-dev pr path 711)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it. After `source "$(jackin-dev pr path 711)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only when the PR requires a local capsule, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.

### Static checks

```sh
actionlint .github/workflows/docs.yml
git diff --check
```

Expected: the Docs workflow passes local syntax validation and the patch has no whitespace errors.

### GitHub Actions smoke

```sh
gh workflow run Docs --ref fix/docs-deploy-timeout
gh run list --workflow Docs --branch fix/docs-deploy-timeout --limit 1
```

Expected: manual dispatch starts successfully from the PR branch. The publishing jobs remain `main`-gated by design, so this smoke validates the dispatchable workflow shape without publishing GitHub Pages from a feature branch.

## Migration notes

None.

