### PR TITLE
chore(ratchet): raise jackin-console clean-build ceiling to 45s

### DIFF
--- a/ratchet.toml
+++ b/ratchet.toml
@@ -764,7 +764,7 @@ key = "jackin-capsule.incremental_s"
 bound = 8
 [[family.entry]]
 key = "jackin-console.clean_s"
-bound = 44
+bound = 45
 [[family.entry]]
 key = "jackin-console.incremental_s"
 bound = 6


### PR DESCRIPTION
The unified usage surfaces work (#898) and TermRock console modernization (#899) grew jackin-console's clean build by one second: today's GitHub-hosted Hygiene sample measured 45s against the 44s ceiling calibrated on 2026-08-23.

This is an intentional budget update per the ratchet policy — the growth comes from reviewed console features, not a regression to refactor away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)