### PR TITLE
fix(ci): lock the docs mise toolchain

### DIFF
--- a/docs/mise.toml
+++ b/docs/mise.toml
@@ -5,3 +5,6 @@
 bun = "1.3.14"
 lychee = "0.24.2"
 node = "24.18.0"
+
+[settings]
+lockfile = true


### PR DESCRIPTION
## Summary
- require lockfile use in the nested Docs mise config
- satisfy Velnor pre-execution locked-install admission

## Root cause
The repository root enforced locked mise installs, but the independently discovered nested docs/mise.toml did not. Velnor correctly rejected that configuration before execution.

## Verification
- parsed with repository-scoped mise configuration
- git diff --check

Signed-off-by: Alexey Zhokhov <alexey@zhokhov.com>