### PR TITLE
fix(release): use pinned nextest tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
           cache_save: false
-          install_args: "cargo-binstall rust cargo:cargo-nextest"
+          install_args: "cargo-binstall rust aqua:nextest-rs/nextest/cargo-nextest"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - uses: ./.github/actions/cache-cargo-registry
       - run: cargo nextest run --workspace --locked --no-fail-fast
@@ -426,7 +426,7 @@ jobs:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
           cache_save: ${{ github.ref == 'refs/heads/main' }}
-          install_args: "cargo-binstall rust cosign syft cargo:cargo-nextest"
+          install_args: "cargo-binstall rust cosign syft aqua:nextest-rs/nextest/cargo-nextest"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
 
       - uses: ./.github/actions/cache-cargo-registry

--- a/.github/workflows/renovate-validate-public-unmerged.yml
+++ b/.github/workflows/renovate-validate-public-unmerged.yml
@@ -50,9 +50,11 @@ jobs:
           # Dockerfile pipes to `sh` downloads these exact release assets.
           for arch in x64 arm64; do
             url="https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-linux-${arch}.tar.gz"
-            if ! curl -fsSLI --max-time 30 -o /dev/null "$url"; then
+            if ! curl --fail --silent --show-error --location --head \
+              --retry 5 --retry-all-errors --retry-delay 2 \
+              --connect-timeout 15 --max-time 60 \
+              -o /dev/null "$url"; then
               echo "::error::${url} did not resolve — mise v${MISE_VERSION} is missing the linux-${arch} release asset"
               exit 1
             fi
           done
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.21"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
@@ -2884,7 +2884,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-agent-status"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -2950,21 +2950,21 @@ dependencies = [
 
 [[package]]
 name = "jackin-brand"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "owo-colors 4.3.0",
 ]
 
 [[package]]
 name = "jackin-build-meta"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "jackin-process",
 ]
 
 [[package]]
 name = "jackin-capsule"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-console"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-diagnostics"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-docker"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "bollard",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-env"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-host"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "fs4",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-image"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-instance"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-isolation"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-launch"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-manifest"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-oppicker"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-otlp-testbed"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "jackin-telemetry",
  "opentelemetry-proto",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-pr-trailers"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-process"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "tokio",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-runtime"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "dhat",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-term"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "compact_str 0.10.0",
  "criterion",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-test-support"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-tui"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crossterm",
  "jackin-brand",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-usage"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-usage-ffi"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "jackin-protocol",
  "jackin-usage",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-xtask"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "phc"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = ["crates/jackin-lints"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.97"
 license = "Apache-2.0"
@@ -67,31 +67,31 @@ futures-util = "0.3"
 hyper-util = { version = "0.1", features = ["tokio"] }
 hex = "0.4"
 insta = "=1.48.0"
-jackin-build-meta = { version = "0.6.1", path = "crates/jackin-build-meta" }
-jackin-brand = { version = "0.6.1", path = "crates/jackin-brand" }
-jackin-agent-status = { version = "0.6.1", path = "crates/jackin-agent-status" }
-jackin-config = { version = "0.6.1", path = "crates/jackin-config" }
-jackin-console = { version = "0.6.1", path = "crates/jackin-console" }
-jackin-oppicker = { version = "0.6.1", path = "crates/jackin-oppicker" }
-jackin-core = { version = "0.6.1", path = "crates/jackin-core" }
-jackin-diagnostics = { version = "0.6.1", path = "crates/jackin-diagnostics" }
-jackin-docker = { version = "0.6.1", path = "crates/jackin-docker" }
-jackin-env = { version = "0.6.1", path = "crates/jackin-env" }
-jackin-host = { version = "0.6.1", path = "crates/jackin-host" }
-jackin-image = { version = "0.6.1", path = "crates/jackin-image" }
-jackin-instance = { version = "0.6.1", path = "crates/jackin-instance" }
-jackin-isolation = { version = "0.6.1", path = "crates/jackin-isolation" }
-jackin-launch = { version = "0.6.1", path = "crates/jackin-launch" }
-jackin-manifest = { version = "0.6.1", path = "crates/jackin-manifest" }
-jackin-otlp-testbed = { version = "0.6.1", path = "crates/jackin-otlp-testbed" }
-jackin-process = { version = "0.6.1", path = "crates/jackin-process" }
-jackin-protocol = { version = "0.6.1", path = "crates/jackin-protocol" }
-jackin-runtime = { version = "0.6.1", path = "crates/jackin-runtime" }
-jackin-telemetry = { version = "0.6.1", path = "crates/jackin-telemetry" }
-jackin-term = { version = "0.6.1", path = "crates/jackin-term" }
-jackin-tui = { version = "0.6.1", path = "crates/jackin-tui" }
-jackin-test-support = { version = "0.6.1", path = "crates/jackin-test-support" }
-jackin-usage = { version = "0.6.1", path = "crates/jackin-usage" }
+jackin-build-meta = { version = "0.6.2", path = "crates/jackin-build-meta" }
+jackin-brand = { version = "0.6.2", path = "crates/jackin-brand" }
+jackin-agent-status = { version = "0.6.2", path = "crates/jackin-agent-status" }
+jackin-config = { version = "0.6.2", path = "crates/jackin-config" }
+jackin-console = { version = "0.6.2", path = "crates/jackin-console" }
+jackin-oppicker = { version = "0.6.2", path = "crates/jackin-oppicker" }
+jackin-core = { version = "0.6.2", path = "crates/jackin-core" }
+jackin-diagnostics = { version = "0.6.2", path = "crates/jackin-diagnostics" }
+jackin-docker = { version = "0.6.2", path = "crates/jackin-docker" }
+jackin-env = { version = "0.6.2", path = "crates/jackin-env" }
+jackin-host = { version = "0.6.2", path = "crates/jackin-host" }
+jackin-image = { version = "0.6.2", path = "crates/jackin-image" }
+jackin-instance = { version = "0.6.2", path = "crates/jackin-instance" }
+jackin-isolation = { version = "0.6.2", path = "crates/jackin-isolation" }
+jackin-launch = { version = "0.6.2", path = "crates/jackin-launch" }
+jackin-manifest = { version = "0.6.2", path = "crates/jackin-manifest" }
+jackin-otlp-testbed = { version = "0.6.2", path = "crates/jackin-otlp-testbed" }
+jackin-process = { version = "0.6.2", path = "crates/jackin-process" }
+jackin-protocol = { version = "0.6.2", path = "crates/jackin-protocol" }
+jackin-runtime = { version = "0.6.2", path = "crates/jackin-runtime" }
+jackin-telemetry = { version = "0.6.2", path = "crates/jackin-telemetry" }
+jackin-term = { version = "0.6.2", path = "crates/jackin-term" }
+jackin-tui = { version = "0.6.2", path = "crates/jackin-tui" }
+jackin-test-support = { version = "0.6.2", path = "crates/jackin-test-support" }
+jackin-usage = { version = "0.6.2", path = "crates/jackin-usage" }
 nix = "0.31"
 opentelemetry_sdk = "0.32"
 opentelemetry-semantic-conventions = { version = "=0.32.1", default-features = false }

--- a/crates/jackin-agent-status/Cargo.toml
+++ b/crates/jackin-agent-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-agent-status"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-brand/Cargo.toml
+++ b/crates/jackin-brand/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-brand"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-build-meta/Cargo.toml
+++ b/crates/jackin-build-meta/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-build-meta"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-capsule/Cargo.toml
+++ b/crates/jackin-capsule/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-capsule"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-config/Cargo.toml
+++ b/crates/jackin-config/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-config"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-config/fuzz/Cargo.lock
+++ b/crates/jackin-config/fuzz/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-console/Cargo.toml
+++ b/crates/jackin-console/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-console"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-core/Cargo.toml
+++ b/crates/jackin-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-dev"
-version = "0.1.41"
+version = "0.1.42"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jackin-diagnostics/Cargo.toml
+++ b/crates/jackin-diagnostics/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-diagnostics"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-docker/Cargo.toml
+++ b/crates/jackin-docker/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-docker"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-env/Cargo.toml
+++ b/crates/jackin-env/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-env"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-env/fuzz/Cargo.lock
+++ b/crates/jackin-env/fuzz/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-diagnostics"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-env"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-process"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "tokio",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-host/Cargo.toml
+++ b/crates/jackin-host/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-host"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-image/Cargo.toml
+++ b/crates/jackin-image/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-image"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-instance/Cargo.toml
+++ b/crates/jackin-instance/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-instance"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-isolation/Cargo.toml
+++ b/crates/jackin-isolation/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-isolation"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-launch/Cargo.toml
+++ b/crates/jackin-launch/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-launch"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-lints/Cargo.lock
+++ b/crates/jackin-lints/Cargo.lock
@@ -334,7 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -690,7 +690,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miow"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
@@ -871,7 +871,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/jackin-lints/Cargo.lock
+++ b/crates/jackin-lints/Cargo.lock
@@ -690,7 +690,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miow"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [

--- a/crates/jackin-manifest/Cargo.toml
+++ b/crates/jackin-manifest/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-manifest"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-manifest/fuzz/Cargo.lock
+++ b/crates/jackin-manifest/fuzz/Cargo.lock
@@ -357,7 +357,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-manifest"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "dockerfile-parser-rs",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-oppicker/Cargo.toml
+++ b/crates/jackin-oppicker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-oppicker"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-process/Cargo.toml
+++ b/crates/jackin-process/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-process"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-protocol/Cargo.toml
+++ b/crates/jackin-protocol/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-protocol"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-protocol/fuzz/Cargo.lock
+++ b/crates/jackin-protocol/fuzz/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "directories",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-protocol"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "jackin-core",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-telemetry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",

--- a/crates/jackin-runtime/Cargo.toml
+++ b/crates/jackin-runtime/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-runtime"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-term/Cargo.toml
+++ b/crates/jackin-term/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-term"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-term/fuzz/Cargo.lock
+++ b/crates/jackin-term/fuzz/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jackin-term"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "compact_str",
  "smallvec",

--- a/crates/jackin-test-support/Cargo.toml
+++ b/crates/jackin-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jackin-test-support"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-tui/Cargo.toml
+++ b/crates/jackin-tui/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-tui"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 publish = false

--- a/crates/jackin-usage-ffi/Cargo.toml
+++ b/crates/jackin-usage-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-usage-ffi"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin-usage/Cargo.toml
+++ b/crates/jackin-usage/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-usage"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]

--- a/crates/jackin/Cargo.toml
+++ b/crates/jackin/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Alexey Zhokhov <alexey@zhokhov.com>"]


### PR DESCRIPTION
## Summary
- install the repository-pinned Aqua cargo-nextest tool in release jobs
- remove the conflicting implicit cargo:cargo-nextest latest version
- bump stable workspace artifacts to v0.6.2 and jackin-dev to v0.1.42 because v0.6.1 is immutable

## Root cause
Release run 31634521715 installed cargo-nextest 0.9.143 while mise.toml activates 0.9.140. Mise correctly rejected the ambiguous shim.

## Evidence
- cargo metadata validates all stable local packages at 0.6.2 and jackin-dev at 0.1.42
- all manifests and nested lockfiles contain no stale 0.6.1/0.1.41 internal versions
- local full check is currently blocked by crates.io index omitting locked tower-http 0.6.21; lockfile remains unchanged except internal versions

Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>
Co-authored-by: Codex <codex@openai.com>