### PR TITLE
fix(ci): restore reusable preview artifacts

### DIFF
--- a/.github/actions/restore-package-result/action.yml
+++ b/.github/actions/restore-package-result/action.yml
@@ -48,7 +48,7 @@ runs:
         search_artifacts: true
         name: ${{ inputs.primary-name }}
         path: ${{ inputs.path }}
-        dry_run: ${{ inputs.dry-run }}
+        dry_run: ${{ inputs.dry-run == 'true' && 'true' || '' }}
         if_no_artifact_found: ignore
     - id: alternate
       if: steps.primary.outputs.found_artifact != 'true' && steps.primary.outputs.dry_run != 'true'
@@ -62,7 +62,7 @@ runs:
         search_artifacts: true
         name: ${{ inputs.alternate-name }}
         path: ${{ inputs.path }}
-        dry_run: ${{ inputs.dry-run }}
+        dry_run: ${{ inputs.dry-run == 'true' && 'true' || '' }}
         if_no_artifact_found: ignore
     - id: current
       if: >-
@@ -77,5 +77,5 @@ runs:
         name_is_regexp: true
         path: ${{ inputs.path }}
         merge_multiple: true
-        dry_run: ${{ inputs.dry-run }}
+        dry_run: ${{ inputs.dry-run == 'true' && 'true' || '' }}
         if_no_artifact_found: ignore


### PR DESCRIPTION
## Summary

Restore input-identical preview archives before provenance attestation while preserving the GitHub-default, Velnor-optional lane model.

## What ships

- Normal preview runs pass an empty `dry_run` input to the pinned artifact action, allowing it to download and extract matching archives.
- Explicit workflow-dispatch probes still pass `true` and remain download-free.
- Archive attestation remains mandatory for restored and newly built artifacts.

## What this addresses

The upstream action tests `dry_run` as a JavaScript string. The composite passed the non-empty string `false`, which the action interpreted as enabled, reported an artifact match, and skipped extraction. Attestation then correctly failed because `dist/*.tar.gz` was empty.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 833
cd "$(jackin-dev pr path 833)/jackin"
source "$(jackin-dev pr path 833)/env.sh"
which jackin
```

## Migration notes

None.
