### PR TITLE
ci(renovate): allow mise lock during dependency bumps

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,6 +48,9 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_BASE_DIR: /tmp/renovate
           RENOVATE_ONBOARDING: false
+          # Let Renovate run `mise lock` so mise.toml tool bumps refresh
+          # mise.lock in the same PR (CI installs mise tools in locked mode).
+          RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: "mise"
           RENOVATE_REPOSITORY_CACHE: enabled
           # Pin the git author identity so the DCO sign-off trailer in
           # renovate.json::commitBody always matches the commit-author


### PR DESCRIPTION
Renovate already tries to run `mise lock` when it bumps a tool in `mise.toml` (native mise manager artifact update), but the execution is blocked:

```
WARN: `mise lock` was requested to run, but `mise` is not permitted in the allowedUnsafeExecutions
```

Result: renovate PRs bump `mise.toml` without `mise.lock`, and CI fails with `<tool>@<version> is not in the lockfile` (mise installs run in locked mode in CI). Fixed manually several times already (e.g. jackin-sentinel #104, ChainArgos/jackin-agent-brown #216).

Fix: set `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: "mise"` (global/admin option, can only be set via env on the self-hosted runner) so future tool bumps carry the `mise.lock` update in the same PR.

Refs: https://docs.renovatebot.com/modules/manager/mise/