### PR TITLE
fix(e2e): wait out broker lease window in usage broker recovery test

### DIFF
--- a/crates/jackin/tests/usage_broker_e2e.rs
+++ b/crates/jackin/tests/usage_broker_e2e.rs
@@ -142,11 +142,28 @@ fn usage_broker_child() -> Result<()> {
         root: root.clone(),
         release: None,
     });
-    let client = ensure_usage_broker_with_executor(
-        UsageBrokerConfig::for_data_dir(root.join("data")),
-        executor,
-    )
-    .test_result()?;
+    // The broker lease is a process-independent authority: a killed owner's
+    // lease stays valid for its full duration, so takeover — and therefore
+    // this client's connect — legitimately fails with Unavailable until the
+    // lease expires. Retry like a real desktop client instead of assuming
+    // recovery is instantaneous.
+    const ENSURE_DEADLINE: Duration = Duration::from_secs(90);
+    let deadline = Instant::now() + ENSURE_DEADLINE;
+    let client = loop {
+        match ensure_usage_broker_with_executor(
+            UsageBrokerConfig::for_data_dir(root.join("data")),
+            Arc::clone(&executor),
+        ) {
+            Ok(client) => break client,
+            Err(error)
+                if error.kind == UsageCoordinationErrorKind::Unavailable
+                    && Instant::now() < deadline =>
+            {
+                std::thread::park_timeout(Duration::from_millis(500));
+            }
+            Err(error) => return Err(error).test_result(),
+        }
+    };
     let state = client.refresh(capability(), 0, true).test_result()?;
     let terminal = client
         .join(capability(), state.generation, Duration::from_secs(5))


### PR DESCRIPTION
## Summary

The Full DinD E2E job on the Velnor lane (run 32898436225) failed
`recovery::usage_broker_killed_owner_recovers_once_without_a_herd` with
`Unavailable: usage broker is unavailable` from every recovery child.

Root cause: the broker lease is a process-independent authority —
`claim_leader` refuses takeover while the existing lease is still fresh
(by design, PID liveness is deliberately not trusted), so a killed
owner's lease blocks takeover for its full 30 s duration. The test
killed the owner about 10 s after it claimed the lease, and the
recovery children each retried the connect for only `CONNECT_RETRY`
(10 s), giving up around the 20 s mark — always before the lease
expired at 30 s. The failure was deterministic; the test had never
actually executed in CI before because the full Docker E2E lane only
became runnable once it moved to Linux CI hosts (PR #928).

## Changes

- `crates/jackin/tests/usage_broker_e2e.rs`: the `usage_broker_child`
  client now retries `ensure_usage_broker_with_executor` with a 500 ms
  backoff until a 90 s deadline when it gets `Unavailable`, mirroring
  what a real desktop client does during the designed takeover delay.
  The single-flight recovery assertion (exactly one new provider
  generation, no herd) is unchanged.

## Testing

- `cargo nextest run -p jackin --features e2e --profile docker-e2e`:
  `recovery::usage_broker_killed_owner_recovers_once_without_a_herd`
  now passes (31.7 s, waits out the lease window), and
  `usage_broker_two_host_processes_make_one_provider_call` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)