### PR TITLE
refactor(tui): add focus taxonomy button cycling

### DIFF
--- a/crates/jackin-tui/src/components.rs
+++ b/crates/jackin-tui/src/components.rs
@@ -56,7 +56,7 @@ pub use error_dialog::{
     estimated_message_rows, render_error_dialog, render_error_dialog_in, required_height,
 };
 pub use filter_input::{FilterInput, filter_input_line, render_filter_input};
-pub use focus_owner::FocusOwner;
+pub use focus_owner::{ButtonFocus, FocusOwner};
 pub use hint_bar::{
     HintBar, line as hint_line, render_hint_bar, render_wrapped_hint_bar, wrapped_height,
 };

--- a/crates/jackin-tui/src/components/confirm_dialog.rs
+++ b/crates/jackin-tui/src/components/confirm_dialog.rs
@@ -15,6 +15,7 @@ use ratatui::{
 
 use crate::{
     HintSpan, ModalOutcome,
+    components::ButtonFocus,
     keymap::{KeyBinding, KeyChord, Keymap, LogicalKey, Visibility},
     theme::{PHOSPHOR_GREEN, WARNING_YELLOW},
 };
@@ -121,6 +122,10 @@ pub enum ConfirmFocus {
     No,
 }
 
+impl ButtonFocus for ConfirmFocus {
+    const RING: &'static [Self] = &[Self::Yes, Self::No];
+}
+
 #[derive(Debug, Clone)]
 pub struct ConfirmState {
     pub(crate) focus: ConfirmFocus,
@@ -205,10 +210,7 @@ impl ConfirmState {
             Some(ConfirmAction::No) => ModalOutcome::Commit(false),
             Some(ConfirmAction::Cancel) => ModalOutcome::Cancel,
             Some(ConfirmAction::ToggleFocus) => {
-                self.focus = match self.focus {
-                    ConfirmFocus::Yes => ConfirmFocus::No,
-                    ConfirmFocus::No => ConfirmFocus::Yes,
-                };
+                self.focus = self.focus.next();
                 ModalOutcome::Continue
             }
             Some(ConfirmAction::CommitFocused) => {
@@ -400,11 +402,7 @@ const fn inset(area: Rect, x: u16) -> Rect {
 
 fn render_buttons(frame: &mut Frame<'_>, area: Rect, state: &ConfirmState) {
     let items = [ButtonStripItem::new("Yes"), ButtonStripItem::new("No")];
-    let focused = match state.focus {
-        ConfirmFocus::Yes => 0,
-        ConfirmFocus::No => 1,
-    };
-    frame.render_widget(ButtonStrip::new(&items).focused(focused), area);
+    frame.render_widget(ButtonStrip::new(&items).focused(state.focus.index()), area);
 }
 
 #[cfg(test)]

--- a/crates/jackin-tui/src/components/confirm_dialog/tests.rs
+++ b/crates/jackin-tui/src/components/confirm_dialog/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for `confirm_dialog`.
 use super::*;
+use crate::components::ButtonFocus;
 use crossterm::event::{KeyCode, KeyEventKind, KeyModifiers};
 
 fn key(code: KeyCode) -> KeyEvent {
@@ -79,6 +80,40 @@ fn tab_cycles_focus() {
     assert_eq!(s.focus, ConfirmFocus::Yes);
     s.handle_key(key(KeyCode::Tab));
     assert_eq!(s.focus, ConfirmFocus::No);
+}
+
+#[test]
+fn confirm_focus_ring_and_index_match_button_order() {
+    assert_eq!(ConfirmFocus::Yes.index(), 0);
+    assert_eq!(ConfirmFocus::No.index(), 1);
+    assert_eq!(ConfirmFocus::Yes.next(), ConfirmFocus::No);
+    assert_eq!(ConfirmFocus::No.next(), ConfirmFocus::Yes);
+    assert_eq!(ConfirmFocus::Yes.prev(), ConfirmFocus::No);
+    assert_eq!(ConfirmFocus::No.prev(), ConfirmFocus::Yes);
+}
+
+#[test]
+fn confirm_focus_keys_keep_existing_toggle_semantics() {
+    for code in [
+        KeyCode::Tab,
+        KeyCode::BackTab,
+        KeyCode::Left,
+        KeyCode::Right,
+        KeyCode::Char('h'),
+        KeyCode::Char('l'),
+    ] {
+        let mut state = ConfirmState::new("Delete?");
+        assert_eq!(state.focus, ConfirmFocus::No);
+        assert!(matches!(
+            state.handle_key(key(code)),
+            ModalOutcome::Continue
+        ));
+        assert_eq!(
+            state.focus,
+            ConfirmFocus::Yes,
+            "{code:?} should toggle focus"
+        );
+    }
 }
 
 #[test]

--- a/crates/jackin-tui/src/components/focus_owner.rs
+++ b/crates/jackin-tui/src/components/focus_owner.rs
@@ -9,6 +9,42 @@
 
 use crate::components::panel::PanelFocus;
 
+/// Focus behavior shared by every button-row dialog: a closed ring of
+/// semantic focus states with a stable [`ButtonStrip`](super::button_strip::ButtonStrip)
+/// index.
+pub trait ButtonFocus: Copy + Eq + 'static {
+    const RING: &'static [Self];
+
+    /// Index into the dialog's button strip items.
+    #[must_use]
+    fn index(self) -> usize {
+        Self::RING
+            .iter()
+            .position(|focus| focus == &self)
+            .unwrap_or(0)
+    }
+
+    #[must_use]
+    fn next(self) -> Self {
+        let ring = Self::RING;
+        if ring.is_empty() {
+            return self;
+        }
+        let idx = self.index();
+        ring[(idx + 1) % ring.len()]
+    }
+
+    #[must_use]
+    fn prev(self) -> Self {
+        let ring = Self::RING;
+        if ring.is_empty() {
+            return self;
+        }
+        let idx = self.index();
+        ring[(idx + ring.len() - 1) % ring.len()]
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FocusOwner<Tab> {
     #[default]

--- a/crates/jackin-tui/src/components/save_discard_dialog.rs
+++ b/crates/jackin-tui/src/components/save_discard_dialog.rs
@@ -9,7 +9,7 @@ use ratatui::{
 };
 
 use crate::keymap::{KeyBinding, KeyChord, Keymap, LogicalKey, Visibility};
-use crate::{HintSpan, ModalOutcome};
+use crate::{HintSpan, ModalOutcome, components::ButtonFocus};
 
 use super::button_strip::{ButtonStrip, ButtonStripItem};
 use super::dialog_layout::{dialog_inner_chunks, render_dialog_shell};
@@ -115,6 +115,10 @@ pub enum SaveDiscardFocus {
     Cancel,
 }
 
+impl ButtonFocus for SaveDiscardFocus {
+    const RING: &'static [Self] = &[Self::Save, Self::Discard, Self::Cancel];
+}
+
 #[derive(Debug, Clone)]
 pub struct SaveDiscardState {
     pub prompt: String,
@@ -137,19 +141,11 @@ impl SaveDiscardState {
             Some(SaveDiscardAction::Discard) => ModalOutcome::Commit(SaveDiscardChoice::Discard),
             Some(SaveDiscardAction::Cancel) => ModalOutcome::Cancel,
             Some(SaveDiscardAction::FocusNext) => {
-                self.focus = match self.focus {
-                    SaveDiscardFocus::Save => SaveDiscardFocus::Discard,
-                    SaveDiscardFocus::Discard => SaveDiscardFocus::Cancel,
-                    SaveDiscardFocus::Cancel => SaveDiscardFocus::Save,
-                };
+                self.focus = self.focus.next();
                 ModalOutcome::Continue
             }
             Some(SaveDiscardAction::FocusPrev) => {
-                self.focus = match self.focus {
-                    SaveDiscardFocus::Save => SaveDiscardFocus::Cancel,
-                    SaveDiscardFocus::Discard => SaveDiscardFocus::Save,
-                    SaveDiscardFocus::Cancel => SaveDiscardFocus::Discard,
-                };
+                self.focus = self.focus.prev();
                 ModalOutcome::Continue
             }
             Some(SaveDiscardAction::CommitFocused) => match self.focus {
@@ -177,12 +173,10 @@ pub fn render_save_discard_dialog(frame: &mut Frame<'_>, area: Rect, state: &Sav
         ButtonStripItem::new("Discard"),
         ButtonStripItem::new("Cancel"),
     ];
-    let focused = match state.focus {
-        SaveDiscardFocus::Save => 0,
-        SaveDiscardFocus::Discard => 1,
-        SaveDiscardFocus::Cancel => 2,
-    };
-    frame.render_widget(ButtonStrip::new(&items).focused(focused), chunks[3]);
+    frame.render_widget(
+        ButtonStrip::new(&items).focused(state.focus.index()),
+        chunks[3],
+    );
 }
 
 #[cfg(test)]

--- a/crates/jackin-tui/src/components/save_discard_dialog/tests.rs
+++ b/crates/jackin-tui/src/components/save_discard_dialog/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for `save_discard_dialog`.
 use super::*;
+use crate::components::ButtonFocus;
 use crossterm::event::{KeyCode, KeyEventKind, KeyEventState, KeyModifiers};
 
 fn key(code: KeyCode) -> KeyEvent {
@@ -50,6 +51,60 @@ fn enter_commits_focused_button() {
         s.handle_key(key(KeyCode::Enter)),
         ModalOutcome::Cancel
     ));
+}
+
+#[test]
+fn save_discard_focus_ring_and_index_match_button_order() {
+    assert_eq!(SaveDiscardFocus::Save.index(), 0);
+    assert_eq!(SaveDiscardFocus::Discard.index(), 1);
+    assert_eq!(SaveDiscardFocus::Cancel.index(), 2);
+    assert_eq!(SaveDiscardFocus::Cancel.next(), SaveDiscardFocus::Save);
+    assert_eq!(SaveDiscardFocus::Save.next(), SaveDiscardFocus::Discard);
+    assert_eq!(SaveDiscardFocus::Discard.next(), SaveDiscardFocus::Cancel);
+    assert_eq!(SaveDiscardFocus::Cancel.prev(), SaveDiscardFocus::Discard);
+    assert_eq!(SaveDiscardFocus::Discard.prev(), SaveDiscardFocus::Save);
+    assert_eq!(SaveDiscardFocus::Save.prev(), SaveDiscardFocus::Cancel);
+}
+
+#[test]
+fn save_discard_focus_keys_keep_existing_next_prev_semantics() {
+    for code in [
+        KeyCode::Tab,
+        KeyCode::Right,
+        KeyCode::Char('l'),
+        KeyCode::Char('L'),
+    ] {
+        let mut state = SaveDiscardState::new("?");
+        assert_eq!(state.focus, SaveDiscardFocus::Cancel);
+        assert!(matches!(
+            state.handle_key(key(code)),
+            ModalOutcome::Continue
+        ));
+        assert_eq!(
+            state.focus,
+            SaveDiscardFocus::Save,
+            "{code:?} should advance focus"
+        );
+    }
+
+    for code in [
+        KeyCode::BackTab,
+        KeyCode::Left,
+        KeyCode::Char('h'),
+        KeyCode::Char('H'),
+    ] {
+        let mut state = SaveDiscardState::new("?");
+        assert_eq!(state.focus, SaveDiscardFocus::Cancel);
+        assert!(matches!(
+            state.handle_key(key(code)),
+            ModalOutcome::Continue
+        ));
+        assert_eq!(
+            state.focus,
+            SaveDiscardFocus::Discard,
+            "{code:?} should reverse focus"
+        );
+    }
 }
 
 #[test]

--- a/docs/content/docs/reference/tui/navigation.mdx
+++ b/docs/content/docs/reference/tui/navigation.mdx
@@ -17,6 +17,14 @@ jackin❯ TUI follows the **W3C ARIA Tabs interaction pattern** for all tabbed i
 
 **PageUp / PageDown** are page-scrolling keys for long list-like modals that expose them, currently the File Browser. They move the selected row by the visible listing height, use the same selection-follow math as rendering, and saturate at the first or last row instead of wrapping. A modal that accepts PageUp/PageDown must advertise them in the footer hints.
 
+### Focus layers
+
+Focus state has three layers, and new components must use the narrowest layer that matches the interaction:
+
+1. `FocusOwner<Tab>` is the screen-level owner for tabbed screens. It answers which region owns input: the tab bar, or one named content block. Borders, tab underlines, cursors, and footer scope derive from that one owner value.
+2. A per-dialog semantic enum implementing `ButtonFocus` is element-level focus inside a button dialog. Use named states such as `Yes` / `No` or `Save` / `Discard` / `Cancel`; do not store a parallel raw index or bool.
+3. `PanelFocus` is border styling only. It is computed from screen-level or dialog-level focus state when rendering; do not store it as independent state.
+
 ### W3C Tabs pattern (required for all tabbed interfaces)
 
 All tabbed surfaces (workspace editor, settings) must implement the W3C tablist/tabpanel pattern:

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,7 +23,7 @@ update the codebase map in the same PR.
 |------|-------|----------|--------|------------|--------|
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | DONE |
 | 002 | Uniform component API contract (shared crate) | P1 | L | 001 | DONE |
-| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | IN PROGRESS |
+| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | DONE |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
 | 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,7 +23,7 @@ update the codebase map in the same PR.
 |------|-------|----------|--------|------------|--------|
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | DONE |
 | 002 | Uniform component API contract (shared crate) | P1 | L | 001 | DONE |
-| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
+| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | IN PROGRESS |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
 | 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |


### PR DESCRIPTION
## Summary
- add a shared `ButtonFocus` contract for semantic dialog button focus rings
- migrate confirm and save/discard dialogs to the shared cycling/index behavior
- document TUI focus layers and mark Plan 003 done

Related: #723

## Checkout
```sh
git fetch origin pull/724/head:pr-724
git switch pr-724
```

## Verification
- [x] `mise exec -- cargo fmt --check`
- [x] `mise exec -- cargo clippy --all-targets --all-features -- -D warnings`
- [x] `mise exec -- cargo nextest run`
- [x] `mise exec -- cargo run -p jackin-tui-lookbook -- --check docs/public/tui-lookbook`
- [x] `cd docs && mise exec -- bun install --frozen-lockfile`
- [x] `cd docs && mise exec -- bun run build`
- [x] `cd docs && mise exec -- cargo xtask docs repo-links`
- [x] `cd docs && mise exec -- cargo xtask roadmap audit`
- [x] `cd docs && mise exec -- bunx tsc --noEmit`
- [x] `cd docs && mise exec -- bun test`

## Documentation
- http://localhost:3000/docs/reference/tui/navigation/
