### PR TITLE
fix(release): make desktop-release-state mise args positional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           fi
 
           # Independent states: formula alone is not enough when menu-bar assets exist.
-          state="$(mise run desktop-release-state "$VERSION" --repo "$GITHUB_REPOSITORY" || true)"
+          state="$(mise run desktop-release-state "$VERSION" "$GITHUB_REPOSITORY" || true)"
           echo "$state"
           cask_complete=$(printf '%s\n' "$state" | sed -n 's/^cask_complete=//p')
           app_complete=$(printf '%s\n' "$state" | sed -n 's/^app_file_assets_complete=//p')
@@ -523,9 +523,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mise run desktop-release-state "$VERSION" --repo "$GITHUB_REPOSITORY" | tee state.env
+          mise run desktop-release-state "$VERSION" "$GITHUB_REPOSITORY" | tee state.env
           # Second run is identical (no writes).
-          mise run desktop-release-state "$VERSION" --repo "$GITHUB_REPOSITORY" | tee state2.env
+          mise run desktop-release-state "$VERSION" "$GITHUB_REPOSITORY" | tee state2.env
           diff -u state.env state2.env
 
       - name: Import Developer ID + notarize (publish only)

--- a/mise.toml
+++ b/mise.toml
@@ -319,8 +319,8 @@ cargo xtask desktop sign-notarize "${args[@]}"
 description = "Print independent Desktop release/cask state KEY=value lines"
 usage = '''
 arg "<version>" help="Release version without leading v"
-arg "--repo" help="GitHub owner/name" default="jackin-project/jackin"
-arg "--tap" help="Homebrew tap owner/name" default="jackin-project/homebrew-tap"
+arg "<repo>" help="GitHub owner/name" default="jackin-project/jackin"
+arg "<tap>" help="Homebrew tap owner/name" default="jackin-project/homebrew-tap"
 '''
 run = 'cargo xtask desktop release-state "$usage_version" --repo "$usage_repo" --tap "$usage_tap"'
 


### PR DESCRIPTION
mise's usage parser no longer binds a separate value token to `arg "--repo"`: with mise 2026.7.12 the value never reaches ``, so `desktop-release-state` invoked `cargo xtask desktop release-state … --repo ""` and clap rejected it — `a value is required for '--repo <REPO>' but none was supplied`. Release has failed at this step on every dispatch and tag push since Aug 12 (runs 31624275693…31659973845, and today's validate dispatch 32692925318).

Fix: positional usage args with defaults (bind correctly on the same mise); the task still forwards `--repo`/`--tap` options to the xtask CLI. Verified locally: `mise run desktop-release-state 0.6.4 jackin-project/jackin` prints the reconciliation state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)