### PR TITLE
fix(hygiene): run DinD E2E on macOS and unbreak dylint toolchain

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -996,7 +996,12 @@ jobs:
 
   dind-chaos:
     name: Full DinD E2E
-    runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
+    # Platform-only (fleet-design exception): these usage-broker E2E tests
+    # hard-require OrbStack — a macOS Docker engine (see require_orbstack in
+    # crates/jackin/tests/usage_broker_e2e/docker.rs). The Velnor fleet has no
+    # macOS runners, so this job always runs GitHub-hosted macOS regardless of
+    # the lane selector, like every other macos-26 leg.
+    runs-on: macos-26
     timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: "0"

--- a/crates/jackin-lints/rust-toolchain
+++ b/crates/jackin-lints/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-04-16"
+channel = "nightly-2026-08-15"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/mise.lock
+++ b/mise.lock
@@ -414,21 +414,6 @@ checksum = "sha256:63ad53934062118f5b0be11785e0bb1603d4b91667d1921f2fd8df9a87120
 url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317831911"
 
-[tools.hyperfine."platforms.linux-x64-baseline"]
-checksum = "sha256:63ad53934062118f5b0be11785e0bb1603d4b91667d1921f2fd8df9a8712040a"
-url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317831911"
-
-[tools.hyperfine."platforms.linux-x64-musl"]
-checksum = "sha256:3285ec7959285288137043dd81dce0dde056227018a8277532d9a364b4f03c2b"
-url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832008"
-
-[tools.hyperfine."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:3285ec7959285288137043dd81dce0dde056227018a8277532d9a364b4f03c2b"
-url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/sharkdp/hyperfine/releases/assets/317832008"
-
 [tools.hyperfine."platforms.macos-arm64"]
 checksum = "sha256:f58d0b90993fadfa122a351428c469ce24afef3865f027f0e6e86f0830d088f1"
 url = "https://github.com/sharkdp/hyperfine/releases/download/v1.20.0/hyperfine-v1.20.0-x86_64-apple-darwin.tar.gz"


### PR DESCRIPTION
Two pre-existing Hygiene failures, unrelated to the lanes conversion (Hygiene has been red on every scheduled run since Aug 16):

1. **Full DinD E2E** — `require_orbstack` (`crates/jackin/tests/usage_broker_e2e/docker.rs`) hard-requires OrbStack, a macOS-only Docker engine, and rejects any engine that does not report `OrbStack` (`mandatory macOS usage-broker lane requires OrbStack; active Docker engine reports Debian GNU/Linux 13 (trixie)`). The job kept running on Linux lanes. Pinned to GitHub-hosted `macos-26` as a fleet-design platform-only exception — the Velnor fleet has no macOS runners — matching every other macos-26 leg.

2. **dylint render purity** — `crates/jackin-lints/rust-toolchain` pinned `nightly-2026-04-16` (rustc 1.97.0-nightly) while `termrock@0.11.0` requires rustc >= 1.97.1: `rustc 1.97.0-nightly is not supported by the following package: termrock@0.11.0 requires rustc 1.97.1`. Bumped the pin to `nightly-2026-08-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)