### PR TITLE
fix(ci): retry pages deploy handoff

### DIFF
--- a/.github/actions/check-deployed-docs/action.yml
+++ b/.github/actions/check-deployed-docs/action.yml
@@ -2,9 +2,10 @@ name: Check deployed docs links
 description: |
   Dump the live sitemap into a URL list, and run a lychee link check
   against that list with the standard remap rules for github.com
-  edit/blob URLs. Used by docs.yml's `deploy` job (after publishing to
-  GitHub Pages) and `check-deployed` job (scheduled live validation) to
-  keep a single source of truth for the deployed link-check contract.
+  edit/blob URLs. Used by docs.yml's `verify-deployed` job (after
+  publishing to GitHub Pages) and `check-deployed` job (scheduled live
+  validation) to keep a single source of truth for the deployed
+  link-check contract.
   No lychee cache is restored here — deployed checks always hit live
   URLs so that stale 503s from a previous run never poison the results.
 inputs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -249,26 +249,65 @@ jobs:
   deploy:
     # docs-link-check covers full-site lychee + docs build; repo-link-check
     # covers <RepoFile /> path validity. Both must pass before publishing.
+    #
+    # GitHub Pages can report a terminal `deployment_failed` for a valid
+    # artifact, then accept the same artifact/SHA on the next deployment.
+    # Keep retries scoped to that opaque Pages handoff instead of rerunning
+    # the whole workflow or retrying source/build/link validation.
     needs: [docs-link-check, repo-link-check]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     outputs:
-      page-url: ${{ steps.deployment.outputs.page_url }}
+      page-url: ${{ steps.deploy1.outputs.page_url || steps.deploy2.outputs.page_url || steps.deploy3.outputs.page_url }}
     permissions:
       contents: read
       pages: write
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy1.outputs.page_url || steps.deploy2.outputs.page_url || steps.deploy3.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Deploy to GitHub Pages
-        id: deployment
+        id: deploy1
+        continue-on-error: true
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+
+      - name: Back off before Pages deploy retry 2
+        if: steps.deploy1.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::notice::GitHub Pages deployment failed on attempt 1; retrying after 30 seconds"
+          sleep 30
+
+      - name: Deploy to GitHub Pages (retry 2)
+        id: deploy2
+        if: steps.deploy1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+
+      - name: Back off before Pages deploy retry 3
+        if: steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::notice::GitHub Pages deployment failed on attempt 2; retrying after 60 seconds"
+          sleep 60
+
+      - name: Deploy to GitHub Pages (retry 3)
+        id: deploy3
+        if: steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+
+      - name: Require Pages deployment success
+        if: steps.deploy1.outcome != 'success' && steps.deploy2.outcome != 'success' && steps.deploy3.outcome != 'success'
+        shell: bash
+        run: |
+          echo "::error::GitHub Pages deployment failed after 3 attempts"
+          exit 1
 
   verify-deployed:
     needs: deploy


### PR DESCRIPTION
## Summary

This PR makes the Docs workflow resilient at the exact GitHub Pages publish boundary that failed after PR #664 merged to `main`. Source classification, docs build, repository-link validation, spell checks, artifact upload, and deployed-site verification stay strict; only the opaque Pages deployment handoff gets bounded retries.

## What ships

- The `deploy` job now runs up to three `actions/deploy-pages` attempts with short backoff notices.
- The job output and environment URL resolve from whichever deploy attempt succeeds, so `verify-deployed` keeps consuming the published page URL normally.
- The deploy job timeout now covers three bounded Pages attempts instead of timing out after the first full deploy-pages timeout.
- The deployed-link composite action description now names the current `verify-deployed` caller.

## Behavior changes

- A transient GitHub Pages `deployment_failed` result for an otherwise valid artifact no longer requires a human to rerun failed jobs manually.
- Source, build, link, content, and live deployed-site failures still fail the Docs workflow through `docs-required`.

## What this addresses

- The July 2, 2026 Docs run for commit `46511939da0439a14575bde4903f608e4bbb8966` created a Pages deployment for a valid uploaded artifact, stayed queued, moved to `syncing_files`, then failed with `Deployment failed, try again later.` The same artifact and SHA succeeded on rerun.
- The architecture allowed a single provider-side deploy transient to escape as a required `main` failure because the workflow treated the Pages handoff as a single-shot operation.

## Not included

- This PR does not rerun whole workflows or whole jobs automatically.
- This PR does not relax `docs-required`; all gated job failures still fail the aggregate check.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 712
cd "$(jackin-dev pr path 712)/jackin"
source "$(jackin-dev pr path 712)/env.sh"
which jackin
```

### Static checks

```sh
actionlint .github/workflows/docs.yml
git diff --check
```

Expected: the Docs workflow passes local syntax validation and the patch has no whitespace errors.

## Migration notes

None.

