### PR TITLE
fix(preview): build fresh on admitted runners

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -264,34 +264,19 @@ jobs:
           ref: ${{ needs.source-changed.outputs.sha }}
       # Velnor admission is fail-closed and must see remote dependencies of
       # local composites in the workflow graph before checkout executes.
-      - name: Bind package-result resolver into admitted closure
-        if: github.event_name == 'velnor-admission-closure'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       - name: Bind nested cache save into admitted closure
         if: github.event_name == 'velnor-admission-closure'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       - name: Bind nested xtask resolver into admitted closure
         if: github.event_name == 'velnor-admission-closure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-      - name: Restore input-identical jackin archive set
-        id: archive-result
-        uses: ./.github/actions/restore-package-result
-        with:
-          workflow: preview.yml
-          branch: ${{ github.ref_name }}
-          primary-name: preview-GitHub-jackin-${{ needs.source-changed.outputs.jackin_archive_contract }}-${{ needs.source-changed.outputs.version }}
-          alternate-name: preview-Velnor-jackin-${{ needs.source-changed.outputs.jackin_archive_contract }}-${{ needs.source-changed.outputs.version }}
-          current-name-regexp: ^preview-(GitHub|Velnor)-jackin-${{ needs.source-changed.outputs.jackin_archive_contract }}-${{ needs.source-changed.outputs.version }}$
-          dry-run: ${{ github.event_name == 'workflow_dispatch' }}
       - uses: ./.github/actions/download-ci-xtask
-        if: steps.archive-result.outputs.found != 'true'
         with:
           token: ${{ github.token }}
           lane: ${{ matrix.config.lane }}
           xtask-contract: ${{ needs.source-changed.outputs.xtask_contract }}
           include-tools: "false"
       - name: Cache Rust toolchain
-        if: steps.archive-result.outputs.found != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -301,11 +286,9 @@ jobs:
           restore-keys: |
             rustup-v2-${{ runner.os }}-${{ runner.arch }}-
       - name: Use the prepared current Rust toolchain
-        if: steps.archive-result.outputs.found != 'true'
         run: >-
           "$CI_XTASK" ci-toolchain prepare
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-        if: steps.archive-result.outputs.found != 'true'
         env:
           # sccache install: blank wrapper in case binstall source-falls-back
           # to cargo, which would probe rustc through a missing sccache.
@@ -317,16 +300,13 @@ jobs:
           install_args: "cargo-binstall zig cargo:cargo-zigbuild cosign syft cargo:sccache"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - id: cargo-registry-cache
-        if: steps.archive-result.outputs.found != 'true'
         uses: ./.github/actions/cache-cargo-registry
       - name: Cache macOS SDK
-        if: steps.archive-result.outputs.found != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/macos-sdk
           key: macos-sdk-26.1
       - name: Build complete signed jackin archive set
-        if: steps.archive-result.outputs.found != 'true'
         env:
           VERSION: ${{ needs.source-changed.outputs.version }}
         run: >-
@@ -334,18 +314,16 @@ jobs:
           --package jackin
           --version "$VERSION"
       - name: Attest complete jackin archive set
-        if: steps.archive-result.outputs.found != 'true' || github.event_name != 'workflow_dispatch'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*.tar.gz
       - name: Upload complete jackin archive set
-        if: steps.archive-result.outputs.found != 'true' || github.event_name != 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-${{ matrix.config.lane }}-jackin-${{ needs.source-changed.outputs.jackin_archive_contract }}-${{ needs.source-changed.outputs.version }}
           path: dist/*.tar.gz*
       - name: Upload jackin cargo timings
-        if: always() && steps.archive-result.outputs.found != 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-timings-preview-jackin-${{ matrix.config.lane }}
@@ -385,35 +363,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.source-changed.outputs.sha }}
-      # Keep the nested dependency explicit for per-job admission closure.
-      - name: Bind package-result resolver into admitted closure
-        if: github.event_name == 'velnor-admission-closure'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       - name: Bind nested cache save into admitted closure
         if: github.event_name == 'velnor-admission-closure'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       - name: Bind nested xtask resolver into admitted closure
         if: github.event_name == 'velnor-admission-closure'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-      - name: Restore input-identical capsule archive set
-        id: archive-result
-        uses: ./.github/actions/restore-package-result
-        with:
-          workflow: preview.yml
-          branch: ${{ github.ref_name }}
-          primary-name: preview-GitHub-jackin-capsule-${{ needs.source-changed.outputs.capsule_archive_contract }}-${{ needs.source-changed.outputs.version }}
-          alternate-name: preview-Velnor-jackin-capsule-${{ needs.source-changed.outputs.capsule_archive_contract }}-${{ needs.source-changed.outputs.version }}
-          current-name-regexp: ^preview-(GitHub|Velnor)-jackin-capsule-${{ needs.source-changed.outputs.capsule_archive_contract }}-${{ needs.source-changed.outputs.version }}$
-          dry-run: ${{ github.event_name == 'workflow_dispatch' }}
       - uses: ./.github/actions/download-ci-xtask
-        if: steps.archive-result.outputs.found != 'true'
         with:
           token: ${{ github.token }}
           lane: ${{ matrix.config.lane }}
           xtask-contract: ${{ needs.source-changed.outputs.xtask_contract }}
           include-tools: "false"
       - name: Cache Rust toolchain
-        if: steps.archive-result.outputs.found != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -423,11 +385,9 @@ jobs:
           restore-keys: |
             rustup-v2-${{ runner.os }}-${{ runner.arch }}-
       - name: Use the prepared current Rust toolchain
-        if: steps.archive-result.outputs.found != 'true'
         run: >-
           "$CI_XTASK" ci-toolchain prepare
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-        if: steps.archive-result.outputs.found != 'true'
         env:
           # sccache install: blank wrapper in case binstall source-falls-back
           # to cargo, which would probe rustc through a missing sccache.
@@ -439,10 +399,8 @@ jobs:
           install_args: "cargo-binstall zig cargo:cargo-zigbuild cosign syft cargo:sccache"
           github_token: ${{ secrets.GH_READONLY_TOKEN }}
       - id: cargo-registry-cache
-        if: steps.archive-result.outputs.found != 'true'
         uses: ./.github/actions/cache-cargo-registry
       - name: Build complete signed capsule archive set
-        if: steps.archive-result.outputs.found != 'true'
         env:
           VERSION: ${{ needs.source-changed.outputs.version }}
         run: >-
@@ -450,18 +408,16 @@ jobs:
           --package jackin-capsule
           --version "$VERSION"
       - name: Attest complete capsule archive set
-        if: steps.archive-result.outputs.found != 'true' || github.event_name != 'workflow_dispatch'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*.tar.gz
       - name: Upload complete capsule archive set
-        if: steps.archive-result.outputs.found != 'true' || github.event_name != 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-${{ matrix.config.lane }}-jackin-capsule-${{ needs.source-changed.outputs.capsule_archive_contract }}-${{ needs.source-changed.outputs.version }}
           path: dist/*.tar.gz*
       - name: Upload capsule cargo timings
-        if: always() && steps.archive-result.outputs.found != 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-timings-preview-capsule-${{ matrix.config.lane }}


### PR DESCRIPTION
## Why\nThe post-#883 main run proved closure discovery and runner capability admission are separate. Velnor correctly rejects `dawidd6/action-download-artifact`; a synthetic bind cannot authorize unsupported executable behavior.\n\n## Fix\nRemove cross-run package restoration from preview builds. Source-changing pushes now build, attest, and upload exact-version archives fresh on Velnor (default) or the explicitly selected lane. This also prevents stale binary/version relabeling.\n\n## Verification\n- actionlint via mise\n- git diff --check\n- no preview reference to restore-package-result or dawidd6 remains\n\nSigned-off-by: Alexey Zhokhov <alexey@zhokhov.com>\nCo-authored-by: Codex <codex@openai.com>