### PR TITLE
refactor(tui): add ink color token

### DIFF
--- a/crates/jackin-tui/src/components/brand_header.rs
+++ b/crates/jackin-tui/src/components/brand_header.rs
@@ -2,11 +2,11 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Widget};
 
-use crate::theme::{BRAND_BLOCK, PHOSPHOR_DARK, WHITE};
+use crate::theme::{BRAND_BLOCK, INK, PHOSPHOR_DARK, WHITE};
 
 #[derive(Debug, Clone, Copy)]
 pub struct BrandHeader<'a> {
@@ -35,7 +35,7 @@ pub fn brand_header_line(label: &str) -> Line<'static> {
         .bg(BRAND_BLOCK)
         .add_modifier(Modifier::BOLD);
     Line::from(vec![
-        Span::styled(" jackin", block.fg(Color::Black)),
+        Span::styled(" jackin", block.fg(INK)),
         Span::styled("❯", block.fg(WHITE)),
         Span::styled(" ", block),
         Span::styled(" · ", Style::default().fg(PHOSPHOR_DARK)),

--- a/crates/jackin-tui/src/components/brand_header/tests.rs
+++ b/crates/jackin-tui/src/components/brand_header/tests.rs
@@ -14,9 +14,9 @@ fn renders_brand_pill_and_label() {
         .map(|x| buffer[(x, 0)].symbol().to_owned())
         .collect();
     assert!(row.contains(" jackin❯  · Console"), "row: {row:?}");
-    // Green block, black word, white chevron — never the same colour.
+    // Green block, ink word, white chevron — never the same colour.
     assert_eq!(buffer[(1, 0)].bg, BRAND_BLOCK);
-    assert_eq!(buffer[(1, 0)].fg, Color::Black);
+    assert_eq!(buffer[(1, 0)].fg, INK);
     assert_eq!(buffer[(7, 0)].symbol(), "❯");
     assert_eq!(buffer[(7, 0)].fg, WHITE);
     assert_eq!(buffer[(11, 0)].fg, PHOSPHOR_DARK);

--- a/crates/jackin-tui/src/components/button_strip.rs
+++ b/crates/jackin-tui/src/components/button_strip.rs
@@ -3,12 +3,12 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
 };
 
-use crate::theme::{PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
+use crate::theme::{INK, PHOSPHOR_DARK, PHOSPHOR_GREEN, WHITE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ButtonStripItem<'a> {
@@ -103,7 +103,7 @@ pub fn button_style(focused: bool, disabled: bool) -> Style {
     if focused {
         Style::default()
             .bg(WHITE)
-            .fg(Color::Black)
+            .fg(INK)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default()

--- a/crates/jackin-tui/src/components/error_dialog.rs
+++ b/crates/jackin-tui/src/components/error_dialog.rs
@@ -5,12 +5,12 @@ use std::cell::Cell;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap};
 
 use crate::keymap::{KeyBinding, KeyChord, Keymap, LogicalKey, Visibility};
-use crate::theme::{DANGER_RED, WHITE};
+use crate::theme::{DANGER_RED, INK, WHITE};
 use crate::{HintSpan, ModalOutcome, centered_rect};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,7 +119,7 @@ impl Widget for ErrorDialog<'_> {
 
         let focused_style = Style::default()
             .bg(WHITE)
-            .fg(Color::Black)
+            .fg(INK)
             .add_modifier(Modifier::BOLD);
         Paragraph::new(Line::from(Span::styled("  OK  ", focused_style)))
             .alignment(Alignment::Center)

--- a/crates/jackin-tui/src/components/status_footer.rs
+++ b/crates/jackin-tui/src/components/status_footer.rs
@@ -2,12 +2,12 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, Widget};
 
 use crate::display_cols;
-use crate::theme::{DANGER_RED, DEBUG_AMBER, LINK_BLUE, WHITE, faded};
+use crate::theme::{DANGER_RED, DEBUG_AMBER, INK, LINK_BLUE, WHITE, faded};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[allow(
@@ -214,11 +214,7 @@ impl<'a> StatusFooter<'a> {
 impl Widget for StatusFooter<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         Block::default()
-            .style(
-                Style::default()
-                    .bg(faded(WHITE, self.alpha))
-                    .fg(Color::Black),
-            )
+            .style(Style::default().bg(faded(WHITE, self.alpha)).fg(INK))
             .render(area, buf);
 
         let right_layout = status_right_group_layout(area.width, self.right);
@@ -229,11 +225,7 @@ impl Widget for StatusFooter<'_> {
                 Style::default()
                     .bg(faded(WHITE, self.alpha))
                     .fg(faded(
-                        if self.hover.usage {
-                            DEBUG_AMBER
-                        } else {
-                            Color::Black
-                        },
+                        if self.hover.usage { DEBUG_AMBER } else { INK },
                         self.alpha,
                     ))
                     .add_modifier(Modifier::BOLD),
@@ -288,7 +280,7 @@ impl Widget for StatusFooter<'_> {
         let activity_fg = if self.hover.left {
             faded(LINK_BLUE, self.alpha)
         } else {
-            Color::Black
+            INK
         };
         let left_spans = vec![
             Span::raw(" "),

--- a/crates/jackin-tui/src/components/text_input.rs
+++ b/crates/jackin-tui/src/components/text_input.rs
@@ -5,13 +5,13 @@ use std::marker::PhantomData;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
 
 use crate::centered_rect;
 use crate::keymap::{KeyBinding, KeyChord, Keymap, LogicalKey, Mods, Visibility};
-use crate::theme::{DANGER_RED, INPUT_BG_DIM, PHOSPHOR_GREEN, WHITE};
+use crate::theme::{DANGER_RED, INK, INPUT_BG_DIM, PHOSPHOR_GREEN, WHITE};
 use crate::{HintSpan, ModalOutcome};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -462,7 +462,7 @@ fn render_input_value(area: Rect, buf: &mut Buffer, state: &TextInputState<'_>) 
     let base_style = crate::theme::GREEN.bg(INPUT_BG_DIM);
     let cursor_style = Style::default()
         .bg(WHITE)
-        .fg(Color::Black)
+        .fg(INK)
         .add_modifier(Modifier::SLOW_BLINK);
     let mut spans = vec![Span::styled(before.to_owned(), base_style)];
     if let Some(ch) = after.chars().next() {
@@ -533,7 +533,7 @@ fn render_input_value_from_parts(area: Rect, buf: &mut Buffer, value: &str, curs
     let cursor = cursor.min(value.len());
     let (before, after) = value.split_at(cursor);
     let cursor_style = Style::default()
-        .fg(Color::Black)
+        .fg(INK)
         .bg(PHOSPHOR_GREEN)
         .add_modifier(Modifier::BOLD);
     let mut spans = vec![Span::styled(before.to_owned(), crate::theme::GREEN)];

--- a/crates/jackin-tui/src/theme.rs
+++ b/crates/jackin-tui/src/theme.rs
@@ -49,6 +49,10 @@ pub const DIALOG_SURFACE: Color = Color::Reset;
 pub const DIALOG_SCROLL_THUMB: Color = color(DIALOG_SCROLL_THUMB_RGB);
 pub const DIALOG_SCROLL_TRACK: Color = color(DIALOG_SCROLL_TRACK_RGB);
 pub const WHITE: Color = color(WHITE_RGB);
+/// Foreground for text on bright chips/buttons.
+///
+/// ANSI black by design so terminals map it consistently with their palette.
+pub const INK: Color = Color::Black;
 pub const TAB_BG_INACTIVE: Color = color(TAB_BG_INACTIVE_RGB);
 pub const TAB_BG_INACTIVE_HOVER: Color = color(TAB_BG_INACTIVE_HOVER_RGB);
 pub const TAB_BG_ACTIVE: Color = color(TAB_BG_ACTIVE_RGB);

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,7 +26,7 @@ update the codebase map in the same PR.
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
-| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | IN PROGRESS |
+| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | DONE |
 | 007 | ErrorPopup on the dialog shell + structured rows | P1 | M | 002 (soft) | TODO |
 | 008 | Launch failure popup onto ErrorPopup | P2 | L | 007 | TODO |
 | 009 | Capsule spawn failure onto ErrorPopup | P2 | M | 007 | TODO |

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,7 +26,7 @@ update the codebase map in the same PR.
 | 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
 | 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
 | 005 | Shared key-glyph constants | P1 | M | — | TODO |
-| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |
+| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | IN PROGRESS |
 | 007 | ErrorPopup on the dialog shell + structured rows | P1 | M | 002 (soft) | TODO |
 | 008 | Launch failure popup onto ErrorPopup | P2 | L | 007 | TODO |
 | 009 | Capsule spawn failure onto ErrorPopup | P2 | M | 007 | TODO |


### PR DESCRIPTION
## Summary

This PR completes Plan 006 by naming the shared bright-chip foreground color as `theme::INK` and routing the remaining shared TUI component uses through that token. The rendered palette is intended to stay identical; the change makes the shared crate easier to audit and reskin without treating raw terminal black as an untracked one-off.

## What ships

- Shared TUI components that render black foreground text on bright chips, buttons, cursors, and footer cells now use the same named palette token.
- The ANSI SGR pass-through table remains unchanged, so terminal color decoding still reflects input escape sequences rather than the jackin❯ palette.
- Plan 006 is marked DONE in the TUI refactoring program table.

## What this addresses

- Completes the Plan 006 raw `Color::Black` sweep for live shared component palette usage.
- Keeps the lookbook baseline stable while making future palette checks able to distinguish intentional terminal decoding from component styling.

## Not included

- No user-facing docs page changes; this is a no-behavior visual token cleanup.
- No changes to `ansi_text.rs`, where raw ANSI colors are intentional decoding behavior.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 727
cd "$(jackin-dev pr path 727)/jackin"
source "$(jackin-dev pr path 727)/env.sh"
which jackin
```

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run -p jackin-tui
cargo nextest run
```

The focused package run covers the shared TUI components touched by the token replacement; the workspace run checks downstream console, launch, and capsule users.

### Lookbook checks

```sh
cargo run -p jackin-tui-lookbook -- --check docs/public/tui-lookbook
```

Expected: `tui lookbook previews are current` and no files under `docs/public/tui-lookbook` change.
