### PR TITLE
chore(deps): update jdx/mise-action digest to c2a8761

### DIFF
--- a/.github/actions/check-deployed-docs/action.yml
+++ b/.github/actions/check-deployed-docs/action.yml
@@ -55,7 +55,7 @@ runs:
         done
 
     - name: Setup lychee via mise
-      uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
       with:
         version: "2026.7.12"
         cache_key_prefix: "mise-v2"

--- a/.github/workflows/construct-public-unmerged.yml
+++ b/.github/workflows/construct-public-unmerged.yml
@@ -224,7 +224,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -337,7 +337,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -419,7 +419,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"

--- a/.github/workflows/construct.yml
+++ b/.github/workflows/construct.yml
@@ -230,7 +230,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -343,7 +343,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -425,7 +425,7 @@ jobs:
             rustup-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"

--- a/.github/workflows/docs-public-unmerged.yml
+++ b/.github/workflows/docs-public-unmerged.yml
@@ -207,7 +207,7 @@ jobs:
         if: github.event_name == 'velnor-admission-closure'
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -367,7 +367,7 @@ jobs:
           steps.link-result.outputs.verified != 'true' ||
           (github.ref == 'refs/heads/main' &&
            needs.changes.outputs.deployment-reuse != 'true')
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -513,7 +513,7 @@ jobs:
 
       - name: Build missing Codebook binary once
         if: steps.codebook-artifact.outputs.hit != 'true'
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -210,7 +210,7 @@ jobs:
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: Setup mise
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -370,7 +370,7 @@ jobs:
           steps.link-result.outputs.verified != 'true' ||
           (github.ref == 'refs/heads/main' &&
            needs.changes.outputs.deployment-reuse != 'true')
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -516,7 +516,7 @@ jobs:
 
       - name: Build missing Codebook binary once
         if: steps.codebook-artifact.outputs.hit != 'true'
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
         with:
           version: "2026.7.12"
           cache_key_prefix: "mise-v2"
@@ -719,7 +719,7 @@ jobs:
 
       - name: Bind deployed-docs toolchain into admitted closure
         if: github.event_name == 'velnor-admission-closure'
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       # Build a sitemap URL that is robust against future
       # actions/deploy-pages versions changing whether `page_url`
@@ -760,7 +760,7 @@ jobs:
 
       - name: Bind deployed-docs toolchain into admitted closure
         if: github.event_name == 'velnor-admission-closure'
-        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Verify deployed docs links
         uses: ./.github/actions/check-deployed-docs


### PR DESCRIPTION
Re-opened from #933 (same Renovate branch, unchanged commits) to escape a wedged pull_request run concurrency group that blocked CI from starting.