### PR TITLE
refactor(tui): unify shared component API

### DIFF
--- a/crates/jackin-capsule/src/tui/components/dialog_widgets.rs
+++ b/crates/jackin-capsule/src/tui/components/dialog_widgets.rs
@@ -531,10 +531,12 @@ fn render_usage_info(
         .iter()
         .map(|(label, active)| (label.as_str(), *active))
         .collect::<Vec<_>>();
-    TabStrip::new(&tab_refs)
-        .focused(tab_bar_focused)
-        .hovered(hovered_tab)
-        .render(frame, tab_area);
+    frame.render_widget(
+        TabStrip::new(&tab_refs)
+            .focused(tab_bar_focused)
+            .hovered(hovered_tab),
+        tab_area,
+    );
     // Body geometry comes from the shared `usage_body_rect`, the same source the
     // scroll-bound path uses, so the rendered viewport and the scroll clamp can
     // never disagree (Bug 2). (`usage_tab_strip_area` above gives the strip its

--- a/crates/jackin-console/src/tui/components/confirm_save.rs
+++ b/crates/jackin-console/src/tui/components/confirm_save.rs
@@ -173,9 +173,10 @@ pub fn render<M: Clone>(frame: &mut Frame<'_>, area: Rect, state: &ConfirmSaveSt
         ConfirmSaveFocus::Save => 0,
         ConfirmSaveFocus::Cancel => 1,
     };
-    jackin_tui::components::ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, chunks[3]);
+    frame.render_widget(
+        jackin_tui::components::ButtonStrip::new(&items).focused(focused),
+        chunks[3],
+    );
 }
 
 #[cfg(test)]

--- a/crates/jackin-console/src/tui/components/editor_rows.rs
+++ b/crates/jackin-console/src/tui/components/editor_rows.rs
@@ -109,10 +109,12 @@ pub fn render_tab_strip(
     tab_bar_focused: bool,
     hovered: Option<usize>,
 ) {
-    jackin_tui::components::TabStrip::new(labels)
-        .focused(tab_bar_focused)
-        .hovered(hovered)
-        .render(frame, area);
+    frame.render_widget(
+        jackin_tui::components::TabStrip::new(labels)
+            .focused(tab_bar_focused)
+            .hovered(hovered),
+        area,
+    );
 }
 
 /// `OpRef` rows skip masking and render as a breadcrumb (3-segment:

--- a/crates/jackin-console/src/tui/components/file_browser/render.rs
+++ b/crates/jackin-console/src/tui/components/file_browser/render.rs
@@ -142,7 +142,7 @@ fn render_listing(frame: &mut Frame<'_>, area: Rect, state: &FileBrowserState) {
         .highlight_symbol(cursor_symbol)
         .offset(offset)
         .selected(selected);
-    list.render_with_block(frame.buffer_mut(), area, block);
+    list.render_with_block(area, frame.buffer_mut(), block);
 }
 
 #[cfg(test)]

--- a/crates/jackin-console/src/tui/components/file_browser/render.rs
+++ b/crates/jackin-console/src/tui/components/file_browser/render.rs
@@ -91,7 +91,7 @@ fn render_listing(frame: &mut Frame<'_>, area: Rect, state: &FileBrowserState) {
     // a background modal and must use the inactive border so exactly one bright
     // border is visible (Defect 9 — one-bright-border rule).
     let block = if state.pending_git_prompt.is_some() {
-        jackin_tui::components::modal_block_inactive()
+        jackin_tui::components::unfocused_block()
             .title(Span::styled(title.clone(), jackin_tui::theme::BOLD_WHITE))
     } else {
         Panel::new()

--- a/crates/jackin-console/src/tui/components/mount_dst_choice.rs
+++ b/crates/jackin-console/src/tui/components/mount_dst_choice.rs
@@ -134,9 +134,10 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, state: &MountDstChoiceState) {
         MountDstFocus::Edit => 1,
         MountDstFocus::Cancel => 2,
     };
-    jackin_tui::components::ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, chunks[4]);
+    frame.render_widget(
+        jackin_tui::components::ButtonStrip::new(&items).focused(focused),
+        chunks[4],
+    );
 }
 
 #[cfg(test)]

--- a/crates/jackin-console/src/tui/components/scope_picker.rs
+++ b/crates/jackin-console/src/tui/components/scope_picker.rs
@@ -90,9 +90,10 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, state: &ScopePickerState) {
         ScopeChoice::AllAgents => 0,
         ScopeChoice::SpecificAgent => 1,
     };
-    jackin_tui::components::ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, chunks[1]);
+    frame.render_widget(
+        jackin_tui::components::ButtonStrip::new(&items).focused(focused),
+        chunks[1],
+    );
 }
 
 #[cfg(test)]

--- a/crates/jackin-console/src/tui/components/source_picker.rs
+++ b/crates/jackin-console/src/tui/components/source_picker.rs
@@ -103,9 +103,10 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, state: &SourcePickerState) {
         SourceChoice::Plain => 0,
         SourceChoice::Op => 1,
     };
-    jackin_tui::components::ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, chunks[1]);
+    frame.render_widget(
+        jackin_tui::components::ButtonStrip::new(&items).focused(focused),
+        chunks[1],
+    );
 
     if !state.op_available {
         frame.render_widget(

--- a/crates/jackin-console/src/tui/input/dispatch.rs
+++ b/crates/jackin-console/src/tui/input/dispatch.rs
@@ -213,7 +213,7 @@ pub fn handle_key(
         let ManagerStage::Settings(settings) = &mut state.stage else {
             return Ok(InputOutcome::Continue);
         };
-        let dismiss = settings.error_popup.as_ref().is_some_and(|p| {
+        let dismiss = settings.error_popup.as_mut().is_some_and(|p| {
             matches!(
                 dismissible_modal_plan(p.handle_key(key)),
                 DismissibleModalPlan::Dismiss

--- a/crates/jackin-console/src/tui/input/list.rs
+++ b/crates/jackin-console/src/tui/input/list.rs
@@ -577,7 +577,8 @@ pub fn handle_list_modal(state: &mut ManagerState<'_>, key: KeyEvent) -> InputOu
                 return InputOutcome::Continue;
             }
             let outcome = if let Some(rect) = container_info_rect {
-                info.handle_key_in_rect(key, rect)
+                info.set_viewport(rect);
+                info.handle_key(key)
             } else {
                 info.handle_key(key)
             };

--- a/crates/jackin-console/src/tui/screens/workspaces/view.rs
+++ b/crates/jackin-console/src/tui/screens/workspaces/view.rs
@@ -827,7 +827,7 @@ pub fn render_picker_sidebar(
         .selected(selected)
         .highlight_spacing(ratatui::widgets::HighlightSpacing::Always);
     list = list.highlight_symbol(if focused { "▸ " } else { "  " });
-    list.render(frame.buffer_mut(), inner);
+    frame.render_widget(list, inner);
 }
 
 pub fn render_provider_picker_sidebar(

--- a/crates/jackin-launch-tui/src/tui/run.rs
+++ b/crates/jackin-launch-tui/src/tui/run.rs
@@ -234,7 +234,7 @@ fn update_forced_select(picker: &mut SelectListState, msg: SelectLoopMessage) ->
     }
 }
 
-fn update_error_prompt(state: &ErrorPopupState, msg: ErrorPromptMessage) -> Option<()> {
+fn update_error_prompt(state: &mut ErrorPopupState, msg: ErrorPromptMessage) -> Option<()> {
     match msg {
         ErrorPromptMessage::Key(key) => match state.handle_key(key) {
             ModalOutcome::Cancel => Some(()),
@@ -612,13 +612,13 @@ impl RichRenderer {
                   through the modal dispatch. The modal nesting is the protocol."
     )]
     fn error_popup_loop(&mut self, title: &str, message: &str) -> anyhow::Result<()> {
-        let state = ErrorPopupState::new(title, message);
+        let mut state = ErrorPopupState::new(title, message);
         loop {
             self.terminal
                 .draw(|frame| draw_error_popup(frame, &state))
                 .context("rendering launch error popup")?;
             if update_error_prompt(
-                &state,
+                &mut state,
                 ErrorPromptMessage::Key(read_pressed_key(
                     &self.input,
                     "reading error popup input",
@@ -941,7 +941,7 @@ impl RichRenderer {
                         }
                     };
                 }
-                KeyCode::Up => match focus {
+                KeyCode::Up | KeyCode::Char('k' | 'K') => match focus {
                     InspFocus::Repos => {
                         wt_sel = wt_sel.saturating_sub(1);
                         file_sel = 0;
@@ -955,12 +955,12 @@ impl RichRenderer {
                     }
                     InspFocus::Diff => {
                         if let Some(d) = diff_state.as_mut() {
-                            d.scroll_up();
+                            drop(d.handle_key(key));
                             diff_scroll_y = d.scroll_y();
                         }
                     }
                 },
-                KeyCode::Down => match focus {
+                KeyCode::Down | KeyCode::Char('j' | 'J') => match focus {
                     InspFocus::Repos => {
                         if wt_sel + 1 < worktrees.len() {
                             wt_sel += 1;
@@ -979,20 +979,20 @@ impl RichRenderer {
                     }
                     InspFocus::Diff => {
                         if let Some(d) = diff_state.as_mut() {
-                            d.scroll_down();
+                            drop(d.handle_key(key));
                             diff_scroll_y = d.scroll_y();
                         }
                     }
                 },
                 KeyCode::PageUp => {
                     if let Some(d) = diff_state.as_mut() {
-                        d.page_up(20);
+                        drop(d.handle_key(key));
                         diff_scroll_y = d.scroll_y();
                     }
                 }
                 KeyCode::PageDown => {
                     if let Some(d) = diff_state.as_mut() {
-                        d.page_down(20);
+                        drop(d.handle_key(key));
                         diff_scroll_y = d.scroll_y();
                     }
                 }

--- a/crates/jackin-launch-tui/src/tui/run/tests.rs
+++ b/crates/jackin-launch-tui/src/tui/run/tests.rs
@@ -135,10 +135,10 @@ fn prompt_context_lines_maps_semantic_styles() {
 
 #[test]
 fn error_prompt_message_acknowledges_enter() {
-    let state = ErrorPopupState::new("Failed", "nope");
+    let mut state = ErrorPopupState::new("Failed", "nope");
 
     let result = update_error_prompt(
-        &state,
+        &mut state,
         ErrorPromptMessage::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
     );
 
@@ -147,10 +147,10 @@ fn error_prompt_message_acknowledges_enter() {
 
 #[test]
 fn error_prompt_message_ignores_navigation() {
-    let state = ErrorPopupState::new("Failed", "nope");
+    let mut state = ErrorPopupState::new("Failed", "nope");
 
     let result = update_error_prompt(
-        &state,
+        &mut state,
         ErrorPromptMessage::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
     );
 

--- a/crates/jackin-tui-lookbook/src/interactors.rs
+++ b/crates/jackin-tui-lookbook/src/interactors.rs
@@ -98,10 +98,7 @@ impl TabStripInteractor {
 
 impl StoryInteraction for TabStripInteractor {
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        TabStrip::new(&self.labels)
-            .focused(true)
-            .hovered(self.hovered)
-            .render(frame, area);
+        frame.render_widget(TabStrip::new(&self.labels).focused(true).hovered(self.hovered), area);
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {
@@ -449,9 +446,7 @@ impl StoryInteraction for ButtonStripInteractor {
             Constraint::Fill(1),
         ])
         .areas(area);
-        ButtonStrip::new(&self.items)
-            .focused(self.focused)
-            .render(frame, strip_area);
+        frame.render_widget(ButtonStrip::new(&self.items).focused(self.focused), strip_area);
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {

--- a/crates/jackin-tui-lookbook/src/interactors.rs
+++ b/crates/jackin-tui-lookbook/src/interactors.rs
@@ -5,9 +5,9 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, MouseButton, MouseEvent, MouseEventKind};
 use jackin_tui::components::{
-    ButtonStrip, ButtonStripItem, ConfirmState, SaveDiscardState, SelectList, SelectListState,
-    TabStrip, TextInput, TextInputState, render_confirm_dialog, render_save_discard_dialog,
-    render_scrollable_block,
+    ButtonStrip, ButtonStripItem, ConfirmState, SaveDiscardState, SelectListState, TabStrip,
+    TextInputState, render_confirm_dialog, render_save_discard_dialog, render_scrollable_block,
+    render_select_list, render_text_input,
 };
 use jackin_tui::{
     lay_out_tabs,
@@ -98,7 +98,12 @@ impl TabStripInteractor {
 
 impl StoryInteraction for TabStripInteractor {
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        frame.render_widget(TabStrip::new(&self.labels).focused(true).hovered(self.hovered), area);
+        frame.render_widget(
+            TabStrip::new(&self.labels)
+                .focused(true)
+                .hovered(self.hovered),
+            area,
+        );
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {
@@ -178,10 +183,7 @@ impl SelectListInteractor {
 
 impl StoryInteraction for SelectListInteractor {
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        frame.render_widget(
-            SelectList::new(&self.state, "Choose agent").context(&self.context),
-            area,
-        );
+        render_select_list(frame, area, &self.state, "Choose agent", &self.context);
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {
@@ -398,7 +400,7 @@ impl TextInputInteractor {
 
 impl StoryInteraction for TextInputInteractor {
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        frame.render_widget(TextInput::new(&self.state), area);
+        render_text_input(frame, area, &self.state);
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {
@@ -446,7 +448,10 @@ impl StoryInteraction for ButtonStripInteractor {
             Constraint::Fill(1),
         ])
         .areas(area);
-        frame.render_widget(ButtonStrip::new(&self.items).focused(self.focused), strip_area);
+        frame.render_widget(
+            ButtonStrip::new(&self.items).focused(self.focused),
+            strip_area,
+        );
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> bool {

--- a/crates/jackin-tui-lookbook/src/stories.rs
+++ b/crates/jackin-tui-lookbook/src/stories.rs
@@ -411,10 +411,7 @@ fn story_tab_strip(frame: &mut Frame<'_>, area: Rect) {
         ("Roles", false),
         ("Secrets", false),
     ];
-    frame.render_widget(
-        TabStrip::new(&labels).focused(true).hovered(Some(2)),
-        area,
-    );
+    frame.render_widget(TabStrip::new(&labels).focused(true).hovered(Some(2)), area);
 }
 
 fn story_confirm_default(frame: &mut Frame<'_>, area: Rect) {

--- a/crates/jackin-tui-lookbook/src/stories.rs
+++ b/crates/jackin-tui-lookbook/src/stories.rs
@@ -401,9 +401,7 @@ fn story_button_strip(frame: &mut Frame<'_>, area: Rect) {
         Constraint::Fill(1),
     ])
     .areas(area);
-    ButtonStrip::new(&items)
-        .focused(0)
-        .render(frame, strip_area);
+    frame.render_widget(ButtonStrip::new(&items).focused(0), strip_area);
 }
 
 fn story_tab_strip(frame: &mut Frame<'_>, area: Rect) {
@@ -413,10 +411,10 @@ fn story_tab_strip(frame: &mut Frame<'_>, area: Rect) {
         ("Roles", false),
         ("Secrets", false),
     ];
-    TabStrip::new(&labels)
-        .focused(true)
-        .hovered(Some(2))
-        .render(frame, area);
+    frame.render_widget(
+        TabStrip::new(&labels).focused(true).hovered(Some(2)),
+        area,
+    );
 }
 
 fn story_confirm_default(frame: &mut Frame<'_>, area: Rect) {
@@ -705,9 +703,7 @@ fn story_button_strip_all_disabled(frame: &mut Frame<'_>, area: Rect) {
         Constraint::Fill(1),
     ])
     .areas(area);
-    ButtonStrip::new(&items)
-        .focused(0)
-        .render(frame, strip_area);
+    frame.render_widget(ButtonStrip::new(&items).focused(0), strip_area);
 }
 
 fn story_save_discard_focus_save(frame: &mut Frame<'_>, area: Rect) {

--- a/crates/jackin-tui/src/components.rs
+++ b/crates/jackin-tui/src/components.rs
@@ -63,9 +63,7 @@ pub use hint_bar::{
 pub use hover_tracker::HoverTracker;
 pub use modal_backdrop::ModalBackdrop;
 pub use modal_lifecycle::{ModalClickResult, classify_click, render_backdrop};
-pub use panel::{
-    Panel, PanelFocus, modal_block, modal_block_inactive, panel_body_area, unfocused_block,
-};
+pub use panel::{Panel, PanelFocus, modal_block, panel_body_area, unfocused_block};
 pub use save_discard_dialog::{
     SAVE_DISCARD_KEYMAP, SaveDiscardAction, SaveDiscardChoice, SaveDiscardFocus, SaveDiscardState,
     render_save_discard_dialog, save_discard_hint_spans,

--- a/crates/jackin-tui/src/components.rs
+++ b/crates/jackin-tui/src/components.rs
@@ -80,8 +80,8 @@ pub use scrollable_panel::{
     vertical_scrollbar_area, viewport_height, viewport_width,
 };
 pub use select_list::{
-    PickerRow, SELECT_LIST_KEYMAP, SelectList, SelectListAction, SelectListState,
-    render_picker_lines, render_picker_list, render_select_list, select_list_hint_spans,
+    PickerRow, SELECT_LIST_KEYMAP, SelectListAction, SelectListState, render_picker_lines,
+    render_picker_list, render_select_list, select_list_hint_spans,
 };
 pub use status_footer::{
     StatusFooter, StatusFooterHover, StatusRightChunk, StatusRightGroup,
@@ -91,7 +91,7 @@ pub use status_footer::{
 pub use status_popup::{StatusPopupState, render_status_popup};
 pub use tab_strip::{TabStrip, tab_cell_style, tab_label_line, tab_underline_line};
 pub use text_input::{
-    BorderStyle, TEXT_INPUT_KEYMAP, TextField, TextInput, TextInputAction, TextInputState,
+    BorderStyle, TEXT_INPUT_KEYMAP, TextField, TextInputAction, TextInputState,
     render_labeled_text_input_dialog, render_text_input, text_input_hint_spans,
     text_input_prompt_rect,
 };

--- a/crates/jackin-tui/src/components/button_strip.rs
+++ b/crates/jackin-tui/src/components/button_strip.rs
@@ -1,11 +1,11 @@
 //! Shared centered button row.
 
 use ratatui::{
-    Frame,
+    buffer::Buffer,
     layout::{Alignment, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Widget},
 };
 
 use crate::theme::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
@@ -63,16 +63,17 @@ impl<'a> ButtonStrip<'a> {
         self
     }
 
-    pub fn render(self, frame: &mut Frame<'_>, area: Rect) {
-        frame.render_widget(
-            Paragraph::new(self.line()).alignment(Alignment::Center),
-            area,
-        );
-    }
-
     #[must_use]
     pub fn line(self) -> Line<'static> {
         button_strip_line(self.items, self.focused, self.gap)
+    }
+}
+
+impl Widget for ButtonStrip<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(self.line())
+            .alignment(Alignment::Center)
+            .render(area, buf);
     }
 }
 

--- a/crates/jackin-tui/src/components/confirm_dialog.rs
+++ b/crates/jackin-tui/src/components/confirm_dialog.rs
@@ -404,9 +404,7 @@ fn render_buttons(frame: &mut Frame<'_>, area: Rect, state: &ConfirmState) {
         ConfirmFocus::Yes => 0,
         ConfirmFocus::No => 1,
     };
-    ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, area);
+    frame.render_widget(ButtonStrip::new(&items).focused(focused), area);
 }
 
 #[cfg(test)]

--- a/crates/jackin-tui/src/components/container_info.rs
+++ b/crates/jackin-tui/src/components/container_info.rs
@@ -180,6 +180,7 @@ pub struct ContainerInfoState {
     rows: Vec<ContainerInfoRow>,
     copied_row: Option<usize>,
     hovered_row: Option<usize>,
+    viewport: Option<Rect>,
     /// Scroll offsets for when the content overflows the dialog area. Shared
     /// with every other dialog through [`DialogBodyScroll`] so vertical and
     /// horizontal scroll behave identically everywhere.
@@ -194,6 +195,7 @@ impl ContainerInfoState {
             rows,
             copied_row: None,
             hovered_row: None,
+            viewport: None,
             scroll: DialogBodyScroll::new(),
         }
     }
@@ -213,7 +215,16 @@ impl ContainerInfoState {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<()> {
-        // Viewport is unknown here; pass 0 so the key is accepted and the
+        if let Some(dialog_rect) = self.viewport {
+            let content_height = self.content_height();
+            let content_width = self.content_width();
+            let axes =
+                crate::components::dialog_scroll_axes(content_width, content_height, dialog_rect);
+            let viewport_width = usize::from(dialog_rect.width.saturating_sub(2));
+            let viewport_height = usize::from(dialog_rect.height.saturating_sub(2));
+            return self.handle_scroll_key(key, viewport_height, viewport_width, axes);
+        }
+        // Viewport is unknown here; pass 0 so the key is accepted and the next
         // render-time clamp settles the final offset, and advertise both axes.
         self.handle_scroll_key(
             key,
@@ -226,14 +237,8 @@ impl ContainerInfoState {
         )
     }
 
-    pub fn handle_key_in_rect(&mut self, key: KeyEvent, dialog_rect: Rect) -> ModalOutcome<()> {
-        let content_height = self.content_height();
-        let content_width = self.content_width();
-        let axes =
-            crate::components::dialog_scroll_axes(content_width, content_height, dialog_rect);
-        let viewport_width = usize::from(dialog_rect.width.saturating_sub(2));
-        let viewport_height = usize::from(dialog_rect.height.saturating_sub(2));
-        self.handle_scroll_key(key, viewport_height, viewport_width, axes)
+    pub fn set_viewport(&mut self, dialog_rect: Rect) {
+        self.viewport = Some(dialog_rect);
     }
 
     /// Shared Esc/q dismiss + scroll-key dispatch for the Debug-info dialog. The

--- a/crates/jackin-tui/src/components/diff_view.rs
+++ b/crates/jackin-tui/src/components/diff_view.rs
@@ -3,6 +3,7 @@
 //! Two modes: side-by-side (modified files, before │ after) and single-pane
 //! (added / untracked / deleted). Uses `similar::TextDiff` for hunk computation.
 
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -200,6 +201,29 @@ impl DiffViewState {
         let max = self.total_rows().saturating_sub(1) as u16;
         let step = (viewport_height / 2).max(1);
         self.scroll_y = self.scroll_y.saturating_add(step).min(max);
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> crate::ModalOutcome<()> {
+        match key.code {
+            KeyCode::Esc => crate::ModalOutcome::Cancel,
+            KeyCode::Up | KeyCode::Char('k' | 'K') => {
+                self.scroll_up();
+                crate::ModalOutcome::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j' | 'J') => {
+                self.scroll_down();
+                crate::ModalOutcome::Continue
+            }
+            KeyCode::PageUp => {
+                self.page_up(20);
+                crate::ModalOutcome::Continue
+            }
+            KeyCode::PageDown => {
+                self.page_down(20);
+                crate::ModalOutcome::Continue
+            }
+            _ => crate::ModalOutcome::Continue,
+        }
     }
 }
 

--- a/crates/jackin-tui/src/components/diff_view/tests.rs
+++ b/crates/jackin-tui/src/components/diff_view/tests.rs
@@ -1,4 +1,5 @@
 use super::{DiffViewState, SinglePaneKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 #[test]
 fn side_by_side_empty_before() {
@@ -35,4 +36,24 @@ fn scroll_clamps() {
     assert_eq!(state.scroll_y, 2); // clamped to total_rows - 1
     state.scroll_up();
     assert_eq!(state.scroll_y, 1);
+}
+
+#[test]
+fn handle_key_scrolls_and_cancels() {
+    let mut state = DiffViewState::single_pane("a\nb\nc\n", SinglePaneKind::Added, "f");
+
+    assert!(matches!(
+        state.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+        crate::ModalOutcome::Continue
+    ));
+    assert_eq!(state.scroll_y(), 1);
+    assert!(matches!(
+        state.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)),
+        crate::ModalOutcome::Continue
+    ));
+    assert_eq!(state.scroll_y(), 0);
+    assert!(matches!(
+        state.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+        crate::ModalOutcome::Cancel
+    ));
 }

--- a/crates/jackin-tui/src/components/error_dialog.rs
+++ b/crates/jackin-tui/src/components/error_dialog.rs
@@ -123,8 +123,7 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
         let len = line.chars().count().max(1);
         rows = rows.saturating_add(u32::try_from(len.div_ceil(width)).unwrap_or(u32::MAX));
     }
-    let result = u16::try_from(rows.max(1)).unwrap_or(u16::MAX);
-    result
+    u16::try_from(rows.max(1)).unwrap_or(u16::MAX)
 }
 
 #[must_use]

--- a/crates/jackin-tui/src/components/error_dialog.rs
+++ b/crates/jackin-tui/src/components/error_dialog.rs
@@ -1,7 +1,5 @@
 //! Single-button error dialog component.
 
-use std::cell::Cell;
-
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
@@ -52,7 +50,7 @@ pub fn error_popup_hint_spans() -> Vec<HintSpan<'static>> {
 pub struct ErrorPopupState {
     pub title: String,
     pub message: String,
-    cached_rows: Cell<Option<(u16, u16)>>,
+    cached_rows: Option<(u16, u16)>,
 }
 
 impl ErrorPopupState {
@@ -61,12 +59,12 @@ impl ErrorPopupState {
         Self {
             title: title.into(),
             message: message.into(),
-            cached_rows: Cell::new(None),
+            cached_rows: None,
         }
     }
 
     #[must_use]
-    pub fn handle_key(&self, key: KeyEvent) -> ModalOutcome<()> {
+    pub fn handle_key(&mut self, key: KeyEvent) -> ModalOutcome<()> {
         match ERROR_POPUP_KEYMAP.dispatch(KeyChord::from(key)) {
             Some(ErrorPopupAction::Dismiss) => ModalOutcome::Cancel,
             None => ModalOutcome::Continue,
@@ -114,7 +112,7 @@ fn render_error_dialog_buffer(area: Rect, buf: &mut Buffer, state: &ErrorPopupSt
 
 #[must_use]
 pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 {
-    if let Some((cached_width, rows)) = state.cached_rows.get()
+    if let Some((cached_width, rows)) = state.cached_rows
         && cached_width == inner_width
     {
         return rows;
@@ -126,7 +124,6 @@ pub fn estimated_message_rows(state: &ErrorPopupState, inner_width: u16) -> u16 
         rows = rows.saturating_add(u32::try_from(len.div_ceil(width)).unwrap_or(u32::MAX));
     }
     let result = u16::try_from(rows.max(1)).unwrap_or(u16::MAX);
-    state.cached_rows.set(Some((inner_width, result)));
     result
 }
 

--- a/crates/jackin-tui/src/components/error_dialog.rs
+++ b/crates/jackin-tui/src/components/error_dialog.rs
@@ -74,57 +74,42 @@ impl ErrorPopupState {
     }
 }
 
-#[derive(Debug)]
-pub struct ErrorDialog<'a> {
-    state: &'a ErrorPopupState,
-}
+fn render_error_dialog_buffer(area: Rect, buf: &mut Buffer, state: &ErrorPopupState) {
+    let title = format!(" {} ", state.title);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(DANGER_RED))
+        .title(Span::styled(title, crate::theme::DANGER));
+    let inner = block.inner(area);
+    Clear.render(area, buf);
+    block.render(area, buf);
 
-impl<'a> ErrorDialog<'a> {
-    #[must_use]
-    pub const fn new(state: &'a ErrorPopupState) -> Self {
-        Self { state }
-    }
-}
+    // Canonical dialog layout: leading spacer + body + spacer + button + trailing spacer.
+    let body_rows = estimated_message_rows(state, inner.width).min(inner.height.saturating_sub(4));
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),         // leading spacer
+            Constraint::Length(body_rows), // message body
+            Constraint::Length(1),         // spacer
+            Constraint::Length(1),         // OK button
+            Constraint::Length(1),         // trailing spacer
+        ])
+        .split(inner);
 
-impl Widget for ErrorDialog<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let title = format!(" {} ", self.state.title);
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(DANGER_RED))
-            .title(Span::styled(title, crate::theme::DANGER));
-        let inner = block.inner(area);
-        Clear.render(area, buf);
-        block.render(area, buf);
+    Paragraph::new(state.message.as_str())
+        .style(Style::default().fg(WHITE))
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: false })
+        .render(chunks[1], buf);
 
-        // Canonical dialog layout: leading spacer + body + spacer + button + trailing spacer.
-        let body_rows =
-            estimated_message_rows(self.state, inner.width).min(inner.height.saturating_sub(4));
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1),         // leading spacer
-                Constraint::Length(body_rows), // message body
-                Constraint::Length(1),         // spacer
-                Constraint::Length(1),         // OK button
-                Constraint::Length(1),         // trailing spacer
-            ])
-            .split(inner);
-
-        Paragraph::new(self.state.message.as_str())
-            .style(Style::default().fg(WHITE))
-            .alignment(Alignment::Center)
-            .wrap(Wrap { trim: false })
-            .render(chunks[1], buf);
-
-        let focused_style = Style::default()
-            .bg(WHITE)
-            .fg(Color::Black)
-            .add_modifier(Modifier::BOLD);
-        Paragraph::new(Line::from(Span::styled("  OK  ", focused_style)))
-            .alignment(Alignment::Center)
-            .render(chunks[3], buf);
-    }
+    let focused_style = Style::default()
+        .bg(WHITE)
+        .fg(Color::Black)
+        .add_modifier(Modifier::BOLD);
+    Paragraph::new(Line::from(Span::styled("  OK  ", focused_style)))
+        .alignment(Alignment::Center)
+        .render(chunks[3], buf);
 }
 
 #[must_use]
@@ -160,7 +145,7 @@ pub fn render_error_dialog(frame: &mut ratatui::Frame<'_>, area: Rect, state: &E
 }
 
 pub fn render_error_dialog_in(frame: &mut ratatui::Frame<'_>, area: Rect, state: &ErrorPopupState) {
-    frame.render_widget(ErrorDialog::new(state), area);
+    render_error_dialog_buffer(area, frame.buffer_mut(), state);
 }
 
 #[cfg(test)]

--- a/crates/jackin-tui/src/components/error_dialog/tests.rs
+++ b/crates/jackin-tui/src/components/error_dialog/tests.rs
@@ -14,7 +14,7 @@ fn key(code: KeyCode) -> KeyEvent {
 
 #[test]
 fn enter_dismisses() {
-    let state = ErrorPopupState::new("Save failed", "workspace already exists");
+    let mut state = ErrorPopupState::new("Save failed", "workspace already exists");
     assert!(matches!(
         state.handle_key(key(KeyCode::Enter)),
         ModalOutcome::Cancel
@@ -23,7 +23,7 @@ fn enter_dismisses() {
 
 #[test]
 fn esc_dismisses() {
-    let state = ErrorPopupState::new("Save failed", "workspace already exists");
+    let mut state = ErrorPopupState::new("Save failed", "workspace already exists");
     assert!(matches!(
         state.handle_key(key(KeyCode::Esc)),
         ModalOutcome::Cancel
@@ -32,7 +32,7 @@ fn esc_dismisses() {
 
 #[test]
 fn o_dismisses() {
-    let state = ErrorPopupState::new("Save failed", "workspace already exists");
+    let mut state = ErrorPopupState::new("Save failed", "workspace already exists");
     assert!(matches!(
         state.handle_key(key(KeyCode::Char('o'))),
         ModalOutcome::Cancel
@@ -41,7 +41,7 @@ fn o_dismisses() {
 
 #[test]
 fn unhandled_key_continues() {
-    let state = ErrorPopupState::new("Save failed", "workspace already exists");
+    let mut state = ErrorPopupState::new("Save failed", "workspace already exists");
     assert!(matches!(
         state.handle_key(key(KeyCode::Char('x'))),
         ModalOutcome::Continue

--- a/crates/jackin-tui/src/components/error_dialog/tests.rs
+++ b/crates/jackin-tui/src/components/error_dialog/tests.rs
@@ -75,7 +75,7 @@ fn render_single_line_message_is_visible() {
     let backend = TestBackend::new(area.width, area.height);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| frame.render_widget(ErrorDialog::new(&state), area))
+        .draw(|frame| render_error_dialog_in(frame, area, &state))
         .unwrap();
 
     let buffer = terminal.backend().buffer();
@@ -102,7 +102,7 @@ fn render_single_line_message_has_one_blank_row_before_ok() {
     let backend = TestBackend::new(area.width, area.height);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
-        .draw(|frame| frame.render_widget(ErrorDialog::new(&state), area))
+        .draw(|frame| render_error_dialog_in(frame, area, &state))
         .unwrap();
 
     let buffer = terminal.backend().buffer();

--- a/crates/jackin-tui/src/components/panel.rs
+++ b/crates/jackin-tui/src/components/panel.rs
@@ -109,21 +109,13 @@ pub fn modal_block<'a>() -> Block<'a> {
 ///
 /// Uses `PHOSPHOR_DARK`. For most cases, prefer `Panel::new().focus(PanelFocus::Unfocused).block()`
 /// which also handles titles. This helper is for untitled containers only.
+///
+/// Also use this for background modals in a dialog stack. Only the topmost
+/// dialog uses `modal_block()` (`PHOSPHOR_GREEN` border); every dialog beneath
+/// uses this helper (`PHOSPHOR_DARK` border), so exactly one `PHOSPHOR_GREEN`
+/// border is visible at a time.
 #[must_use]
 pub fn unfocused_block<'a>() -> Block<'a> {
-    Block::default()
-        .borders(Borders::ALL)
-        .border_style(PanelFocus::Unfocused.border_style())
-}
-
-/// A bordered `Block` for a **background** modal in a dialog stack.
-///
-/// When multiple dialogs are stacked, only the topmost dialog uses `modal_block()`
-/// (`PHOSPHOR_GREEN` border); every dialog beneath uses this helper (`PHOSPHOR_DARK`
-/// border). Exactly one `PHOSPHOR_GREEN` border is visible at a time, which satisfies
-/// the focus-visible one-bright-border rule.
-#[must_use]
-pub fn modal_block_inactive<'a>() -> Block<'a> {
     Block::default()
         .borders(Borders::ALL)
         .border_style(PanelFocus::Unfocused.border_style())

--- a/crates/jackin-tui/src/components/save_discard_dialog.rs
+++ b/crates/jackin-tui/src/components/save_discard_dialog.rs
@@ -182,9 +182,7 @@ pub fn render_save_discard_dialog(frame: &mut Frame<'_>, area: Rect, state: &Sav
         SaveDiscardFocus::Discard => 1,
         SaveDiscardFocus::Cancel => 2,
     };
-    ButtonStrip::new(&items)
-        .focused(focused)
-        .render(frame, chunks[3]);
+    frame.render_widget(ButtonStrip::new(&items).focused(focused), chunks[3]);
 }
 
 #[cfg(test)]

--- a/crates/jackin-tui/src/components/scrollable_panel.rs
+++ b/crates/jackin-tui/src/components/scrollable_panel.rs
@@ -344,11 +344,13 @@ pub fn render_selected_lines_in_area(
     let total = lines.len();
     let offset = cursor_follow_offset(selected.unwrap_or(0), total, viewport, 0);
     let items = lines.into_iter().map(ListItem::new).collect();
-    ScrollableList::new(items)
-        .highlight_spacing(HighlightSpacing::Always)
-        .offset(offset)
-        .selected(selected)
-        .render(frame.buffer_mut(), area);
+    frame.render_widget(
+        ScrollableList::new(items)
+            .highlight_spacing(HighlightSpacing::Always)
+            .offset(offset)
+            .selected(selected),
+        area,
+    );
 }
 
 /// Shared vertical list renderer for selectable rows.
@@ -437,7 +439,7 @@ impl<'a> ScrollableList<'a> {
         self
     }
 
-    pub fn render(self, buf: &mut Buffer, area: Rect) {
+    fn render_inner(self, area: Rect, buf: &mut Buffer) {
         let total = self.items.len();
         let viewport = usize::from(area.height);
         let offset = effective_offset(total, viewport, self.offset);
@@ -473,7 +475,7 @@ impl<'a> ScrollableList<'a> {
         }
     }
 
-    pub fn render_with_block(self, buf: &mut Buffer, area: Rect, block: Block<'a>) {
+    pub fn render_with_block(self, area: Rect, buf: &mut Buffer, block: Block<'a>) {
         let total = self.items.len();
         let inner = block.inner(area);
         let viewport = usize::from(inner.height);
@@ -501,6 +503,12 @@ impl<'a> ScrollableList<'a> {
             }
             .render(vertical_scrollbar_area(area), buf);
         }
+    }
+}
+
+impl Widget for ScrollableList<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.render_inner(area, buf);
     }
 }
 

--- a/crates/jackin-tui/src/components/select_list.rs
+++ b/crates/jackin-tui/src/components/select_list.rs
@@ -510,7 +510,7 @@ pub fn render_picker_list(
         .highlight_spacing(HighlightSpacing::Always)
         .offset(offset)
         .selected(selected)
-        .render(buf, area);
+        .render(area, buf);
 
     // Repaint section dividers edge-to-edge over the gutter the List reserved.
     let offset = usize::from(offset);

--- a/crates/jackin-tui/src/components/select_list.rs
+++ b/crates/jackin-tui/src/components/select_list.rs
@@ -249,143 +249,97 @@ impl SelectListState {
     }
 }
 
-#[derive(Debug)]
-pub struct SelectList<'a> {
-    state: &'a SelectListState,
-    title: &'a str,
-    context: &'a [Line<'a>],
-    empty_label: &'a str,
-}
+fn render_select_list_in(
+    area: Rect,
+    buf: &mut Buffer,
+    state: &SelectListState,
+    title: &str,
+    context: &[Line<'_>],
+) {
+    // SelectList is always a modal overlay — always the active container
+    // when visible. Use PHOSPHOR_GREEN border per the focus-visible rule.
+    // Build the title string first so the borrow lives long enough.
+    let title_str = format!(" {title} ");
+    let block = Panel::new()
+        .title(&title_str)
+        .focus(PanelFocus::Focused)
+        .block();
+    let inner = block.inner(area);
+    Clear.render(area, buf);
+    block.render(area, buf);
 
-impl<'a> SelectList<'a> {
-    #[must_use]
-    pub const fn new(state: &'a SelectListState, title: &'a str) -> Self {
-        Self {
-            state,
-            title,
-            context: &[],
-            empty_label: "no matches",
-        }
+    let mut constraints = vec![Constraint::Length(1), Constraint::Length(1)];
+    if !context.is_empty() {
+        constraints.push(Constraint::Length(
+            u16::try_from(context.len()).unwrap_or(u16::MAX),
+        ));
+        constraints.push(Constraint::Length(1));
+    }
+    constraints.push(Constraint::Min(1));
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+
+    FilterInput::new(&state.filter).render(rows[0], buf);
+
+    let Some(list_area) = rows.last().copied() else {
+        return;
+    };
+    if !context.is_empty() {
+        Paragraph::new(context.to_vec()).render(rows[2], buf);
     }
 
-    #[must_use]
-    pub const fn context(mut self, context: &'a [Line<'a>]) -> Self {
-        self.context = context;
-        self
-    }
-
-    /// Override the placeholder shown when the list has no items (empty or filtered-to-nothing).
-    #[must_use]
-    pub const fn empty_label(mut self, label: &'a str) -> Self {
-        self.empty_label = label;
-        self
-    }
-}
-
-impl Widget for SelectList<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        // SelectList is always a modal overlay — always the active container
-        // when visible. Use PHOSPHOR_GREEN border per the focus-visible rule.
-        // Build the title string first so the borrow lives long enough.
-        let title_str = format!(" {} ", self.title);
-        let block = Panel::new()
-            .title(&title_str)
-            .focus(PanelFocus::Focused)
-            .block();
-        let inner = block.inner(area);
-        Clear.render(area, buf);
-        block.render(area, buf);
-
-        let mut constraints = vec![Constraint::Length(1), Constraint::Length(1)];
-        if !self.context.is_empty() {
-            constraints.push(Constraint::Length(
-                u16::try_from(self.context.len()).unwrap_or(u16::MAX),
-            ));
-            constraints.push(Constraint::Length(1));
-        }
-        constraints.push(Constraint::Min(1));
-        let rows = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(constraints)
-            .split(inner);
-
-        FilterInput::new(&self.state.filter).render(rows[0], buf);
-
-        let Some(list_area) = rows.last().copied() else {
-            return;
-        };
-        if !self.context.is_empty() {
-            Paragraph::new(self.context.to_vec()).render(rows[2], buf);
-        }
-
-        if self.state.filtered.is_empty() {
-            // Distinguish "genuinely empty" (no items) from "filtered to nothing".
-            let placeholder = if self.state.items.is_empty() {
-                self.empty_label
-            } else {
-                "no matches"
-            };
-            // Dim centered placeholder so operators can distinguish "empty" from "broken".
-            Paragraph::new(Line::from(Span::styled(
-                placeholder.to_owned(),
-                crate::theme::DIM,
-            )))
+    if state.filtered.is_empty() {
+        // Dim centered placeholder so operators can distinguish "empty" from "broken".
+        Paragraph::new(Line::from(Span::styled("no matches", crate::theme::DIM)))
             .alignment(Alignment::Center)
             .render(list_area, buf);
-            return;
+        return;
+    }
+    let viewport_cols = usize::from(list_area.width);
+    let content_width = usize::from(state.max_label_width());
+    let scroll_x = crate::components::scrollable_panel::effective_offset(
+        content_width,
+        viewport_cols,
+        state.scroll_x,
+    );
+    let has_horizontal_scroll = is_scrollable(content_width, viewport_cols);
+    let list_body_area = if has_horizontal_scroll {
+        Rect {
+            height: list_area.height.saturating_sub(1),
+            ..list_area
         }
-        let viewport_cols = usize::from(list_area.width);
-        let content_width = usize::from(self.state.max_label_width());
-        let scroll_x = crate::components::scrollable_panel::effective_offset(
-            content_width,
-            viewport_cols,
-            self.state.scroll_x,
-        );
-        let has_horizontal_scroll = is_scrollable(content_width, viewport_cols);
-        let list_body_area = if has_horizontal_scroll {
-            Rect {
-                height: list_area.height.saturating_sub(1),
-                ..list_area
-            }
-        } else {
-            list_area
-        };
-        if list_body_area.height == 0 {
-            return;
-        }
-        let rows: Vec<PickerRow<'_>> = self
-            .state
-            .filtered
-            .iter()
-            .map(|&item| {
-                let label = &self.state.items[item];
-                let skip = usize::from(scroll_x);
-                // With no horizontal scroll, keep the ellipsis affordance for
-                // over-wide labels. Once scrolled, render the exact window.
-                let label_str = if skip == 0 && crate::display_cols(label) > viewport_cols {
-                    let mut s =
-                        crate::display_cols_slice(label, skip, viewport_cols.saturating_sub(1));
-                    s.push('…');
-                    s
-                } else {
-                    crate::display_cols_slice(label, skip, viewport_cols)
-                };
-                PickerRow::Item(ListItem::new(Line::from(Span::styled(
-                    label_str,
-                    Style::default().fg(PHOSPHOR_GREEN),
-                ))))
-            })
-            .collect();
-        render_picker_list(list_body_area, buf, rows, self.state.selected);
-        if has_horizontal_scroll {
-            render_picker_horizontal_scrollbar(
-                list_area,
-                buf,
-                content_width,
-                viewport_cols,
-                scroll_x,
-            );
-        }
+    } else {
+        list_area
+    };
+    if list_body_area.height == 0 {
+        return;
+    }
+    let rows: Vec<PickerRow<'_>> = state
+        .filtered
+        .iter()
+        .map(|&item| {
+            let label = &state.items[item];
+            let skip = usize::from(scroll_x);
+            // With no horizontal scroll, keep the ellipsis affordance for
+            // over-wide labels. Once scrolled, render the exact window.
+            let label_str = if skip == 0 && crate::display_cols(label) > viewport_cols {
+                let mut s = crate::display_cols_slice(label, skip, viewport_cols.saturating_sub(1));
+                s.push('…');
+                s
+            } else {
+                crate::display_cols_slice(label, skip, viewport_cols)
+            };
+            PickerRow::Item(ListItem::new(Line::from(Span::styled(
+                label_str,
+                Style::default().fg(PHOSPHOR_GREEN),
+            ))))
+        })
+        .collect();
+    render_picker_list(list_body_area, buf, rows, state.selected);
+    if has_horizontal_scroll {
+        render_picker_horizontal_scrollbar(list_area, buf, content_width, viewport_cols, scroll_x);
     }
 }
 
@@ -396,7 +350,7 @@ pub fn render_select_list(
     title: &str,
     context: &[Line<'_>],
 ) {
-    frame.render_widget(SelectList::new(state, title).context(context), area);
+    render_select_list_in(area, frame.buffer_mut(), state, title, context);
 }
 
 /// A row in a modal picker list.

--- a/crates/jackin-tui/src/components/select_list/tests.rs
+++ b/crates/jackin-tui/src/components/select_list/tests.rs
@@ -1,9 +1,9 @@
-use super::{PickerRow, SelectList, SelectListState, render_picker_list};
+use super::{PickerRow, SelectListState, render_picker_list, render_select_list_in};
 use crate::theme::{PHOSPHOR_DARK, PHOSPHOR_GREEN};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use ratatui::widgets::{ListItem, Widget};
+use ratatui::widgets::ListItem;
 
 fn row_symbols(buf: &Buffer, y: u16, width: u16) -> String {
     (0..width)
@@ -116,7 +116,7 @@ fn select_list_renders_horizontal_scroll_window() {
         height: 6,
     };
     let mut buf = Buffer::empty(area);
-    SelectList::new(&state, "pick").render(area, &mut buf);
+    render_select_list_in(area, &mut buf, &state, "pick", &[]);
 
     let rendered = row_symbols(&buf, 3, 12);
     assert!(

--- a/crates/jackin-tui/src/components/tab_strip.rs
+++ b/crates/jackin-tui/src/components/tab_strip.rs
@@ -1,11 +1,11 @@
 //! Shared Ratatui tab strip.
 
 use ratatui::{
-    Frame,
+    buffer::Buffer,
     layout::{Position, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Widget},
 };
 
 use crate::{
@@ -42,10 +42,6 @@ impl<'a> TabStrip<'a> {
     pub const fn hovered(mut self, hovered: Option<usize>) -> Self {
         self.hovered = hovered;
         self
-    }
-
-    pub fn render(self, frame: &mut Frame<'_>, area: Rect) {
-        frame.render_widget(self.paragraph(), area);
     }
 
     /// Return the tab under a 0-based terminal coordinate.
@@ -108,6 +104,12 @@ impl<'a> TabStrip<'a> {
     #[must_use]
     pub fn cells(self, start_col: u16) -> Vec<TabCell<'a>> {
         lay_out_tabs(self.labels, start_col)
+    }
+}
+
+impl Widget for TabStrip<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.paragraph().render(area, buf);
     }
 }
 

--- a/crates/jackin-tui/src/components/tab_strip/tests.rs
+++ b/crates/jackin-tui/src/components/tab_strip/tests.rs
@@ -24,9 +24,7 @@ fn tab_strip_exposes_two_rows() {
 
     terminal
         .draw(|frame| {
-            TabStrip::new(&labels)
-                .focused(true)
-                .render(frame, frame.area());
+            frame.render_widget(TabStrip::new(&labels).focused(true), frame.area());
         })
         .unwrap();
 

--- a/crates/jackin-tui/src/components/text_input.rs
+++ b/crates/jackin-tui/src/components/text_input.rs
@@ -384,74 +384,60 @@ impl TextInputState<'_> {
     }
 }
 
-#[derive(Debug)]
-pub struct TextInput<'a> {
-    state: &'a TextInputState<'a>,
-}
+fn render_text_input_in(area: Rect, buf: &mut Buffer, state: &TextInputState<'_>) {
+    Clear.render(area, buf);
 
-impl<'a> TextInput<'a> {
-    #[must_use]
-    pub const fn new(state: &'a TextInputState<'a>) -> Self {
-        Self { state }
-    }
-}
+    let title = Span::styled(format!(" {} ", state.label), crate::theme::BOLD_WHITE);
+    let border_color = match state.border_style() {
+        BorderStyle::Error => DANGER_RED,
+        BorderStyle::Default => PHOSPHOR_GREEN,
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(title);
 
-impl Widget for TextInput<'_> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        Clear.render(area, buf);
+    let inner = block.inner(area);
+    block.render(area, buf);
 
-        let title = Span::styled(format!(" {} ", self.state.label), crate::theme::BOLD_WHITE);
-        let border_color = match self.state.border_style() {
-            BorderStyle::Error => DANGER_RED,
-            BorderStyle::Default => PHOSPHOR_GREEN,
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let input_row = rows[1];
+    let input_area = Rect {
+        x: input_row.x.saturating_add(1),
+        y: input_row.y,
+        width: input_row.width.saturating_sub(2),
+        height: input_row.height,
+    };
+    Block::default()
+        .style(Style::default().bg(INPUT_BG_DIM))
+        .render(input_area, buf);
+    render_input_value(input_area, buf, state);
+
+    if state.is_duplicate() {
+        let key = state.trimmed_value();
+        let message = if state.forbidden_label.is_empty() {
+            format!("\u{26a0} \"{key}\" already exists")
+        } else {
+            format!(
+                "\u{26a0} \"{key}\" already exists in {}",
+                state.forbidden_label
+            )
         };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(border_color))
-            .title(title);
-
-        let inner = block.inner(area);
-        block.render(area, buf);
-
-        let rows = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1),
-                Constraint::Min(1),
-                Constraint::Length(1),
-            ])
-            .split(inner);
-
-        let input_row = rows[1];
-        let input_area = Rect {
-            x: input_row.x.saturating_add(1),
-            y: input_row.y,
-            width: input_row.width.saturating_sub(2),
-            height: input_row.height,
-        };
-        Block::default()
-            .style(Style::default().bg(INPUT_BG_DIM))
-            .render(input_area, buf);
-        render_input_value(input_area, buf, self.state);
-
-        if self.state.is_duplicate() {
-            let key = self.state.trimmed_value();
-            let message = if self.state.forbidden_label.is_empty() {
-                format!("\u{26a0} \"{key}\" already exists")
-            } else {
-                format!(
-                    "\u{26a0} \"{key}\" already exists in {}",
-                    self.state.forbidden_label
-                )
-            };
-            Paragraph::new(message)
-                .style(
-                    Style::default()
-                        .fg(DANGER_RED)
-                        .add_modifier(Modifier::BOLD | Modifier::ITALIC),
-                )
-                .render(rows[2], buf);
-        }
+        Paragraph::new(message)
+            .style(
+                Style::default()
+                    .fg(DANGER_RED)
+                    .add_modifier(Modifier::BOLD | Modifier::ITALIC),
+            )
+            .render(rows[2], buf);
     }
 }
 
@@ -475,7 +461,7 @@ fn render_input_value(area: Rect, buf: &mut Buffer, state: &TextInputState<'_>) 
 }
 
 pub fn render_text_input(frame: &mut ratatui::Frame<'_>, area: Rect, state: &TextInputState<'_>) {
-    frame.render_widget(TextInput::new(state), area);
+    render_text_input_in(area, frame.buffer_mut(), state);
 }
 
 /// Canonical outer rectangle for one-label text-input prompts.

--- a/crates/jackin-tui/src/tests.rs
+++ b/crates/jackin-tui/src/tests.rs
@@ -1,4 +1,18 @@
 use super::*;
+use crate::components::{ConfirmState, confirm_hint_spans, render_confirm_dialog};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+#[test]
+fn component_contract_example_compiles() {
+    let mut state = ConfirmState::new("Proceed?");
+    match state.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)) {
+        ModalOutcome::Commit(_) | ModalOutcome::Cancel | ModalOutcome::Continue => {}
+    }
+
+    let _render: fn(&mut ratatui::Frame<'_>, ratatui::layout::Rect, &ConfirmState) =
+        render_confirm_dialog;
+    let _hints = confirm_hint_spans();
+}
 
 #[test]
 fn text_field_insert_appends() {

--- a/docs/content/docs/reference/tui/components.mdx
+++ b/docs/content/docs/reference/tui/components.mdx
@@ -23,6 +23,16 @@ description: "The hard reuse rule, the full reusable component catalog, and shar
 
 7. **Component APIs follow the TUI boundary.** Component props/state/messages may describe UI state and emit semantic outcomes. They must not own Docker/git/`op`/`gh` calls, config persistence, workspace resolution, or protocol authority. When a component needs work done, it emits an outcome/message that update turns into a typed effect.
 
+### Component API contract
+
+Shared `jackin-tui` components use one of three API shapes:
+
+1. **Stateful interactive component** — `pub struct XState` owns UI state only; rendering is a free function such as `render_x(frame: &mut Frame<'_>, area: Rect, state: &XState)`. Use `&mut XState` only when rendering must clamp scroll state, and document that reason in the component. Keyboard input lives on `XState::handle_key(&mut self, key: KeyEvent) -> ModalOutcome<T>`, where `T` is the component's semantic commit value. Do not add a parallel `impl Widget` wrapper for the same stateful component.
+2. **Pure value widget** — display-only values with no interaction implement Ratatui `Widget`. They may expose one thin `render_x(frame, area, ...)` convenience function, but that function delegates to the widget instead of carrying a second render body.
+3. **Layout and primitive helpers** — rectangle math, scrollbars, blocks, hit testing, and backdrop helpers stay as free functions or small helper types. They do not introduce widget wrappers unless they render a concrete reusable value.
+
+`handle_key` always takes `&mut self` and returns `ModalOutcome<T>`. Mouse and scroll input use separately named methods such as `on_mouse_*`, `handle_scroll`, or viewport setters; do not add a second `handle_key_*` variant for key handling with extra context.
+
 ### What to check before writing new code
 
 Before adding any new TUI widget or state type:

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,7 +22,7 @@ update the codebase map in the same PR.
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | DONE |
-| 002 | Uniform component API contract (shared crate) | P1 | L | 001 | IN PROGRESS |
+| 002 | Uniform component API contract (shared crate) | P1 | L | 001 | DONE |
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,7 +22,7 @@ update the codebase map in the same PR.
 | Plan | Title | Priority | Effort | Depends on | Status |
 |------|-------|----------|--------|------------|--------|
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | DONE |
-| 002 | Uniform component API contract (shared crate) | P1 | L | 001 | TODO |
+| 002 | Uniform component API contract (shared crate) | P1 | L | 001 | IN PROGRESS |
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |


### PR DESCRIPTION
## Related pull requests

- https://github.com/jackin-project/jackin/pull/722

## Summary

This PR converges the shared TUI component crate on one documented API contract so future capsule, console, launch, and lookbook code has a single component usage model to follow. It is stacked on the TUI catalog/lookbook truth repair PR because that branch introduces the plan index and the docs context this plan extends.

## What ships

- The TUI component docs now state the shared component API contract: stateful interactive components expose state plus render and key-handling functions, pure value widgets implement Ratatui `Widget`, and primitive helpers stay as free functions.
- Shared value components now render through the Ratatui widget shape, while stateful dialog-style components use their state plus public render functions without duplicate widget wrapper types.
- Shared key handling now consistently uses mutable component state and `ModalOutcome`, including unified container-info key dispatch and a first-class diff-view key handler.
- Regression coverage now pins the API contract with a shared-crate compile-style test, keeps diff-view key handling covered, and confirms the lookbook previews remain pixel-current.

## Behavior changes

- Contributor-facing TUI APIs are narrower and more consistent. Visual output, layouts, colors, and lookbook SVGs are intentionally unchanged.

## What this addresses

- Resolves Plan 002 in the TUI reusability refactoring program by removing parallel render shapes and duplicate stateful widget wrappers from the shared crate.
- Reduces copy-paste ambiguity for future TUI work: new shared components now have one documented contract instead of several nearby patterns.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 723
cd "$(jackin-dev pr path 723)/jackin"
source "$(jackin-dev pr path 723)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it. After `source "$(jackin-dev pr path 723)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only when the PR requires a local capsule, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run
cargo run -p jackin-tui-lookbook -- --check docs/public/tui-lookbook
```

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  cargo xtask docs repo-links
  cargo xtask roadmap audit
  bunx tsc --noEmit
  bun test
)
```

### Documentation

**http://localhost:3000/docs/reference/tui/components/**  
Confirm the Component API contract subsection appears under Component Reuse and that the component catalog still renders normally.

## Migration notes

None.
