### PR TITLE
fix(nextest): widen the png_baselines_screens_match slow-timeout budget

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,10 +48,21 @@ filter = 'test(/load_agent_skips|load_agent_cleans_up_when_parallel_sidecar/)'
 test-group = 'load-agent'
 slow-timeout = { period = "90s", terminate-after = 3, grace-period = "5s" }
 
+[[profile.default.overrides]]
+# png_baselines_screens_match renders PNG baselines for every console screen;
+# on the shared Velnor runners it can exceed the default 180s terminate budget
+# under parallel suite load (the same shape as the load-agent budget below).
+filter = 'test(/png_baselines_screens_match/)'
+slow-timeout = { period = "120s", terminate-after = 3, grace-period = "5s" }
+
 [[profile.ci.overrides]]
 filter = 'test(/load_agent_skips|load_agent_cleans_up_when_parallel_sidecar/)'
 test-group = 'load-agent'
 slow-timeout = { period = "90s", terminate-after = 3, grace-period = "5s" }
+
+[[profile.ci.overrides]]
+filter = 'test(/png_baselines_screens_match/)'
+slow-timeout = { period = "120s", terminate-after = 3, grace-period = "5s" }
 
 [[profile.docker-e2e.overrides]]
 filter = 'binary(/dind_e2e|usage_broker_e2e/)'

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -392,6 +392,14 @@ jobs:
       - name: Hyperfine cold-start
         run: |
           set -euo pipefail
+          # The Velnor persistent mise store (/opt/mise) can hold a poisoned
+          # hyperfine entry — a version dir mise treats as installed even
+          # though its bin/ layout does not yield an executable (see Velnor
+          # #275/#277 for the cargo-backend variant; the aqua backend has the
+          # same failure shape). Diagnose the stored layout, then force a
+          # real reinstall before resolving through `mise x`.
+          mise where hyperfine 2>/dev/null | xargs -r ls -la || true
+          mise install --force hyperfine
           mise x hyperfine -- hyperfine --warmup 3 --min-runs 10 --export-json cold-start.json \
             'target/release/jackin --help' \
             'target/release/jackin console --help'


### PR DESCRIPTION
png_baselines_screens_match renders PNG baselines for every console screen. On the shared Velnor runners the suite's parallel load can push its wall time past nextest's default 180s terminate budget (TERMINATING at 180.016s while the other 2220 tests pass), intermittently failing the snapshots gate on PR runs.

Same shape and medicine as the existing load-agent override: give this single heavy test a wider terminate budget (120s x 3 = 360s) rather than masking or serializing the whole suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)