### PR TITLE
fix(ci): retry mise asset probes

### DIFF
--- a/.github/workflows/renovate-validate.yml
+++ b/.github/workflows/renovate-validate.yml
@@ -57,7 +57,10 @@ jobs:
           # Dockerfile pipes to `sh` downloads these exact release assets.
           for arch in x64 arm64; do
             url="https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-${arch}.tar.gz"
-            if ! curl -fsSLI --max-time 30 -o /dev/null "$url"; then
+            if ! curl --fail --silent --show-error --location --head \
+              --retry 5 --retry-all-errors --retry-delay 2 \
+              --connect-timeout 15 --max-time 60 \
+              -o /dev/null "$url"; then
               echo "::error::${url} did not resolve — mise v${MISE_VERSION} is missing the linux-${arch} release asset"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- retry transient GitHub release CDN failures during pinned mise validation
- retain fail-closed behavior after bounded retries

## Evidence
- main runs 31633108700 attempts 1 and 2 both received HTTP 503 from the pinned asset URL
- the same asset validation passed on PR #847 before merge

Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>
Co-authored-by: Codex <codex@openai.com>