### PR TITLE
docs(plans): block modal sizing registry plan

### DIFF
--- a/plans/013-modal-sizing-registry.md
+++ b/plans/013-modal-sizing-registry.md
@@ -18,6 +18,7 @@
 - **Depends on**: plans/012-modal-stack-primitive.md (recommended — unified modal kinds shrink the registry)
 - **Category**: tech-debt
 - **Planned at**: commit `a2ec1b237`, 2026-07-03
+- **Execution status**: BLOCKED — drift check found existing launch TUI failure-dialog and run-loop changes before plan work.
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -33,7 +33,7 @@ update the codebase map in the same PR.
 | 010 | Capsule hint renderer consolidation (style single-source, wrap not truncate) | P1 | M | — (coordinate 005) | BLOCKED — shared styling extracted, but wrapping needs operator decision because extra hint rows change capsule content-area reservation |
 | 011 | Capsule footer via StatusFooter + shared confirm hit-test | P2 | M | — (coordinate 010) | BLOCKED — drift check found existing changes in capsule chrome/dialog/palette files and shared button/confirm components before plan work |
 | 012 | ModalStack primitive; settings modal enums converge; stash slots die | P2 | L | 002 (soft) | BLOCKED — drift check found existing console TUI changes across component/input/view files before plan work |
-| 013 | Modal-sizing registry promoted to jackin-tui | P2 | M | 012 | TODO |
+| 013 | Modal-sizing registry promoted to jackin-tui | P2 | M | 012 | BLOCKED — drift check found existing launch TUI failure-dialog/run changes before plan work |
 | 014 | ConfirmSaveState onto a keymap + ButtonFocus | P2 | M | 003 | TODO |
 | 015 | Settings ↔ editor row unification + labeled_field_line | P1 | L | — | TODO |
 | 016 | save_preview dual-pipeline dedup | P2 | L | — | TODO |


### PR DESCRIPTION
## Summary

This PR records the Plan 013 STOP outcome for the modal-sizing registry promotion. The required drift check found existing launch TUI failure-dialog and run-loop changes before implementation began, so the plan is marked blocked instead of moving modal geometry code on stale launch excerpts.

## What ships

- Plan 013 is marked blocked in the plan index.
- The Plan 013 file records the launch TUI drift that prevented implementation.
- No modal sizing registry code is moved or changed by this branch.

## What this addresses

- Preserves the plan’s byte-identical sizing-refactor guard.
- Leaves modal sizing registry promotion for a refreshed plan or operator-directed rebase pass.

## Not included

- No `modal_rects` promotion into `jackin-tui`.
- No capsule or launch dialog sizing migration.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 734
cd "$(jackin-dev pr path 734)/jackin"
source "$(jackin-dev pr path 734)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, and writes `env.sh`.

### Static checks

```sh
git diff --stat a2ec1b237..HEAD -- crates/jackin-console/src/tui/components/modal_rects.rs crates/jackin-capsule/src/tui/components/dialog.rs crates/jackin-launch-tui/src/tui/ crates/jackin-tui/src/geometry.rs
```

Expected: output includes existing launch TUI `failure_dialog.rs`, `run.rs`, and `run/tests.rs` drift, matching the blocked status recorded by the PR.

## Migration notes

None.
