### PR TITLE
fix(ci): enforce internal deployed link checks

### DIFF
--- a/.github/actions/check-deployed-docs/action.yml
+++ b/.github/actions/check-deployed-docs/action.yml
@@ -100,7 +100,8 @@ runs:
           if [[ "$EXTERNAL_LINKS" != "true" ]]; then
             site_origin="${SITEMAP_URL%/sitemap.xml}"
             site_origin_re="$(printf '%s' "$site_origin" | sed 's/[][\/.^$*+?{}()|]/\\&/g')"
-            args+=(--include "^${site_origin_re}(/|$)|^file://")
+            # `--include` overrides exclusions; it is not an allowlist by itself.
+            args+=(--exclude '^https?://' --include "^${site_origin_re}(/|$)")
           fi
 
           lychee "${args[@]}"


### PR DESCRIPTION
## Summary

Make the default post-deploy documentation gate truly internal-only, eliminating external-site flakiness and unnecessary GitHub Actions traffic.

## What ships

- Exclude all HTTP(S) URLs when `external-links` is disabled.
- Re-admit only the deployed jackin❯ documentation origin through Lychee include precedence.
- Preserve the scheduled full-external link audit unchanged.

## What this addresses

Lychee `--include` has precedence over exclusions but is not an allowlist by itself. The previous configuration still sent thousands of external requests and failed on rotating 403/network responses from unrelated sites.

## Verify locally

```sh
mise exec lychee -- lychee --cache=false --exclude '^https?://' --include '^https:\/\/jackin\.tailrocks\.com(/|$)' --host-stats https://jackin.tailrocks.com/reference/errors/
```

The host statistics must list only `jackin.tailrocks.com`.

## Migration notes

None.
