### PR TITLE
chore(ci): raise build-time ratchet ceilings for console clean and runtime incremental

### DIFF
--- a/ratchet.toml
+++ b/ratchet.toml
@@ -751,15 +751,23 @@ provider = "build_times"
 mode = "artifact-ceiling"
 cap = 0
 # Ceilings from Hygiene GitHub-hosted samples (runs 29396473635,
-# 29397057453, and 31887638238). Wall-clock varies materially on shared
-# runners; headroom is ~40% above the highest reviewed sample. Local samples
-# must not set these ceilings.
+# 29397057453, and 31887638238; latest sample run 33319391723). Wall-clock
+# varies materially on shared runners; headroom is ~25-40% above the highest
+# reviewed sample. Local samples must not set these ceilings.
+# Structural note: this family measures absolute wall-clock seconds on shared
+# runners, so single-run samples carry scheduler noise. The jackin-console
+# crate had no source changes in its growth window; its +4s is runner noise.
+# jackin-runtime incremental growth is real code cost from #944 (capsule
+# session control, programmatic launch, ~2.1k lines). Raised with headroom to
+# avoid re-tripping on noise. Flagged to velnor-actions: consider a
+# noise-tolerant provider (median of N samples) instead of single-sample
+# absolute seconds.
 [[family.entry]]
 key = "jackin-runtime.clean_s"
 bound = 220
 [[family.entry]]
 key = "jackin-runtime.incremental_s"
-bound = 12
+bound = 16
 [[family.entry]]
 key = "jackin-capsule.clean_s"
 bound = 111
@@ -768,7 +776,7 @@ key = "jackin-capsule.incremental_s"
 bound = 8
 [[family.entry]]
 key = "jackin-console.clean_s"
-bound = 45
+bound = 62
 [[family.entry]]
 key = "jackin-console.incremental_s"
 bound = 6


### PR DESCRIPTION
## Problem
Hygiene red on main: 2 build-time ratchet violations (run 33319391723)
- `jackin-console.clean_s` 45 -> 49
- `jackin-runtime.incremental_s` 12 -> 13

## Root cause
- **jackin-runtime**: real code cost — #944 added ~2.1k lines (capsule session control, programmatic launch) in the same window.
- **jackin-console**: no source changes to the crate in the window; the +4s is shared-runner wall-clock noise. `ratchet.toml` already documents that wall-clock varies materially on shared runners — single-sample absolute seconds is a noise-sensitive provider.

## Fix
Regenerated entries from the CI `build-time-measure` artifact (`cargo xtask lint ratchet --print build-time`), ceilings set with family headroom:
- console clean 45 -> 62
- runtime incremental 12 -> 16 (all other entries still pass against the new sample)

Structural note filed for velnor-actions: consider median-of-N samples instead of a single-sample absolute-seconds provider to remove this failure class.

## Verification
`cargo xtask lint ratchet --only build-time` OK against run 33319391723 sample.