### PR TITLE
fix: skip process-death lock test under Miri

### DIFF
--- a/crates/jackin-config/src/persist/tests.rs
+++ b/crates/jackin-config/src/persist/tests.rs
@@ -76,7 +76,8 @@ fn config_lock_timeout_uses_injected_clock_without_sleeping() {
 #[cfg(unix)]
 // Re-spawns the test binary as a lock-holding child that must die with a
 // real OS signal; process spawning and kernel flock semantics are outside
-// Miri's model (posix_spawnattr_init is unsupported), so skip under Miri.
+// what Miri models (posix spawn attributes are unsupported), so skip under
+// Miri.
 #[cfg_attr(miri, ignore)]
 fn config_lock_process_death_releases_ownership() {
     const CHILD_PATH: &str = "JACKIN_CONFIG_LOCK_TEST_CHILD";

--- a/crates/jackin-config/src/persist/tests.rs
+++ b/crates/jackin-config/src/persist/tests.rs
@@ -74,6 +74,10 @@ fn config_lock_timeout_uses_injected_clock_without_sleeping() {
 
 #[test]
 #[cfg(unix)]
+// Re-spawns the test binary as a lock-holding child that must die with a
+// real OS signal; process spawning and kernel flock semantics are outside
+// Miri's model (posix_spawnattr_init is unsupported), so skip under Miri.
+#[cfg_attr(miri, ignore)]
 fn config_lock_process_death_releases_ownership() {
     const CHILD_PATH: &str = "JACKIN_CONFIG_LOCK_TEST_CHILD";
     if let Some(path) = std::env::var_os(CHILD_PATH) {


### PR DESCRIPTION
config_lock_process_death_releases_ownership re-spawns the test binary as a lock-holding child and kills it to prove flock ownership release. Process spawning and kernel flock semantics are outside Miri's model: the Velnor Hygiene Miri lane aborts with `unsupported operation: can't call foreign function posix_spawnattr_init` (run 32805689323). Guard the test with `cfg_attr(miri, ignore)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)