### PR TITLE
chore(release): bump workspace to v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,7 +2884,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-agent-status"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -2950,21 +2950,21 @@ dependencies = [
 
 [[package]]
 name = "jackin-brand"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "owo-colors 4.3.0",
 ]
 
 [[package]]
 name = "jackin-build-meta"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "jackin-process",
 ]
 
 [[package]]
 name = "jackin-capsule"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-console"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-diagnostics"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-docker"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-env"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-host"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "fs4",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-image"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-instance"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-isolation"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-launch"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-manifest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-oppicker"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-otlp-testbed"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "jackin-telemetry",
  "opentelemetry-proto",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-pr-trailers"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-process"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "tokio",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "dhat",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-term"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-test-support"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-tui"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossterm",
  "jackin-brand",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-usage"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-usage-ffi"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "jackin-protocol",
  "jackin-usage",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-xtask"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = ["crates/jackin-lints"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.97"
 license = "Apache-2.0"
@@ -67,31 +67,31 @@ futures-util = "0.3"
 hyper-util = { version = "0.1", features = ["tokio"] }
 hex = "0.4"
 insta = "=1.48.0"
-jackin-build-meta = { version = "0.6.0", path = "crates/jackin-build-meta" }
-jackin-brand = { version = "0.6.0", path = "crates/jackin-brand" }
-jackin-agent-status = { version = "0.6.0", path = "crates/jackin-agent-status" }
-jackin-config = { version = "0.6.0", path = "crates/jackin-config" }
-jackin-console = { version = "0.6.0", path = "crates/jackin-console" }
-jackin-oppicker = { version = "0.6.0", path = "crates/jackin-oppicker" }
-jackin-core = { version = "0.6.0", path = "crates/jackin-core" }
-jackin-diagnostics = { version = "0.6.0", path = "crates/jackin-diagnostics" }
-jackin-docker = { version = "0.6.0", path = "crates/jackin-docker" }
-jackin-env = { version = "0.6.0", path = "crates/jackin-env" }
-jackin-host = { version = "0.6.0", path = "crates/jackin-host" }
-jackin-image = { version = "0.6.0", path = "crates/jackin-image" }
-jackin-instance = { version = "0.6.0", path = "crates/jackin-instance" }
-jackin-isolation = { version = "0.6.0", path = "crates/jackin-isolation" }
-jackin-launch = { version = "0.6.0", path = "crates/jackin-launch" }
-jackin-manifest = { version = "0.6.0", path = "crates/jackin-manifest" }
-jackin-otlp-testbed = { version = "0.6.0", path = "crates/jackin-otlp-testbed" }
-jackin-process = { version = "0.6.0", path = "crates/jackin-process" }
-jackin-protocol = { version = "0.6.0", path = "crates/jackin-protocol" }
-jackin-runtime = { version = "0.6.0", path = "crates/jackin-runtime" }
-jackin-telemetry = { version = "0.6.0", path = "crates/jackin-telemetry" }
-jackin-term = { version = "0.6.0", path = "crates/jackin-term" }
-jackin-tui = { version = "0.6.0", path = "crates/jackin-tui" }
-jackin-test-support = { version = "0.6.0", path = "crates/jackin-test-support" }
-jackin-usage = { version = "0.6.0", path = "crates/jackin-usage" }
+jackin-build-meta = { version = "0.6.1", path = "crates/jackin-build-meta" }
+jackin-brand = { version = "0.6.1", path = "crates/jackin-brand" }
+jackin-agent-status = { version = "0.6.1", path = "crates/jackin-agent-status" }
+jackin-config = { version = "0.6.1", path = "crates/jackin-config" }
+jackin-console = { version = "0.6.1", path = "crates/jackin-console" }
+jackin-oppicker = { version = "0.6.1", path = "crates/jackin-oppicker" }
+jackin-core = { version = "0.6.1", path = "crates/jackin-core" }
+jackin-diagnostics = { version = "0.6.1", path = "crates/jackin-diagnostics" }
+jackin-docker = { version = "0.6.1", path = "crates/jackin-docker" }
+jackin-env = { version = "0.6.1", path = "crates/jackin-env" }
+jackin-host = { version = "0.6.1", path = "crates/jackin-host" }
+jackin-image = { version = "0.6.1", path = "crates/jackin-image" }
+jackin-instance = { version = "0.6.1", path = "crates/jackin-instance" }
+jackin-isolation = { version = "0.6.1", path = "crates/jackin-isolation" }
+jackin-launch = { version = "0.6.1", path = "crates/jackin-launch" }
+jackin-manifest = { version = "0.6.1", path = "crates/jackin-manifest" }
+jackin-otlp-testbed = { version = "0.6.1", path = "crates/jackin-otlp-testbed" }
+jackin-process = { version = "0.6.1", path = "crates/jackin-process" }
+jackin-protocol = { version = "0.6.1", path = "crates/jackin-protocol" }
+jackin-runtime = { version = "0.6.1", path = "crates/jackin-runtime" }
+jackin-telemetry = { version = "0.6.1", path = "crates/jackin-telemetry" }
+jackin-term = { version = "0.6.1", path = "crates/jackin-term" }
+jackin-tui = { version = "0.6.1", path = "crates/jackin-tui" }
+jackin-test-support = { version = "0.6.1", path = "crates/jackin-test-support" }
+jackin-usage = { version = "0.6.1", path = "crates/jackin-usage" }
 nix = "0.31"
 opentelemetry_sdk = "0.32"
 opentelemetry-semantic-conventions = { version = "=0.32.1", default-features = false }

--- a/crates/jackin-agent-status/Cargo.toml
+++ b/crates/jackin-agent-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-agent-status"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-brand/Cargo.toml
+++ b/crates/jackin-brand/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-brand"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-build-meta/Cargo.toml
+++ b/crates/jackin-build-meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-build-meta"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-capsule/Cargo.toml
+++ b/crates/jackin-capsule/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-capsule"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-config/Cargo.toml
+++ b/crates/jackin-config/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-config"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-config/fuzz/Cargo.lock
+++ b/crates/jackin-config/fuzz/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-console/Cargo.toml
+++ b/crates/jackin-console/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-console"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-core/Cargo.toml
+++ b/crates/jackin-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-dev"
-version = "0.1.40"
+version = "0.1.41"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jackin-diagnostics/Cargo.toml
+++ b/crates/jackin-diagnostics/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-diagnostics"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-docker/Cargo.toml
+++ b/crates/jackin-docker/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-docker"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-env/Cargo.toml
+++ b/crates/jackin-env/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-env"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-env/fuzz/Cargo.lock
+++ b/crates/jackin-env/fuzz/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-diagnostics"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-env"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-process"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "tokio",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-host/Cargo.toml
+++ b/crates/jackin-host/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-host"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-image/Cargo.toml
+++ b/crates/jackin-image/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-image"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-instance/Cargo.toml
+++ b/crates/jackin-instance/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-instance"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-isolation/Cargo.toml
+++ b/crates/jackin-isolation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-isolation"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-launch/Cargo.toml
+++ b/crates/jackin-launch/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-launch"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-manifest/Cargo.toml
+++ b/crates/jackin-manifest/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-manifest"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-manifest/fuzz/Cargo.lock
+++ b/crates/jackin-manifest/fuzz/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-manifest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "dockerfile-parser-rs",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-oppicker/Cargo.toml
+++ b/crates/jackin-oppicker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-oppicker"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-process/Cargo.toml
+++ b/crates/jackin-process/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-process"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-protocol/Cargo.toml
+++ b/crates/jackin-protocol/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-protocol"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-protocol/fuzz/Cargo.lock
+++ b/crates/jackin-protocol/fuzz/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-runtime/Cargo.toml
+++ b/crates/jackin-runtime/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-runtime"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-term/Cargo.toml
+++ b/crates/jackin-term/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-term"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-term/fuzz/Cargo.lock
+++ b/crates/jackin-term/fuzz/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-term"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "compact_str",
  "smallvec",

--- a/crates/jackin-test-support/Cargo.toml
+++ b/crates/jackin-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-test-support"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-tui/Cargo.toml
+++ b/crates/jackin-tui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-tui"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-usage-ffi/Cargo.toml
+++ b/crates/jackin-usage-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-usage-ffi"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-usage/Cargo.toml
+++ b/crates/jackin-usage/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-usage"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin/Cargo.toml
+++ b/crates/jackin/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]


### PR DESCRIPTION
## Summary

Prepare jackin❯ v0.6.1 from the repaired tagged-release pipeline so the stable artifacts can be published from an exact green main commit.

## What ships

- Advances every stable workspace package and internal dependency requirement to `0.6.1`.
- Regenerates the lockfile with only the matching internal package-version changes.

## What this addresses

- Replaces the failed immutable v0.6.0 release attempt with a new release version after the tagged-build architecture was repaired in #846.

## Verify locally

### Checkout

```sh
export TIRITH=0
```

```sh
jackin-dev pr sync 847
cd "$(jackin-dev pr path 847)/jackin"
source "$(jackin-dev pr path 847)/env.sh"
which jackin
```

### Static checks

```sh
cargo check --workspace --locked
```

## Migration notes

None.
