### PR TITLE
feat(role): validate Claude plugin marketplaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,7 @@ dependencies = [
  "owo-colors 4.3.0",
  "predicates",
  "ratatui",
+ "reqwest",
  "rustls",
  "serde",
  "serde_json",

--- a/crates/jackin/Cargo.toml
+++ b/crates/jackin/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1", features = ["rt", "process", "io-util", "sync", "macros
 futures-util = "0.3"
 fs2 = "0.4"
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 
 [build-dependencies]
 jackin-build-meta = { version = "0.6.0-dev", path = "../jackin-build-meta" }

--- a/crates/jackin/src/lib.rs
+++ b/crates/jackin/src/lib.rs
@@ -35,6 +35,7 @@ pub mod error;
 pub(crate) mod preflight;
 pub mod prompt;
 pub mod role_authoring;
+mod role_claude_plugins;
 pub mod warp;
 pub mod workspace;
 

--- a/crates/jackin/src/role_authoring.rs
+++ b/crates/jackin/src/role_authoring.rs
@@ -27,7 +27,8 @@ pub fn run(command: RoleCommand) -> anyhow::Result<()> {
 
 fn validate(args: RoleRepoPathArgs) -> anyhow::Result<()> {
     let repo_dir = resolve_repo_path(args.path)?;
-    validate_role_repo(&repo_dir)?;
+    let validated = validate_role_repo(&repo_dir)?;
+    crate::role_claude_plugins::validate_claude_plugin_marketplaces(&validated.manifest)?;
     println!("Role repository is valid: {}", repo_dir.display());
     Ok(())
 }
@@ -83,7 +84,8 @@ fn migrate(args: RoleRepoPathArgs) -> anyhow::Result<()> {
         Some((old, new)) => println!("Migrated manifest {old} -> {new}"),
         None => println!("Manifest already at current version"),
     }
-    validate_role_repo(&repo_dir)?;
+    let validated = validate_role_repo(&repo_dir)?;
+    crate::role_claude_plugins::validate_claude_plugin_marketplaces(&validated.manifest)?;
     println!("Role repository is valid: {}", repo_dir.display());
     Ok(())
 }
@@ -100,7 +102,8 @@ fn create(args: &RoleCreateArgs) -> anyhow::Result<()> {
     }
     std::fs::create_dir(&repo_dir).with_context(|| format!("creating {}", repo_dir.display()))?;
     write_scaffold(&repo_dir, &selector)?;
-    validate_role_repo(&repo_dir)?;
+    let validated = validate_role_repo(&repo_dir)?;
+    crate::role_claude_plugins::validate_claude_plugin_marketplaces(&validated.manifest)?;
 
     println!("Created role repository: {}", repo_dir.display());
     println!(

--- a/crates/jackin/src/role_claude_plugins.rs
+++ b/crates/jackin/src/role_claude_plugins.rs
@@ -1,0 +1,221 @@
+//! Claude plugin marketplace validation for role-authoring commands.
+//!
+//! Runtime image builds intentionally keep using Claude Code's own marketplace
+//! and plugin installer. This module belongs to `jackin-role`/`jackin role
+//! validate`: it proves role manifests are resolvable before a role is
+//! published or merged.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Context;
+use jackin_manifest::{ClaudeMarketplaceConfig, RoleManifest};
+use serde::Deserialize;
+
+const OFFICIAL_MARKETPLACE_NAME: &str = "claude-plugins-official";
+const OFFICIAL_MARKETPLACE_SOURCE: &str = "anthropics/claude-plugins-official";
+const MARKETPLACE_MANIFEST_PATH: &str = ".claude-plugin/marketplace.json";
+
+#[derive(Debug, Deserialize)]
+struct MarketplaceManifest {
+    name: String,
+    plugins: Vec<MarketplacePlugin>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketplacePlugin {
+    name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PluginRef<'a> {
+    plugin: &'a str,
+    marketplace: &'a str,
+}
+
+trait MarketplaceResolver {
+    fn resolve(&self, source: &str) -> anyhow::Result<String>;
+}
+
+#[derive(Debug)]
+struct GitHubRawMarketplaceResolver;
+
+impl GitHubRawMarketplaceResolver {
+    fn raw_url(source: &str) -> anyhow::Result<String> {
+        let slug = github_slug(source)?;
+        Ok(format!(
+            "https://raw.githubusercontent.com/{slug}/HEAD/{MARKETPLACE_MANIFEST_PATH}"
+        ))
+    }
+}
+
+impl MarketplaceResolver for GitHubRawMarketplaceResolver {
+    fn resolve(&self, source: &str) -> anyhow::Result<String> {
+        let url = Self::raw_url(source)?;
+        std::thread::spawn(move || fetch_marketplace_manifest(&url))
+            .join()
+            .map_err(|_| anyhow::anyhow!("fetching Claude marketplace manifest panicked"))?
+    }
+}
+
+fn fetch_marketplace_manifest(url: &str) -> anyhow::Result<String> {
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, "jackin-role-validate")
+        .send()
+        .with_context(|| format!("fetching Claude marketplace manifest from {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("fetching Claude marketplace manifest from {url} returned {status}");
+    }
+    response
+        .text()
+        .with_context(|| format!("reading Claude marketplace manifest from {url}"))
+}
+
+/// Validate that every `[claude].plugins` reference uses
+/// `plugin@marketplace`, that each marketplace name resolves to a declared
+/// marketplace (or the official built-in marketplace), and that the fetched
+/// marketplace manifest publishes the requested plugin.
+pub(crate) fn validate_claude_plugin_marketplaces(manifest: &RoleManifest) -> anyhow::Result<()> {
+    validate_claude_plugin_marketplaces_with(manifest, &GitHubRawMarketplaceResolver)
+}
+
+fn validate_claude_plugin_marketplaces_with(
+    manifest: &RoleManifest,
+    resolver: &dyn MarketplaceResolver,
+) -> anyhow::Result<()> {
+    let Some(claude) = &manifest.claude else {
+        return Ok(());
+    };
+    if claude.plugins.is_empty() {
+        return Ok(());
+    }
+
+    let plugin_refs = claude
+        .plugins
+        .iter()
+        .map(|plugin| parse_plugin_ref(plugin))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let mut sources_by_name = BTreeMap::from([(
+        OFFICIAL_MARKETPLACE_NAME.to_owned(),
+        OFFICIAL_MARKETPLACE_SOURCE.to_owned(),
+    )]);
+    for marketplace in &claude.marketplaces {
+        register_marketplace(&mut sources_by_name, marketplace, resolver)?;
+    }
+
+    for plugin_ref in plugin_refs {
+        let source = sources_by_name
+            .get(plugin_ref.marketplace)
+            .ok_or_else(|| unknown_marketplace_error(&sources_by_name, &plugin_ref))?;
+        let manifest_json = resolver.resolve(source)?;
+        let marketplace_manifest: MarketplaceManifest = serde_json::from_str(&manifest_json)
+            .with_context(|| format!("parsing Claude marketplace manifest for {source}"))?;
+        let published_plugins = marketplace_manifest
+            .plugins
+            .iter()
+            .map(|plugin| plugin.name.as_str())
+            .collect::<BTreeSet<_>>();
+        if !published_plugins.contains(plugin_ref.plugin) {
+            anyhow::bail!(
+                "Claude plugin \"{}@{}\" is invalid: marketplace \"{}\" from {} publishes [{}], not \"{}\"",
+                plugin_ref.plugin,
+                plugin_ref.marketplace,
+                marketplace_manifest.name,
+                source,
+                published_plugins.into_iter().collect::<Vec<_>>().join(", "),
+                plugin_ref.plugin
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn register_marketplace(
+    sources_by_name: &mut BTreeMap<String, String>,
+    marketplace: &ClaudeMarketplaceConfig,
+    resolver: &dyn MarketplaceResolver,
+) -> anyhow::Result<()> {
+    let manifest_json = resolver.resolve(&marketplace.source)?;
+    let manifest: MarketplaceManifest =
+        serde_json::from_str(&manifest_json).with_context(|| {
+            format!(
+                "parsing Claude marketplace manifest for {}",
+                marketplace.source
+            )
+        })?;
+    if let Some(previous) =
+        sources_by_name.insert(manifest.name.clone(), marketplace.source.clone())
+        && previous != marketplace.source
+    {
+        anyhow::bail!(
+            "Claude marketplace name \"{}\" is declared by both {} and {}",
+            manifest.name,
+            previous,
+            marketplace.source
+        );
+    }
+    Ok(())
+}
+
+fn parse_plugin_ref(raw: &str) -> anyhow::Result<PluginRef<'_>> {
+    let Some((plugin, marketplace)) = raw.split_once('@') else {
+        anyhow::bail!(
+            "Claude plugin \"{raw}\" must use plugin@marketplace format, e.g. code-review@claude-plugins-official"
+        );
+    };
+    if plugin.is_empty() || marketplace.is_empty() || marketplace.contains('@') {
+        anyhow::bail!(
+            "Claude plugin \"{raw}\" must use plugin@marketplace format, e.g. code-review@claude-plugins-official"
+        );
+    }
+    Ok(PluginRef {
+        plugin,
+        marketplace,
+    })
+}
+
+fn unknown_marketplace_error(
+    sources_by_name: &BTreeMap<String, String>,
+    plugin_ref: &PluginRef<'_>,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Claude plugin \"{}@{}\" references unknown marketplace \"{}\"; declare [[claude.marketplaces]] with a source whose marketplace.json name is \"{}\" or use one of [{}]",
+        plugin_ref.plugin,
+        plugin_ref.marketplace,
+        plugin_ref.marketplace,
+        plugin_ref.marketplace,
+        sources_by_name
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn github_slug(source: &str) -> anyhow::Result<String> {
+    let mut trimmed = source.trim();
+    if let Some(rest) = trimmed.strip_prefix("https://github.com/") {
+        trimmed = rest;
+    }
+    if let Some(rest) = trimmed.strip_prefix("http://github.com/") {
+        trimmed = rest;
+    }
+    if let Some(rest) = trimmed.strip_suffix(".git") {
+        trimmed = rest;
+    }
+    let trimmed = trimmed.trim_end_matches('/');
+    let parts = trimmed.split('/').collect::<Vec<_>>();
+    if parts.len() != 2 || parts.iter().any(|part| part.is_empty()) {
+        anyhow::bail!(
+            "Claude marketplace source \"{source}\" must be a GitHub owner/repo slug or GitHub URL"
+        );
+    }
+    Ok(format!("{}/{}", parts[0], parts[1]))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/jackin/src/role_claude_plugins/tests.rs
+++ b/crates/jackin/src/role_claude_plugins/tests.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+
+use jackin_core::manifest::{ClaudeConfig, ManifestDockerConfig};
+use jackin_manifest::{ClaudeMarketplaceConfig, RoleManifest};
+
+use super::*;
+
+#[derive(Debug)]
+struct FixtureResolver {
+    manifests: BTreeMap<&'static str, &'static str>,
+}
+
+impl MarketplaceResolver for FixtureResolver {
+    fn resolve(&self, source: &str) -> anyhow::Result<String> {
+        self.manifests
+            .get(source)
+            .map(|manifest| (*manifest).to_owned())
+            .ok_or_else(|| anyhow::anyhow!("missing fixture for {source}"))
+    }
+}
+
+fn manifest(plugins: Vec<&str>, marketplaces: Vec<ClaudeMarketplaceConfig>) -> RoleManifest {
+    RoleManifest {
+        version: "v1alpha5".to_owned(),
+        dockerfile: "Dockerfile".to_owned(),
+        published_image: None,
+        identity: None,
+        agents: None,
+        claude: Some(ClaudeConfig {
+            model: None,
+            marketplaces,
+            plugins: plugins.into_iter().map(str::to_owned).collect(),
+            providers: BTreeMap::new(),
+        }),
+        codex: None,
+        amp: None,
+        kimi: None,
+        opencode: None,
+        grok: None,
+        hooks: None,
+        env: BTreeMap::new(),
+        docker: None::<ManifestDockerConfig>,
+    }
+}
+
+fn resolver() -> FixtureResolver {
+    FixtureResolver {
+        manifests: BTreeMap::from([
+            (
+                OFFICIAL_MARKETPLACE_SOURCE,
+                r#"{"name":"claude-plugins-official","plugins":[{"name":"code-review"}]}"#,
+            ),
+            (
+                "tailrocks/tailrocks-marketplace",
+                r#"{"name":"tailrocks-marketplace","plugins":[{"name":"tailrocks-skills"}]}"#,
+            ),
+        ]),
+    }
+}
+
+#[test]
+fn validates_plugin_published_by_declared_marketplace() {
+    let manifest = manifest(
+        vec!["tailrocks-skills@tailrocks-marketplace"],
+        vec![ClaudeMarketplaceConfig {
+            source: "tailrocks/tailrocks-marketplace".to_owned(),
+            sparse: Vec::new(),
+        }],
+    );
+
+    validate_claude_plugin_marketplaces_with(&manifest, &resolver()).unwrap();
+}
+
+#[test]
+fn validates_plugin_published_by_official_marketplace() {
+    let manifest = manifest(vec!["code-review@claude-plugins-official"], Vec::new());
+
+    validate_claude_plugin_marketplaces_with(&manifest, &resolver()).unwrap();
+}
+
+#[test]
+fn rejects_plugin_missing_from_marketplace_manifest() {
+    let manifest = manifest(
+        vec!["rust-best-practices@tailrocks-marketplace"],
+        vec![ClaudeMarketplaceConfig {
+            source: "tailrocks/tailrocks-marketplace".to_owned(),
+            sparse: Vec::new(),
+        }],
+    );
+
+    let error = validate_claude_plugin_marketplaces_with(&manifest, &resolver()).unwrap_err();
+
+    assert!(error.to_string().contains("rust-best-practices"));
+    assert!(error.to_string().contains("tailrocks-skills"));
+}
+
+#[test]
+fn rejects_plugin_without_marketplace_suffix() {
+    let manifest = manifest(vec!["code-review"], Vec::new());
+
+    let error = validate_claude_plugin_marketplaces_with(&manifest, &resolver()).unwrap_err();
+
+    assert!(error.to_string().contains("plugin@marketplace"));
+}
+
+#[test]
+fn rejects_unknown_marketplace_name() {
+    let manifest = manifest(vec!["tailrocks-skills@tailrocks-marketplace"], Vec::new());
+
+    let error = validate_claude_plugin_marketplaces_with(&manifest, &resolver()).unwrap_err();
+
+    assert!(error.to_string().contains("unknown marketplace"));
+    assert!(error.to_string().contains("tailrocks-marketplace"));
+}
+
+#[test]
+fn normalizes_github_marketplace_sources_to_raw_manifest_urls() {
+    assert_eq!(
+        GitHubRawMarketplaceResolver::raw_url(
+            "https://github.com/tailrocks/tailrocks-marketplace.git"
+        )
+        .unwrap(),
+        "https://raw.githubusercontent.com/tailrocks/tailrocks-marketplace/HEAD/.claude-plugin/marketplace.json"
+    );
+    assert_eq!(
+        GitHubRawMarketplaceResolver::raw_url("tailrocks/tailrocks-marketplace").unwrap(),
+        "https://raw.githubusercontent.com/tailrocks/tailrocks-marketplace/HEAD/.claude-plugin/marketplace.json"
+    );
+}

--- a/docs/content/docs/(public)/(role-authoring)/developing/creating-roles.mdx
+++ b/docs/content/docs/(public)/(role-authoring)/developing/creating-roles.mdx
@@ -148,7 +148,7 @@ plugins = ["code-review@claude-plugins-official"]
 name = "My Agent"
 ```
 
-These plugin IDs are written into the agent's runtime state and installed automatically when the container starts.
+These plugin IDs are baked into the derived image during Docker build. `jackin-role validate` and `jackin role validate` fetch each marketplace manifest first, so CI rejects plugin IDs that do not exist in the named marketplace before the role is published.
 
 If you need plugins from a custom marketplace, declare the marketplace separately and keep plugin IDs fully qualified:
 
@@ -175,7 +175,7 @@ source = "jackin-project/jackin-marketplace"
 name = "My Agent"
 ```
 
-jackin adds each declared marketplace at container startup, then installs each plugin ID exactly as written.
+jackin adds each declared marketplace during the derived image build, then installs each plugin ID exactly as written. Every plugin ID must use `plugin@marketplace` format, and each custom marketplace must publish that plugin name in `.claude-plugin/marketplace.json`.
 
 ## Supporting multiple agents
 

--- a/docs/content/docs/(public)/(role-authoring)/developing/role-manifest.mdx
+++ b/docs/content/docs/(public)/(role-authoring)/developing/role-manifest.mdx
@@ -144,6 +144,8 @@ source = "jackin-project/jackin-marketplace"
 
 Each `[[claude.marketplaces]]` block maps to `claude plugin marketplace add <source>`. If `sparse` is set, jackin passes those paths as `claude plugin marketplace add <source> --sparse path1 path2`.
 
+`jackin-role validate` and `jackin role validate` resolve each marketplace's `.claude-plugin/marketplace.json` before a role is published. Every plugin must use `plugin@marketplace` format, and the named marketplace must publish that plugin. For example, a marketplace named `tailrocks-marketplace` that publishes only `tailrocks-skills` accepts `tailrocks-skills@tailrocks-marketplace` and rejects `rust-best-practices@tailrocks-marketplace`.
+
 ## `[codex]`
 
 The `[codex]` table is required when `"codex"` appears in `agents`.
@@ -249,6 +251,8 @@ Each marketplace block declares one Claude marketplace source to register before
 |---|---|---|
 | `source` | Yes | Raw marketplace source passed to `claude plugin marketplace add` |
 | `sparse` | No | Optional sparse-checkout paths for monorepo-backed marketplaces |
+
+Role validation fetches the marketplace manifest from the declared GitHub source and matches plugin references against its published `plugins[].name` values. The built-in `claude-plugins-official` marketplace is available without a `[[claude.marketplaces]]` block.
 
 Example:
 


### PR DESCRIPTION
## Summary

This PR adds pre-publish Claude plugin marketplace validation to the role-authoring command path so role authors and role CI catch invalid plugin references before Docker image construction. `jackin-role validate` and `jackin role validate` now prove that declared Claude plugin marketplace references are syntactically complete, that each named marketplace is resolvable, and that each requested plugin is published by that marketplace.

## What ships

- Role validation now requires Claude plugin references to use `plugin@marketplace` format, including built-in support for `claude-plugins-official` and declared custom marketplace sources.
- Role validation fetches Claude marketplace manifests from GitHub sources and rejects unknown marketplace aliases, unresolvable marketplace manifests, duplicate marketplace names, and plugin names that are not published by the referenced marketplace.
- `jackin-role validate`, `jackin role validate`, `jackin-role migrate`, and role scaffolding now run the semantic Claude plugin check after manifest validation, keeping this pre-publish guard in the role-authoring binary layer.
- Role-authoring docs now explain that Claude plugins are installed during the derived Docker build and that role validation verifies marketplace/plugin references before publishing.
- Regression coverage exercises valid marketplace resolution, official marketplace aliases, missing `@marketplace` format, unknown marketplaces, missing plugin names, and GitHub source URL normalization.

## Behavior changes

- A role manifest with `[claude].plugins = ["rust-best-practices@tailrocks-marketplace"]` now fails role validation when the Tailrocks marketplace publishes `tailrocks-skills` instead of `rust-best-practices`.
- Runtime launch and derived Docker image behavior is unchanged: jackin still lets Docker and Claude Code perform the real plugin installation during image build.

## What this addresses

- Closes #747.
- Fixes the class of failures where role CI accepted stale or misspelled Claude plugin references because validation treated `[claude].plugins` as opaque strings.
- Moves the correctness check to the publish-time role validation boundary, so role PRs fail before an invalid marketplace/plugin pair can reach a later Docker build.

## Hard rule: role validation owns pre-publish plugin resolution

`jackin-role` and `jackin role validate` are the only Jackin surfaces that pre-resolve Claude plugin marketplace references for role repositories. Runtime image creation remains a standard Docker build that calls Claude Code's marketplace and plugin installer, while role validation provides the earlier correctness gate for authors and CI.

## Not included

- This PR does not replace Claude Code's plugin installer or simulate plugin installation during runtime image builds.
- This PR does not add a local marketplace cache; validation resolves the current marketplace manifest when the role-authoring command runs.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 748
cd "$(jackin-dev pr path 748)/jackin"
source "$(jackin-dev pr path 748)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it. After `source "$(jackin-dev pr path 748)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only when the PR requires a local capsule, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

```sh
cargo nextest run -p jackin role_claude_plugins
cargo nextest run -p jackin role_authoring
cargo nextest run -p jackin-manifest
```

These cover Claude marketplace reference parsing and resolution, role-authoring command validation paths, and the unchanged manifest-domain validation layer.

### Docs checks

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run build
  cargo xtask docs repo-links
  cargo xtask roadmap audit
  bunx tsc --noEmit
  bun test
)
```

### User smoke

```sh
jackin-role validate /Users/donbeave/Projects/jackin-agent-roles/jackin-agent-brown
jackin role validate /Users/donbeave/Projects/jackin-agent-roles/jackin-agent-brown
```

Expected: both commands accept the fixed Brown role manifest. Replacing Tailrocks with `rust-best-practices@tailrocks-marketplace` in a temporary role copy should fail with an error explaining that the marketplace publishes `tailrocks-skills`, not `rust-best-practices`.

### Documentation

```sh
(
  cd docs
  bun install --frozen-lockfile
  bun run dev
)
```

Vite serves at `http://localhost:3000/`. Pages to walk:

**http://localhost:3000/developing/creating-roles/**  
UPDATED role-authoring page. Confirm it states that role validation resolves Claude plugin marketplace references before publishing.

**http://localhost:3000/developing/role-manifest/**  
UPDATED role manifest reference. Confirm the Claude plugin marketplace section explains `plugin@marketplace` validation and derived-image installation timing.

## Migration notes

None.
