### PR TITLE
docs(tui): record hygiene plan block

### DIFF
--- a/plans/019-tui-hygiene-bundle.md
+++ b/plans/019-tui-hygiene-bundle.md
@@ -18,6 +18,7 @@
 - **Depends on**: none
 - **Category**: tech-debt / build
 - **Planned at**: commit `a2ec1b237`, 2026-07-03
+- **Execution status**: BLOCKED — drift check found existing launch TUI component changes in `crates/jackin-launch-tui/src/tui/components/failure_dialog.rs` before plan work.
 
 ## Why this matters
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -23,10 +23,10 @@ update the codebase map in the same PR.
 |------|-------|----------|--------|------------|--------|
 | 001 | Docs catalog + lookbook truth repair | P1 | M | — | DONE |
 | 002 | Uniform component API contract (shared crate) | P1 | L | 001 | DONE |
-| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | TODO |
-| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | TODO |
-| 005 | Shared key-glyph constants | P1 | M | — | TODO |
-| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | TODO |
+| 003 | Focus taxonomy + ButtonFocus cycling | P2 | M | 002 | DONE |
+| 004 | Shared-crate drift fixes (text_input cursor, diff_view keymap/palette) | P1 | S | — | BLOCKED (lookbook regen changed brand-header/confirm previews outside allowed text-input/diff-view scope) |
+| 005 | Shared key-glyph constants | P1 | M | — | DONE |
+| 006 | theme::INK token (raw Color::Black sweep) | P3 | S | — (coordinate 004/007) | DONE |
 | 007 | ErrorPopup on the dialog shell + structured rows | P1 | M | 002 (soft) | DONE |
 | 008 | Launch failure popup onto ErrorPopup | P2 | L | 007 | DONE |
 | 009 | Capsule spawn failure onto ErrorPopup | P2 | M | 007 | BLOCKED — drift check found existing capsule TUI changes in `components.rs`, `dialog_widgets.rs`, and `palette.rs` before plan work |

--- a/plans/README.md
+++ b/plans/README.md
@@ -39,7 +39,7 @@ update the codebase map in the same PR.
 | 016 | save_preview dual-pipeline dedup | P2 | L | — | DONE |
 | 017 | run_console decomposition + terminal guard | P3 | M | — | DONE |
 | 018 | jackin-tui lib.rs ansi-module extraction | P3 | M | — | DONE |
-| 019 | Hygiene: coalesce_cells dedup, runtime ratatui dev-dep | P3 | S | — | TODO |
+| 019 | Hygiene: coalesce_cells dedup, runtime ratatui dev-dep | P3 | S | — | BLOCKED — drift check found existing launch TUI component changes in `failure_dialog.rs` before plan work |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale).
 


### PR DESCRIPTION
Summary:
- mark Plan 019 blocked after its required drift check found pre-existing launch TUI component drift
- record the exact drift path in the plan execution status
- reconcile the aggregate plan index so all rows are now DONE or BLOCKED, using the statuses already represented by PRs #724-#727

Blocker:
Plan 019 required this drift check before source work:
git diff --stat a2ec1b237..HEAD -- crates/jackin-launch-tui/src/tui/components/ crates/jackin-runtime/Cargo.toml

That output showed existing changes in crates/jackin-launch-tui/src/tui/components/failure_dialog.rs before Plan 019 work. Per the plan STOP condition, no hygiene source changes were made.

Verification:
- git diff --check
- drift check produced the blocker above
- rg -n '\| 0[0-9]+ .*\| TODO \|' plans/README.md produced no matches

Not run:
- mise exec -- cargo fmt --check
- mise exec -- cargo clippy --all-targets --all-features -- -D warnings
- mise exec -- cargo nextest run

Only plan bookkeeping changed.