### PR TITLE
chore(ci): pin velnor-actions 2026.8.31 (native platform timeout 60m)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ inputs.benchmark_campaign != '' && format('{0}-{1}-{2}', github.workflow, inputs.benchmark_campaign, inputs.benchmark_wave) || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ inputs.benchmark_campaign != '' && format('{0}-{1}-{2}-{3}', github.workflow, github.event_name, inputs.benchmark_campaign, inputs.benchmark_wave) || format('{0}-{1}-{2}', github.workflow, github.event_name, github.ref) }}
   cancel-in-progress: ${{ inputs.benchmark_campaign == '' }}
 
 jobs:
@@ -99,7 +99,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: jackin-project/velnor-actions/.github/workflows/ci-native.yml@052224913aa7c1b6750b8ed34131ae590dd961b1 # 2026.8.28
+    uses: jackin-project/velnor-actions/.github/workflows/ci-native.yml@eeb8a182174f3c97c370ecf3f1e3e4689ae22cfe # 2026.8.31
     with:
       lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -121,7 +121,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: tailrocks/velnor-actions/.github/workflows/ci-native.yml@43fc50c6940beac5a14de96f7e7d7ef3fcac568f # 2026.8.28
+    uses: tailrocks/velnor-actions/.github/workflows/ci-native.yml@84a3d2c5f8f74a3054259ac494581b244bf61ee7 # 2026.8.31
     with:
       lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
@@ -143,7 +143,7 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: ChainArgos/velnor-actions/.github/workflows/ci-native.yml@36d568abb89b4f53aa828fe1740fbb3411ffcb87 # 2026.8.30
+    uses: ChainArgos/velnor-actions/.github/workflows/ci-native.yml@4561d3dc3a410980b8a3858d42b88a34c5e757f4 # 2026.8.31
     with:
       lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}


### PR DESCRIPTION
Re-rendered `.github/workflows/ci.yml` with `velnor-actions-generator render-consumer` at mirror tags `2026.8.31` (jackin-project@eeb8a18, tailrocks@84a3d2c, ChainArgos@4561d3d).

Root fix for `native-usage-menu-bar` exceeding the generated 30-minute platform-lane timeout on main: the generator now renders `timeout-minutes: 60` for the native class from `fleet/classes.toml` `native.platform_timeout_minutes`.

- generator change: jackin-project/velnor-actions#40, tailrocks/velnor-actions#61, ChainArgos/velnor-actions#33 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)