### PR TITLE
docs(plans): block modal stack primitive plan

### DIFF
--- a/plans/012-modal-stack-primitive.md
+++ b/plans/012-modal-stack-primitive.md
@@ -18,6 +18,7 @@
 - **Depends on**: plans/002-tui-component-contract.md (recommended)
 - **Category**: tech-debt
 - **Planned at**: commit `a2ec1b237`, 2026-07-03
+- **Execution status**: BLOCKED — drift check found existing console TUI changes across component, input, and workspace view files before plan work.
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -32,7 +32,7 @@ update the codebase map in the same PR.
 | 009 | Capsule spawn failure onto ErrorPopup | P2 | M | 007 | BLOCKED — drift check found existing capsule TUI changes in `components.rs`, `dialog_widgets.rs`, and `palette.rs` before plan work |
 | 010 | Capsule hint renderer consolidation (style single-source, wrap not truncate) | P1 | M | — (coordinate 005) | BLOCKED — shared styling extracted, but wrapping needs operator decision because extra hint rows change capsule content-area reservation |
 | 011 | Capsule footer via StatusFooter + shared confirm hit-test | P2 | M | — (coordinate 010) | BLOCKED — drift check found existing changes in capsule chrome/dialog/palette files and shared button/confirm components before plan work |
-| 012 | ModalStack primitive; settings modal enums converge; stash slots die | P2 | L | 002 (soft) | TODO |
+| 012 | ModalStack primitive; settings modal enums converge; stash slots die | P2 | L | 002 (soft) | BLOCKED — drift check found existing console TUI changes across component/input/view files before plan work |
 | 013 | Modal-sizing registry promoted to jackin-tui | P2 | M | 012 | TODO |
 | 014 | ConfirmSaveState onto a keymap + ButtonFocus | P2 | M | 003 | TODO |
 | 015 | Settings ↔ editor row unification + labeled_field_line | P1 | L | — | TODO |


### PR DESCRIPTION
## Summary

This PR records the Plan 012 STOP outcome for the ModalStack primitive and settings-modal convergence work. The required drift check found existing console TUI changes across component, input, and workspace view files before implementation began, so the plan is marked blocked instead of starting a large modal-state refactor on stale excerpts.

## What ships

- Plan 012 is marked blocked in the plan index.
- The Plan 012 file records the drift category that prevented implementation.
- No ModalStack, settings modal enum, or stash-slot code is changed by this branch.

## What this addresses

- Preserves the refactoring program’s drift guard for the largest planned TUI refactor.
- Leaves ModalStack work for a refreshed plan or operator-directed rebase pass.

## Not included

- No shared ModalStack primitive.
- No settings modal enum convergence.
- No pending modal-flow stash removal.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 733
cd "$(jackin-dev pr path 733)/jackin"
source "$(jackin-dev pr path 733)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, and writes `env.sh`.

### Static checks

```sh
git diff --stat a2ec1b237..HEAD -- crates/jackin-console/src/tui/ crates/jackin-tui/src/components/modal_lifecycle.rs
```

Expected: output includes existing drift in console TUI component/input/view files, matching the blocked status recorded by the PR.

## Migration notes

None.
