### PR TITLE
fix(hygiene): resolve hyperfine through mise on the cold-start job

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -392,7 +392,7 @@ jobs:
       - name: Hyperfine cold-start
         run: |
           set -euo pipefail
-          hyperfine --warmup 3 --min-runs 10 --export-json cold-start.json \
+          mise x hyperfine -- hyperfine --warmup 3 --min-runs 10 --export-json cold-start.json \
             'target/release/jackin --help' \
             'target/release/jackin console --help'
           {


### PR DESCRIPTION
The Velnor mise integration installs aqua-backed tools outside PATH (no shims), so the bare `hyperfine` invocation fails with `command not found` even after #907's lockfile variant fix (run 32716673652). Invoke it through `mise x hyperfine --` so the binary resolves from the mise environment on both lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)