### PR TITLE
fix(ci): restore registry before offline builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,21 +562,20 @@ jobs:
           chmod +x .ci-prebuilt-tools/*
           echo "hit=true" >> "$GITHUB_OUTPUT"
       - id: cargo-registry-lookup
-        name: Check prepared Cargo registry
+        name: Restore prepared Cargo registry
+        if: steps.ci-xtask-artifact.outputs.hit != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git/db
           key: cargo-registry-v5-${{ needs.changes.outputs.registry-contract }}
-          lookup-only: true
       - id: prepared-inputs
         name: Resolve warmup ownership
         shell: bash
         run: |
           if [ "${{ steps.ci-xtask-artifact.outputs.hit }}" = "true" ] && \
-             [ "${{ steps.ci-tools-artifact.outputs.hit }}" = "true" ] && \
-             [ "${{ steps.cargo-registry-lookup.outputs.cache-hit }}" = "true" ]; then
+             [ "${{ steps.ci-tools-artifact.outputs.hit }}" = "true" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
@@ -682,7 +681,9 @@ jobs:
           fi
           scripts/ci/activate-installed-rust-toolchain.sh "$version"
       - id: cargo-registry-cache
-        if: steps.cargo-registry-lookup.outputs.cache-hit != 'true'
+        if: >-
+          steps.ci-xtask-artifact.outputs.hit != 'true' &&
+          steps.cargo-registry-lookup.outputs.cache-hit != 'true'
         uses: ./.github/actions/cache-cargo-registry
         with:
           contract-key: ${{ needs.changes.outputs.registry-contract }}


### PR DESCRIPTION
## Summary

Restores the exact Cargo registry cache before an offline xtask build instead of treating a lookup-only cache hit as restored state.

## What ships

- The warmup job downloads the registry only when the input-identical xtask artifact is missing and compilation is required.
- A reusable xtask plus tool bundle now bypasses Rust toolchain and registry setup entirely.
- The fallback registry action runs only when both compilation is required and the exact registry restore misses.

## Behavior changes

- Cold xtask inputs can build offline from the exact registry cache.
- Fully prepared inputs avoid downloading the roughly 203 MB registry archive.
- Dependent jobs no longer spend 40 seconds waiting for an xtask artifact after the producer failed against an unrestored cache.

## What this addresses

PR #801 found an exact Cargo-registry key, skipped its real restore, then failed immediately because the new `termrock` revision was unavailable offline. That failure prevented xtask publication and caused two dependent jobs to exhaust their artifact wait budget.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync <PR_NUMBER>
cd "$(jackin-dev pr path <PR_NUMBER>)/jackin"
source "$(jackin-dev pr path <PR_NUMBER>)/env.sh"
which jackin
```

### CI workflow checks

```sh
mise exec -- actionlint .github/workflows/*.yml
```

## Migration notes

None.
