### PR TITLE
fix(docs): register established technical terms

### DIFF
--- a/.codebook.toml
+++ b/.codebook.toml
@@ -45,6 +45,10 @@ ignore_patterns = [
 ]
 
 words = [
+  "ecr",
+  "kube",
+  "Rustacean",
+  "tokei",
   "staticlib",
   "LSUI",
   "LSUIElement",


### PR DESCRIPTION
Codebook 0.3.42 made all docs checks fail on Rustacean, ecr, kube, and tokei. This registers those established project terms centrally; focused 0.3.42 lint passes.