### PR TITLE
fix(ci): resolve push runs to the GitHub lane token everywhere

### DIFF
--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -495,7 +495,7 @@ jobs:
         if: always()
         with:
           token: ${{ github.token }}
-          lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}
+          lane: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}
           xtask-contract: ${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '.cargo/**', 'crates/*/Cargo.toml', 'crates/jackin-xtask/src/**', 'crates/jackin-process/src/**') }}
           include-tools: "false"
       - name: Audit every Construct job's performance

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
     timeout-minutes: 15
     env:
-      CI_LANE: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}
+      CI_LANE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}
       DOCS_XTASK: ${{ github.workspace }}/.ci-prebuilt-xtask/jackin-xtask
     steps:
       - name: Checkout repository
@@ -280,7 +280,7 @@ jobs:
     runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
     timeout-minutes: 20
     env:
-      CI_LANE: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}
+      CI_LANE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}
       DOCS_XTASK: ${{ github.workspace }}/.ci-prebuilt-xtask/jackin-xtask
     steps:
       - name: Checkout repository

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -66,7 +66,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_TERM_COLOR: always
-      CI_LANE: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}
+      CI_LANE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       SCCACHE_GHA_ENABLED: "false"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -501,7 +501,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
-          pattern: preview-${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}-*
+          pattern: preview-${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}-*
           merge-multiple: true
 
       - name: Bind CI xtask resolver into admitted closure
@@ -514,7 +514,7 @@ jobs:
         uses: ./.github/actions/download-ci-xtask
         with:
           token: ${{ github.token }}
-          lane: ${{ (github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') && 'GitHub' || 'Velnor' }}
+          lane: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'GitHub' || 'Velnor' }}
           xtask-contract: ${{ hashFiles('Cargo.lock', 'Cargo.toml', 'rust-toolchain.toml', '.cargo/**', 'crates/*/Cargo.toml', 'crates/jackin-xtask/src/**', 'crates/jackin-process/src/**') }}
           include-tools: "false"
 


### PR DESCRIPTION
Push events execute on the GitHub lane (merged_push_occupancy policy), but six expressions derived the lane token from the workflow_dispatch input alone and labeled push runs 'Velnor'.

Impact: `publish-preview` in preview.yml downloaded the `preview-Velnor-*` artifact pattern while push build jobs upload `preview-GitHub-*`; zero artifacts matched and capsule signing failed: `artifacts/capsule-manifest.json: No such file or directory` (run 32686455135). The same wrong token fed `download-ci-xtask` lane labels (construct.yml, preview.yml) and `CI_LANE` cache keys / xtask lanes (docs.yml, hygiene.yml).

Fix: token now resolves GitHub iff `push` or `dispatch lanes=github` — identical to the runs-on resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)