### PR TITLE
ci(preview): allow cold archive builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -256,7 +256,8 @@ jobs:
     needs: [source-changed]
     if: needs.source-changed.outputs.source == 'true'
     runs-on: ${{ fromJSON(matrix.config.runner) }}
-    timeout-minutes: 60
+    # Cold four-platform archive builds measured just over 60 minutes on GitHub.
+    timeout-minutes: 90
     concurrency:
       group: preview-jackin-${{ needs.source-changed.outputs.jackin_archive_contract }}
       cancel-in-progress: false


### PR DESCRIPTION
<!--
PR body template. Two surfaces describe how to use it:

  - PULL_REQUESTS.md at the repo root — shared PR flow + body-shape
    spec + Verify-locally policy + isolation env vars + review and
    roadmap-retirement rules. Both humans and agents start here.
  - .github/AGENTS.md (next to this template) — agent-only extras:
    merge authorization, body-construction shell quoting, force-push
    policy, jackin-capsule smoke-test mandate, squash-commit format.
    Claude Code auto-loads it via .github/CLAUDE.md when working
    under .github/.

Read both before authoring the body if you are an agent; the shared
file alone if you are a human contributor.

Rules in one line each:
- One paragraph per section, no hard-wrap (GitHub flows the text).
- Explain the shipped feature shape, not every implementation detail.
- No design rationale narration here — link out to a contributor doc instead.
- No file-by-file changelog (use the diff). No function/struct inventory. No full test list (use the runner output).
- No deployed-docs URLs (they break post-merge). Refer to docs by name only.
- No mechanical CI-shaped checks (sidebar diffs, link audits). Those belong in CI.
  Exception: the docs verification gate (`### Docs checks`) is the one sanctioned
  copy-paste block — AGENTS.md requires docs authors run it before merge.
- Verify-locally URLs use http://localhost:3000/... only — never deployed.
- Each verify-locally docs page: bold URL on its own line, soft-break (two
  trailing spaces), description on the next line, blank line between blocks.
- Drop the headings you don't need. "Related pull requests" is only when the PR
  spans multiple repos. "Behavior changes" is only when it adds signal beyond
  "What ships". "Hard rule" is only when the PR introduces or honours a
  non-trivial cross-cutting rule. "Not included" is only when scope boundaries
  or deferred work are useful to call out. "Migration notes" can read "None"
  during pre-release.
-->

## Summary

Give jackin❯ preview publishing enough measured time to complete a cold, signed four-platform archive build on GitHub-hosted runners.

## What ships

- Preview archive jobs receive a 90-minute measured timeout instead of 60 minutes.
- One signed archive set remains one semantic build unit, preserving workflow artifact integrity.

## Behavior changes

- Cold GitHub-hosted preview builds can finish SBOM generation and upload after compiling all four targets.

## What this addresses

- Manual preview run `31287560553` completed compilation and signing, then hit the 60-minute timeout during final SBOM work.
- Preview publishing no longer fails because its measured cold-build runtime exceeds an undersized job budget.

## Verify locally

### Checkout

Paste this first to bypass the `tirith` paste scanner for the rest of the session:

```sh
export TIRITH=0
```

Then paste the checkout block:

```sh
jackin-dev pr sync 837
cd "$(jackin-dev pr path 837)/jackin"
source "$(jackin-dev pr path 837)/env.sh"
which jackin
```

`jackin-dev pr sync` clones or refreshes the PR checkout, checks out the PR's real head branch, builds the local `jackin` binary, copies live config into the PR bundle, creates empty PR-scoped state, writes `env.sh`, builds and exports a local `JACKIN_CAPSULE_BIN` when the changed workspace package is in the `jackin-capsule` dependency closure, and auto-builds the PR construct image when the changed files require it. After `source "$(jackin-dev pr path 837)/env.sh"`, `echo "$JACKIN_CAPSULE_BIN"` is set only when the PR requires a local capsule, and `echo "$JACKIN_CONSTRUCT_IMAGE"` is set only for PRs whose diff requires a local construct image.
