### PR TITLE
docs(plans): block settings editor row plan

### DIFF
--- a/plans/015-settings-editor-row-unification.md
+++ b/plans/015-settings-editor-row-unification.md
@@ -18,6 +18,7 @@
 - **Depends on**: none hard (independent of 012; touches different layers)
 - **Category**: tech-debt
 - **Planned at**: commit `a2ec1b237`, 2026-07-03
+- **Execution status**: BLOCKED — drift check found existing changes in `auth_panel.rs`, `editor_rows.rs`, and the workspace view before plan work.
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -35,7 +35,7 @@ update the codebase map in the same PR.
 | 012 | ModalStack primitive; settings modal enums converge; stash slots die | P2 | L | 002 (soft) | BLOCKED — drift check found existing console TUI changes across component/input/view files before plan work |
 | 013 | Modal-sizing registry promoted to jackin-tui | P2 | M | 012 | BLOCKED — drift check found existing launch TUI failure-dialog/run changes before plan work |
 | 014 | ConfirmSaveState onto a keymap + ButtonFocus | P2 | M | 003 | BLOCKED — drift check found existing confirm/save component changes before plan work |
-| 015 | Settings ↔ editor row unification + labeled_field_line | P1 | L | — | TODO |
+| 015 | Settings ↔ editor row unification + labeled_field_line | P1 | L | — | BLOCKED — drift check found existing console row/auth/workspace view changes before plan work |
 | 016 | save_preview dual-pipeline dedup | P2 | L | — | TODO |
 | 017 | run_console decomposition + terminal guard | P3 | M | — | TODO |
 | 018 | jackin-tui lib.rs ansi-module extraction | P3 | M | — | TODO |


### PR DESCRIPTION
## Summary

This PR records the Plan 015 STOP outcome for settings/editor row unification. The required drift check found existing changes in shared row/auth/workspace view files before implementation began, so the plan is marked blocked instead of moving row renderers on stale excerpts.

## What ships

- Plan 015 is marked blocked in the plan index.
- The Plan 015 file records the row/auth/workspace view drift that prevented implementation.
- No settings/editor row renderer code is changed by this branch.

## What this addresses

- Preserves the parity-refactor guard before a broad row-model move.
- Leaves settings/editor row unification for a refreshed plan or operator-directed rebase pass.

## Not included

- No `labeled_field_line` helper.
- No shared auth/env/mount/general row model.
- No parity snapshot changes.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 736
cd "$(jackin-dev pr path 736)/jackin"
source "$(jackin-dev pr path 736)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, and writes `env.sh`.

### Static checks

```sh
git diff --stat a2ec1b237..HEAD -- crates/jackin-console/src/tui/screens/ crates/jackin-console/src/tui/components/editor_rows.rs crates/jackin-console/src/tui/components/auth_panel.rs crates/jackin-console/src/tui/mount_display.rs
```

Expected: output includes existing drift in `auth_panel.rs`, `editor_rows.rs`, and workspace view files, matching the blocked status recorded by the PR.

## Migration notes

None.
