### PR TITLE
ci: restore core workflow gates

### DIFF
--- a/.github/actions/check-deployed-docs/action.yml
+++ b/.github/actions/check-deployed-docs/action.yml
@@ -73,8 +73,7 @@ runs:
 
     - name: Collect deployed docs URLs
       shell: bash
-      run: |
-        MISE_CONFIG_FILE=docs/mise.toml mise exec -- lychee --dump "${{ inputs.sitemap-url }}" > lychee/deployed-pages.txt
+      run: lychee --dump "${{ inputs.sitemap-url }}" > lychee/deployed-pages.txt
 
     - name: Check deployed docs links
       shell: bash
@@ -104,8 +103,7 @@ runs:
             args+=(--include "^${site_origin_re}(/|$)|^file://")
           fi
 
-          MISE_CONFIG_FILE=docs/mise.toml mise exec -- lychee \
-            "${args[@]}"
+          lychee "${args[@]}"
         }
 
         for attempt in 1 2 3; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,7 +1120,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >-
           "$CI_XTASK" ci-audit
-          --expect-clean "${{ needs.changes.outputs.result-reuse == 'true' }}"
+          --expect-clean "${{ needs.changes.outputs.result-reuse == 'true' && needs.changes.outputs.workflows != 'true' }}"
           --workflow-label CI
       - name: Stage input-identical successful CI result
         if: >-


### PR DESCRIPTION
## Related pull requests

- <https://github.com/jackin-project/jackin-agent-smith/pull/118>
- <https://github.com/jackin-project/jackin-role-action/pull/92>
- <https://github.com/jackin-project/jackin-sentinel/pull/56>
- <https://github.com/jackin-project/jackin-the-architect/pull/247>

## Summary

Restore reliable core CI and deployed-documentation verification after the latest mise update while keeping GitHub-hosted runners as the automatic default.

## What ships

- Deployed documentation checks invoke the already-installed `lychee` binary directly, avoiding implicit installation of unrelated root toolchains.
- Warm-cache enforcement remains strict for input-identical runs but permits cache-contract rotation when workflow definitions change.
- GitHub remains the default lane; explicit Velnor and both-lane dispatch behavior is unchanged.

## What this addresses

- The deployed docs gate exhausted its timeout compiling unrelated Cargo tools before link verification began.
- A workflow-only dependency update legitimately changed cache keys but was rejected as an unexpected warm-cache miss.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 832
cd "$(jackin-dev pr path 832)/jackin"
source "$(jackin-dev pr path 832)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it.

## Migration notes

None.
