### PR TITLE
chore(deps): update debian docker digest

### DIFF
--- a/docker/construct/Dockerfile
+++ b/docker/construct/Dockerfile
@@ -12,7 +12,7 @@ ARG SHELLFIRM_VERSION
 RUN cargo install shellfirm --version "${SHELLFIRM_VERSION}" --locked --root /opt/shellfirm && \
     /opt/shellfirm/bin/shellfirm --version | grep -F "${SHELLFIRM_VERSION}"
 
-FROM debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958
+FROM debian:13@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1
 
 ARG SHELLFIRM_VERSION
 

--- a/docker/construct/VERSION
+++ b/docker/construct/VERSION
@@ -1,1 +1,1 @@
-0.35-trixie
+0.36-trixie


### PR DESCRIPTION
Applies renovate PR #924's Debian digest bump (debian:13@sha256:f324c7f...) together with the required immutable Construct version bump 0.35-trixie → 0.36-trixie, the same pattern as 594f7893. #924 alone cannot pass the construct-assert-version-unpublished gate because the 0.35-trixie tag is already published.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)