### PR TITLE
 (#812)

### DIFF
--- a/crates/jackin-diagnostics/target/telemetry-volume.json
+++ b/crates/jackin-diagnostics/target/telemetry-volume.json
@@ -1,7 +1,0 @@
-{
-  "default_mode_logs": 16,
-  "default_mode_spans": 6,
-  "default_mode_metrics": 0,
-  "max_debug_logs": 64,
-  "max_spans": 48
-}


### PR DESCRIPTION
Remove the tracked `crates/jackin-diagnostics/target/telemetry-volume.json` build artifact.

`/target/` is already in `.gitignore` at the repo root, but this file was committed before the ignore rule covered nested crate paths and remained tracked. Stop tracking it so future local builds don't re-add it.

Discovered as uncommitted local deletion during repo audit.