### PR TITLE
fix(preview): default every trusted path to Velnor

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,10 +9,10 @@ on:
   workflow_dispatch:
     inputs:
       lanes:
-        description: "Which runner(s) to run on. Default github; use both for parity runs."
+        description: "Which runner(s) to run on. Velnor is the default; use both for parity runs."
         type: choice
-        options: [github, velnor, both]
-        default: github
+        options: [velnor, github, both]
+        default: velnor
 
 permissions:
   actions: read
@@ -28,7 +28,7 @@ jobs:
     if: >-
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
+    runs-on: ${{ (github.event_name != 'workflow_dispatch' || inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
     timeout-minutes: 5
     outputs:
       source: ${{ steps.filter.outputs.source }}
@@ -257,7 +257,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"},{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'velnor') && '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]' || '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"},{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]' || '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -302,7 +302,7 @@ jobs:
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
-          cache_save: ${{ github.event_name == 'workflow_run' || github.ref == 'refs/heads/main' }}
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
           install_args: "cargo-binstall zig cargo:cargo-zigbuild cosign syft cargo:sccache"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - id: cargo-registry-cache
@@ -369,7 +369,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"},{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'velnor') && '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]' || '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]') }}
+        config: ${{ fromJSON((github.event_name == 'workflow_dispatch' && inputs.lanes == 'both') && '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"},{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]' || (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && '[{"lane":"GitHub","runner":"\"ubuntu-26.04\"","mise_data_dir":"/home/runner/.local/share/mise"}]' || '[{"lane":"Velnor","runner":"[\"self-hosted\",\"velnor-target-mvp\"]","mise_data_dir":"/opt/mise"}]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -414,7 +414,7 @@ jobs:
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
-          cache_save: ${{ github.event_name == 'workflow_run' || github.ref == 'refs/heads/main' }}
+          cache_save: ${{ github.ref == 'refs/heads/main' }}
           install_args: "cargo-binstall zig cargo:cargo-zigbuild cosign syft cargo:sccache"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - id: cargo-registry-cache
@@ -451,10 +451,9 @@ jobs:
   publish-gate:
     needs: [source-changed, build-preview, build-jackin-capsule]
     if: >-
-      (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') &&
-      needs.source-changed.outputs.source == 'true' &&
-      (github.event_name != 'workflow_dispatch' || inputs.lanes != 'velnor')
-    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
+      github.ref == 'refs/heads/main' &&
+      needs.source-changed.outputs.source == 'true'
+    runs-on: ${{ (github.event_name != 'workflow_dispatch' || inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
     timeout-minutes: 45
     outputs:
       ci_ok: ${{ steps.ci.outputs.ok }}
@@ -466,8 +465,6 @@ jobs:
         id: ci
         env:
           EVENT_NAME: ${{ github.event_name }}
-          CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          CI_SHA: ${{ github.event.workflow_run.head_sha }}
           SOURCE_SHA: ${{ needs.source-changed.outputs.sha }}
         run: |
           set -euo pipefail
@@ -476,19 +473,16 @@ jobs:
             echo "ok=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$CI_CONCLUSION" != "success" ] || [ "$CI_SHA" != "$SOURCE_SHA" ]; then
-            echo "::error::triggering CI does not prove source ${SOURCE_SHA}"
-            exit 1
-          fi
-          echo "ok=true" >> "$GITHUB_OUTPUT"
+          echo "::error::unsupported preview event '${EVENT_NAME}' for source ${SOURCE_SHA}"
+          exit 1
 
   publish-preview:
     needs: [source-changed, build-preview, build-jackin-capsule, publish-gate]
     if: >-
-      (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') &&
+      github.ref == 'refs/heads/main' &&
       needs.source-changed.outputs.source == 'true' &&
       needs.publish-gate.outputs.ci_ok == 'true'
-    runs-on: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
+    runs-on: ${{ (github.event_name != 'workflow_dispatch' || inputs.lanes == 'velnor') && fromJSON('["self-hosted","velnor-target-mvp"]') || 'ubuntu-26.04' }}
     timeout-minutes: 60
     concurrency:
       group: homebrew-tap-publish


### PR DESCRIPTION
## Summary
- default preview source, builds, gate, and publisher to Velnor
- retain explicit GitHub and both dispatch choices
- remove unreachable workflow_run branches after the trigger moved to push
- keep public main/dispatch source binding on `github.sha`

## Verification
- actionlint clean
- no `workflow_run` reference remains in preview.yml
- diff check clean

Signed-off-by: Alexey Zhokhov <donbeave@gmail.com>
Co-authored-by: Codex <codex@openai.com>