### PR TITLE
fix(ci): bind full-history workflow consumers

### DIFF
--- a/.github/workflows/docs-public-unmerged.yml
+++ b/.github/workflows/docs-public-unmerged.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # dorny/paths-filter compares against the PR base commit.
 
       - name: Force docs=true on workflow_dispatch
         id: dispatch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # dorny/paths-filter compares against the event base commit.
 
       - name: Force docs=true on workflow_dispatch
         id: dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # git rev-list derives the immutable CFBundleVersion.
 
       - name: Resolve mode
         id: mode
@@ -424,8 +424,6 @@ jobs:
       app_sha256: ${{ steps.sha.outputs.app_sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
 
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:


### PR DESCRIPTION
## Summary

Align workflow checkout depth with the exact history consumers while preserving docs classification and release behavior.

## What ships

- Documents why both docs classifiers require full history.
- Documents why release version calculation requires full history.
- Restores shallow checkout for the menu-bar build, which consumes the already-derived build number and does not inspect Git history.

## What this addresses

- Clears the actionable full-history findings from the 28-repository Velnor estate audit.

## Verify locally

### Checkout

Run `jackin-dev pr sync 891` and source the generated `env.sh`.

### Static checks

```bash
mise exec -- actionlint .github/workflows/docs.yml .github/workflows/docs-public-unmerged.yml .github/workflows/release.yml
```

## Migration notes

None.
