### PR TITLE
fix(jackin-dev): support PR diffs over 20k lines + add --version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-dev"
-version = "0.1.14"
+version = "0.1.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jackin-dev/src/main.rs
+++ b/crates/jackin-dev/src/main.rs
@@ -35,7 +35,7 @@ const LOCAL_CONSTRUCT_REGISTRY: &str = "jackin-local/construct";
 const CONSTRUCT_STABLE_TAG: &str = "trixie";
 
 #[derive(Parser)]
-#[command(name = "jackin-dev", about = "Developer tooling for jackin")]
+#[command(name = "jackin-dev", about = "Developer tooling for jackin", version)]
 struct Cli {
     #[command(subcommand)]
     command: TopCommand,

--- a/crates/jackin-dev/src/main.rs
+++ b/crates/jackin-dev/src/main.rs
@@ -342,24 +342,77 @@ fn pr_info(pr: u64, repo: &str) -> Result<PullRequestInfo> {
     let json: Value = serde_json::from_slice(&output).context("parsing gh pr view JSON")?;
     let (head_ref_name, head_oid) = parse_pr_refs(&json)?;
 
-    // `gh pr view --json files` caps at 100 files, so a large PR (e.g. #528 with
-    // 113) silently drops changed paths like `docker/construct/*` — downgrading
-    // every `auto_prep` build decision to "not needed" and launching against a
-    // stale image. `gh pr diff --name-only` lists every changed path, uncapped.
-    let mut diff_cmd = command(
-        "gh",
-        ["pr", "diff", &pr.to_string(), "--repo", repo, "--name-only"],
-    );
-    let diff_output = run_output(&mut diff_cmd)?;
-    let diff_text = String::from_utf8(diff_output)
-        .context("`gh pr diff --name-only` output was not valid UTF-8")?;
-    let changed_files = parse_changed_files(&diff_text)?;
+    let changed_files = changed_files(pr, repo)?;
 
     Ok(PullRequestInfo {
         head_ref_name,
         head_oid,
         changed_files,
     })
+}
+
+/// The changed-file list for a PR, uncapped on both file count and diff size.
+///
+/// Two GitHub ceilings stand between us and the file list:
+///
+/// 1. `gh pr view --json files` caps at 100 paths, silently dropping the rest.
+///    A large PR (e.g. #528 with 113) then degrades every `auto_prep` build
+///    decision to "not needed" and launches against a stale image.
+/// 2. `gh pr diff --name-only` dodges that file cap, but GitHub rejects the
+///    diff resource entirely once it exceeds 20000 lines (HTTP 406
+///    `PullRequest.diff too_large`) — and the `--name-only` form routes
+///    through the same resource, so it dies on the same threshold. #713
+///    (~28k diff lines) was the first PR here to clear it.
+///
+/// Try the diff endpoint first (one call for normal PRs), then fall back to
+/// the paginated REST files endpoint — uncapped on both axes — only when the
+/// diff is too large. Any other failure is a real error, not a fallback
+/// trigger.
+fn changed_files(pr: u64, repo: &str) -> Result<Vec<String>> {
+    let mut diff_cmd = command(
+        "gh",
+        ["pr", "diff", &pr.to_string(), "--repo", repo, "--name-only"],
+    );
+    match run_output(&mut diff_cmd) {
+        Ok(diff_output) => {
+            let diff_text = String::from_utf8(diff_output)
+                .context("`gh pr diff --name-only` output was not valid UTF-8")?;
+            parse_changed_files(&diff_text)
+        }
+        Err(diff_err) if is_diff_too_large(&diff_err) => {
+            let mut api_cmd = command(
+                "gh",
+                [
+                    "api",
+                    &format!("repos/{repo}/pulls/{pr}/files"),
+                    "--paginate",
+                    "--jq",
+                    ".[].filename",
+                ],
+            );
+            let api_output = run_output(&mut api_cmd).with_context(|| {
+                format!(
+                    "`gh pr diff --name-only` was too large and the paginated files API \
+                     also failed; original diff error: {diff_err:#}"
+                )
+            })?;
+            let api_text =
+                String::from_utf8(api_output).context("`gh api .../files` output was not UTF-8")?;
+            parse_changed_files(&api_text)
+        }
+        Err(diff_err) => Err(diff_err),
+    }
+}
+
+/// True when an error from `gh pr diff` is GitHub's "diff exceeds 20000 lines"
+/// rejection (HTTP 406 / `PullRequest.diff too_large`) — the one case we route
+/// around via the files endpoint. Detects all three phrasings gh has emitted
+/// across versions.
+fn is_diff_too_large(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}");
+    msg.contains("HTTP 406")
+        || msg.contains("too_large")
+        || msg.contains("exceeded the maximum number of lines")
 }
 
 /// The commit-pinned local construct image ref that `construct build-local`

--- a/crates/jackin-dev/src/tests.rs
+++ b/crates/jackin-dev/src/tests.rs
@@ -289,7 +289,7 @@ fn is_diff_too_large_matches_github_406_phrasings() {
     );
     assert!(is_diff_too_large(&live));
 
-    // Each detection phrasing on its own, for resilience to gh rewordings.
+    // Each detection phrasing on its own, in case gh rewords these later.
     assert!(is_diff_too_large(&anyhow::anyhow!("HTTP 406: nope")));
     assert!(is_diff_too_large(&anyhow::anyhow!(
         "PullRequest.diff too_large"

--- a/crates/jackin-dev/src/tests.rs
+++ b/crates/jackin-dev/src/tests.rs
@@ -263,8 +263,53 @@ fn parse_changed_files_trims_and_drops_blank_lines() {
 }
 
 #[test]
+fn parse_changed_files_accepts_files_api_output() {
+    // The too-large-diff fallback uses `gh api .../files --jq '.[].filename'`,
+    // which is also newline-separated filenames, so the same parser applies.
+    let out = "a.rs\ndocker/construct/Dockerfile\nb.rs\n";
+    let files = parse_changed_files(out).unwrap();
+    assert_eq!(files, vec!["a.rs", "docker/construct/Dockerfile", "b.rs"]);
+}
+
+#[test]
 fn parse_changed_files_rejects_empty() {
     assert!(parse_changed_files("\n  \n").is_err());
+}
+
+#[test]
+fn is_diff_too_large_matches_github_406_phrasings() {
+    // Reproduced from gh against #713 (the first PR here to clear 20k diff lines).
+    let live = anyhow::anyhow!(
+        "`gh pr diff 713 --repo jackin-project/jackin --name-only` failed with \
+         exit status: 1\n\
+         could not find pull request diff: HTTP 406: Sorry, the diff exceeded the \
+         maximum number of lines (20000) \
+         (https://api.github.com/repos/jackin-project/jackin/pulls/713)\n\
+         PullRequest.diff too_large"
+    );
+    assert!(is_diff_too_large(&live));
+
+    // Each detection phrasing on its own, for resilience to gh rewordings.
+    assert!(is_diff_too_large(&anyhow::anyhow!("HTTP 406: nope")));
+    assert!(is_diff_too_large(&anyhow::anyhow!(
+        "PullRequest.diff too_large"
+    )));
+    assert!(is_diff_too_large(&anyhow::anyhow!(
+        "the diff exceeded the maximum number of lines (20000)"
+    )));
+}
+
+#[test]
+fn is_diff_too_large_rejects_unrelated_errors() {
+    // A real failure (auth, network, missing PR) must stay a hard error, not
+    // trigger a misleading fallback to the files endpoint.
+    assert!(!is_diff_too_large(&anyhow::anyhow!("HTTP 404: Not Found")));
+    assert!(!is_diff_too_large(&anyhow::anyhow!(
+        "could not find pull request: HTTP 404"
+    )));
+    assert!(!is_diff_too_large(&anyhow::anyhow!(
+        "gh pr diff failed with exit status: 1\nauthentication required"
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`jackin-dev pr sync` bails before cloning or building whenever a PR's diff exceeds GitHub's 20 000-line ceiling (HTTP 406 `PullRequest.diff too_large`). This PR fixes `jackin-dev` to fall back to the paginated REST files endpoint so the verify-bundle flow works for large PRs again, and bumps the artifact to 0.1.15 so the fix ships via the normal tap auto-release.

## What ships

- `jackin-dev` now lists changed files via `gh pr diff --name-only` first (the fast path for normal PRs), then falls back to `gh api repos/{repo}/pulls/{pr}/files --paginate --jq '.[].filename'` when the diff endpoint rejects the PR as too large. Both produce the same newline-separated filename list, so the existing parser applies unchanged.
- A new `is_diff_too_large` detector matches all three phrasings `gh` has emitted across versions (`HTTP 406`, `too_large`, `exceeded the maximum number of lines`); any other failure stays a hard error rather than silently triggering the fallback.
- `jackin-dev --version` now prints the Cargo package version (e.g. `jackin-dev 0.1.15`), so operators can confirm the fixed build is on `PATH` after `brew upgrade`.
- Artifact version bumped 0.1.14 → 0.1.15 so the `jackin-dev.yml` push-to-main job cross-compiles, signs, cuts the `jackin-dev-v0.1.15` release, and opens + merges the Homebrew tap formula PR automatically.

## Behavior changes

- Operators can `brew upgrade jackin-dev` to 0.1.15 and run `jackin-dev pr sync <PR>` against PRs whose diff exceeds 20 000 lines; previously those PRs failed at the changed-file discovery step with `HTTP 406: ... PullRequest.diff too_large` and never cloned or built. `jackin-dev --version` now confirms the installed build.

## What this addresses

- The verify-bundle blocker that surfaced against #713 (~28 000 diff lines), where `jackin-dev pr sync 713` died before producing a checkout, leaving no way to verify large waves through the standard bundle flow.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 754
cd "$(jackin-dev pr path 754)/jackin"
source "$(jackin-dev pr path 754)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it. After `source "$(jackin-dev pr path 754)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only when the PR requires a local capsule, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.

### Static checks

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
```

### Rust tests

The unit tests cover the too-large detector (all three phrasings, plus unrelated errors that must not trigger the fallback) and the shared filename parser for both the diff and files-API output shapes.

```sh
cargo nextest run -p jackin-dev
```

### User smoke

Build the PR's `jackin-dev` and prove the fallback resolves a too-large PR that the current 0.1.14 binary cannot. #713 (~28 000 diff lines) is the reference case — the Homebrew 0.1.14 bails on it; the PR binary returns the full 280-file list.

```sh
cargo build --release -p jackin-dev
./target/release/jackin-dev --version
./target/release/jackin-dev pr explain 713
```

Expected: `--version` prints `jackin-dev 0.1.15`, and the preview prints `changed files: 280` and runs to completion, with no `HTTP 406` / `too_large` error. For contrast, `jackin-dev pr explain 713` on the Homebrew 0.1.14 prints the `HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)` bail.
