### PR TITLE
docs(tui): block shared drift plan

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -24,7 +24,7 @@ update the codebase map in the same PR.
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | TODO |
 | 002 | Uniform component API contract (shared crate) | P1 | L | 001 | TODO |
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
-| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
+| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | IN PROGRESS |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
 | 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |
 | 007 | ErrorPopup on the dialog shell + structured rows | P1 | M | 002 (soft) | TODO |

--- a/plans/README.md
+++ b/plans/README.md
@@ -24,7 +24,7 @@ update the codebase map in the same PR.
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | TODO |
 | 002 | Uniform component API contract (shared crate) | P1 | L | 001 | TODO |
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
-| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | IN PROGRESS |
+| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | BLOCKED (lookbook regen changed brand-header/confirm previews outside allowed text-input/diff-view scope) |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
 | 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |
 | 007 | ErrorPopup on the dialog shell + structured rows | P1 | M | 002 (soft) | TODO |


### PR DESCRIPTION
## Summary
- mark Plan 004 as blocked after hitting its explicit lookbook STOP condition
- no implementation changes are included

## Blocker
Lookbook regeneration changed `brand-header-console.svg` and `confirm-default.svg`, which are outside Plan 004's allowed text-input/diff-view SVG scope. The plan says to stop and report instead of improvising.

## Checkout
```sh
git fetch origin pull/725/head:pr-725
git switch pr-725
```

## Verification
- [x] `git diff --stat a2ec1b237..HEAD -- crates/jackin-tui/src/components/text_input.rs crates/jackin-tui/src/components/diff_view.rs crates/jackin-tui/src/theme.rs crates/jackin-tui/src/keymap.rs`
- [x] `mise exec -- cargo fmt --check`
- [x] `mise exec -- cargo nextest run -p jackin-tui` before stop condition
- [x] `mise exec -- cargo run -p jackin-tui-lookbook -- docs/public/tui-lookbook && mise exec -- cargo run -p jackin-tui-lookbook -- --check docs/public/tui-lookbook` hit the documented STOP condition
