### PR TITLE
fix(docs): run CI site link check without the response cache

### DIFF
--- a/crates/jackin-xtask/src/docs/site_links.rs
+++ b/crates/jackin-xtask/src/docs/site_links.rs
@@ -26,6 +26,12 @@ fn command(site_url: &str, workspace: &Path, blob_url: &str, edit_url: &str) -> 
         .env("MISE_CONFIG_FILE", workspace.join("docs/mise.toml"))
         .arg("--config")
         .arg("docs/lychee.toml")
+        // The response cache is a local-development optimization; in CI a
+        // restored cache path can arrive as a directory, which makes lychee
+        // fail fatally on save ("Is a directory", os error 21). CI reuse is
+        // already gated by the semantic link-result contract, so run the
+        // site check uncached, exactly like the README link check below.
+        .arg("--cache=false")
         .arg("--verbose")
         .arg("--include-fragments")
         .arg("--remap")


### PR DESCRIPTION
docs-link-check failed on the Velnor lane twice (PR #926 runs 32835298177 attempts) with lychee exiting 1 via `Error: Is a directory (os error 21)` while reporting zero (or one unrelated) link errors: a restored `.lycheecache` path arrives as a directory on Velnor persistent storage, and lychee fails fatally saving the cache. The response cache is a local-dev optimization; CI reuse is already gated by the semantic link-result contract. Pass `--cache=false` for the CI site check, exactly like the README link check already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)