### PR TITLE
fix(docs): bind deployed-check toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -717,6 +717,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Bind deployed-docs toolchain into admitted closure
+        if: github.event_name == 'velnor-admission-closure'
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+
       # Build a sitemap URL that is robust against future
       # actions/deploy-pages versions changing whether `page_url`
       # carries a trailing slash. The current contract has one, but
@@ -753,6 +757,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Bind deployed-docs toolchain into admitted closure
+        if: github.event_name == 'velnor-admission-closure'
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
 
       - name: Verify deployed docs links
         uses: ./.github/actions/check-deployed-docs


### PR DESCRIPTION
Post-merge verification exposed the nested `jdx/mise-action` in `check-deployed-docs` as absent from the `verify-deployed` admission graph. Bind the exact identity in both composite callers.\n\nVerification: actionlint via mise; git diff --check.\n\nSigned-off-by: Alexey Zhokhov <alexey@zhokhov.com>\nCo-authored-by: Codex <codex@openai.com>