### PR TITLE
fix(hygiene): measure the build-time ratchet only on GitHub-hosted runners

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -489,7 +489,12 @@ jobs:
   # Scheduled per-crate clean + incremental build-time ceiling (plans 026/048).
   build-time-measure:
     name: Per-crate build-time ratchet
-    runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
+    # Platform-only (calibration contract): ratchet.toml's build-time ceilings
+    # are sampled exclusively on GitHub-hosted runners and must be measured on
+    # comparable hardware. Velnor runners are materially slower (run 32711045540:
+    # jackin-runtime.clean_s 220 -> 322), which would force ceiling inflation or
+    # flapping, so this job always measures on the GitHub lane.
+    runs-on: ubuntu-26.04
     timeout-minutes: 90
     env:
       CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
`ratchet.toml` documents the build-time ceilings as sampled exclusively on GitHub-hosted Hygiene runs (`Ceilings from Hygiene GitHub-hosted samples … Local samples must not set these ceilings`). Running the measurement on Velnor hardware compares GitHub-calibrated ceilings against materially slower shared runners and fails spuriously — run 32711045540 reported 7 violations (`jackin-runtime.clean_s` 220 → 322, `jackin-console.clean_s` 44 → 68, …).

Fix: pin the measurement job to `ubuntu-26.04`, the same platform-only treatment as the macos-26 legs — it is a timing-calibration gate, not a portable correctness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)