### PR TITLE
chore(deps): update rust crate serde_json to v1.0.151

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "jackin-dev"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "anyhow",
  "clap",
@@ -4158,7 +4158,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -6111,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ semver = "1"
 serde = "1.0"
 # Exact pin from workspace virtualization (#713); no recovered bug citation.
 # Candidate for caret "1" in a dedicated lockfile-refresh PR.
-serde_json = "=1.0.150"
+serde_json = "=1.0.151"
 serde_yaml_ng = "0.10.0"
 sha2 = "0.11"
 smallvec = "1.15"

--- a/crates/jackin-dev/Cargo.toml
+++ b/crates/jackin-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "jackin-dev"
-version = "0.1.48"
+version = "0.1.49"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jackin-env/fuzz/Cargo.lock
+++ b/crates/jackin-env/fuzz/Cargo.lock
@@ -1665,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",

--- a/crates/jackin-protocol/fuzz/Cargo.lock
+++ b/crates/jackin-protocol/fuzz/Cargo.lock
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
Re-opened from #934 (same Renovate branch, unchanged commits) to escape a wedged pull_request run concurrency group that blocked CI from starting.