### PR TITLE
fix(ci): publish validator compatibility artifact

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -368,7 +368,7 @@ jobs:
           sccache-stats-artifact-name: sccache-stats-preview-jackin-${{ matrix.target.target }}-${{ matrix.config.lane }}
           sccache-stats-heading: sccache preview jackin ${{ matrix.target.target }} (${{ matrix.config.lane }})
       - name: Package validator compatibility artifact
-        if: matrix.config.lane == 'GitHub'
+        if: matrix.config.lane == 'GitHub' && contains(matrix.target.target, 'linux')
         shell: bash
         env:
           TARGET: ${{ matrix.target.target }}
@@ -386,7 +386,7 @@ jobs:
             gzip -n > "$archive"
           sha256sum "$archive" > "$archive.sha256"
       - name: Upload validator compatibility artifact
-        if: matrix.config.lane == 'GitHub'
+        if: matrix.config.lane == 'GitHub' && contains(matrix.target.target, 'linux')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jackin-role-${{ matrix.target.target }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -367,6 +367,33 @@ jobs:
           timings-artifact-name: cargo-timings-preview-jackin-${{ matrix.target.target }}-${{ matrix.config.lane }}
           sccache-stats-artifact-name: sccache-stats-preview-jackin-${{ matrix.target.target }}-${{ matrix.config.lane }}
           sccache-stats-heading: sccache preview jackin ${{ matrix.target.target }} (${{ matrix.config.lane }})
+      - name: Package validator compatibility artifact
+        if: matrix.config.lane == 'GitHub'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target.target }}
+        run: |
+          set -euo pipefail
+          archive="jackin-role-${TARGET}.tar.gz"
+          tar --sort=name \
+            --mtime="@0" \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            -cf - \
+            -C "target/${TARGET}/release" \
+            jackin-role |
+            gzip -n > "$archive"
+          sha256sum "$archive" > "$archive.sha256"
+      - name: Upload validator compatibility artifact
+        if: matrix.config.lane == 'GitHub'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jackin-role-${{ matrix.target.target }}
+          path: |
+            jackin-role-${{ matrix.target.target }}.tar.gz
+            jackin-role-${{ matrix.target.target }}.tar.gz.sha256
+          retention-days: 7
 
   build-jackin-capsule:
     name: build preview capsule (${{ matrix.config.lane }}, ${{ matrix.target.target }})


### PR DESCRIPTION
## Summary

Publish a short-lived compatibility artifact from GitHub-lane previews so validator consumers pinned to the admitted action revision recover after the retired standalone artifact expired.

## What ships

- Every GitHub-lane jackin preview emits a deterministic validator-only archive for each Linux target.
- The compatibility archive includes a standard SHA-256 sidecar consumed by the existing fail-closed downloader.

## What this addresses

- Restores downstream role validation without admitting an unreviewed action revision or weakening Velnor capability checks.
- Keeps the canonical combined preview artifact unchanged while consumers migrate to the newer downloader.

## Not included

- Permanent duplicate publication; the compatibility artifact retires after Velnor admits the canonical preview consumer.

## Verify locally

### Checkout

```sh
tirith session disable
```

```sh
jackin-dev pr sync 826
source "$HOME/Projects/jackin-project/test/pr-826/env.sh"
```

### Static checks

```sh
mise x aqua:rhysd/actionlint@1.7.12 -- actionlint .github/workflows/preview.yml
```

### User smoke

Dispatch the Preview workflow on the GitHub lane. Confirm each jackin build uploads a jackin-role artifact containing the validator archive and matching SHA-256 sidecar.

## Migration notes

None.
