### PR TITLE
docs(plans): block confirm save keymap plan

### DIFF
--- a/plans/014-confirm-save-keymap.md
+++ b/plans/014-confirm-save-keymap.md
@@ -18,6 +18,7 @@
 - **Depends on**: plans/003-tui-focus-taxonomy.md (uses `ButtonFocus`)
 - **Category**: tech-debt
 - **Planned at**: commit `a2ec1b237`, 2026-07-03
+- **Execution status**: BLOCKED — drift check found existing changes in `confirm_save.rs`, `confirm_dialog.rs`, and `save_discard_dialog.rs` before plan work.
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -34,7 +34,7 @@ update the codebase map in the same PR.
 | 011 | Capsule footer via StatusFooter + shared confirm hit-test | P2 | M | — (coordinate 010) | BLOCKED — drift check found existing changes in capsule chrome/dialog/palette files and shared button/confirm components before plan work |
 | 012 | ModalStack primitive; settings modal enums converge; stash slots die | P2 | L | 002 (soft) | BLOCKED — drift check found existing console TUI changes across component/input/view files before plan work |
 | 013 | Modal-sizing registry promoted to jackin-tui | P2 | M | 012 | BLOCKED — drift check found existing launch TUI failure-dialog/run changes before plan work |
-| 014 | ConfirmSaveState onto a keymap + ButtonFocus | P2 | M | 003 | TODO |
+| 014 | ConfirmSaveState onto a keymap + ButtonFocus | P2 | M | 003 | BLOCKED — drift check found existing confirm/save component changes before plan work |
 | 015 | Settings ↔ editor row unification + labeled_field_line | P1 | L | — | TODO |
 | 016 | save_preview dual-pipeline dedup | P2 | L | — | TODO |
 | 017 | run_console decomposition + terminal guard | P3 | M | — | TODO |


### PR DESCRIPTION
## Summary

This PR records the Plan 014 STOP outcome for moving `ConfirmSaveState` onto a keymap. The required drift check found existing changes in the confirm/save component files before implementation began, so the plan is marked blocked instead of refactoring key dispatch on stale excerpts.

## What ships

- Plan 014 is marked blocked in the plan index.
- The Plan 014 file records the affected confirm/save component drift.
- No confirm-save keymap or ButtonFocus implementation is changed by this branch.

## What this addresses

- Preserves the plan’s 1:1 keybinding refactor guard.
- Leaves confirm-save keymap work for a refreshed plan or operator-directed rebase pass.

## Not included

- No `CONFIRM_SAVE_KEYMAP` table.
- No `ConfirmSaveFocus` ButtonFocus implementation.
- No footer hint derivation changes.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 735
cd "$(jackin-dev pr path 735)/jackin"
source "$(jackin-dev pr path 735)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, and writes `env.sh`.

### Static checks

```sh
git diff --stat a2ec1b237..HEAD -- crates/jackin-console/src/tui/components/confirm_save.rs crates/jackin-tui/src/components/save_discard_dialog.rs crates/jackin-tui/src/components/confirm_dialog.rs
```

Expected: output includes existing `confirm_save.rs`, `confirm_dialog.rs`, and `save_discard_dialog.rs` drift, matching the blocked status recorded by the PR.

## Migration notes

None.
