### PR TITLE
fix(desktop): wait up to 8s for refresh re-enable after menu Refresh

### DIFF
--- a/native/UITests/JackinDesktopUITests.swift
+++ b/native/UITests/JackinDesktopUITests.swift
@@ -424,7 +424,7 @@ final class JackinDesktopUITests: XCTestCase {
         application.menuBars.menuBarItems["View"].click()
         application.menuItems["Refresh"].click()
         XCTAssertTrue(usageWindow.exists)
-        XCTAssertTrue(element("usage.refresh").waitForEnabled(timeout: 3))
+        XCTAssertTrue(element("usage.refresh").waitForEnabled(timeout: 8))
     }
 
     func testProviderDetailPassesAccessibilityAudit() throws {


### PR DESCRIPTION
View > Refresh runs `store.refreshAll()` across every provider fixture; `usage.refresh` stays disabled while `refreshInProgress`. On GitHub-hosted macos-26 runners the refresh cycle outlives the previous 3s bound: merge cadence runs 32688252587 and 32694086885 both failed this exact `XCTAssertTrue` at 23.9s / 25.2s total test time, while the same commit passes locally in 21.8s with the button re-enabling ~1.1s into the wait.

The test still asserts the re-enable outcome — only the bound moves to the 8s tolerance already used elsewhere in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)