### PR TITLE
ci: manage all tooling with mise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,15 +427,13 @@ jobs:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
           cache_save: ${{ github.ref == 'refs/heads/main' }}
-          install_args: "cargo-binstall rust cosign syft aqua:nextest-rs/nextest/cargo-nextest"
+          install_args: "cargo-binstall rust cosign syft aqua:nextest-rs/nextest/cargo-nextest cargo:uniffi"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
 
       - uses: ./.github/actions/cache-cargo-registry
 
-      - name: Install uniffi-bindgen (pinned)
-        run: |
-          cargo install uniffi --version 0.32.0 --features cli --locked --force
-          uniffi-bindgen --version
+      - name: Verify mise-managed uniffi-bindgen
+        run: uniffi-bindgen --version
 
       - name: Verify Xcode 26.6
         run: xcodebuild -version

--- a/mise.lock
+++ b/mise.lock
@@ -58,6 +58,25 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924880"
 provenance = "github-attestations"
 
+[[tools."aqua:apple/container"]]
+version = "1.2.2"
+backend = "aqua:apple/container"
+
+[tools."aqua:apple/container"."platforms.macos-arm64"]
+checksum = "sha256:f4c7e73f7203725a3512676dfd9ec6c6a98a37093b6fd4a1b0fdcfcb227e2118"
+url = "https://github.com/apple/container/releases/download/1.2.2/container-1.2.2-installer-signed.pkg"
+url_api = "https://api.github.com/repos/apple/container/releases/assets/505922768"
+
+[tools."aqua:apple/container"."platforms.macos-x64"]
+checksum = "sha256:f4c7e73f7203725a3512676dfd9ec6c6a98a37093b6fd4a1b0fdcfcb227e2118"
+url = "https://github.com/apple/container/releases/download/1.2.2/container-1.2.2-installer-signed.pkg"
+url_api = "https://api.github.com/repos/apple/container/releases/assets/505922768"
+
+[tools."aqua:apple/container"."platforms.macos-x64-baseline"]
+checksum = "sha256:f4c7e73f7203725a3512676dfd9ec6c6a98a37093b6fd4a1b0fdcfcb227e2118"
+url = "https://github.com/apple/container/releases/download/1.2.2/container-1.2.2-installer-signed.pkg"
+url_api = "https://api.github.com/repos/apple/container/releases/assets/505922768"
+
 [[tools."aqua:nextest-rs/nextest/cargo-nextest"]]
 version = "0.9.140"
 backend = "aqua:nextest-rs/nextest/cargo-nextest"
@@ -482,6 +501,11 @@ checksum = "sha256:07d4e286e31dd79164df39097e0b59f533c94badbe18158464a455ea88a16
 url = "https://github.com/peripheryapp/periphery/releases/download/3.8.0/periphery-3.8.0.zip"
 url_api = "https://api.github.com/repos/peripheryapp/periphery/releases/assets/489291944"
 
+[tools.periphery."platforms.macos-x64-baseline"]
+checksum = "sha256:07d4e286e31dd79164df39097e0b59f533c94badbe18158464a455ea88a166d7"
+url = "https://github.com/peripheryapp/periphery/releases/download/3.8.0/periphery-3.8.0.zip"
+url_api = "https://api.github.com/repos/peripheryapp/periphery/releases/assets/489291944"
+
 [[tools."pipx:reuse"]]
 version = "6.2.0"
 backend = "pipx:reuse"
@@ -599,7 +623,32 @@ url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/2790
 version = "0.65.0"
 backend = "aqua:realm/SwiftLint"
 
+[tools.swiftlint."platforms.linux-arm64"]
+checksum = "sha256:12d3b84bc5b69ae13a99a5a5c79904f9ce25867f099f6368d0037854f9ee6c26"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_arm64.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315166"
+
+[tools.swiftlint."platforms.linux-arm64-musl"]
+checksum = "sha256:12d3b84bc5b69ae13a99a5a5c79904f9ce25867f099f6368d0037854f9ee6c26"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_arm64.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315166"
+
 [tools.swiftlint."platforms.linux-x64"]
+checksum = "sha256:79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_amd64.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315165"
+
+[tools.swiftlint."platforms.linux-x64-baseline"]
+checksum = "sha256:79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_amd64.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315165"
+
+[tools.swiftlint."platforms.linux-x64-musl"]
+checksum = "sha256:79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_amd64.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315165"
+
+[tools.swiftlint."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:79306a34e5c7cc55a220cd108cbb861dcad5f10138dcdf261e2624ae8b0a486b"
 url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/swiftlint_linux_amd64.zip"
 url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315165"
@@ -610,6 +659,11 @@ url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/portable_swif
 url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315152"
 
 [tools.swiftlint."platforms.macos-x64"]
+checksum = "sha256:d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
+url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/portable_swiftlint.zip"
+url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315152"
+
+[tools.swiftlint."platforms.macos-x64-baseline"]
 checksum = "sha256:d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
 url = "https://github.com/realm/SwiftLint/releases/download/0.65.0/portable_swiftlint.zip"
 url_api = "https://api.github.com/repos/realm/SwiftLint/releases/assets/459315152"
@@ -730,6 +784,11 @@ checksum = "sha256:5302e480b01910fcda9071fcc5a64f0a7fce904965834a1e9ed065bc9638b
 url = "https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-x86_64-unknown-linux-gnu.tar.xz"
 url_api = "https://api.github.com/repos/cpisciotta/xcbeautify/releases/assets/388373840"
 
+[tools.xcbeautify."platforms.linux-x64-baseline"]
+checksum = "sha256:5302e480b01910fcda9071fcc5a64f0a7fce904965834a1e9ed065bc9638bfe9"
+url = "https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-x86_64-unknown-linux-gnu.tar.xz"
+url_api = "https://api.github.com/repos/cpisciotta/xcbeautify/releases/assets/388373840"
+
 [tools.xcbeautify."platforms.macos-arm64"]
 checksum = "sha256:ed32972e41bc3aa19588f8b0f4a0209ef70c663ad60bbf4ad84a2de73355d637"
 url = "https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-arm64-apple-macosx.zip"
@@ -740,9 +799,29 @@ checksum = "sha256:ba65e8efc2ebe8c6f13393aaeb88a0ff849278d9480ee1496affaa3db781a
 url = "https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-x86_64-apple-macosx.zip"
 url_api = "https://api.github.com/repos/cpisciotta/xcbeautify/releases/assets/388376611"
 
+[tools.xcbeautify."platforms.macos-x64-baseline"]
+checksum = "sha256:ba65e8efc2ebe8c6f13393aaeb88a0ff849278d9480ee1496affaa3db781ac6e"
+url = "https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-x86_64-apple-macosx.zip"
+url_api = "https://api.github.com/repos/cpisciotta/xcbeautify/releases/assets/388376611"
+
 [[tools.xcodegen]]
 version = "2.46.0"
 backend = "aqua:yonaskolb/XcodeGen"
+
+[tools.xcodegen."platforms.macos-arm64"]
+checksum = "sha256:4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806"
+url = "https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip"
+url_api = "https://api.github.com/repos/yonaskolb/XcodeGen/releases/assets/478866069"
+
+[tools.xcodegen."platforms.macos-x64"]
+checksum = "sha256:4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806"
+url = "https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip"
+url_api = "https://api.github.com/repos/yonaskolb/XcodeGen/releases/assets/478866069"
+
+[tools.xcodegen."platforms.macos-x64-baseline"]
+checksum = "sha256:4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806"
+url = "https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip"
+url_api = "https://api.github.com/repos/yonaskolb/XcodeGen/releases/assets/478866069"
 
 [[tools.zig]]
 version = "0.16.0"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tools]
+"aqua:apple/container" = "1.2.2"
 "github:open-telemetry/weaver" = "0.24.2"
 actionlint = "1.7.12"
 bun = "1.3.14"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tools]
-"aqua:apple/container" = "1.2.2"
+"aqua:apple/container" = { version = "1.2.2", os = ["macos"] }
 "github:open-telemetry/weaver" = "0.24.2"
 actionlint = "1.7.12"
 bun = "1.3.14"

--- a/scripts/desktop-install-proof.sh
+++ b/scripts/desktop-install-proof.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 # jackin> Desktop clean-host install proof.
 #
-# Verifies a published jackin-desktop cask installs, is notarized + stapled +
+# Verifies a published jackin❯ desktop app installs, is notarized + stapled +
 # Gatekeeper-accepted, reports the expected version, and launches as a menu-bar
 # (LSUIElement) app on a Mac that does NOT have this repo checked out. Copy this
 # single file to the target host, or run the numbered manual fallback by hand.
 #
-# Usage: desktop-install-proof.sh <version> [--keep]
+# Usage: desktop-install-proof.sh <version> <app-bundle> [--keep]
 #   <version>  the released X.Y.Z (e.g. 1.2.0)
 #   --keep     skip the uninstall/cleanup at the end
 #
 # Manual fallback (same steps, no script):
-#   1. brew install --cask jackin-project/tap/jackin-desktop
+#   1. ditto <downloaded-JackinDesktop.app> /Applications/JackinDesktop.app
 #   2. test -d /Applications/JackinDesktop.app
 #   3. spctl --assess --type execute --verbose=2 /Applications/JackinDesktop.app
 #      (expect "accepted" + "source=Notarized Developer ID")
@@ -21,7 +21,7 @@
 #        /Applications/JackinDesktop.app/Contents/Info.plist   (equals <version>)
 #   7. open -a /Applications/JackinDesktop.app; sleep 10; pgrep -x JackinDesktop
 #   8. Confirm by eye: enabled providers appear in the menu bar with real data.
-#   9. pkill -x JackinDesktop; brew uninstall --cask jackin-desktop
+#   9. pkill -x JackinDesktop; rm -R /Applications/JackinDesktop.app
 #
 # This script never prints provider tokens, account values, or any credential
 # material — only command exit statuses and the fixed PASS/FAIL/MANUAL strings.
@@ -31,7 +31,7 @@ set -euo pipefail
 APP="/Applications/JackinDesktop.app"
 
 usage() {
-  echo "usage: $(basename "$0") <version> [--keep]" >&2
+  echo "usage: $(basename "$0") <version> <app-bundle> [--keep]" >&2
   echo "  <version>  released X.Y.Z (e.g. 1.2.0)" >&2
   echo "  --keep     skip uninstall/cleanup at the end" >&2
 }
@@ -42,6 +42,7 @@ fail() {
 }
 
 VERSION=""
+SOURCE_APP=""
 KEEP=0
 for arg in "$@"; do
   case "$arg" in
@@ -52,27 +53,28 @@ for arg in "$@"; do
       ;;
     -*) fail "unknown option: $arg" ;;
     *)
-      if [ -n "$VERSION" ]; then
+      if [ -z "$VERSION" ]; then
+        VERSION="$arg"
+      elif [ -z "$SOURCE_APP" ]; then
+        SOURCE_APP="$arg"
+      else
         fail "unexpected extra argument: $arg"
       fi
-      VERSION="$arg"
       ;;
   esac
 done
 
-if [ -z "$VERSION" ]; then
+if [ -z "$VERSION" ] || [ -z "$SOURCE_APP" ]; then
   usage
   exit 2
 fi
 
-command -v brew >/dev/null 2>&1 || fail "Homebrew (brew) is required on the target host"
+test -d "$SOURCE_APP" || fail "source app bundle not found: $SOURCE_APP"
+test ! -e "$APP" || fail "$APP already exists; clean host required"
 
-# 1. Cask installs on a Mac without the repo.
-if brew install --cask jackin-project/tap/jackin-desktop; then
-  echo "PASS: cask installed (jackin-project/tap/jackin-desktop)"
-else
-  fail "brew install --cask jackin-project/tap/jackin-desktop failed"
-fi
+# 1. Install the independently downloaded published bundle without a package manager.
+ditto "$SOURCE_APP" "$APP" || fail "copying published app bundle failed"
+echo "PASS: published app bundle installed"
 
 # 2. App landed where the cask's app stanza installs it.
 test -d "$APP" || fail "$APP not present after install"
@@ -122,6 +124,6 @@ if [ "$KEEP" -eq 1 ]; then
 fi
 
 pkill -x JackinDesktop || true
-brew uninstall --cask jackin-desktop || fail "brew uninstall --cask jackin-desktop failed"
+rm -R -- "$APP"
 test ! -d "$APP" || fail "$APP still present after uninstall"
 echo "PASS: uninstalled cleanly"

--- a/scripts/phase0-apple-container.sh
+++ b/scripts/phase0-apple-container.sh
@@ -98,10 +98,10 @@ if command -v container &>/dev/null; then
     pass "container CLI installed: $CONTAINER_VERSION"
     echo "container version: $CONTAINER_VERSION" >> "$RESULTS_FILE"
 else
-    fail "container CLI not found" "Install: brew install container (see https://github.com/apple/container)"
+    fail "container CLI not found" "Run: mise install aqua:apple/container"
     echo ""
     red "FATAL: apple/container CLI not installed. Cannot proceed with Phase 0."
-    echo "  Run: brew install container"
+    echo "  Run: mise install aqua:apple/container"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary\n- route Apple Container and UniFFI installation through pinned mise declarations\n- replace Homebrew-dependent desktop proof with validation of an independently downloaded app bundle\n- remove Homebrew setup instructions from Phase 0 tooling\n\n## Verification\n- `mise exec aqua:apple/container@1.2.2 -- container --version`\n- `mise exec cargo:uniffi@0.32.0 -- uniffi-bindgen --version`\n- `bash -n scripts/desktop-install-proof.sh scripts/phase0-apple-container.sh`\n- executable installer audit finds no Homebrew, direct cargo install, global npm install, or curl-pipe shell path\n