### PR TITLE
fix(console): compile prelude wizard invariant helper in release builds

### DIFF
--- a/crates/jackin-console/src/tui/input/prelude.rs
+++ b/crates/jackin-console/src/tui/input/prelude.rs
@@ -55,7 +55,11 @@ pub fn handle_prelude_key(
 /// current step index must name the step that modal belongs to. Steps with
 /// no open modal (cancelled, or completed before the outer dispatcher
 /// reacts) are exempt.
-#[cfg(debug_assertions)]
+///
+/// Compiled unconditionally: `debug_assert!` still type-checks its
+/// expression in release builds, so a `#[cfg(debug_assertions)]` helper
+/// breaks `cargo build --release` (E0425, seen in the preview workflow's
+/// cross-build).
 fn create_prelude_step_matches_modal(step: usize, modal: Option<&Modal<'_>>) -> bool {
     use crate::tui::state::{FileBrowserTarget, Modal, TextInputTarget};
     let Some(modal) = modal else {


### PR DESCRIPTION
## Problem

Main-branch Publish Homebrew Preview failed: `cargo zigbuild --release --locked --target aarch64-apple-darwin` → `error[E0425]: cannot find function create_prelude_step_matches_modal in this scope`.

Root cause: the helper was `#[cfg(debug_assertions)]` while its only caller sits inside `debug_assert!`, which still type-checks the expression in release builds. Debug-profile CI lanes never saw it; only the release cross-build does.

## Fix

Drop the `#[cfg(debug_assertions)]` (helper is small and pure; `debug_assert!` keeps the check debug-only). Verified with `cargo check -p jackin-console --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)