### PR TITLE
ci: re-render ci.yml from velnor-actions 2026.8.32 (fleet-independent PR lanes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: jackin-project/velnor-actions/.github/workflows/ci-native.yml@eeb8a182174f3c97c370ecf3f1e3e4689ae22cfe # 2026.8.31
+    uses: jackin-project/velnor-actions/.github/workflows/ci-native.yml@796dfcd26d4110319c8363155d2eae6885114893 # 2026.8.32
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -121,9 +121,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: tailrocks/velnor-actions/.github/workflows/ci-native.yml@84a3d2c5f8f74a3054259ac494581b244bf61ee7 # 2026.8.31
+    uses: tailrocks/velnor-actions/.github/workflows/ci-native.yml@c222e52030fee9ea6eae573a5769770be01d8438 # 2026.8.32
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -143,9 +143,9 @@ jobs:
       actions: read
       contents: read
       pull-requests: read
-    uses: ChainArgos/velnor-actions/.github/workflows/ci-native.yml@4561d3dc3a410980b8a3858d42b88a34c5e757f4 # 2026.8.31
+    uses: ChainArgos/velnor-actions/.github/workflows/ci-native.yml@77173e8e71aa18e60d21f9f0d1ae57c0695d0233 # 2026.8.32
     with:
-      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || github.event_name == 'push' && 'github' || 'velnor' }}
+      lane: ${{ github.event_name == 'workflow_dispatch' && inputs.lanes || (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && 'github' || 'velnor' }}
       recovery_proof_id: ${{ inputs.recovery_proof_id || '' }}
       benchmark_campaign: ${{ inputs.benchmark_campaign || '' }}
       benchmark_generation: ${{ inputs.benchmark_generation || '' }}
@@ -165,7 +165,7 @@ jobs:
       - tailrocks
       - ChainArgos
     if: ${{ always() }}
-    runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
+    runs-on: ${{ ((github.event_name == 'workflow_dispatch' && inputs.lanes == 'github') || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push') && 'ubuntu-26.04' || fromJSON('["self-hosted","velnor-target-mvp"]') }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,9 +866,9 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
Re-renders `.github/workflows/ci.yml` from the canonical generator at release **2026.8.32** (`tailrocks/velnor-actions@c222e52`, "route public PRs to GitHub").

- Bumps the three owner mirror pins 2026.8.31 → 2026.8.32 (jackin-project@796dfcd, tailrocks@c222e52, ChainArgos@77173e8; all three tags carry byte-identical trees).
- Routes `pull_request`/`merge_group` lanes and `ci-required` to `ubuntu-26.04` — PR checks no longer queue on the degraded Velnor fleet.
- No job renames; required check `ci-required` is unchanged.

Unblocks the queued PRs once merged; blocked PRs then need a branch update to pick up the new workflow.