### PR TITLE
fix(release): make tagged builds self-contained

### DIFF
--- a/.github/actions/build-release-archive/action.yml
+++ b/.github/actions/build-release-archive/action.yml
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 Alexey Zhokhov
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build signed release archive
+description: |
+  Build one cargo-zigbuild release archive, write its SHA256, sign/SBOM/attest
+  it, and upload the archive artifact. Preview and tagged release workflows use
+  this action so the archive build contract stays identical.
+inputs:
+  package:
+    description: "Archive package to build: jackin or jackin-capsule."
+    required: true
+  target:
+    description: Rust target triple used for packaging path and artifact names.
+    required: true
+  zigbuild-target:
+    description: cargo-zigbuild target, optionally with glibc suffix.
+    required: true
+  version:
+    description: Version override passed to the build.
+    required: true
+  archive-basename:
+    description: Archive basename without .tar.gz.
+    required: true
+  artifact-name:
+    description: Uploaded artifact name.
+    required: true
+  timings-artifact-name:
+    description: Uploaded cargo timings artifact name.
+    required: true
+  sccache-stats-artifact-name:
+    description: Optional uploaded sccache stats artifact name.
+    required: false
+    default: ""
+  sccache-stats-heading:
+    description: Optional step-summary heading for sccache stats.
+    required: false
+    default: ""
+  attest:
+    description: Whether to run GitHub artifact attestation for the archive.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Build release binary
+      shell: bash
+      env:
+        PACKAGE: ${{ inputs.package }}
+        ZIGBUILD_TARGET: ${{ inputs.zigbuild-target }}
+        JACKIN_VERSION_OVERRIDE: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        export ZIG_GLOBAL_CACHE_DIR="${ZIG_GLOBAL_CACHE_DIR:-${RUNNER_TEMP:-/tmp}/zig-global-cache}"
+        export ZIG_LOCAL_CACHE_DIR="${ZIG_LOCAL_CACHE_DIR:-${RUNNER_TEMP:-/tmp}/zig-local-cache}"
+        mkdir -p "$ZIG_GLOBAL_CACHE_DIR" "$ZIG_LOCAL_CACHE_DIR"
+        case "$PACKAGE" in
+          jackin)
+            cargo zigbuild --timings --release --locked --target "$ZIGBUILD_TARGET"
+            ;;
+          jackin-capsule)
+            cargo zigbuild --timings --release --locked -p jackin-capsule --target "$ZIGBUILD_TARGET"
+            ;;
+          *)
+            echo "::error::unsupported release archive package: ${PACKAGE}"
+            exit 1
+            ;;
+        esac
+
+    - name: Package deterministic archive
+      id: package
+      shell: bash
+      env:
+        PACKAGE: ${{ inputs.package }}
+        TARGET: ${{ inputs.target }}
+        ARCHIVE_BASENAME: ${{ inputs.archive-basename }}
+        SOURCE_DATE_EPOCH: "0"
+      run: |
+        set -euo pipefail
+
+        archive="${ARCHIVE_BASENAME}.tar.gz"
+        target_dir="${CARGO_TARGET_DIR:-target}"
+        case "$PACKAGE" in
+          jackin) binaries=(jackin jackin-role) ;;
+          jackin-capsule) binaries=(jackin-capsule) ;;
+          *)
+            echo "::error::unsupported release archive package: ${PACKAGE}"
+            exit 1
+            ;;
+        esac
+
+        tar --sort=name \
+          --mtime="@${SOURCE_DATE_EPOCH}" \
+          --owner=0 \
+          --group=0 \
+          --numeric-owner \
+          -cf - \
+          -C "${target_dir}/${TARGET}/release" \
+          "${binaries[@]}" |
+          gzip -n > "$archive"
+
+        if [ "$target_dir" != "target" ] && [ -d "${target_dir}/cargo-timings" ]; then
+          mkdir -p target/cargo-timings
+          cp -a "${target_dir}/cargo-timings/." target/cargo-timings/
+        fi
+
+        echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+    - name: Write archive checksum
+      shell: bash
+      env:
+        ARCHIVE: ${{ steps.package.outputs.archive }}
+      run: |
+        set -euo pipefail
+
+        archive="$ARCHIVE"
+        sha256sum "$archive" | awk '{print $1}' > "$archive.sha256"
+
+    - name: Upload cargo timings
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.timings-artifact-name }}
+        path: target/cargo-timings/*.html
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Write sccache stats
+      if: always() && inputs.sccache-stats-artifact-name != ''
+      shell: bash
+      env:
+        SCCACHE_STATS_ARTIFACT_NAME: ${{ inputs.sccache-stats-artifact-name }}
+        SCCACHE_STATS_HEADING: ${{ inputs.sccache-stats-heading }}
+      run: |
+        set -euo pipefail
+
+        stats_file="${SCCACHE_STATS_ARTIFACT_NAME}.txt"
+        if ! command -v sccache >/dev/null 2>&1; then
+          echo "sccache not installed; skipping stats" | tee "$stats_file"
+        else
+          sccache --show-stats | tee "$stats_file"
+        fi
+        {
+          echo "### ${SCCACHE_STATS_HEADING:-$SCCACHE_STATS_ARTIFACT_NAME}"
+          echo '```text'
+          cat "$stats_file"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload sccache stats
+      if: always() && inputs.sccache-stats-artifact-name != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.sccache-stats-artifact-name }}
+        path: ${{ inputs.sccache-stats-artifact-name }}.txt
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Sign, SBOM, and attest archive
+      uses: ./.github/actions/sign-and-attest-archive
+      with:
+        archive: ${{ steps.package.outputs.archive }}
+        attest: ${{ inputs.attest }}
+
+    - name: Upload archive artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: |
+          ${{ steps.package.outputs.archive }}
+          ${{ steps.package.outputs.archive }}.sha256
+          ${{ steps.package.outputs.archive }}.bundle
+          ${{ steps.package.outputs.archive }}.sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,11 +186,30 @@ jobs:
       needs.check-version.outputs.published != 'true' &&
       needs.check-version.outputs.mode == 'publish'
     needs: [check-version, matrix-setup]
-    uses: ./.github/workflows/rust-nextest.yml
-    with:
-      runner-configs-json: ${{ needs.matrix-setup.outputs.configs }}
-      all-features: false
-    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON(needs.matrix-setup.outputs.configs) }}
+    runs-on: ${{ fromJSON(matrix.config.runner) }}
+    timeout-minutes: 60
+    name: test release workspace (${{ matrix.config.lane }})
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TERM_COLOR: always
+      RUSTC_WRAPPER: ""
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: "2026.7.12"
+          cache_key_prefix: "mise-v2"
+          cache_save: false
+          install_args: "cargo-binstall rust cargo:cargo-nextest"
+          github_token: ${{ secrets.GH_READONLY_TOKEN }}
+      - uses: ./.github/actions/cache-cargo-registry
+      - run: cargo nextest run --workspace --locked --no-fail-fast
 
   build:
     if: >-


### PR DESCRIPTION
## Summary\n\n- restore the release archive action still consumed by tagged builds\n- make release workspace tests independent from CI-prepared artifacts\n- keep tagged-source checkout, locked Nextest, archive signing, SBOM, and attestation gates\n\n## Root cause\n\nRelease v0.6.0 exposed two stale dependencies: #810 deleted `build-release-archive` while `release.yml` still invoked it, and the release test fanout consumed prepared CI artifacts without a release producer.\n\n## Verification\n\n- `actionlint .github/workflows/*.yml`\n- `git diff --check`